### PR TITLE
Align embedded video handling with Python sleap-io

### DIFF
--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -6,6 +6,7 @@ export class Video {
   backendMetadata: Record<string, unknown>;
   sourceVideo: Video | null;
   openBackend: boolean;
+  private _embedded: boolean;
 
   constructor(options: {
     filename: string | string[];
@@ -13,12 +14,18 @@ export class Video {
     backendMetadata?: Record<string, unknown>;
     sourceVideo?: Video | null;
     openBackend?: boolean;
+    embedded?: boolean;
   }) {
     this.filename = options.filename;
     this.backend = options.backend ?? null;
     this.backendMetadata = options.backendMetadata ?? {};
     this.sourceVideo = options.sourceVideo ?? null;
     this.openBackend = options.openBackend ?? true;
+    this._embedded = options.embedded ?? false;
+  }
+
+  get hasEmbeddedImages(): boolean {
+    return this._embedded;
   }
 
   get originalVideo(): Video | null {


### PR DESCRIPTION
## Summary

This PR implements several improvements to align the JavaScript implementation with the Python `sleap-io` library for embedded video handling:

- **O(1) frame lookup using Map** - Improves performance for frame number lookups
- **Add `hasEmbeddedImages` property** - New getter on Video class for checking embedded status
- **Read format from HDF5 attributes** - Falls back to dataset attributes when JSON metadata lacks format
- **Auto-detect video dataset paths** - Scans HDF5 structure when dataset path not in metadata

## Changes

### 1. O(1) Frame Lookup Performance Improvement
**Files:** `src/video/hdf5-video.ts`, `src/video/streaming-hdf5-video.ts`

Changed from `number[]` with `indexOf()` (O(n)) to `Map<number, number>` (O(1)) for frame number lookups:

```typescript
// Before
private frameNumbers: number[];
const index = this.frameNumbers.indexOf(frameIndex);

// After  
private frameNumberToIndex: Map<number, number>;
const index = this.frameNumberToIndex.get(frameIndex);
```

This significantly improves performance for videos with many frames.

### 2. Video `hasEmbeddedImages` Property
**Files:** `src/model/video.ts`, `src/codecs/slp/read.ts`, `src/codecs/slp/read-streaming.ts`

Added `embedded` constructor option and `hasEmbeddedImages` getter:

```typescript
const labels = await readSlp('file.slp');
if (labels.videos[0].hasEmbeddedImages) {
  // Video has images stored in the SLP file
}
```

### 3. Format from HDF5 Attributes Fallback
**Files:** `src/codecs/slp/read.ts`, `src/codecs/slp/read-streaming.ts`

When `format` is not in JSON metadata, readers now check HDF5 dataset attributes:

```typescript
// Falls back to reading attrs.format from the video dataset
let format = backendMeta.format;
if (!format && datasetPath) {
  const attrs = videoDs.attrs ?? {};
  format = attrs.format?.value;
}
```

### 4. Auto-detect Video Dataset Paths
**Files:** `src/codecs/slp/read.ts`, `src/codecs/slp/read-streaming.ts`

When dataset path is null but video is embedded, readers now scan HDF5 structure:

```typescript
// Tries video0/video, video1/video, etc.
// Then scans root keys for video groups
function findVideoDataset(file, videoIndex): string | null
```

## Test plan

- [x] `npm run build` passes
- [x] `npm run typecheck` passes (via successful build)
- [x] `npm test` passes (110 tests)
- [ ] Manual test: Load a `.slp` file with embedded images and verify:
  - `video.hasEmbeddedImages` returns `true`
  - Frame lookup works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)