### PR TITLE
Set docs favicon

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ hooks:
 theme:
   name: material
   logo: assets/sleap-logo.png
+  favicon: assets/sleap-logo.png
   icon:
     repo: fontawesome/brands/github
   palette:


### PR DESCRIPTION
## Summary
- use the SLEAP logo as the docs favicon via mkdocs config

## Testing
- not run (config-only change)