### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bumps version to 0.1.5 for release

## What's new in 0.1.5

- **Automatic streaming for `loadSlp`** (#19): When loading from URLs in browsers, `loadSlp` now automatically uses HTTP range requests, downloading only the annotation data needed. This provides ~5x faster loading for large files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)