### PR TITLE
Use Web Worker for all browser HDF5 operations transparently

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,13 @@ export * from "./codecs/skeleton-yaml.js";
 export * from "./rendering/index.js";
 
 // Streaming HDF5 utilities for advanced use cases
-export { StreamingH5File, openStreamingH5, isStreamingSupported } from "./codecs/slp/h5-streaming.js";
+export {
+  StreamingH5File,
+  openStreamingH5,
+  openH5Worker,
+  isStreamingSupported,
+  type StreamingH5Source,
+} from "./codecs/slp/h5-streaming.js";
 
-// Streaming SLP reader (lower-level API)
+// Streaming SLP reader (uses Web Worker, recommended for browser)
 export { readSlpStreaming } from "./codecs/slp/read-streaming.js";

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -7,43 +7,52 @@ import { createVideoBackend } from "../video/factory.js";
 import { OpenH5Options, SlpSource, isStreamingSupported } from "../codecs/slp/h5.js";
 
 /**
- * Check if a source looks like a URL.
+ * Check if we're in a Node.js environment.
  */
-function isProbablyUrl(source: SlpSource): source is string {
-  return typeof source === "string" && /^https?:\/\//i.test(source);
+function isNode(): boolean {
+  return typeof process !== "undefined" && !!process.versions?.node;
 }
 
 /**
- * Check if we're in a browser environment.
+ * Check if we're in a browser environment with Worker support.
  */
-function isBrowser(): boolean {
-  return typeof window !== "undefined" && typeof Worker !== "undefined";
+function isBrowserWithWorkerSupport(): boolean {
+  return typeof window !== "undefined" && isStreamingSupported();
 }
 
 /**
  * Load an SLP file.
  *
- * When loading from a URL in a browser with `h5.stream` set to 'range' or 'auto',
- * this function automatically uses HTTP range requests for efficient streaming.
- * Only the annotation data needed is downloaded, not the entire file.
+ * In browser environments, this function automatically uses a Web Worker for all
+ * HDF5 operations, keeping the main thread responsive. For URLs, it uses HTTP
+ * range requests to download only the data needed rather than the entire file.
+ *
+ * In Node.js, this uses the native h5wasm bindings directly.
  *
  * @param source - Path, URL, ArrayBuffer, File, or FileSystemFileHandle
  * @param options - Loading options
- * @param options.openVideos - Whether to open video backends (default: true, but false for streaming)
+ * @param options.openVideos - Whether to open video backends (default: true)
  * @param options.h5 - HDF5 options including streaming mode
  * @param options.h5.stream - 'auto' | 'range' | 'download' (default: 'auto')
  *
  * @example
  * ```typescript
- * // Load from URL with streaming (uses range requests automatically)
- * const labels = await loadSlp('https://example.com/labels.slp', {
- *   h5: { stream: 'range' }
- * });
+ * // Browser: Load from URL (automatically uses Worker + range requests)
+ * const labels = await loadSlp('https://example.com/labels.slp');
  *
- * // Force full download
+ * // Browser: Load from file input (automatically uses Worker)
+ * const labels = await loadSlp(fileInput.files[0]);
+ *
+ * // Browser: Load from ArrayBuffer (automatically uses Worker)
+ * const labels = await loadSlp(arrayBuffer);
+ *
+ * // Force full download instead of range requests
  * const labels = await loadSlp('https://example.com/labels.slp', {
  *   h5: { stream: 'download' }
  * });
+ *
+ * // Node.js: Load from file path
+ * const labels = await loadSlp('/path/to/file.slp');
  * ```
  */
 export async function loadSlp(
@@ -51,31 +60,47 @@ export async function loadSlp(
   options?: { openVideos?: boolean; h5?: OpenH5Options }
 ): Promise<Labels> {
   const streamMode = options?.h5?.stream ?? "auto";
+  const openVideos = options?.openVideos ?? true;
 
-  // Use streaming reader for URLs in browser when range requests are enabled
-  if (
-    isProbablyUrl(source) &&
-    isBrowser() &&
-    isStreamingSupported() &&
-    (streamMode === "range" || streamMode === "auto")
-  ) {
-    try {
-      return await readSlpStreaming(source, {
-        filenameHint: options?.h5?.filenameHint,
-        openVideos: options?.openVideos ?? true,
-      });
-    } catch (e) {
-      // If streaming fails and mode is 'auto', fall back to full download
-      if (streamMode === "auto") {
-        console.warn("Streaming failed, falling back to full download:", e);
-      } else {
-        throw e;
+  // In browser with Worker support, use the streaming reader for ALL sources
+  // This offloads h5wasm to a Web Worker, keeping the main thread responsive
+  if (isBrowserWithWorkerSupport() && !isNode() && streamMode !== "download") {
+    // Convert source to a type supported by readSlpStreaming
+    let streamingSource: string | ArrayBuffer | Uint8Array | File;
+
+    if (typeof source === "string") {
+      streamingSource = source;
+    } else if (source instanceof ArrayBuffer || source instanceof Uint8Array) {
+      streamingSource = source;
+    } else if (typeof File !== "undefined" && source instanceof File) {
+      streamingSource = source;
+    } else if (typeof FileSystemFileHandle !== "undefined" && "getFile" in source) {
+      // FileSystemFileHandle - get the File object
+      streamingSource = await (source as FileSystemFileHandle).getFile();
+    } else {
+      // Unknown source type, fall through to standard reader
+      streamingSource = null as unknown as File;
+    }
+
+    if (streamingSource !== null) {
+      try {
+        return await readSlpStreaming(streamingSource, {
+          filenameHint: options?.h5?.filenameHint,
+          openVideos,
+        });
+      } catch (e) {
+        // If streaming fails and mode is 'auto', fall back to main thread
+        if (streamMode === "auto") {
+          console.warn("[sleap-io] Worker-based loading failed, falling back to main thread:", e);
+        } else {
+          throw e;
+        }
       }
     }
   }
 
-  // Fall back to standard reader
-  return readSlp(source, { openVideos: options?.openVideos ?? true, h5: options?.h5 });
+  // Fall back to standard reader (Node.js, or browser without Worker support, or download mode)
+  return readSlp(source, { openVideos, h5: options?.h5 });
 }
 
 export async function saveSlp(


### PR DESCRIPTION
## Summary

- Makes `loadSlp()` automatically use a Web Worker for ALL HDF5 operations in browser environments
- Adds support for local files (File API/WORKERFS) and ArrayBuffers in the worker, not just URLs
- Keeps the main thread responsive and avoids bundler issues with Node.js dependencies
- Matches the h5ls reference implementation pattern where all h5wasm runs in a Worker

## Changes

**Worker enhancements (`h5-worker.ts`):**
- Add `openLocal` message type for File objects via WORKERFS (zero-copy)
- Add `openBuffer` message type for ArrayBuffer/Uint8Array

**Streaming API (`h5-streaming.ts`):**
- Add `openLocal()`, `openBuffer()`, `openAny()` methods to `StreamingH5File`
- Add `openH5Worker()` factory function for any source type
- Export new `StreamingH5Source` type

**SLP Reader (`read-streaming.ts`):**
- Update `readSlpStreaming()` to accept URL, File, ArrayBuffer, or Uint8Array

**Main API (`io/main.ts`):**
- Update `loadSlp()` to automatically use Worker for all browser sources
- Falls back to main thread if Worker fails (with warning)
- Use `h5: { stream: "download" }` to force main thread

**Documentation:**
- Explain automatic Worker behavior in browser
- Add "How It Works" section
- Add low-level Worker API examples

## Test plan

- [ ] Verify `loadSlp(url)` uses Worker in browser
- [ ] Verify `loadSlp(file)` uses Worker in browser  
- [ ] Verify `loadSlp(arrayBuffer)` uses Worker in browser
- [ ] Verify Node.js still works with direct h5wasm
- [ ] Verify `h5: { stream: "download" }` bypasses Worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)