### PR TITLE
Fix BGR channel order handling for encoded images

### DIFF
--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -99,7 +99,7 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     if (!rawBytes || rawBytes.length === 0) return null;
 
     if (isEncodedFormat(this.format)) {
-      const decoded = await decodeImageBytes(rawBytes, this.format);
+      const decoded = await decodeImageBytes(rawBytes, this.format, this.channelOrder);
       return decoded ?? rawBytes;
     }
 
@@ -225,12 +225,43 @@ function isEncodedFormat(format: string): boolean {
   return normalized === "png" || normalized === "jpg" || normalized === "jpeg";
 }
 
-async function decodeImageBytes(bytes: Uint8Array, format: string): Promise<VideoFrame | null> {
+async function decodeImageBytes(
+  bytes: Uint8Array,
+  format: string,
+  channelOrder: string
+): Promise<VideoFrame | null> {
   if (!isBrowser || typeof createImageBitmap === "undefined") return null;
   const mime = format.toLowerCase() === "png" ? "image/png" : "image/jpeg";
   const safeBytes = new Uint8Array(bytes);
   const blob = new Blob([safeBytes.buffer], { type: mime });
-  return createImageBitmap(blob);
+  const bitmap = await createImageBitmap(blob);
+
+  // If channel order is BGR, we need to swap R and B channels
+  // This happens when images were encoded with OpenCV (which uses BGR order)
+  // but the PNG/JPEG bytes were written directly without RGB conversion
+  const useBgr = channelOrder.toUpperCase() === "BGR";
+  if (!useBgr) {
+    return bitmap;
+  }
+
+  // Swap R and B channels by drawing to canvas and manipulating pixel data
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return bitmap;
+
+  ctx.drawImage(bitmap, 0, 0);
+  const imageData = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+  const data = imageData.data;
+
+  // Swap R and B for each pixel (RGBA format: indices 0=R, 1=G, 2=B, 3=A)
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i];
+    const b = data[i + 2];
+    data[i] = b;
+    data[i + 2] = r;
+  }
+
+  return imageData;
 }
 
 function decodeRawFrame(


### PR DESCRIPTION
## Summary
- Adds BGR channel swapping for encoded PNG/JPEG images in video backends
- Adds format_id-based fallback for `channel_order`:
  - When `channel_order` attribute is not present, defaults to "BGR" for `format_id < 1.4` (legacy files)
  - Defaults to "RGB" for newer files (`format_id >= 1.4`)
- Updates both sync (`read.ts`, `hdf5-video.ts`) and streaming (`read-streaming.ts`, `streaming-hdf5-video.ts`) code paths

## Background
When images are encoded with OpenCV (which uses BGR order) and written directly to PNG/JPEG without color conversion, the resulting file has R and B channels swapped. The Python sleap-io handles this by:
1. Reading `channel_order` from the HDF5 attribute if present
2. Falling back to "BGR" for files with `format_id < 1.4` (legacy behavior)

This PR adds the same logic to the JavaScript implementation.

## Test plan
- [x] TypeScript compilation passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] All existing tests pass (`npm test`)
- [ ] Manual testing with legacy BGR-encoded SLP files

🤖 Generated with [Claude Code](https://claude.com/claude-code)