### PR TITLE
Add skeleton YAML codec

### DIFF
--- a/src/codecs/skeleton-yaml.ts
+++ b/src/codecs/skeleton-yaml.ts
@@ -1,0 +1,101 @@
+import YAML from "yaml";
+import { Skeleton, Node, Edge, Symmetry, NodeOrIndex } from "../model/skeleton.js";
+
+type YAMLNodeEntry = { name: string } | string;
+
+type YAMLEdgeEntry =
+  | { source: { name: string } | string; destination: { name: string } | string }
+  | [NodeOrIndex, NodeOrIndex];
+
+type YAMLSymmetryEntry = Array<{ name: string } | string> | [NodeOrIndex, NodeOrIndex];
+
+type YAMLSkeletonData = {
+  nodes: YAMLNodeEntry[];
+  edges?: YAMLEdgeEntry[];
+  symmetries?: YAMLSymmetryEntry[];
+  name?: string;
+};
+
+function getNodeName(entry: YAMLNodeEntry): string {
+  if (typeof entry === "string") return entry;
+  if (entry && typeof entry.name === "string") return entry.name;
+  throw new Error("Invalid node entry in skeleton YAML.");
+}
+
+function resolveName(value: { name?: string } | string): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value.name === "string") return value.name;
+  throw new Error("Invalid name reference in skeleton YAML.");
+}
+
+function decodeSkeleton(data: YAMLSkeletonData, fallbackName?: string): Skeleton {
+  if (!data?.nodes) throw new Error("Skeleton YAML missing nodes.");
+  const nodes = data.nodes.map((entry) => new Node(getNodeName(entry)));
+
+  const edges = (data.edges ?? []).map((edge) => {
+    if (Array.isArray(edge)) {
+      const [source, destination] = edge;
+      return new Edge(nodes[Number(source)], nodes[Number(destination)]);
+    }
+    const sourceName = resolveName(edge.source);
+    const destName = resolveName(edge.destination);
+    const source = nodes.find((node) => node.name === sourceName);
+    const dest = nodes.find((node) => node.name === destName);
+    if (!source || !dest) throw new Error("Edge references unknown node.");
+    return new Edge(source, dest);
+  });
+
+  const symmetries = (data.symmetries ?? []).map((symmetry) => {
+    if (!Array.isArray(symmetry) || symmetry.length !== 2) {
+      throw new Error("Symmetry must contain exactly 2 nodes.");
+    }
+    const [left, right] = symmetry;
+    const leftName = resolveName(left as { name?: string } | string);
+    const rightName = resolveName(right as { name?: string } | string);
+    const leftNode = nodes.find((node) => node.name === leftName);
+    const rightNode = nodes.find((node) => node.name === rightName);
+    if (!leftNode || !rightNode) throw new Error("Symmetry references unknown node.");
+    return new Symmetry([leftNode, rightNode]);
+  });
+
+  return new Skeleton({
+    name: data.name ?? fallbackName,
+    nodes,
+    edges,
+    symmetries,
+  });
+}
+
+export function decodeYamlSkeleton(yamlData: string): Skeleton | Skeleton[] {
+  const parsed = YAML.parse(yamlData) as Record<string, unknown> | null;
+  if (!parsed) throw new Error("Empty skeleton YAML.");
+
+  if (Object.prototype.hasOwnProperty.call(parsed, "nodes")) {
+    return decodeSkeleton(parsed as YAMLSkeletonData);
+  }
+
+  return Object.entries(parsed).map(([name, skeletonData]) =>
+    decodeSkeleton(skeletonData as YAMLSkeletonData, name)
+  );
+}
+
+export function encodeYamlSkeleton(skeletons: Skeleton | Skeleton[]): string {
+  const list = Array.isArray(skeletons) ? skeletons : [skeletons];
+  const payload: Record<string, YAMLSkeletonData> = {};
+
+  list.forEach((skeleton, index) => {
+    const name = skeleton.name ?? `Skeleton-${index}`;
+    const nodes = skeleton.nodes.map((node) => ({ name: node.name }));
+    const edges = skeleton.edges.map((edge) => ({
+      source: { name: edge.source.name },
+      destination: { name: edge.destination.name },
+    }));
+    const symmetries = skeleton.symmetries.map((symmetry) => {
+      const pair = Array.from(symmetry.nodes);
+      return [{ name: pair[0].name }, { name: pair[1].name }];
+    });
+    payload[name] = { nodes, edges, symmetries };
+  });
+
+  return YAML.stringify(payload);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * from "./video/mp4box-video.js";
 export * from "./io/main.js";
 export * from "./codecs/dictionary.js";
 export * from "./codecs/numpy.js";
+export * from "./codecs/skeleton-yaml.js";

--- a/tests/codecs/skeleton-yaml.test.ts
+++ b/tests/codecs/skeleton-yaml.test.ts
@@ -1,0 +1,82 @@
+/* @vitest-environment node */
+import { describe, it, expect } from "vitest";
+import { decodeYamlSkeleton, encodeYamlSkeleton } from "../../src/codecs/skeleton-yaml.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("../data/slp", import.meta.url));
+
+async function readFixture(filename: string) {
+  return readFile(path.join(fixtureRoot, filename), "utf8");
+}
+
+describe("skeleton YAML codec", () => {
+  it("decodes a single skeleton YAML file", async () => {
+    const yamlText = await readFixture("flies13.skeleton.yml");
+    const decoded = decodeYamlSkeleton(yamlText);
+    const skeletons = Array.isArray(decoded) ? decoded : [decoded];
+    expect(skeletons).toHaveLength(1);
+
+    const skeleton = skeletons[0];
+    expect(skeleton.name).toBe("Skeleton-0");
+    expect(skeleton.nodeNames).toEqual([
+      "head",
+      "thorax",
+      "abdomen",
+      "wingL",
+      "wingR",
+      "forelegL4",
+      "forelegR4",
+      "midlegL4",
+      "midlegR4",
+      "hindlegL4",
+      "hindlegR4",
+      "eyeL",
+      "eyeR",
+    ]);
+    expect(skeleton.edges).toHaveLength(12);
+    expect(skeleton.edges[0].source.name).toBe("head");
+    expect(skeleton.edges[0].destination.name).toBe("eyeL");
+    expect(skeleton.symmetries).toHaveLength(10);
+    expect(skeleton.symmetryNames[0]).toEqual(["wingL", "wingR"]);
+  });
+
+  it("decodes YAML with a named skeleton mapping", async () => {
+    const yamlText = await readFixture("fly32.skeleton.yaml");
+    const decoded = decodeYamlSkeleton(yamlText);
+    const skeletons = Array.isArray(decoded) ? decoded : [decoded];
+    expect(skeletons).toHaveLength(1);
+    const skeleton = skeletons[0];
+    expect(skeleton.name).toBe(
+      "M:/talmo/data/leap_datasets/BermanFlies/2018-05-03_cluster-sampled.k=10,n=150.labels.mat"
+    );
+    expect(skeleton.nodeNames).toHaveLength(32);
+    expect(skeleton.edges.length).toBeGreaterThan(0);
+    expect(skeleton.symmetries).toHaveLength(0);
+  });
+
+  it("round-trips skeleton YAML", async () => {
+    const yamlText = await readFixture("flies13.skeleton.yml");
+    const decoded = decodeYamlSkeleton(yamlText);
+    const skeletons = Array.isArray(decoded) ? decoded : [decoded];
+    const encoded = encodeYamlSkeleton(skeletons[0]);
+    const roundTrip = decodeYamlSkeleton(encoded);
+    const roundSkeleton = Array.isArray(roundTrip) ? roundTrip[0] : roundTrip;
+
+    expect(roundSkeleton.nodeNames).toEqual(skeletons[0].nodeNames);
+    expect(roundSkeleton.edgeIndices).toEqual(skeletons[0].edgeIndices);
+    expect(roundSkeleton.symmetryNames).toEqual(skeletons[0].symmetryNames);
+  });
+
+  it("encodes multiple skeletons into a mapping", () => {
+    const left = new Skeleton({ name: "Left", nodes: ["a", "b"] });
+    const right = new Skeleton({ name: "Right", nodes: ["x", "y"] });
+    const yamlText = encodeYamlSkeleton([left, right]);
+    const decoded = decodeYamlSkeleton(yamlText);
+    const skeletons = Array.isArray(decoded) ? decoded : [decoded];
+    const names = skeletons.map((skeleton) => skeleton.name).sort();
+    expect(names).toEqual(["Left", "Right"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add skeleton YAML encode/decode utilities matching sleap-io schema
- export YAML codec entry points from package
- add tests covering fixtures, mapping decode, and round-trip

## Testing
- npm test -- --run tests/codecs/skeleton-yaml.test.ts