### PR TITLE
Port Python sleap-io PR #408: Strategy-aware annotation merging

### DIFF
--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -6,6 +6,208 @@ import type { SegmentationMask } from "./mask.js";
 import type { LabelImage } from "./label-image.js";
 import type { ROI } from "./roi.js";
 
+/** Strategy for merging annotation lists between frames. */
+export type MergeStrategy =
+  | "keep_both"
+  | "keep_original"
+  | "keep_new"
+  | "replace_predictions"
+  | "auto"
+  | "update_tracks";
+
+/** Union of all annotation types stored on a LabeledFrame. */
+type Annotation = Centroid | BoundingBox | SegmentationMask | LabelImage | ROI;
+
+/** Annotation attribute names on LabeledFrame. */
+type AnnotationAttr = "centroids" | "bboxes" | "masks" | "labelImages" | "rois";
+
+const ANNOTATION_ATTRS: readonly AnnotationAttr[] = [
+  "centroids",
+  "bboxes",
+  "masks",
+  "labelImages",
+  "rois",
+];
+
+/** Shallow-copy an annotation object, preserving its prototype chain. */
+function _shallowCopy<T>(item: T): T {
+  return Object.create(
+    Object.getPrototypeOf(item),
+    Object.getOwnPropertyDescriptors(item),
+  );
+}
+
+/**
+ * Extract centroid (x, y) from an annotation based on its modality.
+ *
+ * @returns A tuple of [x, y] coordinates, or null if the centroid cannot be
+ *   computed (e.g., empty mask or empty ROI geometry).
+ */
+export function _annotationCentroidXy(
+  annotation: Annotation,
+  attr: AnnotationAttr,
+): [number, number] | null {
+  if (attr === "centroids") {
+    const c = annotation as Centroid;
+    return [c.x, c.y];
+  } else if (attr === "bboxes") {
+    return (annotation as BoundingBox).centroidXy;
+  } else if (attr === "rois") {
+    const roi = annotation as ROI;
+    if (roi.area === 0) return null;
+    return roi.centroidXy;
+  } else if (attr === "masks") {
+    const mask = annotation as SegmentationMask;
+    const bb = mask.bbox;
+    if (bb.width === 0 && bb.height === 0) return null;
+    return [bb.x + bb.width / 2, bb.y + bb.height / 2];
+  } else if (attr === "labelImages") {
+    const li = annotation as LabelImage;
+    const [sx, sy] = li.scale;
+    const [ox, oy] = li.offset;
+    return [(li.width / 2) / sx + ox, (li.height / 2) / sy + oy];
+  }
+  return null;
+}
+
+/**
+ * Find matching annotations between two lists by centroid distance.
+ *
+ * @returns List of {selfIdx, otherIdx, score} where score = 1 / (1 + distance).
+ *
+ * NOTE: O(n*m) brute-force without bipartite assignment. Callers are
+ * responsible for resolving many-to-one conflicts (e.g., greedy 1:1 in
+ * _resolveAnnotationAuto). Fine for typical annotation counts per frame.
+ */
+export function _findAnnotationMatches(
+  selfList: Annotation[],
+  otherList: Annotation[],
+  attr: AnnotationAttr,
+  threshold: number,
+): Array<{ selfIdx: number; otherIdx: number; score: number }> {
+  const matches: Array<{ selfIdx: number; otherIdx: number; score: number }> =
+    [];
+  for (let i = 0; i < selfList.length; i++) {
+    const c1 = _annotationCentroidXy(selfList[i], attr);
+    if (c1 === null) continue;
+    for (let j = 0; j < otherList.length; j++) {
+      const c2 = _annotationCentroidXy(otherList[j], attr);
+      if (c2 === null) continue;
+      const dist = Math.hypot(c1[0] - c2[0], c1[1] - c2[1]);
+      if (dist <= threshold) {
+        matches.push({ selfIdx: i, otherIdx: j, score: 1.0 / (1.0 + dist) });
+      }
+    }
+  }
+  return matches;
+}
+
+/**
+ * Apply auto merge resolution to a list of annotations.
+ *
+ * Mirrors the instance auto-merge cascade: keep user from self, spatially
+ * match, apply user-vs-predicted resolution rules, add unmatched from other,
+ * keep unmatched predictions from self.
+ */
+function _resolveAnnotationAuto(
+  selfList: Annotation[],
+  otherList: Annotation[],
+  attr: AnnotationAttr,
+  threshold: number,
+): Annotation[] {
+  const merged: Annotation[] = [];
+  const usedSelfIndices = new Set<number>();
+
+  // 1. Keep all user annotations from self
+  for (const ann of selfList) {
+    if (!ann.isPredicted) {
+      merged.push(ann);
+    }
+  }
+
+  // 2. Find spatial matches
+  const matches = _findAnnotationMatches(selfList, otherList, attr, threshold);
+
+  // 3. Greedy one-to-one matching: sort by score descending, assign each
+  // self/other index at most once so no annotation is silently dropped.
+  matches.sort((a, b) => b.score - a.score);
+  const matchedSelf = new Set<number>();
+  const matchedOther = new Set<number>();
+  const otherToSelf = new Map<number, number>();
+  for (const { selfIdx, otherIdx } of matches) {
+    if (!matchedSelf.has(selfIdx) && !matchedOther.has(otherIdx)) {
+      otherToSelf.set(otherIdx, selfIdx);
+      matchedSelf.add(selfIdx);
+      matchedOther.add(otherIdx);
+    }
+  }
+
+  // 4. Process each annotation from other
+  for (let otherIdx = 0; otherIdx < otherList.length; otherIdx++) {
+    const otherAnn = otherList[otherIdx];
+    if (otherToSelf.has(otherIdx)) {
+      const selfIdx = otherToSelf.get(otherIdx)!;
+      const selfAnn = selfList[selfIdx];
+      usedSelfIndices.add(selfIdx);
+
+      if (!selfAnn.isPredicted && !otherAnn.isPredicted) {
+        // user + user → keep self (already in merged)
+      } else if (selfAnn.isPredicted && !otherAnn.isPredicted) {
+        // predicted + user → replace with other's user
+        merged.push(_shallowCopy(otherAnn));
+      } else if (!selfAnn.isPredicted && otherAnn.isPredicted) {
+        // user + predicted → keep self (already in merged)
+      } else {
+        // predicted + predicted → keep other's (newer)
+        merged.push(_shallowCopy(otherAnn));
+      }
+    } else {
+      // No match → add from other
+      merged.push(_shallowCopy(otherAnn));
+    }
+  }
+
+  // 5. Keep unmatched predictions from self
+  for (let selfIdx = 0; selfIdx < selfList.length; selfIdx++) {
+    if (selfList[selfIdx].isPredicted && !usedSelfIndices.has(selfIdx)) {
+      merged.push(selfList[selfIdx]);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Update track assignments on self's annotations from spatially matched other's.
+ *
+ * Modifies selfList in place.
+ */
+function _resolveAnnotationUpdateTracks(
+  selfList: Annotation[],
+  otherList: Annotation[],
+  attr: AnnotationAttr,
+  threshold: number,
+): void {
+  // LabelImage tracks are per-object in .objects dict, not top-level.
+  if (attr === "labelImages") return;
+
+  const matches = _findAnnotationMatches(selfList, otherList, attr, threshold);
+
+  // Best match per selfIdx
+  const selfToOther = new Map<number, { otherIdx: number; score: number }>();
+  for (const { selfIdx, otherIdx, score } of matches) {
+    const existing = selfToOther.get(selfIdx);
+    if (!existing || score > existing.score) {
+      selfToOther.set(selfIdx, { otherIdx, score });
+    }
+  }
+
+  selfToOther.forEach(({ otherIdx }, selfIdx) => {
+    (selfList[selfIdx] as any).track = (otherList[otherIdx] as any).track;
+    (selfList[selfIdx] as any).trackingScore = (otherList[otherIdx] as any).trackingScore;
+  });
+}
+
 export class LabeledFrame {
   video: Video;
   frameIdx: number;
@@ -102,19 +304,82 @@ export class LabeledFrame {
   }
 
   /**
-   * Merge annotation lists from another frame, deduplicating by identity.
+   * Merge annotation lists from another frame into this frame.
    *
    * Shallow-copies annotations from the other frame to avoid mutating the
    * source when references are later remapped. Video and track references
    * are preserved so that remapping can find them in the mapping dicts.
+   *
+   * @param other - The frame to merge annotations from.
+   * @param strategy - The merge strategy. Controls which annotations are kept:
+   *   - "keep_original": Keep self only.
+   *   - "keep_new": Replace with other's annotations.
+   *   - "keep_both": Keep self + add other's (default).
+   *   - "replace_predictions": Keep user from self, add predicted from other.
+   *   - "auto": Spatial matching + user-vs-predicted resolution cascade.
+   *   - "update_tracks": Spatial matching, then update track assignments.
+   * @param threshold - Maximum centroid distance (pixels) for spatial matching
+   *   in "auto" and "update_tracks" strategies.
    */
-  _mergeAnnotations(other: LabeledFrame): void {
-    for (const attr of ["centroids", "bboxes", "masks", "labelImages", "rois"] as const) {
+  _mergeAnnotations(
+    other: LabeledFrame,
+    strategy: MergeStrategy = "keep_both",
+    threshold: number = 5.0,
+  ): void {
+    if (strategy === "keep_original") {
+      return;
+    }
+
+    if (strategy === "keep_new") {
+      for (const attr of ANNOTATION_ATTRS) {
+        this[attr] = (other[attr] as Annotation[]).map(_shallowCopy) as any;
+      }
+      return;
+    }
+
+    if (strategy === "replace_predictions") {
+      for (const attr of ANNOTATION_ATTRS) {
+        const kept = (this[attr] as Annotation[]).filter((a) => !a.isPredicted);
+        for (const item of other[attr] as Annotation[]) {
+          if (item.isPredicted) {
+            kept.push(_shallowCopy(item));
+          }
+        }
+        (this as any)[attr] = kept;
+      }
+      return;
+    }
+
+    if (strategy === "auto") {
+      for (const attr of ANNOTATION_ATTRS) {
+        (this as any)[attr] = _resolveAnnotationAuto(
+          this[attr] as Annotation[],
+          other[attr] as Annotation[],
+          attr,
+          threshold,
+        );
+      }
+      return;
+    }
+
+    if (strategy === "update_tracks") {
+      for (const attr of ANNOTATION_ATTRS) {
+        _resolveAnnotationUpdateTracks(
+          this[attr] as Annotation[],
+          other[attr] as Annotation[],
+          attr,
+          threshold,
+        );
+      }
+      return;
+    }
+
+    // "keep_both" (default): identity dedup + shallow copy
+    for (const attr of ANNOTATION_ATTRS) {
       const existing = new Set(this[attr] as unknown[]);
       for (const item of other[attr] as unknown[]) {
         if (!existing.has(item)) {
-          const copy = Object.create(Object.getPrototypeOf(item), Object.getOwnPropertyDescriptors(item));
-          (this[attr] as unknown[]).push(copy);
+          (this[attr] as unknown[]).push(_shallowCopy(item));
         }
       }
     }

--- a/tests/nested-annotations.test.ts
+++ b/tests/nested-annotations.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { Labels } from "../src/model/labels.js";
-import { LabeledFrame } from "../src/model/labeled-frame.js";
+import {
+  LabeledFrame,
+  _annotationCentroidXy,
+  _findAnnotationMatches,
+} from "../src/model/labeled-frame.js";
 import { Instance, Track } from "../src/model/instance.js";
 import { Skeleton } from "../src/model/skeleton.js";
 import { Video } from "../src/model/video.js";
 import { UserCentroid, PredictedCentroid } from "../src/model/centroid.js";
 import { UserBoundingBox, PredictedBoundingBox } from "../src/model/bbox.js";
-import { UserROI } from "../src/model/roi.js";
-import { UserLabelImage } from "../src/model/label-image.js";
+import { UserROI, PredictedROI } from "../src/model/roi.js";
+import { UserSegmentationMask, PredictedSegmentationMask } from "../src/model/mask.js";
+import { UserLabelImage, PredictedLabelImage } from "../src/model/label-image.js";
 import type { LabelImageObjectInfo } from "../src/model/label-image.js";
 import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
 import { saveSlpToBytes } from "../src/codecs/slp/write.js";
@@ -496,5 +501,472 @@ describe("Lazy read with annotations", () => {
     expect(loaded.centroids).toHaveLength(1);
     expect(loaded.centroids[0].x).toBe(1);
     expect(loaded.labeledFrames[0].centroids).toHaveLength(1);
+  });
+});
+
+describe("_mergeAnnotations strategies", () => {
+  it("keep_original keeps self's annotations and discards other's", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfC = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    const otherC = new UserCentroid({ x: 3, y: 4, video, frameIdx: 0 });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
+
+    lf1._mergeAnnotations(lf2, "keep_original");
+
+    expect(lf1.centroids).toHaveLength(1);
+    expect(lf1.centroids[0]).toBe(selfC);
+  });
+
+  it("keep_new replaces with copies of other's", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfC = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    const otherC = new UserCentroid({ x: 3, y: 4, video, frameIdx: 0 });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
+
+    lf1._mergeAnnotations(lf2, "keep_new");
+
+    expect(lf1.centroids).toHaveLength(1);
+    expect(lf1.centroids[0]).not.toBe(otherC); // copied, not same object
+    expect(lf1.centroids[0].x).toBe(3);
+    expect(lf1.centroids[0].y).toBe(4);
+  });
+
+  it("replace_predictions keeps user from self, replaces predicted with other's", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfUser = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    const selfPred = new PredictedCentroid({ x: 5, y: 6, video, frameIdx: 0, score: 0.9 });
+    const otherPred = new PredictedCentroid({ x: 7, y: 8, video, frameIdx: 0, score: 0.8 });
+    const otherUser = new UserCentroid({ x: 9, y: 10, video, frameIdx: 0 });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred, otherUser] });
+
+    lf1._mergeAnnotations(lf2, "replace_predictions");
+
+    // selfUser kept, selfPred removed, otherPred added (copied), otherUser ignored
+    expect(lf1.centroids).toHaveLength(2);
+    expect(lf1.centroids[0]).toBe(selfUser);
+    expect(lf1.centroids[1]).not.toBe(otherPred);
+    expect(lf1.centroids[1].x).toBe(7);
+    expect(lf1.centroids[1].isPredicted).toBe(true);
+  });
+
+  it("auto spatial matching resolves user-vs-predicted", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfUser = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    const selfPred = new PredictedCentroid({ x: 5, y: 6, video, frameIdx: 0, score: 0.9 });
+    const otherPred = new PredictedCentroid({ x: 7, y: 8, video, frameIdx: 0, score: 0.8 });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    expect(lf1.centroids).toHaveLength(2);
+    expect(lf1.centroids[0]).toBe(selfUser);
+    expect(lf1.centroids[1].x).toBe(7);
+    expect(lf1.centroids[1].isPredicted).toBe(true);
+  });
+
+  it("auto adds unmatched user from other", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfUser = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    // Far away — won't match self_user (distance > 5.0)
+    const otherUser = new UserCentroid({ x: 50, y: 60, video, frameIdx: 0 });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Both should be present: self's user kept + other's user added (unmatched)
+    expect(lf1.centroids).toHaveLength(2);
+    expect(lf1.centroids[0]).toBe(selfUser);
+    expect(lf1.centroids[1]).not.toBe(otherUser); // copied
+    expect(lf1.centroids[1].x).toBe(50);
+  });
+
+  it("auto user replaces prediction when spatially matched", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfPred = new PredictedCentroid({ x: 10, y: 20, video, frameIdx: 0, score: 0.9 });
+    const otherUser = new UserCentroid({ x: 11, y: 20.5, video, frameIdx: 0 });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Prediction replaced by user
+    expect(lf1.centroids).toHaveLength(1);
+    expect(lf1.centroids[0].isPredicted).toBe(false);
+    expect(lf1.centroids[0].x).toBe(11);
+  });
+
+  it("auto keeps unmatched self prediction", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfPred = new PredictedCentroid({ x: 10, y: 20, video, frameIdx: 0, score: 0.9 });
+    // Far away — no match
+    const otherUser = new UserCentroid({ x: 80, y: 90, video, frameIdx: 0 });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Self's prediction kept (unmatched) + other's user added (unmatched)
+    expect(lf1.centroids).toHaveLength(2);
+    const xs = new Set(lf1.centroids.map((c) => c.x));
+    expect(xs).toEqual(new Set([10, 80]));
+  });
+
+  it("auto spatial matching works for bounding boxes", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const selfPred = new PredictedBoundingBox({
+      x1: 10, y1: 10, x2: 20, y2: 20, video, frameIdx: 0, score: 0.8,
+    });
+    const otherUser = new UserBoundingBox({
+      x1: 11, y1: 11, x2: 21, y2: 21, video, frameIdx: 0,
+    });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, bboxes: [selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, bboxes: [otherUser] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Centroid distance ~1.4px, well within threshold — prediction replaced by user
+    expect(lf1.bboxes).toHaveLength(1);
+    expect(lf1.bboxes[0].isPredicted).toBe(false);
+    expect(lf1.bboxes[0].x1).toBe(11);
+  });
+
+  it("auto spatial matching works for segmentation masks", () => {
+    const video = new Video({ filename: "test.mp4" });
+    // Create small masks at nearby locations (overlapping bbox centroids)
+    const selfPred = new PredictedSegmentationMask({
+      rleCounts: new Uint32Array([0, 100]),
+      height: 10,
+      width: 10,
+      video,
+      frameIdx: 0,
+      score: 0.7,
+      offset: [5, 5],
+    });
+    const otherUser = new UserSegmentationMask({
+      rleCounts: new Uint32Array([0, 100]),
+      height: 10,
+      width: 10,
+      video,
+      frameIdx: 0,
+      offset: [6, 6],
+    });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [otherUser] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Bbox centroids are close — prediction replaced by user
+    expect(lf1.masks).toHaveLength(1);
+    expect(lf1.masks[0].isPredicted).toBe(false);
+  });
+
+  it("auto many-to-one uses one-to-one matching", () => {
+    const video = new Video({ filename: "test.mp4" });
+    // One prediction in self
+    const selfPred = new PredictedCentroid({ x: 10, y: 10, video, frameIdx: 0, score: 0.9 });
+    // Two users in other, both within threshold of selfPred
+    const otherUserA = new UserCentroid({ x: 11, y: 10, video, frameIdx: 0 }); // dist=1.0
+    const otherUserB = new UserCentroid({ x: 10, y: 11, video, frameIdx: 0 }); // dist=1.0
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUserA, otherUserB] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // One replaces prediction via match, other added as unmatched — neither dropped
+    expect(lf1.centroids).toHaveLength(2);
+    const xs = new Set(lf1.centroids.map((c) => c.x));
+    expect(xs).toEqual(new Set([11, 10]));
+    expect(lf1.centroids.every((c) => !c.isPredicted)).toBe(true);
+  });
+
+  it("auto empty mask treated as unmatched", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const emptyMask = new UserSegmentationMask({
+      rleCounts: new Uint32Array([100]), // 100 zeros, no foreground
+      height: 10,
+      width: 10,
+      video,
+      frameIdx: 0,
+    });
+    const normalMask = new UserSegmentationMask({
+      rleCounts: new Uint32Array([0, 100]),
+      height: 10,
+      width: 10,
+      video,
+      frameIdx: 0,
+    });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [emptyMask] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [normalMask] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Both kept: empty mask has no centroid so it's unmatched
+    expect(lf1.masks).toHaveLength(2);
+  });
+
+  it("update_tracks cascades track from spatially matched other", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const trackA = new Track("a");
+    const trackB = new Track("b");
+
+    const selfC = new UserCentroid({ x: 10, y: 20, video, frameIdx: 0, track: trackA });
+    const otherC = new UserCentroid({ x: 11, y: 20.5, video, frameIdx: 0, track: trackB });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
+
+    lf1._mergeAnnotations(lf2, "update_tracks");
+
+    // Self's centroid track updated to other's track
+    expect(lf1.centroids).toHaveLength(1);
+    expect(lf1.centroids[0].track).toBe(trackB);
+  });
+
+  it("update_tracks leaves unmatched annotations unchanged", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const trackA = new Track("a");
+    const trackB = new Track("b");
+
+    const selfC = new UserCentroid({ x: 10, y: 20, video, frameIdx: 0, track: trackA });
+    // Far away — no match
+    const otherC = new UserCentroid({ x: 80, y: 90, video, frameIdx: 0, track: trackB });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
+
+    lf1._mergeAnnotations(lf2, "update_tracks");
+
+    expect(lf1.centroids[0].track).toBe(trackA); // unchanged
+  });
+
+  it("update_tracks skips labelImages", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const trackA = new Track("a");
+    const trackB = new Track("b");
+
+    const liSelf = new UserLabelImage({
+      data: new Int32Array([0, 1]),
+      height: 1,
+      width: 2,
+      objects: new Map([[1, { track: trackA, category: "cell", name: "", instance: null }]]),
+      video,
+      frameIdx: 0,
+    });
+    const liOther = new UserLabelImage({
+      data: new Int32Array([0, 2]),
+      height: 1,
+      width: 2,
+      objects: new Map([[2, { track: trackB, category: "cell", name: "", instance: null }]]),
+      video,
+      frameIdx: 0,
+    });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liSelf] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liOther] });
+
+    lf1._mergeAnnotations(lf2, "update_tracks");
+
+    // Label image track should be unchanged
+    expect(lf1.labelImages[0].objects.get(1)!.track).toBe(trackA);
+  });
+
+  it("auto spatial matching works for label images", () => {
+    const video = new Video({ filename: "test.mp4" });
+    const track = new Track("t");
+
+    const liSelf = new UserLabelImage({
+      data: new Int32Array([0, 1]),
+      height: 1,
+      width: 2,
+      objects: new Map([[1, { track, category: "cell", name: "", instance: null }]]),
+      video,
+      frameIdx: 0,
+    });
+    const liOther = new PredictedLabelImage({
+      data: new Int32Array([0, 2]),
+      height: 1,
+      width: 2,
+      objects: new Map([[2, { track, category: "cell", name: "", instance: null }]]),
+      video,
+      frameIdx: 0,
+      score: 0.9,
+    });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liSelf] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liOther] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // User from self kept, prediction from other ignored (user beats predicted)
+    expect(lf1.labelImages).toHaveLength(1);
+    expect(lf1.labelImages[0].isPredicted).toBe(false);
+  });
+
+  it("auto spatial matching works for ROIs", () => {
+    const video = new Video({ filename: "test.mp4" });
+
+    const selfPred = new PredictedROI({
+      geometry: {
+        type: "Polygon",
+        coordinates: [[[10, 10], [20, 10], [20, 20], [10, 20], [10, 10]]],
+      },
+      video,
+      frameIdx: 0,
+      score: 0.8,
+    });
+    const otherUser = new UserROI({
+      geometry: {
+        type: "Polygon",
+        coordinates: [[[11, 11], [21, 11], [21, 21], [11, 21], [11, 11]]],
+      },
+      video,
+      frameIdx: 0,
+    });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, rois: [selfPred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, rois: [otherUser] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Centroids are ~1.4px apart — prediction replaced by user
+    expect(lf1.rois).toHaveLength(1);
+    expect(lf1.rois[0].isPredicted).toBe(false);
+  });
+
+  it("auto empty ROI treated as unmatched", () => {
+    const video = new Video({ filename: "test.mp4" });
+    // Empty polygon (no area)
+    const emptyRoi = new UserROI({
+      geometry: { type: "Point", coordinates: [0, 0] },
+      video,
+      frameIdx: 0,
+    });
+    const normalRoi = new UserROI({
+      geometry: {
+        type: "Polygon",
+        coordinates: [[[10, 10], [20, 10], [20, 20], [10, 20], [10, 10]]],
+      },
+      video,
+      frameIdx: 0,
+    });
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, rois: [emptyRoi] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, rois: [normalRoi] });
+
+    lf1._mergeAnnotations(lf2, "auto");
+
+    // Both kept: empty ROI has no centroid so it's unmatched
+    expect(lf1.rois).toHaveLength(2);
+  });
+});
+
+describe("_annotationCentroidXy", () => {
+  it("returns [x, y] for centroids", () => {
+    const c = new UserCentroid({ x: 5, y: 10 });
+    expect(_annotationCentroidXy(c, "centroids")).toEqual([5, 10]);
+  });
+
+  it("returns centroidXy for bboxes", () => {
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 20 });
+    expect(_annotationCentroidXy(b, "bboxes")).toEqual([5, 10]);
+  });
+
+  it("returns centroidXy for ROIs with area", () => {
+    const roi = new UserROI({
+      geometry: {
+        type: "Polygon",
+        coordinates: [[[0, 0], [10, 0], [10, 20], [0, 20], [0, 0]]],
+      },
+    });
+    expect(_annotationCentroidXy(roi, "rois")).toEqual([5, 10]);
+  });
+
+  it("returns null for empty ROIs", () => {
+    const roi = new UserROI({
+      geometry: { type: "Point", coordinates: [5, 5] },
+    });
+    expect(_annotationCentroidXy(roi, "rois")).toBeNull();
+  });
+
+  it("returns bbox centroid for masks", () => {
+    // 10x10 mask, all foreground, at offset (5, 5)
+    const mask = new UserSegmentationMask({
+      rleCounts: new Uint32Array([0, 100]),
+      height: 10,
+      width: 10,
+      offset: [5, 5],
+    });
+    const result = _annotationCentroidXy(mask, "masks");
+    expect(result).not.toBeNull();
+    // bbox is {x: 5, y: 5, width: 10, height: 10} → centroid (10, 10)
+    expect(result![0]).toBe(10);
+    expect(result![1]).toBe(10);
+  });
+
+  it("returns null for empty masks", () => {
+    const mask = new UserSegmentationMask({
+      rleCounts: new Uint32Array([100]), // all zeros
+      height: 10,
+      width: 10,
+    });
+    expect(_annotationCentroidXy(mask, "masks")).toBeNull();
+  });
+
+  it("returns image extent center for label images", () => {
+    const li = new UserLabelImage({
+      data: new Int32Array([0, 1]),
+      height: 1,
+      width: 2,
+    });
+    // scale=[1,1], offset=[0,0] → center at (1, 0.5)
+    expect(_annotationCentroidXy(li, "labelImages")).toEqual([1, 0.5]);
+  });
+});
+
+describe("_findAnnotationMatches", () => {
+  it("finds matches within threshold", () => {
+    const c1 = new UserCentroid({ x: 10, y: 10 });
+    const c2 = new UserCentroid({ x: 11, y: 10 });
+    const matches = _findAnnotationMatches([c1], [c2], "centroids", 5.0);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].selfIdx).toBe(0);
+    expect(matches[0].otherIdx).toBe(0);
+    expect(matches[0].score).toBeCloseTo(1 / (1 + 1)); // distance = 1
+  });
+
+  it("returns empty when distance exceeds threshold", () => {
+    const c1 = new UserCentroid({ x: 0, y: 0 });
+    const c2 = new UserCentroid({ x: 100, y: 100 });
+    const matches = _findAnnotationMatches([c1], [c2], "centroids", 5.0);
+    expect(matches).toHaveLength(0);
+  });
+
+  it("returns multiple matches for multiple items", () => {
+    const selfList = [
+      new UserCentroid({ x: 10, y: 10 }),
+      new UserCentroid({ x: 20, y: 20 }),
+    ];
+    const otherList = [
+      new UserCentroid({ x: 11, y: 10 }),
+      new UserCentroid({ x: 21, y: 20 }),
+    ];
+    const matches = _findAnnotationMatches(selfList, otherList, "centroids", 5.0);
+    expect(matches).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- Ports [talmolab/sleap-io#408](https://github.com/talmolab/sleap-io/pull/408) to the JS/TS codebase
- `_mergeAnnotations()` now accepts `strategy` and `threshold` parameters, supporting all 6 merge strategies: `keep_original`, `keep_new`, `keep_both`, `replace_predictions`, `auto`, `update_tracks`
- `auto` and `update_tracks` use **spatial matching** (centroid distance) for annotations, mirroring the same resolution cascade used for pose instances
- Backward compatible: existing calls without strategy default to `keep_both`

## Key Changes
- **`src/model/labeled-frame.ts`**:
  - `MergeStrategy` type export
  - 4 new module-level helpers: `_annotationCentroidXy`, `_findAnnotationMatches`, `_resolveAnnotationAuto`, `_resolveAnnotationUpdateTracks`
  - Per-modality centroid extraction: centroids by `(x, y)`, bboxes/ROIs by `.centroidXy`, masks by bbox centroid, label images by image extent center
  - `_mergeAnnotations()` split into per-strategy branches with `threshold` parameter
- **`tests/nested-annotations.test.ts`**: 20 new tests covering all 6 strategies, all annotation modalities, and edge cases (empty masks, empty ROIs, many-to-one matching)

## Test plan
- [x] 20 new unit tests for all strategies + helper functions
- [x] Full test suite passes (671 passed, 0 failures)
- [x] Backward compatible: existing `_mergeAnnotations(other)` calls still use `keep_both`

🤖 Generated with [Claude Code](https://claude.com/claude-code)