### PR TITLE
Fix demo loading error in Web Worker HDF5 mode

### DIFF
--- a/docs/assets/demo/demo.js
+++ b/docs/assets/demo/demo.js
@@ -341,7 +341,8 @@ const handleLoad = async () => {
 
   // Determine source
   const slpSource = file ? await file.arrayBuffer() : slpUrl;
-  const slpFilename = file ? file.name : slpUrl;
+  // Extract just the filename (not the full URL) for the filenameHint
+  const slpFilename = file ? file.name : slpUrl.split("/").pop()?.split("?")[0] || "data.slp";
 
   if (!slpSource) {
     setStatus("Enter an SLP URL or select a file.");
@@ -425,7 +426,14 @@ const handleLoad = async () => {
       setStatus("Ready.");
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
+    let message = "Unknown error";
+    if (error instanceof Error) {
+      message = error.message;
+    } else if (typeof error === "string") {
+      message = error;
+    } else if (error && typeof error === "object") {
+      message = JSON.stringify(error);
+    }
     setStatus(`Load failed: ${message}`);
     console.error(error);
   } finally {

--- a/src/codecs/slp/h5-streaming.ts
+++ b/src/codecs/slp/h5-streaming.ts
@@ -104,7 +104,14 @@ export class StreamingH5File {
       if (data.success) {
         pending.resolve(e.data);
       } else {
-        pending.reject(new Error(data.error || "Worker operation failed"));
+        // Ensure error is a string for the Error message
+        let errorMessage = "Worker operation failed";
+        if (typeof data.error === "string") {
+          errorMessage = data.error;
+        } else if (data.error && typeof data.error === "object") {
+          errorMessage = JSON.stringify(data.error);
+        }
+        pending.reject(new Error(errorMessage));
       }
     }
   }


### PR DESCRIPTION
## Summary

- Fixed bug where demo filename was incorrectly set to the full URL, causing `FS.createLazyFile` to fail with invalid path
- Fixed h5wasm FS access - should use `h5wasm.FS` directly after ready, not `Module.FS`
- Improved error serialization for Emscripten errors (ErrnoError) which are plain objects without proper `.message` property

## Test plan

- [ ] Test the demo at the preview deployment URL
- [ ] Verify SLP files load successfully from the default demo URL
- [ ] Verify skeleton/pose coordinates display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)