### PR TITLE
Bump version to 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Bump version to 0.1.7 for release

## Changes in this release

- Fix `getFrame()` for contiguous buffer video format (#23, #24)
- Add `frame_numbers` reading to streaming reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)