### PR TITLE
Add lite entry point using jsfive for Workers compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ const video = await loadVideo("/path/to/video.mp4", { openBackend: false });
 video.close();
 ```
 
+### Lite mode (Workers-compatible)
+
+For environments that don't support WebAssembly compilation (e.g., Cloudflare Workers), use the `/lite` entry point:
+
+```ts
+import { loadSlpMetadata, validateSlpBuffer } from "@talmolab/sleap-io.js/lite";
+
+// Load metadata without pose coordinates
+const metadata = await loadSlpMetadata(buffer);
+console.log(metadata.skeletons);     // Full skeleton definitions
+console.log(metadata.counts);        // { labeledFrames, instances, points, predictedPoints }
+console.log(metadata.provenance);    // { sleap_version, ... }
+
+// Quick validation
+validateSlpBuffer(buffer);  // throws on invalid
+```
+
+The lite module uses [jsfive](https://github.com/usnistgov/jsfive) (pure JavaScript) instead of h5wasm (WebAssembly), enabling use in restricted environments. It can read all metadata but not pose coordinates or video frames.
+
 ## Architecture
 
 - **I/O layer**: `loadSlp`/`saveSlp` wrap the HDF5 reader/writer in `src/codecs/slp`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ await saveSlp(labels, "/tmp/session-roundtrip.slp", { embed: false });
 - Streaming inputs (URL, `File`, `FileSystemFileHandle`).
 - Data model types (`Labels`, `LabeledFrame`, `Instance`, `Skeleton`, `Video`).
 - Dictionary and numpy codecs.
+- **Lite mode** for Workers-compatible metadata extraction (no WASM).
 
 ## Environments
 

--- a/docs/lite.md
+++ b/docs/lite.md
@@ -1,0 +1,206 @@
+# Lite Mode
+
+The `/lite` entry point provides a Workers-compatible SLP reader that uses [jsfive](https://github.com/usnistgov/jsfive) (pure JavaScript) instead of h5wasm (WebAssembly).
+
+## When to use Lite Mode
+
+Use the lite module when:
+
+- Running in **Cloudflare Workers** or other environments that block runtime WebAssembly compilation
+- You only need **metadata** (skeletons, counts, video info) without actual pose coordinates
+- You want a **smaller bundle** (~50KB vs ~800KB+ for h5wasm)
+- You need **quick validation** of SLP files
+
+## Installation
+
+```ts
+import { loadSlpMetadata, validateSlpBuffer, isHdf5Buffer } from "@talmolab/sleap-io.js/lite";
+```
+
+## API Reference
+
+### `loadSlpMetadata(source, options?)`
+
+Extract metadata from an SLP file without loading pose coordinates.
+
+```ts
+const response = await fetch("https://example.com/file.slp");
+const buffer = await response.arrayBuffer();
+const metadata = await loadSlpMetadata(buffer);
+
+console.log(metadata.version);      // "1.3.4"
+console.log(metadata.skeletons);    // Full skeleton definitions
+console.log(metadata.tracks);       // Track names
+console.log(metadata.videos);       // Video metadata
+console.log(metadata.counts);       // { labeledFrames, instances, points, predictedPoints }
+console.log(metadata.provenance);   // { sleap_version, ... }
+```
+
+**Parameters:**
+
+- `source`: `ArrayBuffer` or `Uint8Array` containing the SLP file
+- `options.filename`: Optional filename hint for embedded video paths
+
+**Returns:** `Promise<SlpMetadata>`
+
+### `validateSlpBuffer(source)`
+
+Quick structural validation of an SLP file.
+
+```ts
+try {
+  validateSlpBuffer(buffer);
+  console.log("Valid SLP file");
+} catch (e) {
+  console.error("Invalid:", e.message);
+}
+```
+
+**Parameters:**
+
+- `source`: `ArrayBuffer` or `Uint8Array` to validate
+
+**Returns:** `true` if valid, throws `Error` with details if invalid
+
+### `isHdf5Buffer(source)`
+
+Check if a buffer starts with the HDF5 magic number.
+
+```ts
+if (isHdf5Buffer(buffer)) {
+  // Might be an SLP file, do full validation
+  const metadata = await loadSlpMetadata(buffer);
+}
+```
+
+**Parameters:**
+
+- `source`: `ArrayBuffer` or `Uint8Array` to check
+
+**Returns:** `boolean`
+
+## Types
+
+### `SlpMetadata`
+
+```ts
+interface SlpMetadata {
+  /** SLEAP version that created this file (e.g., "1.3.4") */
+  version: string;
+
+  /** HDF5 format ID (e.g., 1.2) */
+  formatId: number;
+
+  /** Skeleton definitions with nodes, edges, and symmetries */
+  skeletons: Skeleton[];
+
+  /** Track definitions */
+  tracks: Track[];
+
+  /** Video metadata (without loaded backends) */
+  videos: VideoMetadata[];
+
+  /** Suggestion frame metadata */
+  suggestions: SuggestionMetadata[];
+
+  /** Multi-camera recording session metadata */
+  sessions: SessionMetadata[];
+
+  /** Dataset counts */
+  counts: {
+    labeledFrames: number;
+    instances: number;
+    points: number;
+    predictedPoints: number;
+  };
+
+  /** Whether any video has embedded image data */
+  hasEmbeddedImages: boolean;
+
+  /** Raw provenance data (SLEAP version, build info, etc.) */
+  provenance?: Record<string, unknown>;
+}
+```
+
+### `VideoMetadata`
+
+```ts
+interface VideoMetadata {
+  filename: string;
+  dataset?: string;
+  format?: string;
+  width?: number;
+  height?: number;
+  channels?: number;
+  fps?: number;
+  frameCount?: number;
+  channelOrder?: string;
+  embedded: boolean;
+  sourceVideo?: { filename: string };
+}
+```
+
+## What's Available vs Not Available
+
+### ✅ Available in Lite Mode
+
+| Metadata | Description |
+|----------|-------------|
+| Skeletons | Full definitions with nodes, edges, symmetries |
+| Tracks | Track names |
+| Videos | Filename, dimensions, format, fps |
+| Counts | Frame, instance, and point counts |
+| Provenance | SLEAP version and build info |
+| Sessions | Multi-camera session metadata |
+| Suggestions | Suggestion frame info |
+
+### ❌ Not Available in Lite Mode
+
+| Data | Reason |
+|------|--------|
+| Pose coordinates (x, y) | Requires compound dataset support |
+| Point visibility/scores | Requires compound dataset support |
+| Instance-frame mapping | Requires compound dataset support |
+| Video frame data | Requires VLEN sequence support |
+
+## Full vs Lite Comparison
+
+| Feature | `loadSlp()` | `loadSlpMetadata()` |
+|---------|-------------|---------------------|
+| HDF5 backend | h5wasm (WASM) | jsfive (pure JS) |
+| Bundle size | ~800KB+ | ~50KB |
+| Workers compatible | ❌ | ✅ |
+| Returns | `Labels` object | `SlpMetadata` object |
+| Pose coordinates | ✅ | ❌ |
+| Video frame access | ✅ | ❌ |
+| Skeleton parsing | ✅ | ✅ |
+| Metadata | ✅ | ✅ |
+
+## Example: File Upload Validation
+
+```ts
+import { loadSlpMetadata, validateSlpBuffer, isHdf5Buffer } from "@talmolab/sleap-io.js/lite";
+
+async function handleUpload(file: File) {
+  const buffer = await file.arrayBuffer();
+
+  // Quick check
+  if (!isHdf5Buffer(buffer)) {
+    throw new Error("Not an HDF5 file");
+  }
+
+  // Validate structure
+  validateSlpBuffer(buffer);
+
+  // Extract metadata
+  const metadata = await loadSlpMetadata(buffer, { filename: file.name });
+
+  return {
+    valid: true,
+    skeletons: metadata.skeletons.map(s => s.name),
+    frameCount: metadata.counts.labeledFrames,
+    instanceCount: metadata.counts.instances,
+    sleapVersion: metadata.provenance?.sleap_version,
+  };
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,3 +59,5 @@ nav:
   - Overview: index.md
   - Demo: demo.md
   - API: api.md
+  - Lite Mode: lite.md
+  - Rendering: rendering.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.2",
       "dependencies": {
         "h5wasm": "^0.8.8",
+        "jsfive": "^0.3.10",
         "mp4box": "^0.5.4",
         "skia-canvas": "^3.0.8",
         "yaml": "^2.6.1"
@@ -1709,6 +1710,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsfive": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/jsfive/-/jsfive-0.3.14.tgz",
+      "integrity": "sha512-CptUQRZw1JHgQKhuZX6ozL/5PndJWetPz3K/Raeh5U/ise8FO84BIcBwbUBq2WsCl/zrnu3phnwazL+IuvaQ5A==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "pako": "^2.0.4"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -1889,6 +1899,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parenthesis": {
       "version": "3.1.8",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./lite": {
+      "types": "./dist/lite.d.ts",
+      "import": "./dist/lite.js"
     }
   },
   "main": "./dist/index.js",
@@ -17,13 +21,14 @@
     "url": "https://github.com/talmolab/sleap-io.js.git"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts src/lite.ts --format esm --dts",
     "test": "vitest",
     "test:coverage": "vitest --run --coverage",
     "lint": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "h5wasm": "^0.8.8",
+    "jsfive": "^0.3.10",
     "mp4box": "^0.5.4",
     "skia-canvas": "^3.0.8",
     "yaml": "^2.6.1"

--- a/src/codecs/slp/jsfive.ts
+++ b/src/codecs/slp/jsfive.ts
@@ -1,0 +1,107 @@
+/**
+ * jsfive-based HDF5 file interface.
+ * Pure JavaScript implementation for Workers-compatible environments.
+ */
+
+import * as hdf5 from "jsfive";
+
+export type JsfiveSource = ArrayBuffer | Uint8Array;
+
+export interface JsfiveDataset {
+  value: unknown;
+  shape: number[];
+  dtype: string;
+  attrs: Record<string, unknown>;
+}
+
+export interface JsfiveGroup {
+  keys: string[];
+  attrs: Record<string, unknown>;
+  get(path: string): JsfiveDataset | JsfiveGroup | null;
+}
+
+export interface JsfiveFile {
+  get(path: string): JsfiveDataset | JsfiveGroup | null;
+  keys: string[];
+  close(): void;
+}
+
+/**
+ * Open an HDF5 file using jsfive (pure JavaScript, no WASM).
+ *
+ * @param source - ArrayBuffer or Uint8Array containing the HDF5 file
+ * @param filename - Optional filename hint for error messages
+ * @returns JsfiveFile interface for reading the file
+ */
+export function openJsfiveFile(source: JsfiveSource, filename?: string): JsfiveFile {
+  let buffer: ArrayBuffer;
+  if (source instanceof Uint8Array) {
+    // Create a proper ArrayBuffer copy to avoid SharedArrayBuffer issues
+    const slice = source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength);
+    buffer = slice as ArrayBuffer;
+  } else {
+    buffer = source;
+  }
+  const file = new hdf5.File(buffer, filename ?? "data.slp");
+
+  return {
+    get: (path: string): JsfiveDataset | JsfiveGroup | null => {
+      try {
+        const item = file.get(path);
+        if (!item) return null;
+        return item as JsfiveDataset | JsfiveGroup;
+      } catch {
+        return null;
+      }
+    },
+    keys: file.keys as string[],
+    close: () => {
+      // jsfive doesn't need explicit close
+    },
+  };
+}
+
+/**
+ * Check if an item is a jsfive dataset (has value property).
+ */
+export function isDataset(item: JsfiveDataset | JsfiveGroup | null): item is JsfiveDataset {
+  if (!item) return false;
+  return "value" in item || "shape" in item;
+}
+
+/**
+ * Check if an item is a jsfive group (has keys property but no value).
+ */
+export function isGroup(item: JsfiveDataset | JsfiveGroup | null): item is JsfiveGroup {
+  if (!item) return false;
+  return "keys" in item && !("value" in item);
+}
+
+/**
+ * Safely get attributes from a dataset or group.
+ */
+export function getAttrs(item: JsfiveDataset | JsfiveGroup | null): Record<string, unknown> {
+  if (!item) return {};
+  return (item.attrs ?? {}) as Record<string, unknown>;
+}
+
+/**
+ * Safely get the shape of a dataset.
+ */
+export function getShape(item: JsfiveDataset | JsfiveGroup | null): number[] {
+  if (!item || !isDataset(item)) return [];
+  return item.shape ?? [];
+}
+
+/**
+ * Safely get the value of a dataset.
+ */
+export function getValue(item: JsfiveDataset | JsfiveGroup | null): unknown {
+  if (!item || !isDataset(item)) return null;
+  try {
+    return item.value;
+  } catch {
+    // jsfive throws on compound datasets
+    return null;
+  }
+}

--- a/src/codecs/slp/parsers.ts
+++ b/src/codecs/slp/parsers.ts
@@ -1,0 +1,369 @@
+/**
+ * Shared parsing functions for SLP file metadata.
+ * Used by both the full h5wasm-based reader and the lite jsfive-based reader.
+ */
+
+import { Skeleton, Node } from "../../model/skeleton.js";
+import { Track } from "../../model/instance.js";
+
+const textDecoder = new TextDecoder();
+
+/**
+ * Parse JSON from HDF5 attribute.
+ * Handles string, Uint8Array, and buffer variations.
+ */
+export function parseJsonAttr(attr: unknown): unknown {
+  if (!attr) return null;
+  const value = (attr as { value?: unknown }).value ?? attr;
+  if (typeof value === "string") return JSON.parse(value);
+  if (value instanceof Uint8Array) return JSON.parse(textDecoder.decode(value));
+  if (value && typeof value === "object" && "buffer" in value) {
+    return JSON.parse(textDecoder.decode(new Uint8Array((value as { buffer: ArrayBuffer }).buffer)));
+  }
+  return JSON.parse(String(value));
+}
+
+/**
+ * Trim trailing nulls and whitespace from a string (for fixed-width HDF5 strings).
+ */
+function trimHdf5String(str: string): string {
+  return str.trim().replace(/\0+$/, "");
+}
+
+/**
+ * Parse a single JSON entry from a dataset value.
+ * Handles both string and Uint8Array entries.
+ * Trims trailing nulls/whitespace for fixed-width HDF5 strings.
+ */
+export function parseJsonEntry(entry: unknown): unknown {
+  if (typeof entry === "string") return JSON.parse(trimHdf5String(entry));
+  if (entry instanceof Uint8Array) return JSON.parse(trimHdf5String(textDecoder.decode(entry)));
+  if (entry && typeof entry === "object" && "buffer" in entry) {
+    return JSON.parse(trimHdf5String(textDecoder.decode(new Uint8Array((entry as { buffer: ArrayBuffer }).buffer))));
+  }
+  return entry;
+}
+
+/**
+ * Resolve edge type from py/reduce patterns in SLEAP metadata.
+ * Type 1 = regular edge, Type 2 = symmetry.
+ */
+export function resolveEdgeType(
+  edgeType: unknown,
+  cache: Map<number, number>,
+  state: { nextId: number }
+): number {
+  if (!edgeType || typeof edgeType !== "object") return 1;
+  const et = edgeType as Record<string, unknown>;
+
+  if (et["py/reduce"]) {
+    const reduce = et["py/reduce"] as unknown[];
+    const tuple = (reduce[1] as Record<string, unknown>)?.["py/tuple"] as number[] | undefined;
+    const typeId = tuple?.[0] ?? 1;
+    cache.set(state.nextId, typeId);
+    state.nextId += 1;
+    return typeId;
+  }
+  if (et["py/tuple"]) {
+    const tuple = et["py/tuple"] as number[];
+    const typeId = tuple[0] ?? 1;
+    cache.set(state.nextId, typeId);
+    state.nextId += 1;
+    return typeId;
+  }
+  if (et["py/id"]) {
+    const pyId = et["py/id"] as number;
+    return cache.get(pyId) ?? pyId;
+  }
+  return 1;
+}
+
+/**
+ * Parse skeletons from metadata JSON.
+ * Handles py/reduce patterns for edge types and builds full Skeleton objects.
+ */
+export function parseSkeletons(metadataJson: unknown): Skeleton[] {
+  if (!metadataJson || typeof metadataJson !== "object") return [];
+
+  const meta = metadataJson as Record<string, unknown>;
+  const nodeNames = (meta.nodes as Array<{ name?: string } | string> ?? []).map(
+    (node) => (typeof node === "object" ? node.name ?? "" : String(node))
+  );
+  const skeletonEntries = meta.skeletons as Array<Record<string, unknown>> ?? [];
+  const skeletons: Skeleton[] = [];
+
+  for (const entry of skeletonEntries) {
+    const edges: Array<[number, number]> = [];
+    const symmetries: Array<[number, number]> = [];
+    const typeCache = new Map<number, number>();
+    const typeState = { nextId: 1 };
+
+    const entryNodes = entry.nodes as Array<{ id?: number } | number> ?? [];
+    const skeletonNodeIds = entryNodes.map((node) =>
+      Number(typeof node === "object" ? node.id ?? 0 : node)
+    );
+    const nodeOrder = skeletonNodeIds.length
+      ? skeletonNodeIds
+      : nodeNames.map((_, index) => index);
+
+    const nodes = nodeOrder
+      .map((nodeId: number) => nodeNames[nodeId])
+      .filter((name): name is string => name !== undefined)
+      .map((name) => new Node(name));
+
+    const nodeIndexById = new Map<number, number>();
+    nodeOrder.forEach((nodeId: number, index: number) => {
+      nodeIndexById.set(Number(nodeId), index);
+    });
+
+    const links = entry.links as Array<{ source: number; target: number; type?: unknown }> ?? [];
+    for (const link of links) {
+      const source = Number(link.source);
+      const target = Number(link.target);
+      const edgeType = resolveEdgeType(link.type, typeCache, typeState);
+      if (edgeType === 2) {
+        symmetries.push([source, target]);
+      } else {
+        edges.push([source, target]);
+      }
+    }
+
+    const remapPair = (pair: [number, number]): [number, number] | null => {
+      const sourceIndex = nodeIndexById.get(pair[0]);
+      const targetIndex = nodeIndexById.get(pair[1]);
+      if (sourceIndex === undefined || targetIndex === undefined) return null;
+      return [sourceIndex, targetIndex];
+    };
+
+    const mappedEdges = edges
+      .map(remapPair)
+      .filter((pair): pair is [number, number] => pair !== null);
+
+    const seenSymmetries = new Set<string>();
+    const mappedSymmetries = symmetries
+      .map(remapPair)
+      .filter((pair): pair is [number, number] => pair !== null)
+      .filter(([a, b]) => {
+        const key = a < b ? `${a}-${b}` : `${b}-${a}`;
+        if (seenSymmetries.has(key)) return false;
+        seenSymmetries.add(key);
+        return true;
+      });
+
+    const graph = entry.graph as { name?: string } | undefined;
+    const skeleton = new Skeleton({
+      nodes,
+      edges: mappedEdges,
+      symmetries: mappedSymmetries,
+      name: graph?.name ?? (entry.name as string | undefined),
+    });
+    skeletons.push(skeleton);
+  }
+
+  return skeletons;
+}
+
+/**
+ * Parse tracks from tracks_json dataset values.
+ */
+export function parseTracks(values: unknown[]): Track[] {
+  const tracks: Track[] = [];
+  for (const entry of values) {
+    let parsed = entry;
+    if (typeof entry === "string") {
+      try {
+        parsed = JSON.parse(trimHdf5String(entry));
+      } catch {
+        parsed = trimHdf5String(entry);
+      }
+    } else if (entry instanceof Uint8Array) {
+      try {
+        parsed = JSON.parse(trimHdf5String(textDecoder.decode(entry)));
+      } catch {
+        parsed = trimHdf5String(textDecoder.decode(entry));
+      }
+    }
+
+    if (Array.isArray(parsed)) {
+      tracks.push(new Track(String(parsed[1] ?? parsed[0])));
+    } else if (parsed && typeof parsed === "object" && "name" in parsed) {
+      tracks.push(new Track(String((parsed as { name: unknown }).name)));
+    } else {
+      tracks.push(new Track(String(parsed)));
+    }
+  }
+  return tracks;
+}
+
+/**
+ * Video metadata extracted from videos_json without creating backends.
+ */
+export interface VideoMetadata {
+  /** Original filename or "." for embedded */
+  filename: string;
+  /** HDF5 dataset path for embedded videos */
+  dataset?: string;
+  /** Video format (e.g., "mp4", "hdf5") */
+  format?: string;
+  /** Video width in pixels */
+  width?: number;
+  /** Video height in pixels */
+  height?: number;
+  /** Number of color channels */
+  channels?: number;
+  /** Frames per second */
+  fps?: number;
+  /** Total number of frames */
+  frameCount?: number;
+  /** Channel order (e.g., "RGB", "BGR") */
+  channelOrder?: string;
+  /** Whether video is embedded in the SLP file */
+  embedded: boolean;
+  /** Source video metadata if this is derived */
+  sourceVideo?: { filename: string };
+}
+
+/**
+ * Parse video metadata from videos_json dataset values.
+ * Returns metadata objects WITHOUT creating video backends.
+ */
+export function parseVideosMetadata(values: unknown[], labelsPath?: string): VideoMetadata[] {
+  const videos: VideoMetadata[] = [];
+
+  for (const entry of values) {
+    if (!entry) continue;
+
+    let parsed: Record<string, unknown>;
+    if (typeof entry === "string") {
+      // jsfive returns fixed-width strings with trailing spaces/nulls - trim before parsing
+      parsed = JSON.parse(trimHdf5String(entry)) as Record<string, unknown>;
+    } else if (entry instanceof Uint8Array) {
+      parsed = JSON.parse(trimHdf5String(textDecoder.decode(entry))) as Record<string, unknown>;
+    } else {
+      parsed = entry as Record<string, unknown>;
+    }
+
+    const backendMeta = (parsed.backend ?? {}) as Record<string, unknown>;
+    let filename = (backendMeta.filename ?? parsed.filename ?? "") as string;
+    const dataset = (backendMeta.dataset ?? null) as string | null;
+    let embedded = false;
+
+    if (filename === ".") {
+      embedded = true;
+      filename = labelsPath ?? "embedded";
+    }
+
+    const shape = backendMeta.shape as number[] | undefined;
+
+    videos.push({
+      filename,
+      dataset: dataset ?? undefined,
+      format: backendMeta.format as string | undefined,
+      width: shape?.[2],
+      height: shape?.[1],
+      channels: shape?.[3],
+      frameCount: shape?.[0],
+      fps: backendMeta.fps as number | undefined,
+      channelOrder: backendMeta.channel_order as string | undefined,
+      embedded,
+      sourceVideo: parsed.source_video as { filename: string } | undefined,
+    });
+  }
+
+  return videos;
+}
+
+/**
+ * Suggestion frame metadata.
+ */
+export interface SuggestionMetadata {
+  /** Video index */
+  video: number;
+  /** Frame index within the video */
+  frameIdx: number;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Parse suggestions from suggestions_json dataset values.
+ */
+export function parseSuggestions(values: unknown[]): SuggestionMetadata[] {
+  const suggestions: SuggestionMetadata[] = [];
+  for (const entry of values) {
+    const parsed = parseJsonEntry(entry) as Record<string, unknown>;
+    suggestions.push({
+      video: Number(parsed.video ?? 0),
+      frameIdx: (parsed.frame_idx ?? parsed.frameIdx ?? 0) as number,
+      metadata: parsed,
+    });
+  }
+  return suggestions;
+}
+
+/**
+ * Camera metadata from recording sessions.
+ */
+export interface CameraMetadata {
+  /** Camera name */
+  name?: string;
+  /** Rotation vector (Rodrigues) */
+  rvec: number[];
+  /** Translation vector */
+  tvec: number[];
+  /** 3x3 intrinsic camera matrix */
+  matrix?: number[][];
+  /** Lens distortion coefficients */
+  distortions?: number[];
+}
+
+/**
+ * Recording session metadata.
+ */
+export interface SessionMetadata {
+  /** Camera definitions with calibration */
+  cameras: CameraMetadata[];
+  /** Mapping of camera name/key to video index */
+  videosByCamera: Record<string, number>;
+  /** Additional session metadata */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Parse recording session metadata from sessions_json dataset values.
+ */
+export function parseSessionsMetadata(values: unknown[]): SessionMetadata[] {
+  const sessions: SessionMetadata[] = [];
+
+  for (const entry of values) {
+    const parsed = parseJsonEntry(entry) as Record<string, unknown>;
+    const calibration = (parsed.calibration ?? {}) as Record<string, unknown>;
+    const cameras: CameraMetadata[] = [];
+
+    for (const [key, data] of Object.entries(calibration)) {
+      if (key === "metadata") continue;
+      const cameraData = data as Record<string, unknown>;
+      cameras.push({
+        name: (cameraData.name as string | undefined) ?? key,
+        rvec: (cameraData.rotation as number[] | undefined) ?? [0, 0, 0],
+        tvec: (cameraData.translation as number[] | undefined) ?? [0, 0, 0],
+        matrix: cameraData.matrix as number[][] | undefined,
+        distortions: cameraData.distortions as number[] | undefined,
+      });
+    }
+
+    const videosByCamera: Record<string, number> = {};
+    const map = (parsed.camcorder_to_video_idx_map ?? {}) as Record<string, unknown>;
+    for (const [cameraKey, videoIdx] of Object.entries(map)) {
+      videosByCamera[cameraKey] = Number(videoIdx);
+    }
+
+    sessions.push({
+      cameras,
+      videosByCamera,
+      metadata: parsed.metadata as Record<string, unknown> | undefined,
+    });
+  }
+
+  return sessions;
+}

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -1,8 +1,9 @@
 import { openH5File, OpenH5Options, SlpSource } from "./h5.js";
+import { parseJsonAttr, parseSkeletons } from "./parsers.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
 import { Instance, PredictedInstance, Track, pointsFromArray, predictedPointsFromArray } from "../../model/instance.js";
-import { Skeleton, Node } from "../../model/skeleton.js";
+import { Skeleton } from "../../model/skeleton.js";
 import { SuggestionFrame } from "../../model/suggestions.js";
 import { Video } from "../../model/video.js";
 import { createVideoBackend } from "../../video/factory.js";
@@ -23,10 +24,10 @@ export async function readSlp(
 
     const metadataAttrs = (metadataGroup as unknown as { attrs?: Record<string, any> }).attrs ?? {};
     const formatId = Number(metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0);
-    const metadataJson = parseJsonAttr(metadataAttrs["json"]);
+    const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<string, unknown> | null;
 
     const labelsPath = typeof source === "string" ? source : options?.h5?.filenameHint ?? "slp-data.slp";
-    const skeletons = readSkeletons(metadataJson);
+    const skeletons = parseSkeletons(metadataJson);
     const tracks = readTracks(file.get("tracks_json"));
     const videos = await readVideos(file.get("videos_json"), labelsPath, options?.openVideos ?? true, file);
     const suggestions = readSuggestions(file.get("suggestions_json"), videos);
@@ -56,107 +57,14 @@ export async function readSlp(
       tracks,
       suggestions,
       sessions,
-      provenance: metadataJson?.provenance ?? {},
+      provenance: (metadataJson?.provenance as Record<string, unknown>) ?? {},
     });
   } finally {
     close();
   }
 }
 
-function parseJsonAttr(attr: any): any {
-  if (!attr) return null;
-  const value = attr.value ?? attr;
-  if (typeof value === "string") return JSON.parse(value);
-  if (value instanceof Uint8Array) return JSON.parse(textDecoder.decode(value));
-  if (value.buffer) return JSON.parse(textDecoder.decode(new Uint8Array(value.buffer)));
-  return JSON.parse(String(value));
-}
-
-function readSkeletons(metadataJson: any): Skeleton[] {
-  if (!metadataJson) return [];
-  const nodeNames = (metadataJson.nodes ?? []).map((node: any) => node.name ?? node);
-  const skeletonEntries = metadataJson.skeletons ?? [];
-  const skeletons: Skeleton[] = [];
-  for (const entry of skeletonEntries) {
-    const edges: Array<[number, number]> = [];
-    const symmetries: Array<[number, number]> = [];
-    const typeCache = new Map<number, number>();
-    const typeState = { nextId: 1 };
-    const skeletonNodeIds = (entry.nodes ?? []).map((node: any) => Number(node.id ?? node));
-    const nodeOrder = skeletonNodeIds.length ? skeletonNodeIds : nodeNames.map((_: unknown, index: number) => index);
-    const nodes = nodeOrder
-      .map((nodeId: number) => nodeNames[nodeId])
-      .filter((name: string | undefined) => name !== undefined)
-      .map((name: string) => new Node(name));
-    const nodeIndexById = new Map<number, number>();
-    nodeOrder.forEach((nodeId: number, index: number) => {
-      nodeIndexById.set(Number(nodeId), index);
-    });
-
-    for (const link of entry.links ?? []) {
-      const source = Number(link.source);
-      const target = Number(link.target);
-      const edgeType = resolveEdgeType(link.type, typeCache, typeState);
-      if (edgeType === 2) {
-        symmetries.push([source, target]);
-      } else {
-        edges.push([source, target]);
-      }
-    }
-
-    const remapPair = (pair: [number, number]): [number, number] | null => {
-      const sourceIndex = nodeIndexById.get(pair[0]);
-      const targetIndex = nodeIndexById.get(pair[1]);
-      if (sourceIndex === undefined || targetIndex === undefined) return null;
-      return [sourceIndex, targetIndex];
-    };
-
-    const mappedEdges = edges
-      .map(remapPair)
-      .filter((pair): pair is [number, number] => pair !== null);
-
-    const seenSymmetries = new Set<string>();
-    const mappedSymmetries = symmetries
-      .map(remapPair)
-      .filter((pair): pair is [number, number] => pair !== null)
-      .filter(([a, b]) => {
-        const key = a < b ? `${a}-${b}` : `${b}-${a}`;
-        if (seenSymmetries.has(key)) return false;
-        seenSymmetries.add(key);
-        return true;
-      });
-
-    const skeleton = new Skeleton({
-      nodes,
-      edges: mappedEdges,
-      symmetries: mappedSymmetries,
-      name: entry.graph?.name ?? entry.name,
-    });
-    skeletons.push(skeleton);
-  }
-  return skeletons;
-}
-
-function resolveEdgeType(edgeType: any, cache: Map<number, number>, state: { nextId: number }): number {
-  if (!edgeType) return 1;
-  if (edgeType["py/reduce"]) {
-    const typeId = edgeType["py/reduce"][1]?.["py/tuple"]?.[0] ?? 1;
-    cache.set(state.nextId, typeId);
-    state.nextId += 1;
-    return typeId;
-  }
-  if (edgeType["py/tuple"]) {
-    const typeId = edgeType["py/tuple"][0] ?? 1;
-    cache.set(state.nextId, typeId);
-    state.nextId += 1;
-    return typeId;
-  }
-  if (edgeType["py/id"]) {
-    const pyId = edgeType["py/id"];
-    return cache.get(pyId) ?? pyId;
-  }
-  return 1;
-}
+// parseJsonAttr and parseSkeletons are imported from parsers.ts
 
 function readTracks(dataset: any): Track[] {
   if (!dataset) return [];

--- a/src/lite.ts
+++ b/src/lite.ts
@@ -1,0 +1,335 @@
+/**
+ * Lightweight SLP file reader using jsfive (pure JavaScript).
+ *
+ * This module provides Workers-compatible SLP file reading without WASM.
+ * It can extract all metadata but cannot read pose coordinates (which
+ * require compound dataset support).
+ *
+ * @example
+ * ```typescript
+ * import { loadSlpMetadata } from '@talmolab/sleap-io.js/lite';
+ *
+ * const response = await fetch('https://example.com/file.slp');
+ * const buffer = await response.arrayBuffer();
+ * const metadata = await loadSlpMetadata(buffer);
+ *
+ * console.log('Skeletons:', metadata.skeletons.map(s => s.name));
+ * console.log('Frames:', metadata.counts.labeledFrames);
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import {
+  openJsfiveFile,
+  getAttrs,
+  getShape,
+  getValue,
+  isDataset,
+  type JsfiveSource,
+} from "./codecs/slp/jsfive.js";
+import {
+  parseJsonAttr,
+  parseSkeletons,
+  parseTracks,
+  parseVideosMetadata,
+  parseSuggestions,
+  parseSessionsMetadata,
+} from "./codecs/slp/parsers.js";
+import type {
+  VideoMetadata,
+  SuggestionMetadata,
+  SessionMetadata,
+} from "./codecs/slp/parsers.js";
+import type { Skeleton } from "./model/skeleton.js";
+import type { Track } from "./model/instance.js";
+
+// Re-export types for consumer convenience
+export type {
+  VideoMetadata,
+  SuggestionMetadata,
+  SessionMetadata,
+  CameraMetadata,
+} from "./codecs/slp/parsers.js";
+export type { JsfiveSource } from "./codecs/slp/jsfive.js";
+export { Skeleton, Node, Edge, Symmetry } from "./model/skeleton.js";
+export { Track } from "./model/instance.js";
+
+/**
+ * Metadata extracted from an SLP file without loading pose data.
+ */
+export interface SlpMetadata {
+  /** SLEAP version that created this file (e.g., "1.3.4") */
+  version: string;
+
+  /** HDF5 format ID (e.g., 1.2) */
+  formatId: number;
+
+  /** Skeleton definitions with nodes, edges, and symmetries */
+  skeletons: Skeleton[];
+
+  /** Track definitions */
+  tracks: Track[];
+
+  /** Video metadata (without loaded backends) */
+  videos: VideoMetadata[];
+
+  /** Suggestion frame metadata */
+  suggestions: SuggestionMetadata[];
+
+  /** Multi-camera recording session metadata */
+  sessions: SessionMetadata[];
+
+  /** Dataset counts */
+  counts: {
+    /** Number of labeled frames */
+    labeledFrames: number;
+    /** Total number of instances (user + predicted) */
+    instances: number;
+    /** Number of user-labeled points */
+    points: number;
+    /** Number of predicted points */
+    predictedPoints: number;
+  };
+
+  /** Whether any video has embedded image data */
+  hasEmbeddedImages: boolean;
+
+  /** Raw provenance data (SLEAP version, build info, etc.) */
+  provenance?: Record<string, unknown>;
+}
+
+/**
+ * Load SLP file metadata using jsfive (no WASM required).
+ *
+ * This is a lightweight alternative to `loadSlp()` for environments
+ * that don't support WebAssembly compilation (e.g., Cloudflare Workers).
+ *
+ * Returns metadata only - does NOT include:
+ * - Actual pose coordinates (requires compound dataset reading)
+ * - Video frame data (requires VLEN sequence reading)
+ * - Instance-frame relationships
+ * - Instance scores
+ *
+ * @param source - ArrayBuffer or Uint8Array containing the SLP file
+ * @param options - Optional configuration
+ * @param options.filename - Filename hint for embedded video paths
+ * @returns SlpMetadata object with skeletons, counts, video info
+ * @throws Error if the file is not a valid SLP file
+ *
+ * @example
+ * ```typescript
+ * const buffer = await fetch('file.slp').then(r => r.arrayBuffer());
+ * const metadata = await loadSlpMetadata(buffer);
+ *
+ * console.log(`${metadata.skeletons.length} skeleton(s)`);
+ * console.log(`${metadata.counts.labeledFrames} labeled frames`);
+ * console.log(`${metadata.counts.instances} instances`);
+ * ```
+ */
+export async function loadSlpMetadata(
+  source: JsfiveSource,
+  options?: { filename?: string }
+): Promise<SlpMetadata> {
+  const file = openJsfiveFile(source, options?.filename);
+
+  try {
+    // Verify SLEAP structure
+    const requiredKeys = ["metadata", "frames", "instances", "points"];
+    for (const key of requiredKeys) {
+      if (!file.keys.includes(key)) {
+        throw new Error(`Invalid SLP file: missing /${key}`);
+      }
+    }
+
+    // Read metadata group attributes
+    const metadataGroup = file.get("metadata");
+    if (!metadataGroup) {
+      throw new Error("Invalid SLP file: missing /metadata group");
+    }
+
+    const metadataAttrs = getAttrs(metadataGroup);
+    const formatId = Number(
+      (metadataAttrs.format_id as { value?: unknown })?.value ??
+        metadataAttrs.format_id ??
+        1.0
+    );
+    const metadataJson = parseJsonAttr(metadataAttrs.json) as Record<string, unknown> | null;
+
+    if (!metadataJson) {
+      throw new Error("Invalid SLP file: missing metadata.attrs.json");
+    }
+
+    // Parse skeletons using shared logic
+    const skeletons = parseSkeletons(metadataJson);
+
+    // Parse tracks from tracks_json dataset
+    const tracksDataset = file.get("tracks_json");
+    const tracksValue = getValue(tracksDataset);
+    const tracks = Array.isArray(tracksValue) ? parseTracks(tracksValue) : [];
+
+    // Parse video metadata from videos_json dataset
+    const videosDataset = file.get("videos_json");
+    const videosValue = getValue(videosDataset);
+    const labelsPath = options?.filename ?? "slp-data.slp";
+    let videos = Array.isArray(videosValue)
+      ? parseVideosMetadata(videosValue, labelsPath)
+      : [];
+
+    // Enrich embedded videos with attributes from their datasets
+    videos = videos.map((video) => {
+      if (!video.embedded || !video.dataset) return video;
+
+      // Try to get video dataset attributes
+      const videoDs = file.get(video.dataset);
+      if (!videoDs || !isDataset(videoDs)) return video;
+
+      const attrs = getAttrs(videoDs);
+      const enriched = { ...video };
+
+      if (attrs.format !== undefined) enriched.format = String(attrs.format);
+      if (attrs.width !== undefined) enriched.width = Number(attrs.width);
+      if (attrs.height !== undefined) enriched.height = Number(attrs.height);
+      if (attrs.channels !== undefined) enriched.channels = Number(attrs.channels);
+
+      // Try to get frame count from shape
+      const shape = getShape(videoDs);
+      if (shape.length > 0) {
+        enriched.frameCount = shape[0];
+      }
+
+      return enriched;
+    });
+
+    // Parse suggestions from suggestions_json dataset
+    const suggestionsDataset = file.get("suggestions_json");
+    const suggestionsValue = getValue(suggestionsDataset);
+    const suggestions = Array.isArray(suggestionsValue)
+      ? parseSuggestions(suggestionsValue)
+      : [];
+
+    // Parse sessions from sessions_json dataset
+    const sessionsDataset = file.get("sessions_json");
+    const sessionsValue = getValue(sessionsDataset);
+    const sessions = Array.isArray(sessionsValue)
+      ? parseSessionsMetadata(sessionsValue)
+      : [];
+
+    // Get counts from dataset shapes (works without reading compound values)
+    const framesDs = file.get("frames");
+    const instancesDs = file.get("instances");
+    const pointsDs = file.get("points");
+    const predPointsDs = file.get("pred_points");
+
+    const counts = {
+      labeledFrames: getShape(framesDs)[0] ?? 0,
+      instances: getShape(instancesDs)[0] ?? 0,
+      points: getShape(pointsDs)[0] ?? 0,
+      predictedPoints: getShape(predPointsDs)[0] ?? 0,
+    };
+
+    // Check for embedded images by looking at video metadata
+    const hasEmbeddedImages = videos.some(
+      (v) => v.embedded && (v.format || v.width)
+    );
+
+    return {
+      version: (metadataJson.version as string) ?? "unknown",
+      formatId,
+      skeletons,
+      tracks,
+      videos,
+      suggestions,
+      sessions,
+      counts,
+      hasEmbeddedImages,
+      provenance: metadataJson.provenance as Record<string, unknown> | undefined,
+    };
+  } finally {
+    file.close();
+  }
+}
+
+/**
+ * Validate that a buffer contains a valid SLP file.
+ *
+ * Performs quick structural validation without fully parsing the file.
+ * Returns true if valid, throws an error with details if invalid.
+ *
+ * @param source - ArrayBuffer or Uint8Array containing the SLP file
+ * @returns true if the file is a valid SLP file
+ * @throws Error with details if the file is invalid
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   validateSlpBuffer(buffer);
+ *   console.log('Valid SLP file');
+ * } catch (e) {
+ *   console.error('Invalid:', e.message);
+ * }
+ * ```
+ */
+export function validateSlpBuffer(source: JsfiveSource): boolean {
+  const file = openJsfiveFile(source);
+
+  try {
+    // Check for required SLEAP structure
+    const requiredKeys = ["metadata", "frames", "instances", "points"];
+    const missingKeys = requiredKeys.filter((k) => !file.keys.includes(k));
+
+    if (missingKeys.length > 0) {
+      throw new Error(`Invalid SLP file: missing ${missingKeys.join(", ")}`);
+    }
+
+    // Verify metadata has required attributes
+    const metadata = file.get("metadata");
+    if (!metadata) {
+      throw new Error("Invalid SLP file: cannot read metadata group");
+    }
+
+    const attrs = getAttrs(metadata);
+    if (!attrs.json) {
+      throw new Error("Invalid SLP file: missing metadata.attrs.json");
+    }
+
+    return true;
+  } finally {
+    file.close();
+  }
+}
+
+/**
+ * Check if a buffer looks like an HDF5 file.
+ *
+ * Performs a quick magic number check without fully parsing.
+ * This is faster than validateSlpBuffer for initial filtering.
+ *
+ * @param source - ArrayBuffer or Uint8Array to check
+ * @returns true if the buffer starts with the HDF5 magic number
+ *
+ * @example
+ * ```typescript
+ * if (isHdf5Buffer(buffer)) {
+ *   // Might be an SLP file, do full validation
+ *   const metadata = await loadSlpMetadata(buffer);
+ * }
+ * ```
+ */
+export function isHdf5Buffer(source: JsfiveSource): boolean {
+  const bytes = source instanceof Uint8Array ? source : new Uint8Array(source);
+  if (bytes.length < 8) return false;
+
+  // HDF5 magic number: 0x89 0x48 0x44 0x46 0x0d 0x0a 0x1a 0x0a
+  // or ASCII: \211HDF\r\n\032\n
+  return (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x48 &&
+    bytes[2] === 0x44 &&
+    bytes[3] === 0x46 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  );
+}

--- a/src/types/jsfive.d.ts
+++ b/src/types/jsfive.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Type declarations for jsfive package.
+ * jsfive is a pure JavaScript HDF5 reader.
+ */
+declare module "jsfive" {
+  export class File {
+    constructor(buffer: ArrayBuffer, filename?: string);
+    get(path: string): Dataset | Group | null;
+    keys: string[];
+  }
+
+  export interface Dataset {
+    value: unknown;
+    shape: number[];
+    dtype: string;
+    attrs: Record<string, unknown>;
+  }
+
+  export interface Group {
+    keys: string[];
+    attrs: Record<string, unknown>;
+    get(path: string): Dataset | Group | null;
+  }
+}

--- a/tests/lite.test.ts
+++ b/tests/lite.test.ts
@@ -1,0 +1,180 @@
+/* @vitest-environment node */
+import { describe, it, expect } from "vitest";
+import { loadSlpMetadata, validateSlpBuffer, isHdf5Buffer } from "../src/lite.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
+
+function loadFixtureBuffer(filename: string): Buffer {
+  return readFileSync(path.join(fixtureRoot, "slp", filename));
+}
+
+describe("loadSlpMetadata", () => {
+  it("extracts metadata from typical SLP file", async () => {
+    const buffer = loadFixtureBuffer("typical.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    expect(metadata.version).toBeDefined();
+    expect(metadata.formatId).toBeGreaterThanOrEqual(1.0);
+    expect(metadata.skeletons.length).toBeGreaterThan(0);
+    expect(metadata.counts.labeledFrames).toBeGreaterThan(0);
+    expect(metadata.counts.instances).toBeGreaterThan(0);
+  });
+
+  it("extracts skeleton with nodes, edges, and name", async () => {
+    const buffer = loadFixtureBuffer("minimal_instance.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    expect(metadata.skeletons.length).toBe(1);
+    const skeleton = metadata.skeletons[0];
+    expect(skeleton.nodeNames).toEqual(["A", "B"]);
+    expect(skeleton.edges.length).toBe(1);
+  });
+
+  it("reads provenance metadata", async () => {
+    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    expect(metadata.provenance).toBeDefined();
+    expect(metadata.provenance?.sleap_version).toBe("1.2.7");
+  });
+
+  it("extracts track information", async () => {
+    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    expect(metadata.tracks.length).toBeGreaterThan(0);
+    expect(metadata.tracks[0].name).toBeDefined();
+  });
+
+  it("extracts video metadata for embedded videos", async () => {
+    const buffer = loadFixtureBuffer("minimal_instance.pkg.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    expect(metadata.videos.length).toBeGreaterThan(0);
+    const video = metadata.videos[0];
+    expect(video.embedded).toBe(true);
+    // Embedded videos should have dimensions from attributes
+    expect(video.width).toBeGreaterThan(0);
+    expect(video.height).toBeGreaterThan(0);
+    expect(metadata.hasEmbeddedImages).toBe(true);
+  });
+
+  it("extracts video metadata for external videos", async () => {
+    const buffer = loadFixtureBuffer("typical.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    expect(metadata.videos.length).toBeGreaterThan(0);
+    const video = metadata.videos[0];
+    expect(video.filename).toBeDefined();
+    // External videos have metadata from backend info
+    expect(typeof video.filename).toBe("string");
+  });
+
+  it("counts points and predicted points separately", async () => {
+    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    // This file has predictions, so should have predicted points
+    expect(metadata.counts.points).toBeGreaterThanOrEqual(0);
+    expect(metadata.counts.predictedPoints).toBeGreaterThanOrEqual(0);
+    expect(metadata.counts.instances).toBeGreaterThan(0);
+  });
+
+  it("parses multiview session metadata", async () => {
+    const buffer = loadFixtureBuffer("multiview.slp");
+    const metadata = await loadSlpMetadata(buffer);
+
+    // Multiview files should have session data
+    if (metadata.sessions.length > 0) {
+      const session = metadata.sessions[0];
+      expect(session.cameras.length).toBeGreaterThan(0);
+      expect(Object.keys(session.videosByCamera).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("throws on invalid file", async () => {
+    const invalidBuffer = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]);
+
+    await expect(loadSlpMetadata(invalidBuffer)).rejects.toThrow();
+  });
+
+  it("throws on file missing required datasets", async () => {
+    // HDF5 magic number but not a valid SLP
+    const hdf5Header = new Uint8Array([0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+    // This will throw because jsfive can't parse a truncated HDF5
+    await expect(loadSlpMetadata(hdf5Header)).rejects.toThrow();
+  });
+});
+
+describe("validateSlpBuffer", () => {
+  it("returns true for valid SLP file", () => {
+    const buffer = loadFixtureBuffer("typical.slp");
+    expect(validateSlpBuffer(buffer)).toBe(true);
+  });
+
+  it("returns true for minimal SLP file", () => {
+    const buffer = loadFixtureBuffer("minimal_instance.slp");
+    expect(validateSlpBuffer(buffer)).toBe(true);
+  });
+
+  it("throws for invalid buffer", () => {
+    const invalidBuffer = new Uint8Array([0, 0, 0, 0]);
+    expect(() => validateSlpBuffer(invalidBuffer)).toThrow();
+  });
+});
+
+describe("isHdf5Buffer", () => {
+  it("returns true for HDF5 file", () => {
+    const buffer = loadFixtureBuffer("typical.slp");
+    expect(isHdf5Buffer(buffer)).toBe(true);
+  });
+
+  it("returns false for non-HDF5 buffer", () => {
+    const notHdf5 = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(isHdf5Buffer(notHdf5)).toBe(false);
+  });
+
+  it("returns false for too-short buffer", () => {
+    const tooShort = new Uint8Array([0x89, 0x48, 0x44]);
+    expect(isHdf5Buffer(tooShort)).toBe(false);
+  });
+});
+
+describe("lite vs full comparison", () => {
+  it("extracts same skeleton info as full loadSlp", async () => {
+    // Import full loadSlp
+    const { loadSlp } = await import("../src/io/main.js");
+
+    const buffer = loadFixtureBuffer("minimal_instance.slp");
+    const liteMetadata = await loadSlpMetadata(buffer);
+
+    const fullPath = path.join(fixtureRoot, "slp", "minimal_instance.slp");
+    const fullLabels = await loadSlp(fullPath, { openVideos: false });
+
+    // Compare skeletons
+    expect(liteMetadata.skeletons.length).toBe(fullLabels.skeletons.length);
+    expect(liteMetadata.skeletons[0].nodeNames).toEqual(fullLabels.skeletons[0].nodeNames);
+    expect(liteMetadata.skeletons[0].edgeIndices).toEqual(fullLabels.skeletons[0].edgeIndices);
+
+    // Compare counts
+    expect(liteMetadata.counts.labeledFrames).toBe(fullLabels.labeledFrames.length);
+    expect(liteMetadata.videos.length).toBe(fullLabels.videos.length);
+    expect(liteMetadata.tracks.length).toBe(fullLabels.tracks.length);
+  });
+
+  it("extracts same provenance as full loadSlp", async () => {
+    const { loadSlp } = await import("../src/io/main.js");
+
+    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const liteMetadata = await loadSlpMetadata(buffer);
+
+    const fullPath = path.join(fixtureRoot, "slp", "predictions_1.2.7_provenance_and_tracking.slp");
+    const fullLabels = await loadSlp(fullPath, { openVideos: false });
+
+    expect(liteMetadata.provenance?.sleap_version).toBe(fullLabels.provenance.sleap_version);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `/lite` entry point that uses [jsfive](https://github.com/usnistgov/jsfive) (pure JavaScript HDF5 reader) instead of h5wasm
- Enables sleap-io.js to run in Cloudflare Workers and other environments that block runtime WebAssembly compilation
- Refactors shared parsing logic into `parsers.ts` for reuse between both backends

## New API

```typescript
import { loadSlpMetadata, validateSlpBuffer, isHdf5Buffer } from '@talmolab/sleap-io.js/lite';

// Load all metadata without pose coordinates
const metadata = await loadSlpMetadata(buffer);
console.log(metadata.skeletons);    // Full skeleton definitions
console.log(metadata.tracks);       // Track names
console.log(metadata.videos);       // Video metadata
console.log(metadata.counts);       // Frame/instance/point counts
console.log(metadata.provenance);   // SLEAP version info

// Quick validation
validateSlpBuffer(buffer);  // throws on invalid
isHdf5Buffer(buffer);       // magic number check
```

## Available Metadata (Lite Mode)

| Metadata | Available |
|----------|-----------|
| Skeletons (nodes, edges, symmetries) | ✅ |
| Track names | ✅ |
| Video metadata (filename, dimensions, format, fps) | ✅ |
| Dataset counts (frames, instances, points) | ✅ |
| Provenance (SLEAP version, etc.) | ✅ |
| Multi-camera session data | ✅ |
| Pose coordinates (x, y) | ❌ |
| Video frame data | ❌ |

## Changes

- **New files:**
  - `src/lite.ts` - Lite entry point with `loadSlpMetadata`, `validateSlpBuffer`, `isHdf5Buffer`
  - `src/codecs/slp/parsers.ts` - Shared parsing logic extracted from read.ts
  - `src/codecs/slp/jsfive.ts` - jsfive backend wrapper
  - `src/types/jsfive.d.ts` - Type declarations for jsfive
  - `tests/lite.test.ts` - 18 tests for lite module
  - `docs/lite.md` - Full documentation for lite mode

- **Modified files:**
  - `src/codecs/slp/read.ts` - Now imports from parsers.ts
  - `package.json` - Added jsfive dependency and /lite export
  - `README.md` - Added lite mode documentation
  - `docs/index.md` - Added lite mode to features list
  - `mkdocs.yml` - Added lite.md to navigation

## Test plan

- [x] All 110 existing tests pass
- [x] 18 new tests for lite module
- [x] Verified metadata extraction matches full loadSlp output
- [x] Tested with various SLP fixtures (typical, minimal, multiview, provenance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)