### PR TITLE
Add repository metadata for trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": ["dist"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/talmolab/sleap-io.js.git"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- add package.json repository metadata required for npm provenance verification

## Testing
- not run (metadata-only change)