### PR TITLE
Fix streaming mode returning skeletons with empty nodes arrays

### DIFF
--- a/src/codecs/slp/h5-worker.ts
+++ b/src/codecs/slp/h5-worker.ts
@@ -132,19 +132,38 @@ function getKeys(path) {
   return item.keys ? item.keys() : [];
 }
 
+function serializeAttrValue(attr) {
+  if (!attr) return null;
+  // h5wasm Attribute objects have a .value property
+  const val = attr.value !== undefined ? attr.value : attr;
+  // Convert Uint8Array to string for JSON attributes
+  if (val instanceof Uint8Array) {
+    return { value: new TextDecoder().decode(val) };
+  }
+  // Wrap primitive values to preserve structure
+  return { value: val };
+}
+
 function getAttr(path, name) {
   if (!currentFile) throw new Error('No file open');
   const item = path === '/' || !path ? currentFile : currentFile.get(path);
   if (!item) throw new Error('Path not found: ' + path);
   const attrs = item.attrs;
-  return attrs?.[name] || null;
+  const attr = attrs?.[name];
+  return serializeAttrValue(attr);
 }
 
 function getAttrs(path) {
   if (!currentFile) throw new Error('No file open');
   const item = path === '/' || !path ? currentFile : currentFile.get(path);
   if (!item) throw new Error('Path not found: ' + path);
-  return item.attrs || {};
+  const rawAttrs = item.attrs || {};
+  // Serialize all attributes for proper transfer through postMessage
+  const serialized = {};
+  for (const key of Object.keys(rawAttrs)) {
+    serialized[key] = serializeAttrValue(rawAttrs[key]);
+  }
+  return serialized;
 }
 
 function getDatasetMeta(path) {


### PR DESCRIPTION
## Summary

Fixes #26 - When using `loadSlp()` with streaming mode (`h5.stream: 'range'`), skeletons were returned with empty `nodes`, `edges`, and `symmetries` arrays.

**Root Cause:** h5wasm's `item.attrs` returns proxy objects with `.value` getters that don't serialize through `postMessage`. The worker was returning these directly, causing attribute data to be lost when transferred to the main thread.

**Fix:** Added `serializeAttrValue()` helper to properly extract `.value` from h5wasm Attribute objects and convert `Uint8Array` to strings before transferring.

## Test plan

- [x] Verified fix with test file https://slp.sh/7ahF3D/labels.slp
- [x] Skeleton now has 14 nodes (was 0), 21 edges (was 0)
- [x] All 110 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)