### PR TITLE
Bump version to 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump version to 0.1.9

## Changes since 0.1.8
- #32: Read channel_order from HDF5 dataset attributes (fixes BGR display for files with HDF5 attr)

🤖 Generated with [Claude Code](https://claude.ai/code)