### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- bump package version to 0.1.2 (includes repository metadata for trusted publishing)

## Testing
- not run (version bump only)