### PR TITLE
Port Python sleap-io PR #411: Remove video/frameIdx from annotation objects

### DIFF
--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -79,10 +79,53 @@ export async function readSlp(
     const identities = readIdentities(file.get("identities_json"));
     const sessions = readSessions(file.get("sessions_json"), videos, skeletons, labeledFrames, identities);
     const allInstances = labeledFrames.flatMap((f) => f.instances);
-    const { rois, bboxes } = readRoisAndBboxes(file, videos, tracks, allInstances);
-    const masks = readMasks(file, videos, tracks);
-    const centroids = readCentroids(file, videos, tracks);
-    const labelImages = readLabelImages(file, videos, tracks, allInstances);
+    const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(file, videos, tracks, allInstances);
+    const maskTuples = readMasks(file, videos, tracks);
+    const centroidTuples = readCentroids(file, videos, tracks);
+    const labelImageTuples = readLabelImages(file, videos, tracks, allInstances);
+
+    // Distribute annotations into LabeledFrames using routing tuples
+    const frameMap = new Map<string, LabeledFrame>();
+    for (const lf of labeledFrames) {
+      const vidIdx = videos.indexOf(lf.video);
+      frameMap.set(`${vidIdx}:${lf.frameIdx}`, lf);
+    }
+    const getOrCreateFrame = (vidIdx: number, frameIdx: number): LabeledFrame => {
+      const key = `${vidIdx}:${frameIdx}`;
+      let lf = frameMap.get(key);
+      if (!lf) {
+        lf = new LabeledFrame({ video: videos[vidIdx], frameIdx });
+        frameMap.set(key, lf);
+        labeledFrames.push(lf);
+      }
+      return lf;
+    };
+
+    const staticRois: ROI[] = [];
+    const distributeTuples = <T>(
+      tuples: [T, number, number][],
+      push: (lf: LabeledFrame, ann: T) => void,
+    ): void => {
+      for (const [ann, vidIdx, frameIdx] of tuples) {
+        if (vidIdx >= 0 && vidIdx < videos.length && frameIdx >= 0) {
+          push(getOrCreateFrame(vidIdx, frameIdx), ann);
+        }
+      }
+    };
+
+    // Distribute ROIs — undistributed ones are static ROIs
+    for (const [roi, vidIdx, frameIdx] of roiTuples) {
+      if (vidIdx >= 0 && vidIdx < videos.length && frameIdx >= 0) {
+        getOrCreateFrame(vidIdx, frameIdx).rois.push(roi);
+      } else {
+        staticRois.push(roi);
+      }
+    }
+
+    distributeTuples(bboxTuples, (lf, b) => lf.bboxes.push(b));
+    distributeTuples(maskTuples, (lf, m) => lf.masks.push(m));
+    distributeTuples(centroidTuples, (lf, c) => lf.centroids.push(c));
+    distributeTuples(labelImageTuples, (lf, li) => lf.labelImages.push(li));
 
     return new Labels({
       labeledFrames,
@@ -93,11 +136,7 @@ export async function readSlp(
       sessions,
       identities,
       provenance: (metadataJson?.provenance as Record<string, unknown>) ?? {},
-      rois,
-      masks,
-      bboxes,
-      centroids,
-      labelImages,
+      rois: staticRois,
     });
   } finally {
     close();
@@ -167,24 +206,20 @@ export async function readSlpLazy(
     // Pass empty labeledFrames since frames aren't materialized yet.
     const identities = readIdentities(file.get("identities_json"));
     const sessions = readSessions(file.get("sessions_json"), videos, skeletons, [], identities);
-    const { rois, bboxes } = readRoisAndBboxes(file, videos, tracks);
-    const masks = readMasks(file, videos, tracks);
-    const centroids = readCentroids(file, videos, tracks);
-    const labelImages = readLabelImages(file, videos, tracks);
+    const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(file, videos, tracks);
+    const maskTuples = readMasks(file, videos, tracks);
+    const centroidTuples = readCentroids(file, videos, tracks);
+    const labelImageTuples = readLabelImages(file, videos, tracks);
 
     // Build per-frame annotation dicts for lazy materialization
-    const videoIndexMap = new Map<Video, number>();
-    for (let i = 0; i < videos.length; i++) videoIndexMap.set(videos[i], i);
-
-    const buildAnnByFrame = <T extends { video: any; frameIdx: number | null }>(
-      annotations: T[],
+    const buildAnnByFrame = <T>(
+      tuples: [T, number, number][],
     ): { byFrame: Map<string, T[]>; undistributed: T[] } => {
       const byFrame = new Map<string, T[]>();
       const undistributed: T[] = [];
-      for (const ann of annotations) {
-        if (ann.video !== null && ann.frameIdx !== null) {
-          const vidIdx = videoIndexMap.get(ann.video) ?? -1;
-          const key = `${vidIdx}:${ann.frameIdx}`;
+      for (const [ann, vidIdx, frameIdx] of tuples) {
+        if (vidIdx >= 0 && frameIdx >= 0) {
+          const key = `${vidIdx}:${frameIdx}`;
           const list = byFrame.get(key);
           if (list) list.push(ann);
           else byFrame.set(key, [ann]);
@@ -195,11 +230,11 @@ export async function readSlpLazy(
       return { byFrame, undistributed };
     };
 
-    const cResult = buildAnnByFrame(centroids);
-    const bResult = buildAnnByFrame(bboxes);
-    const mResult = buildAnnByFrame(masks);
-    const rResult = buildAnnByFrame(rois);
-    const liResult = buildAnnByFrame(labelImages);
+    const cResult = buildAnnByFrame(centroidTuples);
+    const bResult = buildAnnByFrame(bboxTuples);
+    const mResult = buildAnnByFrame(maskTuples);
+    const rResult = buildAnnByFrame(roiTuples);
+    const liResult = buildAnnByFrame(labelImageTuples);
 
     store._centroidByFrame = cResult.byFrame;
     store._bboxByFrame = bResult.byFrame;
@@ -624,7 +659,7 @@ function readRoisAndBboxes(
   videos: Video[],
   tracks: Track[],
   instances?: Array<Instance | PredictedInstance>,
-): { rois: ROI[]; bboxes: BoundingBox[] } {
+): { rois: [ROI, number, number][]; bboxes: [BoundingBox, number, number][] } {
   const { rois, migratedBboxes } = readRoisWithMigration(file, videos, tracks, instances);
   let bboxes = readBboxes(file, videos, tracks);
   if (bboxes.length === 0 && migratedBboxes.length > 0) {
@@ -638,7 +673,7 @@ function readRoisWithMigration(
   videos: Video[],
   tracks: Track[],
   instances?: Array<Instance | PredictedInstance>,
-): { rois: ROI[]; migratedBboxes: BoundingBox[] } {
+): { rois: [ROI, number, number][]; migratedBboxes: [BoundingBox, number, number][] } {
   const roisDs = file.get("rois");
   if (!roisDs) return { rois: [], migratedBboxes: [] };
   const roisData = normalizeStructDataset(roisDs);
@@ -667,8 +702,8 @@ function readRoisWithMigration(
   const isPredictedCol = roisData.is_predicted ?? [];
   const trackingScoresCol = roisData.tracking_score ?? [];
 
-  const rois: ROI[] = [];
-  const migratedBboxes: BoundingBox[] = [];
+  const rois: [ROI, number, number][] = [];
+  const migratedBboxes: [BoundingBox, number, number][] = [];
 
   for (let i = 0; i < annotationTypes.length; i++) {
     const wkbStart = Number(wkbStarts[i]);
@@ -680,7 +715,6 @@ function readRoisWithMigration(
     const video = videoIdx >= 0 && videoIdx < videos.length ? videos[videoIdx] : null;
 
     const frameIdxVal = Number(frameIndices[i]);
-    const frameIdx = frameIdxVal === -1 ? null : frameIdxVal;
 
     const trackIdx = Number(trackIndices[i]);
     const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
@@ -695,7 +729,7 @@ function readRoisWithMigration(
     // Migration: annotation_type === 1 (BOUNDING_BOX) -> BoundingBox object
     // Skip predicted ROIs during bbox migration (only migrate user-type box-shaped ROIs)
     if (annotType === AnnotationType.BOUNDING_BOX && !isPred) {
-      const tmpRoi = new UserROI({ geometry, name: names[i] ?? "", category: categories[i] ?? "", source: sources[i] ?? "", video, frameIdx, track });
+      const tmpRoi = new UserROI({ geometry, name: names[i] ?? "", category: categories[i] ?? "", source: sources[i] ?? "", video, track });
       const b = tmpRoi.bounds;
       const scoreVal = Number(scores[i]);
       const bboxScore = Number.isNaN(scoreVal) ? null : scoreVal;
@@ -705,8 +739,6 @@ function readRoisWithMigration(
         y1: b.minY,
         x2: b.maxX,
         y2: b.maxY,
-        video,
-        frameIdx,
         track,
         trackingScore: roiTrackingScore,
         category: categories[i] ?? "",
@@ -714,22 +746,24 @@ function readRoisWithMigration(
         source: sources[i] ?? "",
       };
 
+      let bbox: BoundingBox;
       if (bboxScore !== null) {
-        migratedBboxes.push(new PredictedBoundingBox({ ...bboxOptions, score: bboxScore }));
+        bbox = new PredictedBoundingBox({ ...bboxOptions, score: bboxScore });
       } else {
-        migratedBboxes.push(new UserBoundingBox(bboxOptions));
+        bbox = new UserBoundingBox(bboxOptions);
       }
 
       // Format >= 1.6: resolve instance references for migrated bboxes
       if (instanceIndices.length > 0) {
         const instIdx = Number(instanceIndices[i]);
-        const bbox = migratedBboxes[migratedBboxes.length - 1];
         if (instances && instIdx >= 0 && instIdx < instances.length) {
           bbox.instance = instances[instIdx];
         } else if (instIdx >= 0) {
           bbox._instanceIdx = instIdx;
         }
       }
+
+      migratedBboxes.push([bbox, videoIdx, frameIdxVal]);
     } else {
       const roiOptions = {
         geometry,
@@ -737,7 +771,6 @@ function readRoisWithMigration(
         category: categories[i] ?? "",
         source: sources[i] ?? "",
         video,
-        frameIdx,
         track,
         trackingScore: roiTrackingScore,
       };
@@ -760,14 +793,14 @@ function readRoisWithMigration(
         }
       }
 
-      rois.push(roi);
+      rois.push([roi, videoIdx, frameIdxVal]);
     }
   }
 
   return { rois, migratedBboxes };
 }
 
-function readBboxes(file: any, videos: Video[], tracks: Track[]): BoundingBox[] {
+function readBboxes(file: any, _videos: Video[], tracks: Track[]): [BoundingBox, number, number][] {
   const bboxesDs = file.get("bboxes");
   if (!bboxesDs) return [];
   const bboxesData = normalizeStructDataset(bboxesDs);
@@ -800,13 +833,11 @@ function readBboxes(file: any, videos: Video[], tracks: Track[]): BoundingBox[] 
   const instanceIndices = bboxesData.instance ?? [];
   const trackingScores = bboxesData.tracking_score ?? [];
 
-  const bboxes: BoundingBox[] = [];
+  const bboxes: [BoundingBox, number, number][] = [];
   for (let i = 0; i < count; i++) {
     const videoIdx = Number(videoIndices[i]);
-    const video = videoIdx >= 0 && videoIdx < videos.length ? videos[videoIdx] : null;
 
     const frameIdxVal = Number(frameIndices[i]);
-    const frameIdx = frameIdxVal === -1 ? null : frameIdxVal;
 
     const trackIdx = Number(trackIndices[i]);
     const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
@@ -841,8 +872,6 @@ function readBboxes(file: any, videos: Video[], tracks: Track[]): BoundingBox[] 
       x2: bx2,
       y2: by2,
       angle: Number(angles[i]),
-      video,
-      frameIdx,
       track,
       trackingScore,
       category: categories[i] ?? "",
@@ -861,7 +890,7 @@ function readBboxes(file: any, videos: Video[], tracks: Track[]): BoundingBox[] 
       bbox._instanceIdx = instanceIdx;
     }
 
-    bboxes.push(bbox);
+    bboxes.push([bbox, videoIdx, frameIdxVal]);
   }
   return bboxes;
 }
@@ -929,7 +958,7 @@ function readScoreMaps(file: any, indexPath: string, dataPath: string): Map<numb
   return result;
 }
 
-function readMasks(file: any, videos: Video[], tracks: Track[]): SegmentationMask[] {
+function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationMask, number, number][] {
   const masksDs = file.get("masks");
   if (!masksDs) return [];
   const masksData = normalizeStructDataset(masksDs);
@@ -968,7 +997,7 @@ function readMasks(file: any, videos: Video[], tracks: Track[]): SegmentationMas
   // Read score maps if present
   const scoreMaps = readScoreMaps(file, "mask_score_map_index", "mask_score_maps");
 
-  const masks: SegmentationMask[] = [];
+  const masks: [SegmentationMask, number, number][] = [];
   for (let i = 0; i < heights.length; i++) {
     const rleStart = Number(rleStarts[i]);
     const rleEnd = Number(rleEnds[i]);
@@ -983,10 +1012,8 @@ function readMasks(file: any, videos: Video[], tracks: Track[]): SegmentationMas
     }
 
     const videoIdx = Number(videoIndices[i]);
-    const video = videoIdx >= 0 && videoIdx < videos.length ? videos[videoIdx] : null;
 
     const frameIdxVal = Number(frameIndices[i]);
-    const frameIdx = frameIdxVal === -1 ? null : frameIdxVal;
 
     const trackIdx = Number(trackIndices[i]);
     const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
@@ -1006,8 +1033,6 @@ function readMasks(file: any, videos: Video[], tracks: Track[]): SegmentationMas
       name: names[i] ?? "",
       category: categories[i] ?? "",
       source: sources[i] ?? "",
-      video,
-      frameIdx,
       track,
       trackingScore: maskTrackingScore,
       scale: [scaleX, scaleY] as [number, number],
@@ -1036,17 +1061,17 @@ function readMasks(file: any, videos: Video[], tracks: Track[]): SegmentationMas
       mask._instanceIdx = instIdx;
     }
 
-    masks.push(mask);
+    masks.push([mask, videoIdx, frameIdxVal]);
   }
   return masks;
 }
 
 function readLabelImages(
   file: any,
-  videos: Video[],
+  _videos: Video[],
   tracks: Track[],
   instances?: Array<Instance | PredictedInstance>,
-): LabelImage[] {
+): [LabelImage, number, number][] {
   const liDs = file.get("label_images");
   if (!liDs) return [];
   const liData = normalizeStructDataset(liDs);
@@ -1115,12 +1140,10 @@ function readLabelImages(
   // Read score maps if present
   const liScoreMaps = readScoreMaps(file, "label_image_score_map_index", "label_image_score_maps");
 
-  const labelImages: LabelImage[] = [];
+  const labelImages: [LabelImage, number, number][] = [];
   for (let i = 0; i < videoIndices.length; i++) {
     const videoIdx = Number(videoIndices[i]);
-    const video = videoIdx >= 0 && videoIdx < videos.length ? videos[videoIdx] : null;
     const frameIdxVal = Number(frameIndices[i]);
-    const frameIdx = frameIdxVal === -1 ? null : frameIdxVal;
     const height = Number(heights[i]);
     const width = Number(widths[i]);
 
@@ -1210,8 +1233,6 @@ function readLabelImages(
         height,
         width,
         objects,
-        video,
-        frameIdx,
         source: sources[i] ?? "",
         score: liScore,
         scoreMap: sm?.scoreMap ?? null,
@@ -1224,8 +1245,6 @@ function readLabelImages(
         height,
         width,
         objects,
-        video,
-        frameIdx,
         source: sources[i] ?? "",
         scale: liScale,
         offset: liOffset,
@@ -1236,7 +1255,7 @@ function readLabelImages(
       li._objectInstanceIdxs = deferredInstances;
     }
 
-    labelImages.push(li);
+    labelImages.push([li, videoIdx, frameIdxVal]);
   }
   return labelImages;
 }
@@ -1432,7 +1451,7 @@ function parseVideoIdFromDataset(dataset: string): number | null {
   return Number.isNaN(id) ? null : id;
 }
 
-function readCentroids(file: any, videos: Video[], tracks: Track[]): Centroid[] {
+function readCentroids(file: any, _videos: Video[], tracks: Track[]): [Centroid, number, number][] {
   const centroidsDs = file.get("centroids");
   if (!centroidsDs) return [];
   const data = normalizeStructDataset(centroidsDs);
@@ -1454,13 +1473,11 @@ function readCentroids(file: any, videos: Video[], tracks: Track[]): Centroid[] 
   const scores = data.score ?? [];
   const trackingScores = data.tracking_score ?? [];
 
-  const centroids: Centroid[] = [];
+  const centroids: [Centroid, number, number][] = [];
   for (let i = 0; i < count; i++) {
     const videoIdx = Number(videoIndices[i]);
-    const video = videoIdx >= 0 && videoIdx < videos.length ? videos[videoIdx] : null;
 
     const frameIdxVal = Number(frameIndices[i]);
-    const frameIdx = frameIdxVal === -1 ? null : frameIdxVal;
 
     const trackIdx = Number(trackIndices[i]);
     const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
@@ -1477,8 +1494,6 @@ function readCentroids(file: any, videos: Video[], tracks: Track[]): Centroid[] 
       x: Number(xs[i]),
       y: Number(ys[i]),
       z,
-      video,
-      frameIdx,
       track,
       trackingScore,
       category: categories[i] ?? "",
@@ -1500,7 +1515,7 @@ function readCentroids(file: any, videos: Video[], tracks: Track[]): Centroid[] 
       centroid._instanceIdx = instanceIdx;
     }
 
-    centroids.push(centroid);
+    centroids.push([centroid, videoIdx, frameIdxVal]);
   }
   return centroids;
 }

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -127,6 +127,35 @@ export async function readSlp(
     distributeTuples(centroidTuples, (lf, c) => lf.centroids.push(c));
     distributeTuples(labelImageTuples, (lf, li) => lf.labelImages.push(li));
 
+    // Resolve deferred instance references (_instanceIdx) to live instances.
+    // Mirrors Labels.materialize() for eager mode so bboxes/centroids/masks/
+    // labelImages get their .instance set on read (ROIs are already resolved
+    // in readRoisWithMigration since it receives `instances`).
+    const allInstancesFlat = labeledFrames.flatMap((lf) => lf.instances);
+    const resolveInstanceRef = (ann: { _instanceIdx: number | null; instance: Instance | null }): void => {
+      if (ann._instanceIdx !== null && ann._instanceIdx >= 0 && ann._instanceIdx < allInstancesFlat.length) {
+        ann.instance = allInstancesFlat[ann._instanceIdx];
+        ann._instanceIdx = null;
+      }
+    };
+    for (const lf of labeledFrames) {
+      for (const b of lf.bboxes) resolveInstanceRef(b);
+      for (const c of lf.centroids) resolveInstanceRef(c);
+      for (const m of lf.masks) resolveInstanceRef(m);
+      for (const r of lf.rois) resolveInstanceRef(r);
+      for (const li of lf.labelImages) {
+        if (li._objectInstanceIdxs) {
+          for (const [labelId, instIdx] of li._objectInstanceIdxs) {
+            const obj = li.objects.get(labelId);
+            if (obj && instIdx >= 0 && instIdx < allInstancesFlat.length) {
+              obj.instance = allInstancesFlat[instIdx];
+            }
+          }
+          li._objectInstanceIdxs = null;
+        }
+      }
+    }
+
     return new Labels({
       labeledFrames,
       videos,

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -88,11 +88,38 @@ function writeSlpToFile(file: any, labels: Labels, embeddedVideoData?: Map<numbe
   writeLabeledFrames(file, labels);
   writeNegativeFrames(file, labels);
   const allInstances = labels.labeledFrames.flatMap((f) => f.instances);
-  writeRois(file, labels.rois, labels.videos, labels.tracks, allInstances);
-  writeMasks(file, labels.masks, labels.videos, labels.tracks, allInstances);
-  writeBboxes(file, labels.bboxes, labels.videos, labels.tracks, allInstances);
-  writeCentroids(file, labels.centroids, labels.videos, labels.tracks, allInstances);
-  writeLabelImages(file, labels.labelImages, labels.videos, labels.tracks, allInstances);
+
+  // Build flat annotation lists with routing contexts from parent LabeledFrames
+  const allRois: ROI[] = [];
+  const roiCtx: [number, number][] = [];
+  const allMasks: SegmentationMask[] = [];
+  const maskCtx: [number, number][] = [];
+  const allBboxes: BoundingBox[] = [];
+  const bboxCtx: [number, number][] = [];
+  const allCentroids: Centroid[] = [];
+  const centroidCtx: [number, number][] = [];
+  const allLabelImages: LabelImage[] = [];
+  const liCtx: [number, number][] = [];
+
+  for (const lf of labels.labeledFrames) {
+    const vidIdx = labels.videos.indexOf(lf.video);
+    for (const r of lf.rois) { allRois.push(r); roiCtx.push([vidIdx, lf.frameIdx]); }
+    for (const m of lf.masks) { allMasks.push(m); maskCtx.push([vidIdx, lf.frameIdx]); }
+    for (const b of lf.bboxes) { allBboxes.push(b); bboxCtx.push([vidIdx, lf.frameIdx]); }
+    for (const c of lf.centroids) { allCentroids.push(c); centroidCtx.push([vidIdx, lf.frameIdx]); }
+    for (const li of lf.labelImages) { allLabelImages.push(li); liCtx.push([vidIdx, lf.frameIdx]); }
+  }
+  // Static ROIs
+  for (const r of labels._staticRois) {
+    allRois.push(r);
+    roiCtx.push([r.video ? labels.videos.indexOf(r.video) : -1, -1]);
+  }
+
+  writeRois(file, allRois, labels.videos, labels.tracks, allInstances, roiCtx);
+  writeMasks(file, allMasks, labels.videos, labels.tracks, allInstances, maskCtx);
+  writeBboxes(file, allBboxes, labels.videos, labels.tracks, allInstances, bboxCtx);
+  writeCentroids(file, allCentroids, labels.videos, labels.tracks, allInstances, centroidCtx);
+  writeLabelImages(file, allLabelImages, labels.videos, labels.tracks, allInstances, liCtx);
 }
 
 /**
@@ -144,11 +171,7 @@ export async function saveSlpToBytes(
       suggestions: labels.suggestions,
       sessions: labels.sessions,
       provenance: labels.provenance,
-      rois: labels.rois,
-      masks: labels.masks,
-      bboxes: labels.bboxes,
-      centroids: labels.centroids,
-      labelImages: labels.labelImages,
+      rois: labels._staticRois,
       identities: labels.identities,
     });
   }
@@ -849,7 +872,7 @@ function createMatrixDataset(file: any, name: string, rows: number[][], fieldNam
   setStringAttr(dataset, "field_names", JSON.stringify(fieldNames));
 }
 
-function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name: string }>, instances?: Array<Instance | PredictedInstance>): void {
+function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name: string }>, instances?: Array<Instance | PredictedInstance>, contexts?: [number, number][]): void {
   if (!rois.length) return;
 
   const rows: number[][] = [];
@@ -860,15 +883,16 @@ function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name
   const sources: string[] = [];
   const hasInstances = instances && instances.length > 0;
 
-  for (const roi of rois) {
+  for (let i = 0; i < rois.length; i++) {
+    const roi = rois[i];
     const wkb = encodeWkb(roi.geometry);
     const wkbStart = wkbOffset;
     const wkbEnd = wkbOffset + wkb.length;
     wkbChunks.push(wkb);
     wkbOffset = wkbEnd;
 
-    const videoIdx = roi.video ? videos.indexOf(roi.video) : -1;
-    const frameIdx = roi.frameIdx ?? -1;
+    const videoIdx = contexts ? contexts[i][0] : (roi.video ? videos.indexOf(roi.video) : -1);
+    const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = roi.track ? tracks.indexOf(roi.track as any) : -1;
     const instanceIdx = hasInstances && roi.instance ? instances.indexOf(roi.instance) : -1;
     const score = roi.isPredicted ? (roi as PredictedROI).score : Number.NaN;
@@ -906,6 +930,7 @@ function writeMasks(
   videos: Video[],
   tracks: Array<{ name: string }>,
   instances: (Instance | PredictedInstance)[],
+  contexts?: [number, number][],
 ): void {
   if (!masks.length) return;
 
@@ -934,8 +959,8 @@ function writeMasks(
     rleChunks.push(rleBytes);
     rleOffset = rleEnd;
 
-    const videoIdx = mask.video ? videos.indexOf(mask.video) : -1;
-    const frameIdx = mask.frameIdx ?? -1;
+    const videoIdx = contexts ? contexts[i][0] : -1;
+    const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = mask.track ? tracks.indexOf(mask.track as any) : -1;
     const score = mask.isPredicted ? (mask as PredictedSegmentationMask).score : Number.NaN;
     const isPredicted = mask.isPredicted ? 1 : 0;
@@ -1004,9 +1029,10 @@ function writeMasks(
 function writeBboxes(
   file: any,
   bboxes: BoundingBox[],
-  videos: Video[],
+  _videos: Video[],
   tracks: Array<{ name: string }>,
   instances: (Instance | PredictedInstance)[],
+  contexts?: [number, number][],
 ): void {
   if (!bboxes.length) return;
 
@@ -1015,9 +1041,10 @@ function writeBboxes(
   const names: string[] = [];
   const sources: string[] = [];
 
-  for (const bbox of bboxes) {
-    const videoIdx = bbox.video ? videos.indexOf(bbox.video) : -1;
-    const frameIdx = bbox.frameIdx ?? -1;
+  for (let i = 0; i < bboxes.length; i++) {
+    const bbox = bboxes[i];
+    const videoIdx = contexts ? contexts[i][0] : -1;
+    const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = bbox.track ? tracks.indexOf(bbox.track as any) : -1;
     const score = bbox.isPredicted ? (bbox as PredictedBoundingBox).score : Number.NaN;
     const instanceIdx = bbox.instance ? instances.indexOf(bbox.instance as Instance) : -1;
@@ -1054,9 +1081,10 @@ function writeBboxes(
 function writeLabelImages(
   file: any,
   labelImages: LabelImage[],
-  videos: Video[],
+  _videos: Video[],
   tracks: Track[],
   instances: (Instance | PredictedInstance)[],
+  contexts?: [number, number][],
 ): void {
   if (!labelImages.length) return;
 
@@ -1082,8 +1110,8 @@ function writeLabelImages(
 
   for (let liIdx = 0; liIdx < labelImages.length; liIdx++) {
     const li = labelImages[liIdx];
-    const videoIdx = li.video ? videos.indexOf(li.video) : -1;
-    const frameIdx = li.frameIdx ?? -1;
+    const videoIdx = contexts ? contexts[liIdx][0] : -1;
+    const frameIdx = contexts ? contexts[liIdx][1] : -1;
 
     // Compress pixel data: Int32Array -> raw bytes -> zlib
     const pixelBytes = new Uint8Array(li.data.buffer, li.data.byteOffset, li.data.byteLength);
@@ -1182,9 +1210,10 @@ function writeLabelImages(
 function writeCentroids(
   file: any,
   centroids: Centroid[],
-  videos: Video[],
+  _videos: Video[],
   tracks: Array<{ name: string }>,
   instances: (Instance | PredictedInstance)[],
+  contexts?: [number, number][],
 ): void {
   if (!centroids.length) return;
 
@@ -1193,9 +1222,10 @@ function writeCentroids(
   const names: string[] = [];
   const sources: string[] = [];
 
-  for (const c of centroids) {
-    const videoIdx = c.video ? videos.indexOf(c.video) : -1;
-    const frameIdx = c.frameIdx ?? -1;
+  for (let i = 0; i < centroids.length; i++) {
+    const c = centroids[i];
+    const videoIdx = contexts ? contexts[i][0] : -1;
+    const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = c.track ? tracks.indexOf(c.track as any) : -1;
     const score = c.isPredicted ? (c as PredictedCentroid).score : Number.NaN;
     const instanceIdx = c.instance ? instances.indexOf(c.instance as Instance) : -1;

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -15,6 +15,7 @@ import { LabelImage, PredictedLabelImage } from "../../model/label-image.js";
 import { deflate } from "pako";
 import { Identity } from "../../model/identity.js";
 import { Instance3D, PredictedInstance3D } from "../../model/instance3d.js";
+import type { LazyDataStore } from "../../model/lazy.js";
 
 // File writer hook — registered by h5-node.ts (imported as side-effect from Node entry point).
 let _writeToFile: ((filename: string, bytes: Uint8Array) => Promise<void>) | null = null;
@@ -123,6 +124,274 @@ function writeSlpToFile(file: any, labels: Labels, embeddedVideoData?: Map<numbe
 }
 
 /**
+ * Sentinel error thrown by {@link makeLazySourceLabels} when the lazy source
+ * fast path cannot safely swap videos in place (multi-camera sessions
+ * referencing a video that's getting swapped). The dispatch layer catches
+ * this and falls back to materializing the labels.
+ */
+class LazySourceFallback extends Error {
+  constructor() {
+    super("lazy source mode requires materialization");
+    this.name = "LazySourceFallback";
+  }
+}
+
+/**
+ * Build a shallow Labels copy with `videos[]` swapped to source paths,
+ * suitable for the lazy fast-path writer when `embed: "source"` is set.
+ *
+ * The lazy data store is keyed by `videoIdx` (not video object identity),
+ * so we don't need to remap any annotations — only the `videos[]` array,
+ * the `suggestions` (which reference videos by identity), and we need to
+ * verify no `RecordingSession` references a video that's being swapped.
+ *
+ * Note: the eager source-mode path (`saveSlpToBytes`) does NOT remap
+ * suggestions or check sessions today. The lazy path here is more correct;
+ * fixing eager is a separate follow-up.
+ *
+ * @throws LazySourceFallback if any session references a swapped video.
+ */
+function makeLazySourceLabels(labels: Labels): Labels {
+  const restoredVideos = labels.videos.map((v) => v.sourceVideo ?? v);
+  const videoMap = new Map<Video, Video>();
+  for (let i = 0; i < labels.videos.length; i++) {
+    if (labels.videos[i] !== restoredVideos[i]) {
+      videoMap.set(labels.videos[i], restoredVideos[i]);
+    }
+  }
+
+  // No swaps needed — just return the original labels.
+  if (videoMap.size === 0) return labels;
+
+  // Multi-camera sessions referencing a swapped video are too complex for
+  // the lazy fast path. Bail out so the dispatch layer can materialize.
+  for (const session of labels.sessions) {
+    for (const v of session.videoByCamera.values()) {
+      if (videoMap.has(v)) {
+        throw new LazySourceFallback();
+      }
+    }
+  }
+
+  const remappedSuggestions = labels.suggestions.map((s) => {
+    const newVideo = videoMap.get(s.video);
+    if (!newVideo) return s;
+    return new SuggestionFrame({
+      video: newVideo,
+      frameIdx: s.frameIdx,
+      group: s.group,
+      metadata: s.metadata,
+    });
+  });
+
+  const out = new Labels({
+    videos: restoredVideos,
+    skeletons: labels.skeletons,
+    tracks: labels.tracks,
+    suggestions: remappedSuggestions,
+    sessions: labels.sessions, // safe: verified no swapped refs
+    identities: labels.identities,
+    provenance: labels.provenance,
+    rois: labels._staticRois,
+  });
+  out._lazyFrameList = labels._lazyFrameList;
+  out._lazyDataStore = labels._lazyDataStore;
+  return out;
+}
+
+/**
+ * Write `frames`/`instances`/`points`/`pred_points` HDF5 datasets directly
+ * from the lazy store's parsed column data, bypassing materialization.
+ *
+ * The columns are stored as `Record<string, any[]>` (parsed from the original
+ * HDF5 reader). We rebuild row-major typed arrays and call the existing
+ * {@link createMatrixDataset} helper so we get identical output to the eager
+ * writer for these four datasets.
+ *
+ * TODO: a column-aware fast path could avoid the row rebuild entirely.
+ */
+function writeLazyMatrixDataset(
+  file: any,
+  name: string,
+  columns: Record<string, any[]>,
+  fieldNames: string[],
+  dtype: string,
+): void {
+  const rowCount = (columns[fieldNames[0]] ?? []).length;
+  const colCount = fieldNames.length;
+  const rows: number[][] = [];
+  for (let i = 0; i < rowCount; i++) {
+    const row = new Array<number>(colCount);
+    for (let j = 0; j < colCount; j++) {
+      const col = columns[fieldNames[j]] ?? [];
+      const v = col[i];
+      row[j] = v === undefined || v === null ? 0 : Number(v);
+    }
+    rows.push(row);
+  }
+  createMatrixDataset(file, name, rows, fieldNames, dtype);
+}
+
+function writeLazyFramesAndInstances(file: any, store: LazyDataStore): void {
+  writeLazyMatrixDataset(
+    file,
+    "frames",
+    store.framesData,
+    ["frame_id", "video", "frame_idx", "instance_id_start", "instance_id_end"],
+    "<i8",
+  );
+  writeLazyMatrixDataset(
+    file,
+    "instances",
+    store.instancesData,
+    [
+      "instance_id",
+      "instance_type",
+      "frame_id",
+      "skeleton",
+      "track",
+      "from_predicted",
+      "score",
+      "point_id_start",
+      "point_id_end",
+      "tracking_score",
+    ],
+    "<f8",
+  );
+  writeLazyMatrixDataset(
+    file,
+    "points",
+    store.pointsData,
+    ["x", "y", "visible", "complete"],
+    "<f8",
+  );
+  writeLazyMatrixDataset(
+    file,
+    "pred_points",
+    store.predPointsData,
+    ["x", "y", "visible", "complete", "score"],
+    "<f8",
+  );
+}
+
+function writeLazyNegativeFrames(file: any, store: LazyDataStore): void {
+  if (store.negativeFrames.size === 0) return;
+  const rows: number[][] = [];
+  for (const key of store.negativeFrames) {
+    const [vidStr, fidxStr] = key.split(":");
+    rows.push([Number(vidStr), Number(fidxStr)]);
+  }
+  // Deterministic ordering for byte-stable output.
+  rows.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  createMatrixDataset(file, "negative_frames", rows, ["video_id", "frame_idx"], "<i8");
+}
+
+/**
+ * Lazy fast-path SLP writer. Mirrors Python's `_write_labels_lazy`.
+ *
+ * Reuses metadata writers (which only depend on eager `Labels` fields like
+ * `videos`/`tracks`/`suggestions`/`identities`/`sessions`/`provenance`) and
+ * pulls frames/instances/points/pred_points/negative_frames + per-type
+ * annotation maps directly from `LazyDataStore`. No `LabeledFrame` or
+ * `Instance` objects are constructed in this path.
+ *
+ * Limitations (matching Python):
+ *   - `writeSessions` is called with an empty `labeledFrames` list, so any
+ *     `FrameGroup` references that resolve via labeled-frame index are lost.
+ *   - Instance associations on annotations are persisted via the stored
+ *     `_instanceIdx` field (no live `instance` references in lazy mode).
+ *
+ * @throws Error if `labels.isLazy` is false or the lazy store is missing.
+ */
+function writeSlpToFileLazy(file: any, labels: Labels): void {
+  const store = labels._lazyDataStore;
+  if (!labels.isLazy || !store) {
+    throw new Error("writeSlpToFileLazy requires lazy Labels with a data store");
+  }
+
+  writeMetadata(file, labels);
+  writeVideos(file, labels.videos);
+  writeTracks(file, labels.tracks);
+  writeSuggestions(file, labels.suggestions, labels.videos);
+  writeIdentities(file, labels.identities);
+  // Sessions: pass empty labeledFrames since they aren't materialized.
+  // Frame-group refs resolved by lf index will be lost — matches Python.
+  writeSessions(file, labels.sessions, labels.videos, [], labels.identities);
+
+  writeLazyFramesAndInstances(file, store);
+  writeLazyNegativeFrames(file, store);
+
+  // Build per-type (annotation, context) pairs from the lazy store maps.
+  // Per-frame Map keys are "vidIdx:frameIdx" strings (see read.ts).
+  const allRois: ROI[] = [];
+  const roiCtx: [number, number][] = [];
+  const allMasks: SegmentationMask[] = [];
+  const maskCtx: [number, number][] = [];
+  const allBboxes: BoundingBox[] = [];
+  const bboxCtx: [number, number][] = [];
+  const allCentroids: Centroid[] = [];
+  const centroidCtx: [number, number][] = [];
+  const allLabelImages: LabelImage[] = [];
+  const liCtx: [number, number][] = [];
+
+  const collectFrameBound = <T>(
+    byFrame: Map<string, T[]>,
+    out: T[],
+    ctxOut: [number, number][],
+  ): void => {
+    for (const [key, list] of byFrame) {
+      const [vidStr, fidxStr] = key.split(":");
+      const vidIdx = Number(vidStr);
+      const fidx = Number(fidxStr);
+      for (const ann of list) {
+        out.push(ann);
+        ctxOut.push([vidIdx, fidx]);
+      }
+    }
+  };
+
+  collectFrameBound(store._roiByFrame, allRois, roiCtx);
+  collectFrameBound(store._maskByFrame, allMasks, maskCtx);
+  collectFrameBound(store._bboxByFrame, allBboxes, bboxCtx);
+  collectFrameBound(store._centroidByFrame, allCentroids, centroidCtx);
+  collectFrameBound(store._labelImageByFrame, allLabelImages, liCtx);
+
+  // Undistributed ROIs (static ROIs): preserve the video association by
+  // looking up videos.indexOf(roi.video) instead of using -1. The other
+  // four undistributed lists shouldn't have annotations with .video after
+  // PR #94 (those classes no longer carry video), so they always use -1.
+  for (const roi of store._undistributedRois) {
+    allRois.push(roi);
+    const vidIdx = roi.video ? labels.videos.indexOf(roi.video) : -1;
+    roiCtx.push([vidIdx, -1]);
+  }
+  for (const m of store._undistributedMasks) {
+    allMasks.push(m);
+    maskCtx.push([-1, -1]);
+  }
+  for (const b of store._undistributedBboxes) {
+    allBboxes.push(b);
+    bboxCtx.push([-1, -1]);
+  }
+  for (const c of store._undistributedCentroids) {
+    allCentroids.push(c);
+    centroidCtx.push([-1, -1]);
+  }
+  for (const li of store._undistributedLabelImages) {
+    allLabelImages.push(li);
+    liCtx.push([-1, -1]);
+  }
+
+  // Pass undefined for `instances` so each writer uses the _instanceIdx
+  // fallback (Side fix A) for any annotations with deferred instance links.
+  writeRois(file, allRois, labels.videos, labels.tracks, undefined, roiCtx);
+  writeMasks(file, allMasks, labels.videos, labels.tracks, [], maskCtx);
+  writeBboxes(file, allBboxes, labels.videos, labels.tracks, [], bboxCtx);
+  writeCentroids(file, allCentroids, labels.videos, labels.tracks, [], centroidCtx);
+  writeLabelImages(file, allLabelImages, labels.videos, labels.tracks, [], liCtx);
+}
+
+/**
  * Serialize Labels to SLP format and return the bytes.
  * Works in both Node.js and browser environments.
  *
@@ -142,6 +411,55 @@ export async function saveSlpToBytes(
   options?: SlpWriteOptions
 ): Promise<Uint8Array> {
   const embedMode = options?.embed ?? false;
+
+  // Lazy fast path: skip materialization for embed modes that don't need
+  // to read pixel data from videos. Mirrors Python's write_labels dispatch.
+  if (labels.isLazy) {
+    const needsMaterialization =
+      embedMode === true ||
+      embedMode === "all" ||
+      embedMode === "user" ||
+      embedMode === "suggestions" ||
+      embedMode === "user+suggestions";
+
+    if (!needsMaterialization) {
+      let lazyWriteLabels: Labels = labels;
+      let proceedWithFastPath = true;
+
+      if (embedMode === "source") {
+        try {
+          lazyWriteLabels = makeLazySourceLabels(labels);
+        } catch (e) {
+          if (e instanceof LazySourceFallback) {
+            // Multi-camera session references would break under the swap.
+            // Fall back to materialization + the eager source-mode path.
+            labels.materialize();
+            proceedWithFastPath = false;
+          } else {
+            throw e;
+          }
+        }
+      }
+
+      if (proceedWithFastPath) {
+        const module = await getH5Module();
+        const memPath = `/tmp/sleap_output_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
+        const file = new module.File(memPath, "w");
+        try {
+          writeSlpToFileLazy(file, lazyWriteLabels);
+        } finally {
+          file.close();
+        }
+        const fs = getH5FileSystem(module);
+        const bytes = fs.readFile!(memPath);
+        fs.unlink!(memPath);
+        return bytes;
+      }
+    } else {
+      // Embed modes that need pixel data: materialize and continue with eager path.
+      labels.materialize();
+    }
+  }
 
   // Source mode: restore original video paths before writing
   let writeLabels = labels;
@@ -894,7 +1212,11 @@ function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name
     const videoIdx = contexts ? contexts[i][0] : (roi.video ? videos.indexOf(roi.video) : -1);
     const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = roi.track ? tracks.indexOf(roi.track as any) : -1;
-    const instanceIdx = hasInstances && roi.instance ? instances.indexOf(roi.instance) : -1;
+    // Fall back to stored _instanceIdx when no live instance link (e.g., lazy mode).
+    const instanceIdx =
+      hasInstances && roi.instance
+        ? instances.indexOf(roi.instance)
+        : (roi._instanceIdx ?? -1);
     const score = roi.isPredicted ? (roi as PredictedROI).score : Number.NaN;
     const isPredicted = roi.isPredicted ? 1 : 0;
     const trackingScore = roi.trackingScore ?? Number.NaN;
@@ -1047,7 +1369,10 @@ function writeBboxes(
     const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = bbox.track ? tracks.indexOf(bbox.track as any) : -1;
     const score = bbox.isPredicted ? (bbox as PredictedBoundingBox).score : Number.NaN;
-    const instanceIdx = bbox.instance ? instances.indexOf(bbox.instance as Instance) : -1;
+    // Fall back to stored _instanceIdx when no live instance link (e.g., lazy mode).
+    const instanceIdx = bbox.instance
+      ? instances.indexOf(bbox.instance as Instance)
+      : (bbox._instanceIdx ?? -1);
 
     const trackingScore = bbox.trackingScore ?? Number.NaN;
 
@@ -1228,7 +1553,10 @@ function writeCentroids(
     const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = c.track ? tracks.indexOf(c.track as any) : -1;
     const score = c.isPredicted ? (c as PredictedCentroid).score : Number.NaN;
-    const instanceIdx = c.instance ? instances.indexOf(c.instance as Instance) : -1;
+    // Fall back to stored _instanceIdx when no live instance link (e.g., lazy mode).
+    const instanceIdx = c.instance
+      ? instances.indexOf(c.instance as Instance)
+      : (c._instanceIdx ?? -1);
     const isPredicted = c.isPredicted ? 1 : 0;
     const trackingScore = c.trackingScore ?? Number.NaN;
 

--- a/src/io/geojson.ts
+++ b/src/io/geojson.ts
@@ -40,7 +40,6 @@ export function roisFromGeoJSON(
       name: String(props.name ?? ""),
       category: String(props.category ?? ""),
       source: String(props.source ?? ""),
-      frameIdx: typeof props.frame_idx === "number" ? props.frame_idx : null,
     });
   });
 }

--- a/src/io/trackmate.ts
+++ b/src/io/trackmate.ts
@@ -12,6 +12,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Labels } from "../model/labels.js";
+import { LabeledFrame } from "../model/labeled-frame.js";
 import { Track } from "../model/instance.js";
 import { PredictedCentroid } from "../model/centroid.js";
 import { Video } from "../model/video.js";
@@ -184,7 +185,7 @@ export function readTrackMateCsv(
   const tracks = [...trackMap.values()];
 
   // Build PredictedCentroid objects
-  const centroids: PredictedCentroid[] = [];
+  const centroidsByFrame = new Map<number, PredictedCentroid[]>();
   for (const row of dataRows) {
     const spotId = parseInt(row[col["ID"]], 10);
     const tidStr = row[col["TRACK_ID"]];
@@ -202,25 +203,27 @@ export function readTrackMateCsv(
     const trackingScore = targetToCost.get(spotId) ?? null;
     const label = col["LABEL"] !== undefined ? row[col["LABEL"]] : `ID${spotId}`;
 
-    centroids.push(
-      new PredictedCentroid({
-        x,
-        y,
-        z,
-        video: videoObj,
-        frameIdx,
-        track,
-        trackingScore,
-        score,
-        name: label,
-        source: "trackmate",
-      }),
-    );
+    const centroid = new PredictedCentroid({
+      x,
+      y,
+      z,
+      track,
+      trackingScore,
+      score,
+      name: label,
+      source: "trackmate",
+    });
+    centroidsByFrame.set(frameIdx, [...(centroidsByFrame.get(frameIdx) ?? []), centroid]);
   }
 
-  // Assemble Labels
+  // Assemble Labels with LabeledFrames
   const videos = videoObj ? [videoObj] : [];
-  const labels = new Labels({ videos, tracks, centroids });
+  const video = videoObj ?? new Video({ filename: "" });
+  const labeledFrames: LabeledFrame[] = [];
+  for (const [frameIdx, frameCentroids] of [...centroidsByFrame.entries()].sort((a, b) => a[0] - b[0])) {
+    labeledFrames.push(new LabeledFrame({ video, frameIdx, centroids: frameCentroids }));
+  }
+  const labels = new Labels({ labeledFrames, videos, tracks });
   labels.provenance["filename"] = spotsPath;
   return labels;
 }

--- a/src/model/bbox.ts
+++ b/src/model/bbox.ts
@@ -1,4 +1,3 @@
-import type { Video } from "./video.js";
 import type { Track, Instance } from "./instance.js";
 import type { SegmentationMask } from "./mask.js";
 import { ROI } from "./roi.js";
@@ -10,8 +9,6 @@ export interface BoundingBoxOptions {
   x2: number;
   y2: number;
   angle?: number;
-  video?: Video | null;
-  frameIdx?: number | null;
   track?: Track | null;
   instance?: Instance | null;
   trackingScore?: number | null;
@@ -27,8 +24,6 @@ export class BoundingBox {
   x2: number;
   y2: number;
   angle: number;
-  video: Video | null;
-  frameIdx: number | null;
   track: Track | null;
   trackingScore: number | null;
   instance: Instance | null;
@@ -49,8 +44,6 @@ export class BoundingBox {
     this.x2 = options.x2;
     this.y2 = options.y2;
     this.angle = options.angle ?? 0;
-    this.video = options.video ?? null;
-    this.frameIdx = options.frameIdx ?? null;
     this.track = options.track ?? null;
     this.trackingScore = options.trackingScore ?? null;
     this.instance = options.instance ?? null;
@@ -167,11 +160,6 @@ export class BoundingBox {
     return false;
   }
 
-  /** Whether the bbox has no temporal association. */
-  get isStatic(): boolean {
-    return this.frameIdx === null;
-  }
-
   /** Whether the bbox is rotated (angle != 0). */
   get isRotated(): boolean {
     return this.angle !== 0;
@@ -186,8 +174,6 @@ export class BoundingBox {
       name: this.name,
       category: this.category,
       source: this.source,
-      video: this.video,
-      frameIdx: this.frameIdx,
       track: this.track,
       instance: this.instance,
     });

--- a/src/model/centroid.ts
+++ b/src/model/centroid.ts
@@ -1,4 +1,3 @@
-import type { Video } from "./video.js";
 import type { Track } from "./instance.js";
 import { Instance, PredictedInstance, _registerCentroidFactory } from "./instance.js";
 import { Skeleton } from "./skeleton.js";
@@ -25,8 +24,6 @@ export interface CentroidOptions {
   x: number;
   y: number;
   z?: number | null;
-  video?: Video | null;
-  frameIdx?: number | null;
   track?: Track | null;
   trackingScore?: number | null;
   instance?: Instance | null;
@@ -38,8 +35,11 @@ export interface CentroidOptions {
 /**
  * A point representing the center of an object.
  *
- * Supports optional 3D coordinates, video/frame/track/instance metadata,
+ * Supports optional 3D coordinates, track/instance metadata,
  * and interconversion with single-node Instance objects.
+ *
+ * Spatial-temporal context (video, frame index) is derived from the parent
+ * LabeledFrame, matching how Instance/PredictedInstance work.
  *
  * This class is abstract. Use UserCentroid or PredictedCentroid.
  */
@@ -47,8 +47,6 @@ export class Centroid {
   x: number;
   y: number;
   z: number | null;
-  video: Video | null;
-  frameIdx: number | null;
   track: Track | null;
   trackingScore: number | null;
   instance: Instance | null;
@@ -67,8 +65,6 @@ export class Centroid {
     this.x = options.x;
     this.y = options.y;
     this.z = options.z ?? null;
-    this.video = options.video ?? null;
-    this.frameIdx = options.frameIdx ?? null;
     this.track = options.track ?? null;
     this.trackingScore = options.trackingScore ?? null;
     this.instance = options.instance ?? null;
@@ -95,11 +91,6 @@ export class Centroid {
   /** Whether this is a predicted centroid (has a score). */
   get isPredicted(): boolean {
     return false;
-  }
-
-  /** Whether the centroid has no temporal association. */
-  get isStatic(): boolean {
-    return this.frameIdx === null;
   }
 
   /**

--- a/src/model/label-image.ts
+++ b/src/model/label-image.ts
@@ -1,4 +1,3 @@
-import type { Video } from "./video.js";
 import type { Instance } from "./instance.js";
 import { Track } from "./instance.js";
 import { type BoundingBox, UserBoundingBox, PredictedBoundingBox } from "./bbox.js";
@@ -27,8 +26,6 @@ export interface LabelImageOptions {
   height: number;
   width: number;
   objects?: Map<number, LabelImageObjectInfo>;
-  video?: Video | null;
-  frameIdx?: number | null;
   source?: string;
   scale?: [number, number];
   offset?: [number, number];
@@ -49,8 +46,6 @@ export class LabelImage {
   width: number;
   /** Map from label ID (positive int) to object metadata. */
   objects: Map<number, LabelImageObjectInfo>;
-  video: Video | null;
-  frameIdx: number | null;
   source: string;
   /** Spatial scale factor: image_coord = li_coord / scale + offset. Default [1, 1]. */
   scale: [number, number];
@@ -74,8 +69,6 @@ export class LabelImage {
     this.height = options.height;
     this.width = options.width;
     this.objects = options.objects ?? new Map();
-    this.video = options.video ?? null;
-    this.frameIdx = options.frameIdx ?? null;
     this.source = options.source ?? "";
     this.scale = scale;
     this.offset = options.offset ?? [0, 0];
@@ -117,11 +110,6 @@ export class LabelImage {
     return cats;
   }
 
-  /** Whether this label image has no temporal association (frameIdx is null). */
-  get isStatic(): boolean {
-    return this.frameIdx === null;
-  }
-
   /** Whether this is a predicted label image (has a score). */
   get isPredicted(): boolean {
     return false;
@@ -156,8 +144,6 @@ export class LabelImage {
       height: targetHeight,
       width: targetWidth,
       objects: new Map(this.objects),
-      video: this.video,
-      frameIdx: this.frameIdx,
       source: this.source,
       scale: [1, 1],
       offset: [0, 0],
@@ -269,8 +255,6 @@ export class LabelImage {
     options?: {
       tracks?: Track[] | Map<number, Track>;
       categories?: string[] | Map<number, string>;
-      video?: Video | null;
-      frameIdx?: number | null;
       source?: string;
     },
   ): UserLabelImage {
@@ -344,8 +328,6 @@ export class LabelImage {
       height,
       width,
       objects,
-      video: options?.video ?? null,
-      frameIdx: options?.frameIdx ?? null,
       source: options?.source ?? "",
     });
   }
@@ -354,8 +336,6 @@ export class LabelImage {
   static fromMasks(
     masks: SegmentationMask[],
     options?: {
-      video?: Video | null;
-      frameIdx?: number | null;
       source?: string;
     },
   ): UserLabelImage {
@@ -407,8 +387,6 @@ export class LabelImage {
       height,
       width,
       objects,
-      video: options?.video ?? null,
-      frameIdx: options?.frameIdx ?? null,
       source: options?.source ?? "",
       scale,
       offset,
@@ -425,8 +403,6 @@ export class LabelImage {
    * @param options.categories - Category strings. Array (1-indexed) or Map<labelId, string>.
    * @param options.createTracks - If true and tracks is not provided, auto-create one Track
    *   per unique non-zero label ID found across ALL frames.
-   * @param options.frameIdx - Custom frame indices. Defaults to [0, 1, ..., T-1].
-   * @param options.video - Video reference shared across all frames.
    * @param options.source - Source string shared across all frames.
    */
   static fromStack(options: {
@@ -434,11 +410,9 @@ export class LabelImage {
     tracks?: Map<number, Track> | Track[] | null;
     categories?: Map<number, string> | string[] | null;
     createTracks?: boolean;
-    frameIdx?: number[] | null;
-    video?: Video | null;
     source?: string;
   }): UserLabelImage[] {
-    const { data, video, source } = options;
+    const { data, source } = options;
     if (data.length === 0) return [];
 
     // Determine height/width from first frame
@@ -497,14 +471,11 @@ export class LabelImage {
     const result: UserLabelImage[] = [];
     for (let t = 0; t < data.length; t++) {
       const frameData = data[t];
-      const frameIdx = options.frameIdx ? options.frameIdx[t] : t;
 
       result.push(
         LabelImage.fromArray(frameData as number[][], height, width, {
           tracks: trackMap,
           categories: catMap,
-          video,
-          frameIdx,
           source,
         }),
       );
@@ -545,8 +516,6 @@ export class LabelImage {
       names?: string[] | null;
       scores?: number[] | null;
       createTracks?: boolean;
-      video?: Video | null;
-      frameIdx?: number | null;
       source?: string;
       scale?: [number, number];
       offset?: [number, number];
@@ -711,8 +680,6 @@ export class LabelImage {
       height,
       width,
       objects,
-      video: options?.video ?? null,
-      frameIdx: options?.frameIdx ?? null,
       source: options?.source ?? "",
       scale: options?.scale,
       offset: options?.offset,
@@ -749,8 +716,6 @@ export class LabelImage {
         category: info.category,
         name: info.name,
         instance: info.instance,
-        video: this.video,
-        frameIdx: this.frameIdx,
         source: this.source,
         scale: [...this.scale] as [number, number],
         offset: [...this.offset] as [number, number],
@@ -826,8 +791,6 @@ export class LabelImage {
         y1,
         x2,
         y2,
-        video: this.video,
-        frameIdx: this.frameIdx,
         track: info.track,
         instance: info.instance,
         category: info.category,

--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -1,10 +1,10 @@
 import { Instance, PredictedInstance } from "./instance.js";
 import { Video } from "./video.js";
-import type { Centroid } from "./centroid.js";
-import type { BoundingBox } from "./bbox.js";
-import type { SegmentationMask } from "./mask.js";
-import type { LabelImage } from "./label-image.js";
-import type { ROI } from "./roi.js";
+import { Centroid } from "./centroid.js";
+import { BoundingBox } from "./bbox.js";
+import { SegmentationMask } from "./mask.js";
+import { LabelImage } from "./label-image.js";
+import { ROI } from "./roi.js";
 
 /** Strategy for merging annotation lists between frames. */
 export type MergeStrategy =
@@ -382,6 +382,42 @@ export class LabeledFrame {
           (this[attr] as unknown[]).push(_shallowCopy(item));
         }
       }
+    }
+  }
+
+  /**
+   * Append an annotation to this frame, routing to the correct list by type.
+   *
+   * @param annotation - Any annotation type: Instance, PredictedInstance,
+   *   Centroid, BoundingBox, SegmentationMask, LabelImage, or ROI.
+   * @throws TypeError if the annotation type is not recognized.
+   */
+  append(
+    annotation:
+      | Instance
+      | PredictedInstance
+      | Centroid
+      | BoundingBox
+      | SegmentationMask
+      | LabelImage
+      | ROI,
+  ): void {
+    if (annotation instanceof PredictedInstance || annotation instanceof Instance) {
+      this.instances.push(annotation);
+    } else if (annotation instanceof Centroid) {
+      this.centroids.push(annotation);
+    } else if (annotation instanceof BoundingBox) {
+      this.bboxes.push(annotation);
+    } else if (annotation instanceof SegmentationMask) {
+      this.masks.push(annotation);
+    } else if (annotation instanceof LabelImage) {
+      this.labelImages.push(annotation);
+    } else if (annotation instanceof ROI) {
+      this.rois.push(annotation);
+    } else {
+      throw new TypeError(
+        `Unknown annotation type: ${(annotation as object).constructor?.name ?? typeof annotation}`,
+      );
     }
   }
 

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -30,14 +30,8 @@ export class Labels {
   provenance: Record<string, unknown>;
   identities: Identity[];
 
-  // Annotation fields: accepted as constructor kwargs, distributed into
-  // LabeledFrames at init time. Undistributed annotations (video=null or
-  // frameIdx=null) are kept here. Access via property getters.
-  _initRois: ROI[];
-  _initMasks: SegmentationMask[];
-  _initBboxes: BoundingBox[];
-  _initCentroids: Centroid[];
-  _initLabelImages: LabelImage[];
+  // Static ROIs: not tied to any specific frame (e.g., arena boundaries).
+  _staticRois: ROI[];
 
   /** @internal Lazy frame list for on-demand materialization. */
   _lazyFrameList: LazyFrameList | null = null;
@@ -73,10 +67,6 @@ export class Labels {
     sessions?: RecordingSession[];
     provenance?: Record<string, unknown>;
     rois?: ROI[];
-    masks?: SegmentationMask[];
-    bboxes?: BoundingBox[];
-    centroids?: Centroid[];
-    labelImages?: LabelImage[];
     identities?: Identity[];
   }) {
     this.labeledFrames = options?.labeledFrames ?? [];
@@ -86,11 +76,7 @@ export class Labels {
     this.suggestions = options?.suggestions ?? [];
     this.sessions = options?.sessions ?? [];
     this.provenance = options?.provenance ?? {};
-    this._initRois = options?.rois ?? [];
-    this._initMasks = options?.masks ?? [];
-    this._initBboxes = options?.bboxes ?? [];
-    this._initCentroids = options?.centroids ?? [];
-    this._initLabelImages = options?.labelImages ?? [];
+    this._staticRois = options?.rois ?? [];
     this.identities = options?.identities ?? [];
 
     if (!this.videos.length && this.labeledFrames.length) {
@@ -121,61 +107,18 @@ export class Labels {
       this.tracks = Array.from(uniqueTracks.values());
     }
 
-    // Skip distribution for lazy Labels — annotations handled by LazyDataStore
+    // Collect tracks from annotations already on frames
     if (!this._lazyFrameList) {
-      this._distributeAnnotations();
-      // Collect tracks from annotations on frames
       for (const lf of this.labeledFrames) {
         this._collectAnnotationTracks(lf);
       }
     }
-  }
-
-  /** Distribute flat annotation lists into their corresponding LabeledFrames. */
-  private _distributeAnnotations(): void {
-    const frameMap = new Map<Video, Map<number, LabeledFrame>>();
-    for (const lf of this.labeledFrames) {
-      let byIdx = frameMap.get(lf.video);
-      if (!byIdx) { byIdx = new Map(); frameMap.set(lf.video, byIdx); }
-      byIdx.set(lf.frameIdx, lf);
+    // Collect tracks from static ROIs
+    for (const roi of this._staticRois) {
+      if (roi.track && !this.tracks.includes(roi.track)) {
+        this.tracks.push(roi.track);
+      }
     }
-
-    const getOrCreate = (video: Video, frameIdx: number): LabeledFrame => {
-      let byIdx = frameMap.get(video);
-      if (byIdx) {
-        const existing = byIdx.get(frameIdx);
-        if (existing) return existing;
-      } else {
-        byIdx = new Map();
-        frameMap.set(video, byIdx);
-      }
-      const lf = new LabeledFrame({ video, frameIdx });
-      byIdx.set(frameIdx, lf);
-      this.labeledFrames.push(lf);
-      return lf;
-    };
-
-    const distribute = <T extends { video: Video | null; frameIdx: number | null }>(
-      items: T[],
-      attr: "centroids" | "bboxes" | "masks" | "labelImages" | "rois",
-    ): T[] => {
-      const remaining: T[] = [];
-      for (const ann of items) {
-        if (ann.video !== null && ann.frameIdx !== null) {
-          const lf = getOrCreate(ann.video, ann.frameIdx);
-          (lf[attr] as unknown[]).push(ann);
-        } else {
-          remaining.push(ann);
-        }
-      }
-      return remaining;
-    };
-
-    this._initCentroids = distribute(this._initCentroids, "centroids");
-    this._initBboxes = distribute(this._initBboxes, "bboxes");
-    this._initMasks = distribute(this._initMasks, "masks");
-    this._initLabelImages = distribute(this._initLabelImages, "labelImages");
-    this._initRois = distribute(this._initRois, "rois");
   }
 
   /** Collect tracks from annotations on a frame into this.tracks. */
@@ -299,13 +242,24 @@ export class Labels {
         }
       }
     }
+    // Build annotation -> frameIdx map for sorting
+    const annFrameIdx = new Map<unknown, number>();
+    for (const lf of this.labeledFrames) {
+      for (const ann of [
+        ...lf.centroids, ...lf.bboxes, ...lf.masks, ...lf.rois,
+        ...lf.instances,
+      ]) {
+        annFrameIdx.set(ann, lf.frameIdx);
+      }
+      for (const li of lf.labelImages) {
+        annFrameIdx.set(li, lf.frameIdx);
+      }
+    }
     // Sort each list by frameIdx
     for (const videoMap of this._trackIndex.values()) {
       for (const list of videoMap.values()) {
         list.sort(
-          (a, b) =>
-            ((a as { frameIdx?: number | null }).frameIdx ?? 0) -
-            ((b as { frameIdx?: number | null }).frameIdx ?? 0),
+          (a, b) => (annFrameIdx.get(a) ?? 0) - (annFrameIdx.get(b) ?? 0),
         );
       }
     }
@@ -353,58 +307,6 @@ export class Labels {
     this._invalidateIndices();
   }
 
-  /** Find an existing LabeledFrame or create a new one. */
-  private _findOrCreateFrame(video: Video, frameIdx: number): LabeledFrame {
-    const existing = this.getFrame(video, frameIdx);
-    if (existing) return existing;
-    const lf = new LabeledFrame({ video, frameIdx });
-    this.labeledFrames.push(lf);
-    this._invalidateIndices();
-    return lf;
-  }
-
-  /** Add an annotation to the appropriate LabeledFrame. */
-  private _addAnnotation(
-    annotation: { video: Video | null; frameIdx: number | null; track?: Track | null },
-    attr: "centroids" | "bboxes" | "masks" | "labelImages" | "rois",
-  ): void {
-    if (annotation.video === null || annotation.frameIdx === null) {
-      throw new Error(`Annotation must have video and frameIdx set.`);
-    }
-    const lf = this._findOrCreateFrame(annotation.video, annotation.frameIdx);
-    (lf[attr] as unknown[]).push(annotation);
-    this._invalidateIndices();
-    if (!this.videos.includes(annotation.video)) this.videos.push(annotation.video);
-    if (annotation.track && !this.tracks.includes(annotation.track)) {
-      this.tracks.push(annotation.track);
-    }
-  }
-
-  addCentroid(centroid: Centroid): void {
-    this._addAnnotation(centroid, "centroids");
-  }
-
-  addBbox(bbox: BoundingBox): void {
-    this._addAnnotation(bbox, "bboxes");
-  }
-
-  addMask(mask: SegmentationMask): void {
-    this._addAnnotation(mask, "masks");
-  }
-
-  addLabelImage(labelImage: LabelImage): void {
-    this._addAnnotation(labelImage, "labelImages");
-    for (const info of labelImage.objects.values()) {
-      if (info.track && !this.tracks.includes(info.track)) {
-        this.tracks.push(info.track);
-      }
-    }
-  }
-
-  addRoi(roi: ROI): void {
-    this._addAnnotation(roi, "rois");
-  }
-
   /** Remove all predicted instances and predicted annotations from all frames. */
   removePredictions(): void {
     if (this._lazyFrameList) this.materialize();
@@ -421,10 +323,7 @@ export class Labels {
       const undist = this._lazyDataStore._undistributedCentroids;
       return [...undist, ...[...byFrame.values()].flat()];
     }
-    return [
-      ...this._initCentroids,
-      ...this.labeledFrames.flatMap((lf) => lf.centroids),
-    ];
+    return this.labeledFrames.flatMap((lf) => lf.centroids);
   }
 
   /** Flat view of all bounding boxes across all frames. */
@@ -434,10 +333,7 @@ export class Labels {
       const undist = this._lazyDataStore._undistributedBboxes;
       return [...undist, ...[...byFrame.values()].flat()];
     }
-    return [
-      ...this._initBboxes,
-      ...this.labeledFrames.flatMap((lf) => lf.bboxes),
-    ];
+    return this.labeledFrames.flatMap((lf) => lf.bboxes);
   }
 
   /** Flat view of all segmentation masks across all frames. */
@@ -447,10 +343,7 @@ export class Labels {
       const undist = this._lazyDataStore._undistributedMasks;
       return [...undist, ...[...byFrame.values()].flat()];
     }
-    return [
-      ...this._initMasks,
-      ...this.labeledFrames.flatMap((lf) => lf.masks),
-    ];
+    return this.labeledFrames.flatMap((lf) => lf.masks);
   }
 
   /** Flat view of all label images across all frames. */
@@ -460,13 +353,10 @@ export class Labels {
       const undist = this._lazyDataStore._undistributedLabelImages;
       return [...undist, ...[...byFrame.values()].flat()];
     }
-    return [
-      ...this._initLabelImages,
-      ...this.labeledFrames.flatMap((lf) => lf.labelImages),
-    ];
+    return this.labeledFrames.flatMap((lf) => lf.labelImages);
   }
 
-  /** Flat view of all ROIs across all frames. */
+  /** Flat view of all ROIs across all frames and static ROIs. */
   get rois(): ROI[] {
     if (this._lazyFrameList && this._lazyDataStore) {
       const byFrame = this._lazyDataStore._roiByFrame;
@@ -474,7 +364,7 @@ export class Labels {
       return [...undist, ...[...byFrame.values()].flat()];
     }
     return [
-      ...this._initRois,
+      ...this._staticRois,
       ...this.labeledFrames.flatMap((lf) => lf.rois),
     ];
   }
@@ -517,13 +407,9 @@ export class Labels {
       }
     }
 
-    // Keep undistributed annotations from the store
+    // Keep undistributed ROIs as static ROIs
     if (store) {
-      this._initRois = store._undistributedRois;
-      this._initMasks = store._undistributedMasks;
-      this._initBboxes = store._undistributedBboxes;
-      this._initCentroids = store._undistributedCentroids;
-      this._initLabelImages = store._undistributedLabelImages;
+      this._staticRois = store._undistributedRois;
     }
   }
 
@@ -591,12 +477,14 @@ export class Labels {
     return toDict(this, options);
   }
 
+  /** Static ROIs (not attached to any LabeledFrame). */
   get staticRois(): ROI[] {
-    return this.rois.filter((roi) => roi.isStatic);
+    return [...this._staticRois];
   }
 
+  /** Frame-bound ROIs (attached to LabeledFrames). */
   get temporalRois(): ROI[] {
-    return this.rois.filter((roi) => !roi.isStatic);
+    return this.labeledFrames.flatMap((lf) => lf.rois);
   }
 
   getRois(filters?: {
@@ -608,19 +496,24 @@ export class Labels {
     predicted?: boolean;
   }): ROI[] {
     if (!filters) return [...this.rois];
-    // Fast path: O(1) frame lookup when both video and frameIdx given
     let results: ROI[];
     if (filters.video !== undefined && filters.frameIdx !== undefined) {
       const lf = this.getFrame(filters.video, filters.frameIdx);
       results = lf ? lf.rois : [];
+    } else if (filters.video !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.video === filters.video) results.push(...lf.rois);
+      }
+      // Also include static ROIs for the video
+      results.push(...this._staticRois.filter((r) => r.video === filters.video));
+    } else if (filters.frameIdx !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.frameIdx === filters.frameIdx) results.push(...lf.rois);
+      }
     } else {
       results = this.rois;
-      if (filters.video !== undefined) {
-        results = results.filter((r) => r.video === filters.video);
-      }
-      if (filters.frameIdx !== undefined) {
-        results = results.filter((r) => r.frameIdx === filters.frameIdx);
-      }
     }
     if (filters.category !== undefined) {
       results = results.filter((r) => r.category === filters.category);
@@ -650,14 +543,18 @@ export class Labels {
     if (filters.video !== undefined && filters.frameIdx !== undefined) {
       const lf = this.getFrame(filters.video, filters.frameIdx);
       results = lf ? lf.masks : [];
+    } else if (filters.video !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.video === filters.video) results.push(...lf.masks);
+      }
+    } else if (filters.frameIdx !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.frameIdx === filters.frameIdx) results.push(...lf.masks);
+      }
     } else {
       results = this.masks;
-      if (filters.video !== undefined) {
-        results = results.filter((m) => m.video === filters.video);
-      }
-      if (filters.frameIdx !== undefined) {
-        results = results.filter((m) => m.frameIdx === filters.frameIdx);
-      }
     }
     if (filters.category !== undefined) {
       results = results.filter((m) => m.category === filters.category);
@@ -674,14 +571,6 @@ export class Labels {
     return results;
   }
 
-  get staticBboxes(): BoundingBox[] {
-    return this.bboxes.filter((b) => b.isStatic);
-  }
-
-  get temporalBboxes(): BoundingBox[] {
-    return this.bboxes.filter((b) => !b.isStatic);
-  }
-
   getBboxes(filters?: {
     video?: Video;
     frameIdx?: number;
@@ -695,14 +584,18 @@ export class Labels {
     if (filters.video !== undefined && filters.frameIdx !== undefined) {
       const lf = this.getFrame(filters.video, filters.frameIdx);
       results = lf ? lf.bboxes : [];
+    } else if (filters.video !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.video === filters.video) results.push(...lf.bboxes);
+      }
+    } else if (filters.frameIdx !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.frameIdx === filters.frameIdx) results.push(...lf.bboxes);
+      }
     } else {
       results = this.bboxes;
-      if (filters.video !== undefined) {
-        results = results.filter((b) => b.video === filters.video);
-      }
-      if (filters.frameIdx !== undefined) {
-        results = results.filter((b) => b.frameIdx === filters.frameIdx);
-      }
     }
     if (filters.category !== undefined) {
       results = results.filter((b) => b.category === filters.category);
@@ -732,14 +625,18 @@ export class Labels {
     if (filters.video !== undefined && filters.frameIdx !== undefined) {
       const lf = this.getFrame(filters.video, filters.frameIdx);
       results = lf ? lf.centroids : [];
+    } else if (filters.video !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.video === filters.video) results.push(...lf.centroids);
+      }
+    } else if (filters.frameIdx !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.frameIdx === filters.frameIdx) results.push(...lf.centroids);
+      }
     } else {
       results = this.centroids;
-      if (filters.video !== undefined) {
-        results = results.filter((c) => c.video === filters.video);
-      }
-      if (filters.frameIdx !== undefined) {
-        results = results.filter((c) => c.frameIdx === filters.frameIdx);
-      }
     }
     if (filters.category !== undefined) {
       results = results.filter((c) => c.category === filters.category);
@@ -756,14 +653,6 @@ export class Labels {
     return results;
   }
 
-  get staticLabelImages(): LabelImage[] {
-    return this.labelImages.filter((li) => li.isStatic);
-  }
-
-  get temporalLabelImages(): LabelImage[] {
-    return this.labelImages.filter((li) => !li.isStatic);
-  }
-
   getLabelImages(filters?: {
     video?: Video;
     frameIdx?: number;
@@ -776,14 +665,18 @@ export class Labels {
     if (filters.video !== undefined && filters.frameIdx !== undefined) {
       const lf = this.getFrame(filters.video, filters.frameIdx);
       results = lf ? lf.labelImages : [];
+    } else if (filters.video !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.video === filters.video) results.push(...lf.labelImages);
+      }
+    } else if (filters.frameIdx !== undefined) {
+      results = [];
+      for (const lf of this.labeledFrames) {
+        if (lf.frameIdx === filters.frameIdx) results.push(...lf.labelImages);
+      }
     } else {
       results = this.labelImages;
-      if (filters.video !== undefined) {
-        results = results.filter((li) => li.video === filters.video);
-      }
-      if (filters.frameIdx !== undefined) {
-        results = results.filter((li) => li.frameIdx === filters.frameIdx);
-      }
     }
     if (filters.track !== undefined) {
       results = results.filter((li) =>
@@ -837,21 +730,9 @@ export class Labels {
       const mapped = videoMap.get(frame.video);
       if (mapped) frame.video = mapped;
 
-      // Update nested annotations
-      for (const c of frame.centroids) {
-        if (c.video && videoMap.has(c.video)) c.video = videoMap.get(c.video)!;
-      }
-      for (const b of frame.bboxes) {
-        if (b.video && videoMap.has(b.video)) b.video = videoMap.get(b.video)!;
-      }
-      for (const m of frame.masks) {
-        if (m.video && videoMap.has(m.video)) m.video = videoMap.get(m.video)!;
-      }
+      // Update ROIs that have video references
       for (const r of frame.rois) {
         if (r.video && videoMap.has(r.video)) r.video = videoMap.get(r.video)!;
-      }
-      for (const li of frame.labelImages) {
-        if (li.video && videoMap.has(li.video)) li.video = videoMap.get(li.video)!;
       }
     }
 
@@ -860,17 +741,9 @@ export class Labels {
       if (mapped) suggestion.video = mapped;
     }
 
-    // Update undistributed annotations (e.g., static ROIs with frameIdx=null)
-    for (const ann of [
-      ...this._initCentroids,
-      ...this._initBboxes,
-      ...this._initMasks,
-      ...this._initRois,
-    ] as any[]) {
-      if (ann.video && videoMap.has(ann.video)) ann.video = videoMap.get(ann.video)!;
-    }
-    for (const li of this._initLabelImages) {
-      if (li.video && videoMap.has(li.video)) li.video = videoMap.get(li.video)!;
+    // Update static ROIs
+    for (const roi of this._staticRois) {
+      if (roi.video && videoMap.has(roi.video)) roi.video = videoMap.get(roi.video)!;
     }
 
     this.videos = this.videos.map((v) => videoMap!.get(v) ?? v);
@@ -1098,11 +971,7 @@ export class Labels {
         }),
         sessions: structuredClone(this.sessions),
         provenance: { ...this.provenance },
-        rois: cloneAncillary(this._initRois),
-        masks: cloneAncillary(this._initMasks),
-        bboxes: cloneAncillary(this._initBboxes),
-        centroids: cloneAncillary(this._initCentroids),
-        labelImages: cloneAncillary(this._initLabelImages),
+        rois: cloneAncillary(this._staticRois),
         identities: structuredClone(this.identities),
       });
     }

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -487,6 +487,18 @@ export class Labels {
     return this.labeledFrames.flatMap((lf) => lf.rois);
   }
 
+  /**
+   * Filter ROIs across the Labels object.
+   *
+   * Filtering rule (matches sibling getters like `getMasks`/`getBboxes`):
+   *   - Frame-aware filters (`video` or `frameIdx`) walk only `labeledFrames`.
+   *     Static ROIs are excluded from these results.
+   *   - Otherwise (no filter, or only `category`/`track`/`instance`/`predicted`)
+   *     the search runs over `this.rois` — the union of static + frame-bound.
+   *
+   * To access static ROIs directly, use `staticRois`. To access only frame-bound
+   * ROIs across all frames, use `temporalRois`.
+   */
   getRois(filters?: {
     video?: Video;
     frameIdx?: number;
@@ -505,8 +517,6 @@ export class Labels {
       for (const lf of this.labeledFrames) {
         if (lf.video === filters.video) results.push(...lf.rois);
       }
-      // Also include static ROIs for the video
-      results.push(...this._staticRois.filter((r) => r.video === filters.video));
     } else if (filters.frameIdx !== undefined) {
       results = [];
       for (const lf of this.labeledFrames) {

--- a/src/model/mask.ts
+++ b/src/model/mask.ts
@@ -1,4 +1,3 @@
-import type { Video } from "./video.js";
 import type { Track, Instance } from "./instance.js";
 import { ROI, _registerMaskFactory } from "./roi.js";
 import type { Geometry } from "./roi.js";
@@ -85,8 +84,6 @@ export interface SegmentationMaskOptions {
   name?: string;
   category?: string;
   source?: string;
-  video?: Video | null;
-  frameIdx?: number | null;
   track?: Track | null;
   trackingScore?: number | null;
   instance?: Instance | null;
@@ -101,8 +98,6 @@ export class SegmentationMask {
   name: string;
   category: string;
   source: string;
-  video: Video | null;
-  frameIdx: number | null;
   track: Track | null;
   trackingScore: number | null = null;
   instance: Instance | null;
@@ -129,8 +124,6 @@ export class SegmentationMask {
     this.name = options.name ?? "";
     this.category = options.category ?? "";
     this.source = options.source ?? "";
-    this.video = options.video ?? null;
-    this.frameIdx = options.frameIdx ?? null;
     this.track = options.track ?? null;
     this.trackingScore = options.trackingScore ?? null;
     this.instance = options.instance ?? null;
@@ -219,8 +212,6 @@ export class SegmentationMask {
       name: this.name,
       category: this.category,
       source: this.source,
-      video: this.video,
-      frameIdx: this.frameIdx,
       track: this.track,
       instance: this.instance,
       scale: [1, 1],
@@ -292,8 +283,6 @@ export class SegmentationMask {
       y1: y,
       x2: x + width,
       y2: y + height,
-      video: this.video,
-      frameIdx: this.frameIdx,
       track: this.track,
       instance: this.instance,
       category: this.category,
@@ -337,8 +326,6 @@ export class SegmentationMask {
         name: this.name,
         category: this.category,
         source: this.source,
-        video: this.video,
-        frameIdx: this.frameIdx,
         track: this.track,
         instance: this.instance,
       },

--- a/src/model/roi.ts
+++ b/src/model/roi.ts
@@ -38,7 +38,6 @@ export interface ROIOptions {
   category?: string;
   source?: string;
   video?: Video | null;
-  frameIdx?: number | null;
   track?: Track | null;
   trackingScore?: number | null;
   instance?: Instance | null;
@@ -50,7 +49,6 @@ export class ROI {
   category: string;
   source: string;
   video: Video | null;
-  frameIdx: number | null;
   track: Track | null;
   trackingScore: number | null = null;
   instance: Instance | null;
@@ -68,7 +66,6 @@ export class ROI {
     this.category = options.category ?? "";
     this.source = options.source ?? "";
     this.video = options.video ?? null;
-    this.frameIdx = options.frameIdx ?? null;
     this.track = options.track ?? null;
     this.trackingScore = options.trackingScore ?? null;
     this.instance = options.instance ?? null;
@@ -169,7 +166,6 @@ export class ROI {
       category: this.category,
       source: this.source,
       video: this.video,
-      frameIdx: this.frameIdx,
       track: this.track,
       trackingScore: this.trackingScore,
       instance: this.instance,
@@ -212,14 +208,8 @@ export class ROI {
         name: this.name,
         category: this.category,
         source: this.source,
-        frame_idx: this.frameIdx,
-        roi_type: this.isStatic ? "static" : "temporal",
       },
     };
-  }
-
-  get isStatic(): boolean {
-    return this.frameIdx === null;
   }
 
   get isBbox(): boolean {
@@ -303,8 +293,6 @@ export class ROI {
       name: this.name,
       category: this.category,
       source: this.source,
-      video: this.video,
-      frameIdx: this.frameIdx,
       track: this.track,
       instance: this.instance,
     });

--- a/tests/bbox.test.ts
+++ b/tests/bbox.test.ts
@@ -20,7 +20,6 @@ describe("BoundingBox", () => {
     expect(bb.height).toBe(80);
     expect(bb.angle).toBe(0);
     expect(bb.isPredicted).toBe(false);
-    expect(bb.isStatic).toBe(true);
     expect(bb.isRotated).toBe(false);
   });
 
@@ -102,9 +101,10 @@ describe("BoundingBox", () => {
     expect(xywh.height).toBe(80);
   });
 
-  it("isStatic when frameIdx is set", () => {
-    const bb = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90, frameIdx: 5 });
-    expect(bb.isStatic).toBe(false);
+  it("no longer has isStatic or frameIdx", () => {
+    const bb = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
+    expect((bb as any).isStatic).toBeUndefined();
+    expect((bb as any).frameIdx).toBeUndefined();
   });
 
   it("centroidXy returns [x, y] tuple", () => {

--- a/tests/centroid.test.ts
+++ b/tests/centroid.test.ts
@@ -11,6 +11,7 @@ import { Instance, PredictedInstance, Track } from "../src/model/instance.js";
 import { Skeleton } from "../src/model/skeleton.js";
 import { Labels } from "../src/model/labels.js";
 import { Video } from "../src/model/video.js";
+import { LabeledFrame } from "../src/model/labeled-frame.js";
 
 describe("Centroid", () => {
   it("is abstract — cannot be instantiated directly", () => {
@@ -22,8 +23,6 @@ describe("Centroid", () => {
     expect(c.x).toBe(10.5);
     expect(c.y).toBe(20.3);
     expect(c.z).toBeNull();
-    expect(c.video).toBeNull();
-    expect(c.frameIdx).toBeNull();
     expect(c.track).toBeNull();
     expect(c.trackingScore).toBeNull();
     expect(c.instance).toBeNull();
@@ -31,27 +30,24 @@ describe("Centroid", () => {
     expect(c.name).toBe("");
     expect(c.source).toBe("");
     expect(c.isPredicted).toBe(false);
-    expect(c.isStatic).toBe(true);
   });
 
   it("constructs UserCentroid with all options", () => {
     const track = new Track("track1");
     const c = new UserCentroid({
       x: 100, y: 200, z: 1.5,
-      frameIdx: 5, track,
+      track,
       trackingScore: 0.8,
       category: "cell",
       name: "ID42",
       source: "center_of_mass",
     });
     expect(c.z).toBe(1.5);
-    expect(c.frameIdx).toBe(5);
     expect(c.track).toBe(track);
     expect(c.trackingScore).toBe(0.8);
     expect(c.category).toBe("cell");
     expect(c.name).toBe("ID42");
     expect(c.source).toBe("center_of_mass");
-    expect(c.isStatic).toBe(false);
   });
 
   it("constructs PredictedCentroid with score", () => {
@@ -247,12 +243,19 @@ describe("Labels.getCentroids", () => {
     const v1 = new Video({ filename: "v1.mp4" });
     const v2 = new Video({ filename: "v2.mp4" });
     const t1 = new Track("t1");
-    const centroids = [
-      new UserCentroid({ x: 1, y: 2, video: v1, frameIdx: 0 }),
-      new UserCentroid({ x: 3, y: 4, video: v1, frameIdx: 1 }),
-      new PredictedCentroid({ x: 5, y: 6, video: v2, frameIdx: 0, score: 0.9, track: t1 }),
-    ];
-    const labels = new Labels({ centroids, videos: [v1, v2], tracks: [t1] });
+
+    const lf0v1 = new LabeledFrame({ video: v1, frameIdx: 0 });
+    lf0v1.centroids.push(new UserCentroid({ x: 1, y: 2 }));
+    const lf1v1 = new LabeledFrame({ video: v1, frameIdx: 1 });
+    lf1v1.centroids.push(new UserCentroid({ x: 3, y: 4 }));
+    const lf0v2 = new LabeledFrame({ video: v2, frameIdx: 0 });
+    lf0v2.centroids.push(new PredictedCentroid({ x: 5, y: 6, score: 0.9, track: t1 }));
+
+    const labels = new Labels({
+      labeledFrames: [lf0v1, lf1v1, lf0v2],
+      videos: [v1, v2],
+      tracks: [t1],
+    });
 
     expect(labels.getCentroids()).toHaveLength(3);
     expect(labels.getCentroids({ video: v1 })).toHaveLength(2);

--- a/tests/geojson.test.ts
+++ b/tests/geojson.test.ts
@@ -64,6 +64,5 @@ describe("GeoJSON I/O", () => {
     expect(rois).toHaveLength(1);
     expect(rois[0].name).toBe("");
     expect(rois[0].category).toBe("");
-    expect(rois[0].frameIdx).toBe(null);
   });
 });

--- a/tests/label-image-slp.test.ts
+++ b/tests/label-image-slp.test.ts
@@ -37,16 +37,16 @@ describe("LabelImage SLP I/O", () => {
         [1, { track: track1, category: "neuron", name: "cell_A", instance: null }],
         [2, { track: track2, category: "glia", name: "cell_B", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
       source: "cellpose",
     });
 
+    const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
+
     const labels = new Labels({
+      labeledFrames: [lf],
       videos: [video],
       skeletons: [skeleton],
       tracks: [track1, track2],
-      labelImages: [li],
     });
 
     const loaded = await roundTrip(labels);
@@ -56,10 +56,7 @@ describe("LabelImage SLP I/O", () => {
     expect(loadedLi.height).toBe(10);
     expect(loadedLi.width).toBe(10);
     expect(loadedLi.nObjects).toBe(2);
-    expect(loadedLi.frameIdx).toBe(0);
     expect(loadedLi.source).toBe("cellpose");
-    expect(loadedLi.video).not.toBeNull();
-    expect(loadedLi.video!.filename).toBe("test.mp4");
 
     const obj1 = loadedLi.objects.get(1);
     expect(obj1).toBeDefined();
@@ -109,14 +106,14 @@ describe("LabelImage SLP I/O", () => {
         [2, { track: null, category: "", name: "", instance: null }],
         [3, { track: null, category: "", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
     });
 
+    const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
+
     const labels = new Labels({
+      labeledFrames: [lf],
       videos: [video],
       skeletons: [skeleton],
-      labelImages: [li],
     });
 
     const loaded = await roundTrip(labels);
@@ -144,15 +141,13 @@ describe("LabelImage SLP I/O", () => {
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track: null, category: "", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
     });
+    frame.labelImages.push(li);
 
     const labelsWithLI = new Labels({
       labeledFrames: [frame],
       videos: [video],
       skeletons: [skeleton],
-      labelImages: [li],
     });
 
     const loadedWithLI = await roundTrip(labelsWithLI);
@@ -160,19 +155,17 @@ describe("LabelImage SLP I/O", () => {
     expect(loadedWithLI.labelImages[0].data[0]).toBe(1);
 
     // Labels with bboxes but no labelImages (format 2.0) should also round-trip
-    // Use a fresh frame to avoid shared mutation from the previous Labels
     const inst2 = new Instance({ points: { a: [1, 2] }, skeleton });
     const frame2 = new LabeledFrame({ video, frameIdx: 0, instances: [inst2] });
     const bb = new UserBoundingBox({
       x1: 0, y1: 10, x2: 100, y2: 90,
-      video, frameIdx: 0,
     });
+    frame2.bboxes.push(bb);
 
     const labelsWithBbox = new Labels({
       labeledFrames: [frame2],
       videos: [video],
       skeletons: [skeleton],
-      bboxes: [bb],
     });
 
     const loadedWithBbox = await roundTrip(labelsWithBbox);
@@ -185,7 +178,7 @@ describe("LabelImage SLP I/O", () => {
     const skeleton = new Skeleton({ nodes: ["a"] });
     const track = new Track("t1");
 
-    const labelImages: LabelImage[] = [];
+    const frames: LabeledFrame[] = [];
     for (const frameIdx of [0, 5, 10]) {
       const data = new Int32Array(8 * 8);
       // Each frame gets a unique pattern: fill first N pixels where N = frameIdx + 1
@@ -193,26 +186,24 @@ describe("LabelImage SLP I/O", () => {
         data[i] = 1;
       }
 
-      labelImages.push(
-        new UserLabelImage({
-          data,
-          height: 8,
-          width: 8,
-          objects: new Map<number, LabelImageObjectInfo>([
-            [1, { track, category: "cell", name: `frame_${frameIdx}`, instance: null }],
-          ]),
-          video,
-          frameIdx,
-          source: "auto",
-        }),
-      );
+      const li = new UserLabelImage({
+        data,
+        height: 8,
+        width: 8,
+        objects: new Map<number, LabelImageObjectInfo>([
+          [1, { track, category: "cell", name: `frame_${frameIdx}`, instance: null }],
+        ]),
+        source: "auto",
+      });
+
+      frames.push(new LabeledFrame({ video, frameIdx, labelImages: [li] }));
     }
 
     const labels = new Labels({
+      labeledFrames: frames,
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      labelImages,
     });
 
     const loaded = await roundTrip(labels);
@@ -222,8 +213,10 @@ describe("LabelImage SLP I/O", () => {
     // Verify each frame
     for (let i = 0; i < 3; i++) {
       const expectedFrameIdx = [0, 5, 10][i];
-      const loadedLi = loaded.labelImages[i];
-      expect(loadedLi.frameIdx).toBe(expectedFrameIdx);
+      const loadedLf = loaded.labeledFrames[i];
+      expect(loadedLf.frameIdx).toBe(expectedFrameIdx);
+      expect(loadedLf.labelImages).toHaveLength(1);
+      const loadedLi = loadedLf.labelImages[0];
       expect(loadedLi.height).toBe(8);
       expect(loadedLi.width).toBe(8);
       expect(loadedLi.source).toBe("auto");
@@ -256,47 +249,44 @@ describe("LabelImage SLP I/O", () => {
       return d;
     };
 
-    const li1 = new UserLabelImage({
+    const lf0 = new LabeledFrame({ video, frameIdx: 0 });
+    lf0.labelImages.push(new UserLabelImage({
       data: makeData(),
       height: 4,
       width: 4,
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track: trackA, category: "neuron", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
       source: "model",
-    });
+    }));
 
-    const li2 = new UserLabelImage({
+    const lf5 = new LabeledFrame({ video, frameIdx: 5 });
+    lf5.labelImages.push(new UserLabelImage({
       data: makeData(),
       height: 4,
       width: 4,
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track: trackB, category: "glia", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 5,
       source: "model",
-    });
+    }));
 
-    const li3 = new UserLabelImage({
+    const lf10 = new LabeledFrame({ video, frameIdx: 10 });
+    lf10.labelImages.push(new UserLabelImage({
       data: makeData(),
       height: 4,
       width: 4,
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track: trackA, category: "neuron", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 10,
       source: "model",
-    });
+    }));
 
     const labels = new Labels({
+      labeledFrames: [lf0, lf5, lf10],
       videos: [video],
       skeletons: [skeleton],
       tracks: [trackA, trackB],
-      labelImages: [li1, li2, li3],
     });
 
     const loaded = await roundTrip(labels);
@@ -305,11 +295,9 @@ describe("LabelImage SLP I/O", () => {
     // Filter by frameIdx
     const atFrame0 = loaded.getLabelImages({ frameIdx: 0 });
     expect(atFrame0).toHaveLength(1);
-    expect(atFrame0[0].frameIdx).toBe(0);
 
     const atFrame5 = loaded.getLabelImages({ frameIdx: 5 });
     expect(atFrame5).toHaveLength(1);
-    expect(atFrame5[0].frameIdx).toBe(5);
 
     // Filter by track
     const loadedTrackA = loaded.tracks.find((t) => t.name === "trackA")!;
@@ -319,11 +307,9 @@ describe("LabelImage SLP I/O", () => {
 
     const withTrackA = loaded.getLabelImages({ track: loadedTrackA });
     expect(withTrackA).toHaveLength(2);
-    expect(withTrackA.map((li) => li.frameIdx).sort()).toEqual([0, 10]);
 
     const withTrackB = loaded.getLabelImages({ track: loadedTrackB });
     expect(withTrackB).toHaveLength(1);
-    expect(withTrackB[0].frameIdx).toBe(5);
 
     // Filter by category
     const neurons = loaded.getLabelImages({ category: "neuron" });
@@ -331,7 +317,6 @@ describe("LabelImage SLP I/O", () => {
 
     const glia = loaded.getLabelImages({ category: "glia" });
     expect(glia).toHaveLength(1);
-    expect(glia[0].frameIdx).toBe(5);
   });
 
   it("round-trips empty label image (all zeros, no objects)", async () => {
@@ -345,15 +330,15 @@ describe("LabelImage SLP I/O", () => {
       height: 6,
       width: 6,
       objects: new Map(),
-      video,
-      frameIdx: 3,
       source: "empty",
     });
 
+    const lf = new LabeledFrame({ video, frameIdx: 3, labelImages: [li] });
+
     const labels = new Labels({
+      labeledFrames: [lf],
       videos: [video],
       skeletons: [skeleton],
-      labelImages: [li],
     });
 
     const loaded = await roundTrip(labels);
@@ -363,8 +348,10 @@ describe("LabelImage SLP I/O", () => {
     expect(loadedLi.height).toBe(6);
     expect(loadedLi.width).toBe(6);
     expect(loadedLi.nObjects).toBe(0);
-    expect(loadedLi.frameIdx).toBe(3);
     expect(loadedLi.source).toBe("empty");
+
+    // Verify frame index
+    expect(loaded.labeledFrames[0].frameIdx).toBe(3);
 
     // All pixels should be zero
     for (let i = 0; i < loadedLi.data.length; i++) {
@@ -394,16 +381,14 @@ describe("LabelImage SLP I/O", () => {
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track, category: "cell", name: "inst_obj", instance }],
       ]),
-      video,
-      frameIdx: 0,
     });
+    frame.labelImages.push(li);
 
     const labels = new Labels({
       labeledFrames: [frame],
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      labelImages: [li],
     });
 
     const loaded = await roundTrip(labels);
@@ -433,16 +418,16 @@ describe("LabelImage SLP I/O", () => {
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track, category: "cell", name: "lazy_test", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
       source: "test",
     });
 
+    const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
+
     const labels = new Labels({
+      labeledFrames: [lf],
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      labelImages: [li],
     });
 
     const bytes = await saveSlpToBytes(labels);

--- a/tests/label-image.test.ts
+++ b/tests/label-image.test.ts
@@ -62,8 +62,6 @@ describe("LabelImage", () => {
       expect(li.height).toBe(2);
       expect(li.width).toBe(2);
       expect(li.objects.size).toBe(0);
-      expect(li.video).toBeNull();
-      expect(li.frameIdx).toBeNull();
       expect(li.source).toBe("");
     });
 
@@ -82,11 +80,9 @@ describe("LabelImage", () => {
         height,
         width,
         objects,
-        frameIdx: 5,
         source: "cellpose",
       });
       expect(li.objects.size).toBe(2);
-      expect(li.frameIdx).toBe(5);
       expect(li.source).toBe("cellpose");
     });
   });
@@ -185,17 +181,12 @@ describe("LabelImage", () => {
     });
   });
 
-  describe("isStatic", () => {
-    it("is true when frameIdx is null", () => {
+  describe("no longer has isStatic or frameIdx", () => {
+    it("does not have isStatic or frameIdx properties", () => {
       const { data, height, width } = makeLabelData([[0]]);
       const li = new UserLabelImage({ data, height, width });
-      expect(li.isStatic).toBe(true);
-    });
-
-    it("is false when frameIdx is set", () => {
-      const { data, height, width } = makeLabelData([[0]]);
-      const li = new UserLabelImage({ data, height, width, frameIdx: 0 });
-      expect(li.isStatic).toBe(false);
+      expect((li as any).isStatic).toBeUndefined();
+      expect((li as any).frameIdx).toBeUndefined();
     });
   });
 
@@ -406,13 +397,11 @@ describe("LabelImage", () => {
       expect(li.objects.get(3)!.category).toBe("nucleus");
     });
 
-    it("passes through video, frameIdx, source", () => {
+    it("passes through source", () => {
       const flat = new Int32Array([0, 1]);
       const li = LabelImage.fromArray(flat, 1, 2, {
-        frameIdx: 42,
         source: "stardist",
       });
-      expect(li.frameIdx).toBe(42);
       expect(li.source).toBe("stardist");
     });
   });
@@ -649,8 +638,6 @@ describe("LabelImage.fromStack", () => {
     const frame2 = [[0, 1], [2, 0]];
     const result = LabelImage.fromStack({ data: [frame1, frame2] });
     expect(result).toHaveLength(2);
-    expect(result[0].frameIdx).toBe(0);
-    expect(result[1].frameIdx).toBe(1);
     expect(result[0].height).toBe(2);
     expect(result[0].width).toBe(2);
   });
@@ -683,13 +670,11 @@ describe("LabelImage.fromStack", () => {
     expect(result[0].objects.get(2)?.category).toBe("nucleus");
   });
 
-  it("uses custom frameIdx", () => {
+  it("fromStack returns correct number of items", () => {
     const result = LabelImage.fromStack({
       data: [[[1]], [[2]]],
-      frameIdx: [10, 20],
     });
-    expect(result[0].frameIdx).toBe(10);
-    expect(result[1].frameIdx).toBe(20);
+    expect(result).toHaveLength(2);
   });
 
   it("returns empty array for empty data", () => {
@@ -987,15 +972,14 @@ describe("LabelImage.fromBinaryMasks", () => {
     expect(li.objects.has(10)).toBe(true);
   });
 
-  it("passes through video, frameIdx, source", () => {
+  it("passes through source", () => {
     const li = LabelImage.fromBinaryMasks(
       [
         [1, 0],
         [0, 1],
       ],
-      { frameIdx: 42, source: "test.png" },
+      { source: "test.png" },
     );
-    expect(li.frameIdx).toBe(42);
     expect(li.source).toBe("test.png");
   });
 
@@ -1353,7 +1337,7 @@ describe("normalizeLabelIds", () => {
     expect(li.objects.has(5)).toBe(false);
   });
 
-  it("preserves video/frameIdx/source metadata", () => {
+  it("preserves source metadata", () => {
     const li = LabelImage.fromBinaryMasks(
       [
         [
@@ -1361,10 +1345,9 @@ describe("normalizeLabelIds", () => {
           [0, 0],
         ],
       ],
-      { frameIdx: 7, source: "test.png" },
+      { source: "test.png" },
     );
     normalizeLabelIds([li]);
-    expect(li.frameIdx).toBe(7);
     expect(li.source).toBe("test.png");
   });
 
@@ -1456,7 +1439,6 @@ describe("LabelImage.toBboxes", () => {
       [0, 1, 0],
     ]);
     const track = new Track("t1");
-    const video = new Video({ filename: "test.mp4" });
     const li = new UserLabelImage({
       data,
       height: 3,
@@ -1464,15 +1446,11 @@ describe("LabelImage.toBboxes", () => {
       objects: new Map([
         [1, { track, category: "cell", name: "obj1", instance: null }],
       ]),
-      video,
-      frameIdx: 5,
       source: "cellpose",
     });
     const bboxes = li.toBboxes();
     const bb = bboxes[0];
     expect(bb.track).toBe(track);
-    expect(bb.video).toBe(video);
-    expect(bb.frameIdx).toBe(5);
     expect(bb.category).toBe("cell");
     expect(bb.name).toBe("obj1");
     expect(bb.source).toBe("cellpose");

--- a/tests/labels-rois-masks.test.ts
+++ b/tests/labels-rois-masks.test.ts
@@ -58,6 +58,24 @@ describe("Labels ROI and Mask integration", () => {
     expect(labels.getRois({ video: v2 })).toEqual([roi2]);
   });
 
+  it("getRois({video}) returns frame-bound ROIs only, excluding static ROIs", () => {
+    // Frame-aware filters (video or frameIdx) walk only labeledFrames.
+    // Static ROIs are accessed via labels.staticRois directly.
+    const v = new Video({ filename: "v.mp4" });
+    const staticRoi = ROI.fromBbox(0, 0, 100, 100, { video: v });
+    const frameRoi = ROI.fromBbox(0, 0, 50, 50, { video: v });
+    const lf = new LabeledFrame({ video: v, frameIdx: 5, rois: [frameRoi] });
+    const labels = new Labels({ labeledFrames: [lf], rois: [staticRoi] });
+
+    // getRois({video}) returns only the frame-bound ROI, not the static one.
+    expect(labels.getRois({ video: v })).toEqual([frameRoi]);
+    // The static ROI is still accessible via staticRois.
+    expect(labels.staticRois).toEqual([staticRoi]);
+    // And via the union view.
+    expect(labels.rois).toContain(staticRoi);
+    expect(labels.rois).toContain(frameRoi);
+  });
+
   it("getRois filters by frameIdx", () => {
     const v = new Video({ filename: "test.mp4" });
     const roi1 = ROI.fromBbox(0, 0, 10, 10);

--- a/tests/labels-rois-masks.test.ts
+++ b/tests/labels-rois-masks.test.ts
@@ -10,14 +10,16 @@ import {
   SegmentationMask,
   UserBoundingBox,
   PredictedBoundingBox,
+  LabeledFrame,
 } from "../src/index.js";
 
 describe("Labels ROI and Mask integration", () => {
-  it("stores rois and masks", () => {
+  it("stores rois and masks on frames", () => {
     const video = new Video({ filename: "test.mp4" });
     const roi = ROI.fromBbox(10, 20, 100, 200, { video });
-    const mask = SegmentationMask.fromArray(new Uint8Array(16), 4, 4, { video });
-    const labels = new Labels({ videos: [video], rois: [roi], masks: [mask] });
+    const mask = SegmentationMask.fromArray(new Uint8Array(16), 4, 4);
+    const lf = new LabeledFrame({ video, frameIdx: 0, rois: [roi], masks: [mask] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [video] });
     expect(labels.rois).toHaveLength(1);
     expect(labels.masks).toHaveLength(1);
     expect(labels.rois[0]).toBe(roi);
@@ -33,8 +35,9 @@ describe("Labels ROI and Mask integration", () => {
   it("filters staticRois and temporalRois", () => {
     const video = new Video({ filename: "test.mp4" });
     const staticRoi = ROI.fromBbox(0, 0, 10, 10, { video });
-    const temporalRoi = ROI.fromBbox(0, 0, 20, 20, { video, frameIdx: 5 });
-    const labels = new Labels({ rois: [staticRoi, temporalRoi] });
+    const temporalRoi = ROI.fromBbox(0, 0, 20, 20, { video });
+    const lf = new LabeledFrame({ video, frameIdx: 5, rois: [temporalRoi] });
+    const labels = new Labels({ labeledFrames: [lf], rois: [staticRoi] });
 
     expect(labels.staticRois).toHaveLength(1);
     expect(labels.staticRois[0]).toBe(staticRoi);
@@ -47,17 +50,22 @@ describe("Labels ROI and Mask integration", () => {
     const v2 = new Video({ filename: "b.mp4" });
     const roi1 = ROI.fromBbox(0, 0, 10, 10, { video: v1 });
     const roi2 = ROI.fromBbox(0, 0, 10, 10, { video: v2 });
-    const labels = new Labels({ videos: [v1, v2], rois: [roi1, roi2] });
+    const lf1 = new LabeledFrame({ video: v1, frameIdx: 0, rois: [roi1] });
+    const lf2 = new LabeledFrame({ video: v2, frameIdx: 0, rois: [roi2] });
+    const labels = new Labels({ labeledFrames: [lf1, lf2], videos: [v1, v2] });
 
     expect(labels.getRois({ video: v1 })).toEqual([roi1]);
     expect(labels.getRois({ video: v2 })).toEqual([roi2]);
   });
 
   it("getRois filters by frameIdx", () => {
-    const roi1 = ROI.fromBbox(0, 0, 10, 10, { frameIdx: 0 });
-    const roi2 = ROI.fromBbox(0, 0, 10, 10, { frameIdx: 5 });
+    const v = new Video({ filename: "test.mp4" });
+    const roi1 = ROI.fromBbox(0, 0, 10, 10);
+    const roi2 = ROI.fromBbox(0, 0, 10, 10);
     const roi3 = ROI.fromBbox(0, 0, 10, 10);
-    const labels = new Labels({ rois: [roi1, roi2, roi3] });
+    const lf0 = new LabeledFrame({ video: v, frameIdx: 0, rois: [roi1] });
+    const lf5 = new LabeledFrame({ video: v, frameIdx: 5, rois: [roi2] });
+    const labels = new Labels({ labeledFrames: [lf0, lf5], rois: [roi3] });
 
     expect(labels.getRois({ frameIdx: 0 })).toEqual([roi1]);
     expect(labels.getRois({ frameIdx: 5 })).toEqual([roi2]);
@@ -86,28 +94,35 @@ describe("Labels ROI and Mask integration", () => {
 
   it("getRois with combined filters uses AND logic", () => {
     const v1 = new Video({ filename: "a.mp4" });
-    const roi1 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "animal", frameIdx: 0 });
-    const roi2 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "arena", frameIdx: 0 });
-    const roi3 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "animal", frameIdx: 5 });
-    const labels = new Labels({ rois: [roi1, roi2, roi3] });
+    const roi1 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "animal" });
+    const roi2 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "arena" });
+    const roi3 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "animal" });
+    const lf0 = new LabeledFrame({ video: v1, frameIdx: 0, rois: [roi1, roi2] });
+    const lf5 = new LabeledFrame({ video: v1, frameIdx: 5, rois: [roi3] });
+    const labels = new Labels({ labeledFrames: [lf0, lf5] });
 
     const result = labels.getRois({ video: v1, category: "animal", frameIdx: 0 });
     expect(result).toEqual([roi1]);
   });
 
   it("getMasks filters by frameIdx", () => {
-    const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { frameIdx: 0 });
-    const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { frameIdx: 3 });
-    const labels = new Labels({ masks: [m1, m2] });
+    const v = new Video({ filename: "test.mp4" });
+    const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2);
+    const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2);
+    const lf0 = new LabeledFrame({ video: v, frameIdx: 0, masks: [m1] });
+    const lf3 = new LabeledFrame({ video: v, frameIdx: 3, masks: [m2] });
+    const labels = new Labels({ labeledFrames: [lf0, lf3] });
 
     expect(labels.getMasks({ frameIdx: 0 })).toEqual([m1]);
     expect(labels.getMasks({ frameIdx: 3 })).toEqual([m2]);
   });
 
   it("getMasks filters by category", () => {
+    const v = new Video({ filename: "test.mp4" });
     const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { category: "bg" });
     const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { category: "fg" });
-    const labels = new Labels({ masks: [m1, m2] });
+    const lf = new LabeledFrame({ video: v, frameIdx: 0, masks: [m1, m2] });
+    const labels = new Labels({ labeledFrames: [lf] });
 
     expect(labels.getMasks({ category: "bg" })).toEqual([m1]);
   });
@@ -115,9 +130,11 @@ describe("Labels ROI and Mask integration", () => {
   it("getMasks filters by video", () => {
     const v1 = new Video({ filename: "a.mp4" });
     const v2 = new Video({ filename: "b.mp4" });
-    const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { video: v1 });
-    const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { video: v2 });
-    const labels = new Labels({ masks: [m1, m2] });
+    const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2);
+    const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2);
+    const lf1 = new LabeledFrame({ video: v1, frameIdx: 0, masks: [m1] });
+    const lf2 = new LabeledFrame({ video: v2, frameIdx: 0, masks: [m2] });
+    const labels = new Labels({ labeledFrames: [lf1, lf2] });
 
     expect(labels.getMasks({ video: v1 })).toEqual([m1]);
     expect(labels.getMasks({ video: v2 })).toEqual([m2]);
@@ -125,29 +142,34 @@ describe("Labels ROI and Mask integration", () => {
 
   it("getMasks filters by track", () => {
     const track = new Track({ name: "t1" });
+    const v = new Video({ filename: "test.mp4" });
     const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { track });
     const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2);
-    const labels = new Labels({ masks: [m1, m2] });
+    const lf = new LabeledFrame({ video: v, frameIdx: 0, masks: [m1, m2] });
+    const labels = new Labels({ labeledFrames: [lf] });
 
     expect(labels.getMasks({ track })).toEqual([m1]);
   });
-
 });
 
 describe("getBboxes", () => {
   it("returns all bboxes without filters", () => {
     const bb1 = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
     const bb2 = new PredictedBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35, score: 0.9 });
-    const labels = new Labels({ bboxes: [bb1, bb2] });
+    const v = new Video({ filename: "test.mp4" });
+    const lf = new LabeledFrame({ video: v, frameIdx: 0, bboxes: [bb1, bb2] });
+    const labels = new Labels({ labeledFrames: [lf] });
     expect(labels.getBboxes()).toHaveLength(2);
   });
 
   it("filters by video", () => {
     const v1 = new Video({ filename: "a.mp4" });
     const v2 = new Video({ filename: "b.mp4" });
-    const bb1 = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90, video: v1 });
-    const bb2 = new UserBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35, video: v2 });
-    const labels = new Labels({ bboxes: [bb1, bb2] });
+    const bb1 = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
+    const bb2 = new UserBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35 });
+    const lf1 = new LabeledFrame({ video: v1, frameIdx: 0, bboxes: [bb1] });
+    const lf2 = new LabeledFrame({ video: v2, frameIdx: 0, bboxes: [bb2] });
+    const labels = new Labels({ labeledFrames: [lf1, lf2] });
     expect(labels.getBboxes({ video: v1 })).toEqual([bb1]);
     expect(labels.getBboxes({ video: v2 })).toEqual([bb2]);
   });
@@ -155,17 +177,22 @@ describe("getBboxes", () => {
   it("filters by predicted", () => {
     const bb1 = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
     const bb2 = new PredictedBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35, score: 0.9 });
-    const labels = new Labels({ bboxes: [bb1, bb2] });
+    const v = new Video({ filename: "test.mp4" });
+    const lf = new LabeledFrame({ video: v, frameIdx: 0, bboxes: [bb1, bb2] });
+    const labels = new Labels({ labeledFrames: [lf] });
     expect(labels.getBboxes({ predicted: false })).toEqual([bb1]);
     expect(labels.getBboxes({ predicted: true })).toEqual([bb2]);
   });
 
-  it("staticBboxes and temporalBboxes", () => {
+  it("bboxes on frames are accessible via getBboxes", () => {
+    const v = new Video({ filename: "test.mp4" });
     const bb1 = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
-    const bb2 = new UserBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35, frameIdx: 5 });
-    const labels = new Labels({ bboxes: [bb1, bb2] });
-    expect(labels.staticBboxes).toEqual([bb1]);
-    expect(labels.temporalBboxes).toEqual([bb2]);
+    const bb2 = new UserBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35 });
+    const lf0 = new LabeledFrame({ video: v, frameIdx: 0, bboxes: [bb1] });
+    const lf5 = new LabeledFrame({ video: v, frameIdx: 5, bboxes: [bb2] });
+    const labels = new Labels({ labeledFrames: [lf0, lf5] });
+    expect(labels.getBboxes({ frameIdx: 0 })).toEqual([bb1]);
+    expect(labels.getBboxes({ frameIdx: 5 })).toEqual([bb2]);
   });
 
   it("defaults bboxes to empty array", () => {

--- a/tests/lazy-write.test.ts
+++ b/tests/lazy-write.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Tests for the lazy SLP write fast path (`writeSlpToFileLazy`).
+ *
+ * These exercise `saveSlpToBytes(lazy)` without explicit materialization —
+ * the dispatch in `saveSlpToBytes` should detect lazy mode and route to the
+ * fast path that pulls raw column data + per-frame annotation maps directly
+ * from `LazyDataStore`.
+ */
+import { describe, it, expect } from "vitest";
+import { Labels } from "../src/model/labels.js";
+import { LabeledFrame } from "../src/model/labeled-frame.js";
+import { Instance, PredictedInstance, Track } from "../src/model/instance.js";
+import { Skeleton } from "../src/model/skeleton.js";
+import { Video } from "../src/model/video.js";
+import { UserCentroid, PredictedCentroid } from "../src/model/centroid.js";
+import { UserBoundingBox, PredictedBoundingBox } from "../src/model/bbox.js";
+import { UserROI } from "../src/model/roi.js";
+import { UserSegmentationMask } from "../src/model/mask.js";
+import { UserLabelImage } from "../src/model/label-image.js";
+import type { LabelImageObjectInfo } from "../src/model/label-image.js";
+import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
+import { saveSlpToBytes } from "../src/codecs/slp/write.js";
+
+/** Save eager → read lazy → save lazy → read eager. The middle step is the
+ *  lazy fast path; we verify that `lazy.materialize()` is never needed. */
+async function lazyRoundTrip(labels: Labels): Promise<Labels> {
+  const bytes1 = await saveSlpToBytes(labels);
+  const lazy = await readSlpLazy(new Uint8Array(bytes1).buffer, {
+    openVideos: false,
+  });
+  expect(lazy.isLazy).toBe(true);
+  const bytes2 = await saveSlpToBytes(lazy);
+  // Confirm the lazy save did not materialize as a side effect.
+  expect(lazy.isLazy).toBe(true);
+  return readSlp(new Uint8Array(bytes2).buffer, { openVideos: false });
+}
+
+describe("lazy SLP write fast path", () => {
+  it("preserves user instances", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A", "B"] });
+    const track = new Track("t1");
+    const inst1 = new Instance({ points: { A: [1, 2], B: [3, 4] }, skeleton, track });
+    const inst2 = new Instance({ points: { A: [5, 6], B: [7, 8] }, skeleton, track });
+    const lf0 = new LabeledFrame({ video, frameIdx: 0, instances: [inst1] });
+    const lf1 = new LabeledFrame({ video, frameIdx: 1, instances: [inst2] });
+    const labels = new Labels({ labeledFrames: [lf0, lf1] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames).toHaveLength(2);
+    expect(loaded.labeledFrames[0].instances).toHaveLength(1);
+    expect(loaded.labeledFrames[1].instances).toHaveLength(1);
+    expect(loaded.labeledFrames[0].instances[0].points[0].xy).toEqual([1, 2]);
+    expect(loaded.labeledFrames[1].instances[0].points[1].xy).toEqual([7, 8]);
+  });
+
+  it("preserves predicted instances mixed with user instances", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const userInst = new Instance({ points: { A: [1, 2] }, skeleton });
+    const predInst = PredictedInstance.fromArray([[3, 4]], skeleton, 0.85);
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [userInst, predInst],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].instances).toHaveLength(2);
+    const loadedUser = loaded.labeledFrames[0].instances.find(
+      (i) => !(i instanceof PredictedInstance),
+    );
+    const loadedPred = loaded.labeledFrames[0].instances.find(
+      (i) => i instanceof PredictedInstance,
+    ) as PredictedInstance | undefined;
+    expect(loadedUser).toBeDefined();
+    expect(loadedPred).toBeDefined();
+    expect(loadedPred!.score).toBeCloseTo(0.85);
+  });
+
+  it("preserves frame-bound centroids", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const c1 = new UserCentroid({ x: 1, y: 2, category: "cell" });
+    const c2 = new PredictedCentroid({ x: 3, y: 4, score: 0.9 });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      centroids: [c1, c2],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].centroids).toHaveLength(2);
+    const xs = loaded.labeledFrames[0].centroids.map((c) => c.x).sort();
+    expect(xs).toEqual([1, 3]);
+  });
+
+  it("preserves frame-bound bboxes", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [0, 0] }, skeleton });
+    const b1 = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, category: "obj" });
+    const b2 = new PredictedBoundingBox({
+      x1: 5,
+      y1: 5,
+      x2: 15,
+      y2: 15,
+      score: 0.7,
+    });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      bboxes: [b1, b2],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].bboxes).toHaveLength(2);
+    expect(loaded.labeledFrames[0].bboxes.find((b) => b.category === "obj")).toBeDefined();
+  });
+
+  it("preserves frame-bound masks", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [0, 0] }, skeleton });
+    const mask = UserSegmentationMask.fromArray(new Uint8Array(16), 4, 4, {
+      name: "m1",
+      category: "cell",
+    });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 3,
+      instances: [inst],
+      masks: [mask],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].masks).toHaveLength(1);
+    expect(loaded.labeledFrames[0].masks[0].name).toBe("m1");
+    expect(loaded.labeledFrames[0].masks[0].category).toBe("cell");
+    expect(loaded.labeledFrames[0].frameIdx).toBe(3);
+  });
+
+  it("preserves frame-bound label images", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const track = new Track("t1");
+    const inst = new Instance({ points: { A: [0, 0] }, skeleton });
+    const li = new UserLabelImage({
+      data: new Int32Array([0, 1, 0, 1]),
+      height: 2,
+      width: 2,
+      objects: new Map<number, LabelImageObjectInfo>([
+        [1, { track, category: "cell", name: "obj", instance: null }],
+      ]),
+    });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      labelImages: [li],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].labelImages).toHaveLength(1);
+    const loadedLi = loaded.labeledFrames[0].labelImages[0];
+    expect(loadedLi.height).toBe(2);
+    expect(loadedLi.width).toBe(2);
+    expect(loadedLi.nObjects).toBe(1);
+  });
+
+  it("preserves static ROI video association (Side fix B regression)", async () => {
+    // Static ROIs with a video reference must round-trip with the video
+    // intact through the lazy fast path. Before Side fix B this was lost
+    // because the collector emitted (-1, -1) for all undistributed entries.
+    const v1 = new Video({ filename: "v1.mp4" });
+    const v2 = new Video({ filename: "v2.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [0, 0] }, skeleton });
+    const frameRoi = UserROI.fromBbox(0, 0, 50, 50, { video: v1, category: "frame-roi" });
+    const staticRoi = UserROI.fromBbox(0, 0, 100, 100, { video: v2, category: "arena" });
+    const lf = new LabeledFrame({
+      video: v1,
+      frameIdx: 0,
+      instances: [inst],
+      rois: [frameRoi],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [v1, v2],
+      rois: [staticRoi],
+    });
+
+    const loaded = await lazyRoundTrip(labels);
+
+    // Frame-bound ROI preserved on its frame
+    expect(loaded.labeledFrames[0].rois).toHaveLength(1);
+    expect(loaded.labeledFrames[0].rois[0].category).toBe("frame-roi");
+
+    // Static ROI preserved as static, with video association intact
+    expect(loaded.staticRois).toHaveLength(1);
+    expect(loaded.staticRois[0].category).toBe("arena");
+    expect(loaded.staticRois[0].video).not.toBeNull();
+    expect(loaded.staticRois[0].video!.filename).toBe("v2.mp4");
+  });
+
+  it("preserves negative frames", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [0, 0] }, skeleton });
+    const lfNorm = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const lfNeg = new LabeledFrame({ video, frameIdx: 5, isNegative: true });
+    const labels = new Labels({ labeledFrames: [lfNorm, lfNeg] });
+
+    const loaded = await lazyRoundTrip(labels);
+    const negFrames = loaded.labeledFrames.filter((f) => f.isNegative);
+    expect(negFrames).toHaveLength(1);
+    expect(negFrames[0].frameIdx).toBe(5);
+  });
+
+  it("preserves instance association on centroid via _instanceIdx (Side fix A)", async () => {
+    // After lazy read, the centroid has _instanceIdx set but instance===null.
+    // The lazy writer must persist _instanceIdx so the link survives a round
+    // trip. After eager read, instance points to the materialized instance.
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const c = new UserCentroid({ x: 1, y: 2, instance: inst });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      centroids: [c],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].centroids).toHaveLength(1);
+    expect(loaded.labeledFrames[0].instances).toHaveLength(1);
+    expect(loaded.labeledFrames[0].centroids[0].instance).toBe(
+      loaded.labeledFrames[0].instances[0],
+    );
+  });
+
+  it("preserves instance association on bbox via _instanceIdx (Side fix A)", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const b = new UserBoundingBox({
+      x1: 0,
+      y1: 0,
+      x2: 10,
+      y2: 10,
+      instance: inst,
+    });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      bboxes: [b],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].bboxes[0].instance).toBe(
+      loaded.labeledFrames[0].instances[0],
+    );
+  });
+
+  it("preserves instance association on roi via _instanceIdx (Side fix A)", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const roi = UserROI.fromBbox(0, 0, 50, 50, { instance: inst });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      rois: [roi],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    expect(loaded.labeledFrames[0].rois[0].instance).toBe(
+      loaded.labeledFrames[0].instances[0],
+    );
+  });
+
+  it("mixed annotation types round-trip in a single frame", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const track = new Track("t1");
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
+    const c = new UserCentroid({ x: 1, y: 2 });
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
+    const m = UserSegmentationMask.fromArray(new Uint8Array(16), 4, 4);
+    const li = new UserLabelImage({
+      data: new Int32Array([0, 1]),
+      height: 1,
+      width: 2,
+    });
+    const roi = UserROI.fromBbox(0, 0, 50, 50);
+
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      centroids: [c],
+      bboxes: [b],
+      masks: [m],
+      labelImages: [li],
+      rois: [roi],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const loaded = await lazyRoundTrip(labels);
+    const frame = loaded.labeledFrames[0];
+    expect(frame.instances).toHaveLength(1);
+    expect(frame.centroids).toHaveLength(1);
+    expect(frame.bboxes).toHaveLength(1);
+    expect(frame.masks).toHaveLength(1);
+    expect(frame.labelImages).toHaveLength(1);
+    expect(frame.rois).toHaveLength(1);
+  });
+
+  it("embed:'source' restores source video paths in the lazy fast path", async () => {
+    // Construct a Labels where the (only) video has a sourceVideo set.
+    // Save eager → read lazy → save lazy with embed:'source' → read eager.
+    // The loaded video should match the source filename.
+    const sourceVideo = new Video({ filename: "original.mp4" });
+    const wrappedVideo = new Video({
+      filename: "wrapper.mp4",
+      sourceVideo,
+    });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const lf = new LabeledFrame({
+      video: wrappedVideo,
+      frameIdx: 0,
+      instances: [inst],
+    });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const bytes1 = await saveSlpToBytes(labels);
+    const lazy = await readSlpLazy(new Uint8Array(bytes1).buffer, {
+      openVideos: false,
+    });
+    expect(lazy.isLazy).toBe(true);
+    // Manually attach a sourceVideo to the lazy-loaded video so the swap
+    // has something to do (the read path doesn't re-create sourceVideo refs).
+    lazy.videos[0].sourceVideo = new Video({ filename: "restored.mp4" });
+
+    const bytes2 = await saveSlpToBytes(lazy, { embed: "source" });
+    expect(lazy.isLazy).toBe(true); // still lazy after the source-mode save
+
+    const loaded = await readSlp(new Uint8Array(bytes2).buffer, {
+      openVideos: false,
+    });
+    expect(loaded.videos[0].filename).toBe("restored.mp4");
+  });
+
+  it("embed:'all' forces materialization in lazy mode", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const labels = new Labels({ labeledFrames: [lf] });
+
+    const bytes1 = await saveSlpToBytes(labels);
+    const lazy = await readSlpLazy(new Uint8Array(bytes1).buffer, {
+      openVideos: false,
+    });
+    expect(lazy.isLazy).toBe(true);
+
+    // embed:"all" tries to read pixel data — must materialize first.
+    // We can't actually embed pixels (no real video), so embed mode that
+    // requires pixel reads will go through the materialize path. Without
+    // a backing video file, the embed step itself may throw, so we just
+    // verify the materialization side-effect: after the call attempt,
+    // lazy.isLazy should become false (materialization happens before
+    // embed processing).
+    try {
+      await saveSlpToBytes(lazy, { embed: "all" });
+    } catch {
+      // Expected — no real video to embed pixels from.
+    }
+    expect(lazy.isLazy).toBe(false);
+  });
+});

--- a/tests/mask.test.ts
+++ b/tests/mask.test.ts
@@ -338,20 +338,15 @@ describe("SegmentationMask.toBbox", () => {
 
   it("propagates metadata", () => {
     const track = new Track("t1");
-    const video = new Video({ filename: "test.mp4" });
     const mask = makeMask2D(10, 10, (r, c) => r >= 2 && r < 5 && c >= 1 && c < 4);
     const sm = SegmentationMask.fromArray(mask, 10, 10, {
       track,
-      video,
-      frameIdx: 3,
       category: "cell",
       name: "obj1",
       source: "manual",
     });
     const bb = sm.toBbox();
     expect(bb.track).toBe(track);
-    expect(bb.video).toBe(video);
-    expect(bb.frameIdx).toBe(3);
     expect(bb.category).toBe("cell");
     expect(bb.name).toBe("obj1");
     expect(bb.source).toBe("manual");

--- a/tests/model/labels-copy.test.ts
+++ b/tests/model/labels-copy.test.ts
@@ -31,27 +31,24 @@ function makeLabels(): Labels {
   const roi = new UserROI({
     geometry: { type: "Point", coordinates: [1, 2] },
     video,
-    frameIdx: 0,
   });
-  const centroid = new UserCentroid({ x: 5, y: 6, video, frameIdx: 0 });
-  const bbox = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0 });
+  const centroid = new UserCentroid({ x: 5, y: 6 });
+  const bbox = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
   const li = new UserLabelImage({
     data: new Int32Array([0, 1, 0, 0]),
     height: 2,
     width: 2,
-    video,
-    frameIdx: 0,
   });
+  frame.centroids.push(centroid);
+  frame.bboxes.push(bbox);
+  frame.labelImages.push(li);
+  frame.rois.push(roi);
   return new Labels({
     labeledFrames: [frame],
     videos: [video],
     skeletons: [skeleton],
     tracks: [track],
     suggestions: [suggestion],
-    rois: [roi],
-    centroids: [centroid],
-    bboxes: [bbox],
-    labelImages: [li],
   });
 }
 
@@ -131,11 +128,11 @@ describe("Labels.copy (eager)", () => {
     // ROI's video should be the copy's video
     expect(copy.rois[0].video).toBe(copy.videos[0]);
     // Centroid's video should be the copy's video
-    expect(copy.centroids[0].video).toBe(copy.videos[0]);
+    // centroids no longer have .video
     // BBox's video should be the copy's video
-    expect(copy.bboxes[0].video).toBe(copy.videos[0]);
+    // bboxes no longer have .video
     // LabelImage's video should be the copy's video
-    expect(copy.labelImages[0].video).toBe(copy.videos[0]);
+    // labelImages no longer have .video
   });
 
   it("copy preserves skeleton structure", () => {
@@ -248,25 +245,21 @@ describe("Labels.copy + replaceVideos integration", () => {
     const skeleton = new Skeleton({ nodes: [nodeA] });
     const video = new Video({ filename: "original.mp4" });
     const track = new Track("t1");
-    const centroid = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    const centroid = new UserCentroid({ x: 1, y: 2 });
     const li = new UserLabelImage({
       data: new Int32Array([0, 1, 0, 0]),
       height: 2,
       width: 2,
-      video,
-      frameIdx: 0,
     });
     const instance = Instance.fromArray([[5, 10]], skeleton);
     instance.track = track;
-    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [instance] });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [instance], centroids: [centroid], labelImages: [li] });
 
     const labels = new Labels({
       labeledFrames: [frame],
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      centroids: [centroid],
-      labelImages: [li],
     });
 
     const copy = labels.copy();
@@ -276,13 +269,13 @@ describe("Labels.copy + replaceVideos integration", () => {
     // Original is untouched
     expect(labels.videos[0].filename).toBe("original.mp4");
     expect(labels.labeledFrames[0].video.filename).toBe("original.mp4");
-    expect(labels.centroids[0].video!.filename).toBe("original.mp4");
-    expect(labels.labelImages[0].video!.filename).toBe("original.mp4");
+    // centroids no longer have .video
+    // labelImages no longer have .video
 
     // Copy has the replacement
     expect(copy.videos[0].filename).toBe("replaced.mp4");
     expect(copy.labeledFrames[0].video.filename).toBe("replaced.mp4");
-    expect(copy.centroids[0].video!.filename).toBe("replaced.mp4");
-    expect(copy.labelImages[0].video!.filename).toBe("replaced.mp4");
+    // centroids no longer have .video
+    // labelImages no longer have .video
   });
 });

--- a/tests/model/labels-index.test.ts
+++ b/tests/model/labels-index.test.ts
@@ -89,12 +89,16 @@ describe("Labels track index", () => {
     const video = new Video({ filename: "test.mp4" });
     const t1 = new Track("t1");
     const t2 = new Track("t2");
-    const c1 = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track: t1 });
-    const c2 = new UserCentroid({ x: 3, y: 4, video, frameIdx: 5, track: t1 });
-    const c3 = new UserCentroid({ x: 5, y: 6, video, frameIdx: 2, track: t2 });
+    const c1 = new UserCentroid({ x: 1, y: 2, track: t1 });
+    const c2 = new UserCentroid({ x: 3, y: 4, track: t1 });
+    const c3 = new UserCentroid({ x: 5, y: 6, track: t2 });
 
     const labels = new Labels({
-      centroids: [c1, c2, c3],
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, centroids: [c1] }),
+        new LabeledFrame({ video, frameIdx: 5, centroids: [c2] }),
+        new LabeledFrame({ video, frameIdx: 2, centroids: [c3] }),
+      ],
       videos: [video],
       tracks: [t1, t2],
     });
@@ -143,14 +147,8 @@ describe("Labels track index", () => {
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track, category: "cell", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
     });
-    const labels = new Labels({
-      labelImages: [li],
-      videos: [video],
-      tracks: [track],
-    });
+    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video, frameIdx: 0, labelImages: [li] })], videos: [video], tracks: [track] });
 
     const anns = labels.getTrackAnnotations(video, track);
     expect(anns).toHaveLength(1);
@@ -208,9 +206,9 @@ describe("Labels.find() fast path", () => {
 describe("get*() fast paths", () => {
   it("getCentroids uses O(1) frame lookup when video+frameIdx given", () => {
     const video = new Video({ filename: "test.mp4" });
-    const c0 = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const c1 = new UserCentroid({ x: 3, y: 4, video, frameIdx: 1 });
-    const labels = new Labels({ centroids: [c0, c1], videos: [video] });
+    const c0 = new UserCentroid({ x: 1, y: 2});
+    const c1 = new UserCentroid({ x: 3, y: 4});
+    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video: video, frameIdx: 0, centroids: [c0] }), new LabeledFrame({ video: video, frameIdx: 1, centroids: [c1] })], videos: [video] });
 
     // Fast path: both video and frameIdx
     let result = labels.getCentroids({ video, frameIdx: 0 });
@@ -253,7 +251,7 @@ describe("get*() fast paths", () => {
       video,
       frameIdx: 0,
     });
-    const labels = new Labels({ bboxes: [b1, b2], videos: [video] });
+    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video: video, frameIdx: 0, bboxes: [b1, b2] })], videos: [video] });
 
     // Fast path with video+frameIdx
     let result = labels.getBboxes({ video, frameIdx: 0 });
@@ -279,11 +277,8 @@ describe("get*() fast paths", () => {
     const mask = new UserSegmentationMask({
       rleCounts: new Uint32Array([16]),
       height: 4,
-      width: 4,
-      video,
-      frameIdx: 0,
-    });
-    const labels = new Labels({ masks: [mask], videos: [video] });
+      width: 4, });
+    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video: video, frameIdx: 0, masks: [mask] })], videos: [video] });
 
     let result = labels.getMasks({ video, frameIdx: 0 });
     expect(result).toHaveLength(1);
@@ -302,10 +297,9 @@ describe("get*() fast paths", () => {
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track: null, category: "cell", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
     });
-    const labels = new Labels({ labelImages: [li], videos: [video] });
+    const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [video] });
 
     let result = labels.getLabelImages({ video, frameIdx: 0 });
     expect(result).toHaveLength(1);
@@ -320,14 +314,14 @@ describe("get*() fast paths", () => {
     const roi1 = new UserROI({
       geometry: { type: "Point", coordinates: [0, 0] },
       video,
-      frameIdx: 0,
     });
     const roi2 = new UserROI({
       geometry: { type: "Point", coordinates: [5, 5] },
       video,
-      frameIdx: 1,
     });
-    const labels = new Labels({ rois: [roi1, roi2], videos: [video] });
+    const lf0 = new LabeledFrame({ video, frameIdx: 0, rois: [roi1] });
+    const lf1 = new LabeledFrame({ video, frameIdx: 1, rois: [roi2] });
+    const labels = new Labels({ labeledFrames: [lf0, lf1], videos: [video] });
 
     // Fast path with video+frameIdx
     let result = labels.getRois({ video, frameIdx: 0 });
@@ -388,23 +382,21 @@ describe("Index invalidation", () => {
     expect(labels.getFrame(newVideo, 0)).toBe(lf);
   });
 
-  it("addCentroid() invalidates indices", () => {
+  it("append() with annotations invalidates indices", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("t1");
-    const c0 = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
-    const labels = new Labels({
-      centroids: [c0],
-      videos: [video],
-      tracks: [track],
-    });
+    const c0 = new UserCentroid({ x: 1, y: 2, track });
+    const lf0 = new LabeledFrame({ video, frameIdx: 0, centroids: [c0] });
+    const labels = new Labels({ labeledFrames: [lf0], videos: [video], tracks: [track] });
 
     // Build track index
     let anns = labels.getTrackAnnotations(video, track);
     expect(anns).toHaveLength(1);
 
-    // Add another centroid to the same track
-    const c1 = new UserCentroid({ x: 3, y: 4, video, frameIdx: 1, track });
-    labels.addCentroid(c1);
+    // Append a new frame with another centroid on the same track
+    const c1 = new UserCentroid({ x: 3, y: 4, track });
+    const lf1 = new LabeledFrame({ video, frameIdx: 1, centroids: [c1] });
+    labels.append(lf1);
 
     // Track index should be invalidated and rebuilt
     anns = labels.getTrackAnnotations(video, track);
@@ -444,7 +436,7 @@ describe("Labels.removePredictions()", () => {
     const pred = PredictedInstance.fromArray([[1, 2], [3, 4]], skel, 0.9);
     pred.track = track;
     const lf = new LabeledFrame({ video, frameIdx: 0, instances: [pred] });
-    const c = new UserCentroid({ x: 5, y: 6, video, frameIdx: 0, track });
+    const c = new UserCentroid({ x: 5, y: 6, track });
     lf.centroids.push(c);
 
     const labels = new Labels({

--- a/tests/model/labels-replace-videos.test.ts
+++ b/tests/model/labels-replace-videos.test.ts
@@ -56,14 +56,13 @@ describe("Labels.replaceVideos", () => {
       rleCounts: new Uint32Array([16]),
       height: 4,
       width: 4,
-      video: oldVideo,
-      frameIdx: 0,
     });
-    const labels = new Labels({ videos: [oldVideo], masks: [mask] });
+    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, masks: [mask] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
 
-    expect(mask.video).toBe(newVideo);
+    // masks no longer have .video
   });
 
   it("replaces video references on bboxes", () => {
@@ -71,25 +70,25 @@ describe("Labels.replaceVideos", () => {
     const newVideo = new Video({ filename: "new.mp4" });
     const bbox = new UserBoundingBox({
       x1: 0, y1: 0, x2: 10, y2: 10,
-      video: oldVideo,
-      frameIdx: 0,
     });
-    const labels = new Labels({ videos: [oldVideo], bboxes: [bbox] });
+    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, bboxes: [bbox] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
 
-    expect(bbox.video).toBe(newVideo);
+    // bboxes no longer have .video
   });
 
   it("replaces video references on centroids", () => {
     const oldVideo = new Video({ filename: "old.mp4" });
     const newVideo = new Video({ filename: "new.mp4" });
-    const centroid = new UserCentroid({ x: 1, y: 2, video: oldVideo, frameIdx: 0 });
-    const labels = new Labels({ videos: [oldVideo], centroids: [centroid] });
+    const centroid = new UserCentroid({ x: 1, y: 2 });
+    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, centroids: [centroid] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
 
-    expect(centroid.video).toBe(newVideo);
+    // centroids no longer have .video
   });
 
   it("replaces video references on label images", () => {
@@ -99,14 +98,13 @@ describe("Labels.replaceVideos", () => {
       data: new Int32Array([0, 0, 0, 0]),
       height: 2,
       width: 2,
-      video: oldVideo,
-      frameIdx: 0,
     });
-    const labels = new Labels({ videos: [oldVideo], labelImages: [li] });
+    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, labelImages: [li] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
 
-    expect(li.video).toBe(newVideo);
+    // labelImages no longer have .video
   });
 
   it("accepts a videoMap directly", () => {

--- a/tests/nested-annotations.test.ts
+++ b/tests/nested-annotations.test.ts
@@ -30,8 +30,8 @@ async function roundTripLazy(labels: Labels): Promise<Labels> {
 describe("LabeledFrame annotation fields", () => {
   it("has centroids, bboxes, masks, labelImages, rois fields", () => {
     const video = new Video({ filename: "test.mp4" });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0 });
+    const c = new UserCentroid({ x: 1, y: 2});
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10});
 
     const lf = new LabeledFrame({ video, frameIdx: 0, centroids: [c], bboxes: [b] });
     expect(lf.centroids).toHaveLength(1);
@@ -45,10 +45,10 @@ describe("LabeledFrame annotation fields", () => {
 
   it("removePredictions removes predicted annotations", () => {
     const video = new Video({ filename: "test.mp4" });
-    const cUser = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const cPred = new PredictedCentroid({ x: 3, y: 4, video, frameIdx: 0, score: 0.9 });
-    const bUser = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0 });
-    const bPred = new PredictedBoundingBox({ x1: 5, y1: 5, x2: 15, y2: 15, video, frameIdx: 0, score: 0.8 });
+    const cUser = new UserCentroid({ x: 1, y: 2});
+    const cPred = new PredictedCentroid({ x: 3, y: 4, score: 0.9 });
+    const bUser = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10});
+    const bPred = new PredictedBoundingBox({ x1: 5, y1: 5, x2: 15, y2: 15, score: 0.8 });
 
     const lf = new LabeledFrame({
       video,
@@ -66,8 +66,8 @@ describe("LabeledFrame annotation fields", () => {
 
   it("_mergeAnnotations merges, deduplicates, and copies new items", () => {
     const video = new Video({ filename: "test.mp4" });
-    const shared = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const unique = new UserCentroid({ x: 3, y: 4, video, frameIdx: 0 });
+    const shared = new UserCentroid({ x: 1, y: 2});
+    const unique = new UserCentroid({ x: 3, y: 4});
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [shared] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [shared, unique] });
@@ -84,20 +84,19 @@ describe("LabeledFrame annotation fields", () => {
   });
 });
 
-describe("Labels annotation distribution", () => {
-  it("distributes flat annotation lists into LabeledFrames", () => {
+describe("Labels annotation on LabeledFrames", () => {
+  it("annotations are placed on LabeledFrames", () => {
     const video = new Video({ filename: "test.mp4" });
-    const c1 = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const c2 = new UserCentroid({ x: 3, y: 4, video, frameIdx: 1 });
-    const b1 = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0 });
+    const c1 = new UserCentroid({ x: 1, y: 2 });
+    const c2 = new UserCentroid({ x: 3, y: 4 });
+    const b1 = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
 
-    const labels = new Labels({ centroids: [c1, c2], bboxes: [b1], videos: [video] });
+    const lf0 = new LabeledFrame({ video, frameIdx: 0, centroids: [c1], bboxes: [b1] });
+    const lf1 = new LabeledFrame({ video, frameIdx: 1, centroids: [c2] });
 
-    // Two frames created (one for each unique frameIdx)
+    const labels = new Labels({ labeledFrames: [lf0, lf1], videos: [video] });
+
     expect(labels.labeledFrames).toHaveLength(2);
-
-    const lf0 = labels.labeledFrames.find((lf) => lf.frameIdx === 0)!;
-    const lf1 = labels.labeledFrames.find((lf) => lf.frameIdx === 1)!;
     expect(lf0.centroids).toHaveLength(1);
     expect(lf0.centroids[0]).toBe(c1);
     expect(lf1.centroids).toHaveLength(1);
@@ -110,14 +109,14 @@ describe("Labels annotation distribution", () => {
     expect(labels.bboxes).toHaveLength(1);
   });
 
-  it("distributes to existing LabeledFrames", () => {
+  it("annotations on existing LabeledFrames", () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
-    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    const c = new UserCentroid({ x: 1, y: 2 });
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] });
 
-    const labels = new Labels({ labeledFrames: [lf], centroids: [c] });
+    const labels = new Labels({ labeledFrames: [lf] });
 
     expect(labels.labeledFrames).toHaveLength(1);
     expect(labels.labeledFrames[0].centroids).toHaveLength(1);
@@ -125,76 +124,65 @@ describe("Labels annotation distribution", () => {
     expect(labels.labeledFrames[0].instances).toHaveLength(1);
   });
 
-  it("distributes across multiple videos", () => {
+  it("annotations across multiple videos via LabeledFrames", () => {
     const v1 = new Video({ filename: "v1.mp4" });
     const v2 = new Video({ filename: "v2.mp4" });
-    const c1 = new UserCentroid({ x: 1, y: 2, video: v1, frameIdx: 0 });
-    const c2 = new UserCentroid({ x: 3, y: 4, video: v2, frameIdx: 0 });
+    const c1 = new UserCentroid({ x: 1, y: 2 });
+    const c2 = new UserCentroid({ x: 3, y: 4 });
 
-    const labels = new Labels({ centroids: [c1, c2], videos: [v1, v2] });
+    const lfV1 = new LabeledFrame({ video: v1, frameIdx: 0, centroids: [c1] });
+    const lfV2 = new LabeledFrame({ video: v2, frameIdx: 0, centroids: [c2] });
+
+    const labels = new Labels({ labeledFrames: [lfV1, lfV2], videos: [v1, v2] });
 
     expect(labels.labeledFrames).toHaveLength(2);
-    const lfV1 = labels.labeledFrames.find((lf) => lf.video === v1)!;
-    const lfV2 = labels.labeledFrames.find((lf) => lf.video === v2)!;
     expect(lfV1.centroids[0]).toBe(c1);
     expect(lfV2.centroids[0]).toBe(c2);
   });
 
-  it("keeps undistributable annotations in _init fields", () => {
+  it("static ROIs stored on Labels._staticRois", () => {
     const video = new Video({ filename: "test.mp4" });
-    // Static ROI has no frameIdx
-    const roi = UserROI.fromBbox(0, 0, 10, 10, { video, frameIdx: null });
+    // Static ROI (not on any frame)
+    const roi = UserROI.fromBbox(0, 0, 10, 10, { video });
 
     const labels = new Labels({ rois: [roi], videos: [video] });
 
-    // Not distributed — stays in _init
-    expect(labels._initRois).toHaveLength(1);
-    // But accessible via property
+    expect(labels._staticRois).toHaveLength(1);
+    // Accessible via property
     expect(labels.rois).toHaveLength(1);
     expect(labels.rois[0]).toBe(roi);
   });
 });
 
-describe("Labels add_* methods", () => {
-  it("addCentroid finds-or-creates frame", () => {
+describe("LabeledFrame.append() routing", () => {
+  it("append routes centroids to centroids list", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("t1");
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
+    const c = new UserCentroid({ x: 1, y: 2, track });
+    const lf = new LabeledFrame({ video, frameIdx: 0 });
+    lf.append(c);
 
-    const labels = new Labels({ videos: [video] });
-    labels.addCentroid(c);
+    expect(lf.centroids).toHaveLength(1);
+    expect(lf.centroids[0]).toBe(c);
 
-    expect(labels.labeledFrames).toHaveLength(1);
-    expect(labels.labeledFrames[0].centroids[0]).toBe(c);
-    expect(labels.tracks).toContain(track);
-
-    // Adding to same frame reuses it
-    const c2 = new UserCentroid({ x: 3, y: 4, video, frameIdx: 0 });
-    labels.addCentroid(c2);
-    expect(labels.labeledFrames).toHaveLength(1);
-    expect(labels.labeledFrames[0].centroids).toHaveLength(2);
+    // Adding to same frame appends
+    const c2 = new UserCentroid({ x: 3, y: 4 });
+    lf.append(c2);
+    expect(lf.centroids).toHaveLength(2);
   });
 
-  it("addCentroid requires video and frameIdx", () => {
-    const labels = new Labels();
-    const c = new UserCentroid({ x: 1, y: 2 });
-    expect(() => labels.addCentroid(c)).toThrow("video and frameIdx");
-  });
-
-  it("addBbox auto-populates videos and tracks", () => {
+  it("append routes bboxes to bboxes list", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("t1");
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0, track });
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, track });
+    const lf = new LabeledFrame({ video, frameIdx: 0 });
+    lf.append(b);
 
-    const labels = new Labels();
-    labels.addBbox(b);
-
-    expect(labels.videos).toContain(video);
-    expect(labels.tracks).toContain(track);
-    expect(labels.labeledFrames[0].bboxes[0]).toBe(b);
+    expect(lf.bboxes).toHaveLength(1);
+    expect(lf.bboxes[0]).toBe(b);
   });
 
-  it("addLabelImage collects tracks from objects", () => {
+  it("Labels collects tracks from annotations on frames", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("t1");
     const li = new UserLabelImage({
@@ -204,12 +192,10 @@ describe("Labels add_* methods", () => {
       objects: new Map<number, LabelImageObjectInfo>([
         [1, { track, category: "cell", name: "", instance: null }],
       ]),
-      video,
-      frameIdx: 0,
     });
 
-    const labels = new Labels();
-    labels.addLabelImage(li);
+    const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [video] });
 
     expect(labels.tracks).toContain(track);
     expect(labels.labeledFrames).toHaveLength(1);
@@ -219,11 +205,14 @@ describe("Labels add_* methods", () => {
 describe("Labels property getters", () => {
   it("centroids returns flat view across frames", () => {
     const video = new Video({ filename: "test.mp4" });
-    const c1 = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const c2 = new UserCentroid({ x: 3, y: 4, video, frameIdx: 1 });
-    const c3 = new UserCentroid({ x: 5, y: 6, video, frameIdx: 0 });
+    const c1 = new UserCentroid({ x: 1, y: 2 });
+    const c2 = new UserCentroid({ x: 3, y: 4 });
+    const c3 = new UserCentroid({ x: 5, y: 6 });
 
-    const labels = new Labels({ centroids: [c1, c2, c3], videos: [video] });
+    const lf0 = new LabeledFrame({ video, frameIdx: 0, centroids: [c1, c3] });
+    const lf1 = new LabeledFrame({ video, frameIdx: 1, centroids: [c2] });
+
+    const labels = new Labels({ labeledFrames: [lf0, lf1], videos: [video] });
 
     const flat = labels.centroids;
     expect(flat).toHaveLength(3);
@@ -234,12 +223,13 @@ describe("Labels property getters", () => {
 });
 
 describe("Labels track collection from annotations", () => {
-  it("update collects tracks from nested annotations", () => {
+  it("collects tracks from nested annotations on frames", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("t1");
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
+    const c = new UserCentroid({ x: 1, y: 2, track });
+    const lf = new LabeledFrame({ video, frameIdx: 0, centroids: [c] });
 
-    const labels = new Labels({ centroids: [c], videos: [video] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [video] });
 
     expect(labels.tracks).toContain(track);
   });
@@ -247,7 +237,7 @@ describe("Labels track collection from annotations", () => {
   it("append collects annotation tracks", () => {
     const video = new Video({ filename: "test.mp4" });
     const tBbox = new Track("t_bbox");
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0, track: tBbox });
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, track: tBbox });
     const lf = new LabeledFrame({ video, frameIdx: 0, bboxes: [b] });
 
     const labels = new Labels({ videos: [video] });
@@ -257,21 +247,17 @@ describe("Labels track collection from annotations", () => {
   });
 });
 
-describe("Labels _findOrCreateFrame", () => {
-  it("reuses existing frames", () => {
+describe("Labels.getFrame", () => {
+  it("finds existing frames by video and frameIdx", () => {
     const video = new Video({ filename: "test.mp4" });
+    const lf0 = new LabeledFrame({ video, frameIdx: 0 });
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0 })],
+      labeledFrames: [lf0],
       videos: [video],
     });
 
-    const lf = (labels as any)._findOrCreateFrame(video, 0);
-    expect(lf).toBe(labels.labeledFrames[0]);
-    expect(labels.labeledFrames).toHaveLength(1);
-
-    const lf2 = (labels as any)._findOrCreateFrame(video, 1);
-    expect(labels.labeledFrames).toHaveLength(2);
-    expect(lf2.frameIdx).toBe(1);
+    expect(labels.getFrame(video, 0)).toBe(lf0);
+    expect(labels.getFrame(video, 1)).toBeNull();
   });
 });
 
@@ -281,11 +267,11 @@ describe("SLP round-trip with annotations", () => {
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
-    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0 });
+    const c = new UserCentroid({ x: 1, y: 2, track });
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c], bboxes: [b] });
 
-    const labels = new Labels({ labeledFrames: [lf], centroids: [c], bboxes: [b] });
+    const labels = new Labels({ labeledFrames: [lf] });
 
     const loaded = await roundTrip(labels);
 
@@ -308,15 +294,16 @@ describe("SLP round-trip with annotations", () => {
       new PredictedCentroid({
         x: i,
         y: i * 2,
-        video,
-        frameIdx: i,
         track,
         score: 0.9,
       }),
     );
 
+    const frames = centroids.map((c, i) =>
+      new LabeledFrame({ video, frameIdx: i, centroids: [c] })
+    );
     const labels = new Labels({
-      centroids,
+      labeledFrames: frames,
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
@@ -339,11 +326,11 @@ describe("Lazy read with annotations", () => {
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
-    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0 });
+    const c = new UserCentroid({ x: 1, y: 2, track });
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c], bboxes: [b] });
 
-    const labels = new Labels({ labeledFrames: [lf], centroids: [c], bboxes: [b] });
+    const labels = new Labels({ labeledFrames: [lf] });
 
     const lazy = await roundTripLazy(labels);
 
@@ -358,19 +345,13 @@ describe("Lazy read with annotations", () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
-    const centroids = Array.from({ length: 3 }, (_, i) =>
-      new PredictedCentroid({
-        x: i,
-        y: i,
-        video,
-        frameIdx: i,
-        track,
-        score: 0.9,
-      }),
-    );
+    const frames = Array.from({ length: 3 }, (_, i) => {
+      const c = new PredictedCentroid({ x: i, y: i, track, score: 0.9 });
+      return new LabeledFrame({ video, frameIdx: i, centroids: [c] });
+    });
 
     const labels = new Labels({
-      centroids,
+      labeledFrames: frames,
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
@@ -394,11 +375,11 @@ describe("Lazy read with annotations", () => {
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
+    const c = new UserCentroid({ x: 1, y: 2, track });
 
+    const lf0 = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] });
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst] })],
-      centroids: [c],
+      labeledFrames: [lf0],
     });
 
     const lazy = await roundTripLazy(labels);
@@ -414,13 +395,11 @@ describe("Lazy read with annotations", () => {
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, video, frameIdx: 0, track });
+    const c = new UserCentroid({ x: 1, y: 2, track });
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, track });
 
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst] })],
-      centroids: [c],
-      bboxes: [b],
+      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c], bboxes: [b] })],
     });
 
     const lazy = await roundTripLazy(labels);
@@ -441,11 +420,10 @@ describe("Lazy read with annotations", () => {
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
+    const c = new UserCentroid({ x: 1, y: 2, track });
 
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst] })],
-      centroids: [c],
+      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] })],
     });
 
     const lazy = await roundTripLazy(labels);
@@ -459,12 +437,13 @@ describe("Lazy read with annotations", () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
-    // Centroid-only data creates supplementary frames (no /frames entries)
-    const centroids = Array.from({ length: 3 }, (_, i) =>
-      new PredictedCentroid({ x: i, y: i, video, frameIdx: i, track, score: 0.9 }),
-    );
+    // Centroid-only data
+    const frames = Array.from({ length: 3 }, (_, i) => {
+      const c = new PredictedCentroid({ x: i, y: i, track, score: 0.9 });
+      return new LabeledFrame({ video, frameIdx: i, centroids: [c] });
+    });
 
-    const labels = new Labels({ centroids, videos: [video], skeletons: [skeleton], tracks: [track] });
+    const labels = new Labels({ labeledFrames: frames, videos: [video], skeletons: [skeleton], tracks: [track] });
     const lazy = await roundTripLazy(labels);
 
     // at(-1) should return the last supplementary frame
@@ -486,15 +465,15 @@ describe("Lazy read with annotations", () => {
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
-    const c = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0, track });
+    const c = new UserCentroid({ x: 1, y: 2, track });
 
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst] })],
-      centroids: [c],
+      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] })],
     });
 
-    // Write -> lazy read -> write -> eager read
+    // Write -> lazy read -> materialize -> write -> eager read
     const lazy = await roundTripLazy(labels);
+    lazy.materialize();
     const bytes2 = await saveSlpToBytes(lazy);
     const loaded = await readSlp(new Uint8Array(bytes2).buffer, { openVideos: false });
 
@@ -507,8 +486,8 @@ describe("Lazy read with annotations", () => {
 describe("_mergeAnnotations strategies", () => {
   it("keep_original keeps self's annotations and discards other's", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfC = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const otherC = new UserCentroid({ x: 3, y: 4, video, frameIdx: 0 });
+    const selfC = new UserCentroid({ x: 1, y: 2});
+    const otherC = new UserCentroid({ x: 3, y: 4});
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
@@ -521,8 +500,8 @@ describe("_mergeAnnotations strategies", () => {
 
   it("keep_new replaces with copies of other's", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfC = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const otherC = new UserCentroid({ x: 3, y: 4, video, frameIdx: 0 });
+    const selfC = new UserCentroid({ x: 1, y: 2});
+    const otherC = new UserCentroid({ x: 3, y: 4});
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
@@ -537,10 +516,10 @@ describe("_mergeAnnotations strategies", () => {
 
   it("replace_predictions keeps user from self, replaces predicted with other's", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfUser = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const selfPred = new PredictedCentroid({ x: 5, y: 6, video, frameIdx: 0, score: 0.9 });
-    const otherPred = new PredictedCentroid({ x: 7, y: 8, video, frameIdx: 0, score: 0.8 });
-    const otherUser = new UserCentroid({ x: 9, y: 10, video, frameIdx: 0 });
+    const selfUser = new UserCentroid({ x: 1, y: 2});
+    const selfPred = new PredictedCentroid({ x: 5, y: 6, score: 0.9 });
+    const otherPred = new PredictedCentroid({ x: 7, y: 8, score: 0.8 });
+    const otherUser = new UserCentroid({ x: 9, y: 10});
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred, otherUser] });
@@ -557,9 +536,9 @@ describe("_mergeAnnotations strategies", () => {
 
   it("auto spatial matching resolves user-vs-predicted", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfUser = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
-    const selfPred = new PredictedCentroid({ x: 5, y: 6, video, frameIdx: 0, score: 0.9 });
-    const otherPred = new PredictedCentroid({ x: 7, y: 8, video, frameIdx: 0, score: 0.8 });
+    const selfUser = new UserCentroid({ x: 1, y: 2});
+    const selfPred = new PredictedCentroid({ x: 5, y: 6, score: 0.9 });
+    const otherPred = new PredictedCentroid({ x: 7, y: 8, score: 0.8 });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred] });
@@ -574,9 +553,9 @@ describe("_mergeAnnotations strategies", () => {
 
   it("auto adds unmatched user from other", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfUser = new UserCentroid({ x: 1, y: 2, video, frameIdx: 0 });
+    const selfUser = new UserCentroid({ x: 1, y: 2});
     // Far away — won't match self_user (distance > 5.0)
-    const otherUser = new UserCentroid({ x: 50, y: 60, video, frameIdx: 0 });
+    const otherUser = new UserCentroid({ x: 50, y: 60});
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
@@ -592,8 +571,8 @@ describe("_mergeAnnotations strategies", () => {
 
   it("auto user replaces prediction when spatially matched", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfPred = new PredictedCentroid({ x: 10, y: 20, video, frameIdx: 0, score: 0.9 });
-    const otherUser = new UserCentroid({ x: 11, y: 20.5, video, frameIdx: 0 });
+    const selfPred = new PredictedCentroid({ x: 10, y: 20, score: 0.9 });
+    const otherUser = new UserCentroid({ x: 11, y: 20.5});
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
@@ -608,9 +587,9 @@ describe("_mergeAnnotations strategies", () => {
 
   it("auto keeps unmatched self prediction", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfPred = new PredictedCentroid({ x: 10, y: 20, video, frameIdx: 0, score: 0.9 });
+    const selfPred = new PredictedCentroid({ x: 10, y: 20, score: 0.9 });
     // Far away — no match
-    const otherUser = new UserCentroid({ x: 80, y: 90, video, frameIdx: 0 });
+    const otherUser = new UserCentroid({ x: 80, y: 90});
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
@@ -626,10 +605,10 @@ describe("_mergeAnnotations strategies", () => {
   it("auto spatial matching works for bounding boxes", () => {
     const video = new Video({ filename: "test.mp4" });
     const selfPred = new PredictedBoundingBox({
-      x1: 10, y1: 10, x2: 20, y2: 20, video, frameIdx: 0, score: 0.8,
+      x1: 10, y1: 10, x2: 20, y2: 20, score: 0.8,
     });
     const otherUser = new UserBoundingBox({
-      x1: 11, y1: 11, x2: 21, y2: 21, video, frameIdx: 0,
+      x1: 11, y1: 11, x2: 21, y2: 21,
     });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, bboxes: [selfPred] });
@@ -677,10 +656,10 @@ describe("_mergeAnnotations strategies", () => {
   it("auto many-to-one uses one-to-one matching", () => {
     const video = new Video({ filename: "test.mp4" });
     // One prediction in self
-    const selfPred = new PredictedCentroid({ x: 10, y: 10, video, frameIdx: 0, score: 0.9 });
+    const selfPred = new PredictedCentroid({ x: 10, y: 10, score: 0.9 });
     // Two users in other, both within threshold of selfPred
-    const otherUserA = new UserCentroid({ x: 11, y: 10, video, frameIdx: 0 }); // dist=1.0
-    const otherUserB = new UserCentroid({ x: 10, y: 11, video, frameIdx: 0 }); // dist=1.0
+    const otherUserA = new UserCentroid({ x: 11, y: 10}); // dist=1.0
+    const otherUserB = new UserCentroid({ x: 10, y: 11}); // dist=1.0
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUserA, otherUserB] });
@@ -725,8 +704,8 @@ describe("_mergeAnnotations strategies", () => {
     const trackA = new Track("a");
     const trackB = new Track("b");
 
-    const selfC = new UserCentroid({ x: 10, y: 20, video, frameIdx: 0, track: trackA });
-    const otherC = new UserCentroid({ x: 11, y: 20.5, video, frameIdx: 0, track: trackB });
+    const selfC = new UserCentroid({ x: 10, y: 20, track: trackA });
+    const otherC = new UserCentroid({ x: 11, y: 20.5, track: trackB });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
@@ -743,9 +722,9 @@ describe("_mergeAnnotations strategies", () => {
     const trackA = new Track("a");
     const trackB = new Track("b");
 
-    const selfC = new UserCentroid({ x: 10, y: 20, video, frameIdx: 0, track: trackA });
+    const selfC = new UserCentroid({ x: 10, y: 20, track: trackA });
     // Far away — no match
-    const otherC = new UserCentroid({ x: 80, y: 90, video, frameIdx: 0, track: trackB });
+    const otherC = new UserCentroid({ x: 80, y: 90, track: trackB });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });

--- a/tests/nested-annotations.test.ts
+++ b/tests/nested-annotations.test.ts
@@ -460,7 +460,7 @@ describe("Lazy read with annotations", () => {
     expect(lazy._lazyFrameList!.at(-(lazy.length + 1))).toBeUndefined();
   });
 
-  it("lazy write round-trips correctly", async () => {
+  it("lazy write round-trips correctly without explicit materialize", async () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
@@ -471,9 +471,10 @@ describe("Lazy read with annotations", () => {
       labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] })],
     });
 
-    // Write -> lazy read -> materialize -> write -> eager read
+    // Write -> lazy read -> save lazy directly -> eager read.
+    // The lazy fast path in saveSlpToBytes handles this without materialize().
     const lazy = await roundTripLazy(labels);
-    lazy.materialize();
+    expect(lazy.isLazy).toBe(true);
     const bytes2 = await saveSlpToBytes(lazy);
     const loaded = await readSlp(new Uint8Array(bytes2).buffer, { openVideos: false });
 

--- a/tests/python-compat-gen.test.ts
+++ b/tests/python-compat-gen.test.ts
@@ -45,22 +45,21 @@ describe("Python compatibility (#76)", () => {
     const maskData = new Uint8Array(10 * 10);
     maskData[0] = 1; maskData[1] = 1;
     const mask = SegmentationMask.fromArray(maskData, 10, 10, {
-      name: "mask1", category: "cell", source: "model", video, frameIdx: 0,
+      name: "mask1", category: "cell", source: "model",
     });
 
     const bbox = new UserBoundingBox({
-      x1: 0, y1: 20, x2: 100, y2: 100,
-      video, frameIdx: 0, track, category: "animal", name: "bb1", source: "manual",
+      x1: 0, y1: 20, x2: 100, y2: 100, track, category: "animal", name: "bb1", source: "manual",
     });
 
+    frame.masks.push(mask);
+    frame.bboxes.push(bbox);
     const labels = new Labels({
       skeletons: [skeleton],
       videos: [video],
       labeledFrames: [frame],
       tracks: [track],
       rois: [roi],
-      masks: [mask],
-      bboxes: [bbox],
     });
 
     const bytes = await saveSlpToBytes(labels);

--- a/tests/roi.test.ts
+++ b/tests/roi.test.ts
@@ -75,12 +75,10 @@ describe("ROI", () => {
     expect(roi.category).toBe("cat1");
   });
 
-  it("isStatic", () => {
+  it("no longer has isStatic or frameIdx", () => {
     const roi1 = ROI.fromBbox(0, 0, 10, 10);
-    expect(roi1.isStatic).toBe(true);
-
-    const roi2 = ROI.fromBbox(0, 0, 10, 10, { frameIdx: 5 });
-    expect(roi2.isStatic).toBe(false);
+    expect((roi1 as any).isStatic).toBeUndefined();
+    expect((roi1 as any).frameIdx).toBeUndefined();
   });
 
   it("isBbox for axis-aligned rectangle", () => {
@@ -155,11 +153,10 @@ describe("ROI", () => {
     expect(data[0 * 20 + 0]).toBe(0);
   });
 
-  it("with video and frameIdx", () => {
+  it("with video", () => {
     const video = new Video({ filename: "test.mp4" });
-    const roi = ROI.fromBbox(0, 0, 10, 10, { video, frameIdx: 5 });
+    const roi = ROI.fromBbox(0, 0, 10, 10, { video });
     expect(roi.video).toBe(video);
-    expect(roi.frameIdx).toBe(5);
   });
 
   it("rasterize point geometry returns empty mask", () => {
@@ -353,21 +350,13 @@ describe("fromMultiPolygon and explode", () => {
 
 describe("toGeoJSON", () => {
   it("returns correct Feature structure", () => {
-    const roi = ROI.fromBbox(0, 0, 10, 10, { name: "test", category: "cat", source: "src", frameIdx: 5 });
+    const roi = ROI.fromBbox(0, 0, 10, 10, { name: "test", category: "cat", source: "src" });
     const feature = roi.toGeoJSON();
     expect(feature.type).toBe("Feature");
     expect(feature.geometry.type).toBe("Polygon");
     expect(feature.properties.name).toBe("test");
     expect(feature.properties.category).toBe("cat");
     expect(feature.properties.source).toBe("src");
-    expect(feature.properties.frame_idx).toBe(5);
-    expect(feature.properties.roi_type).toBe("temporal");
-  });
-
-  it("static ROI has roi_type static", () => {
-    const roi = ROI.fromBbox(0, 0, 10, 10);
-    const feature = roi.toGeoJSON();
-    expect(feature.properties.roi_type).toBe("static");
   });
 });
 

--- a/tests/slp-rois-masks.test.ts
+++ b/tests/slp-rois-masks.test.ts
@@ -30,7 +30,6 @@ describe("SLP ROI/Mask I/O", () => {
       category: "arena",
       source: "manual",
       video,
-      frameIdx: 5,
       track,
     });
 
@@ -45,12 +44,14 @@ describe("SLP ROI/Mask I/O", () => {
       },
     );
 
+    // Put temporal ROI on a frame, keep static ROI on Labels
+    const lfRoi = new LabeledFrame({ video, frameIdx: 5, rois: [bboxRoi] });
     const labels = new Labels({
-      labeledFrames: [frame],
+      labeledFrames: [frame, lfRoi],
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      rois: [bboxRoi, polyRoi],
+      rois: [polyRoi],
     });
 
     const loaded = await roundTrip(labels);
@@ -65,8 +66,6 @@ describe("SLP ROI/Mask I/O", () => {
     expect(loadedBbox).toBeDefined();
     expect(loadedBbox.category).toBe("arena");
     expect(loadedBbox.source).toBe("manual");
-    expect(loadedBbox.frameIdx).toBe(5);
-    expect(loadedBbox.video).not.toBeNull();
     expect(loadedBbox.track).not.toBeNull();
     expect(loadedBbox.track!.name).toBe("track0");
 
@@ -81,8 +80,6 @@ describe("SLP ROI/Mask I/O", () => {
     expect(loadedPoly).toBeDefined();
     expect(loadedPoly.category).toBe("region");
     expect(loadedPoly.source).toBe("auto");
-    expect(loadedPoly.frameIdx).toBeNull(); // static ROI
-    expect(loadedPoly.video).not.toBeNull();
     expect(loadedPoly.track).toBeNull();
   });
 
@@ -104,15 +101,13 @@ describe("SLP ROI/Mask I/O", () => {
       name: "mask1",
       category: "cell",
       source: "model",
-      video,
-      frameIdx: 3,
     });
 
+    const lfMask = new LabeledFrame({ video, frameIdx: 3, masks: [mask] });
     const labels = new Labels({
-      labeledFrames: [frame],
+      labeledFrames: [frame, lfMask],
       videos: [video],
       skeletons: [skeleton],
-      masks: [mask],
     });
 
     const loaded = await roundTrip(labels);
@@ -124,8 +119,6 @@ describe("SLP ROI/Mask I/O", () => {
     expect(loadedMask.name).toBe("mask1");
     expect(loadedMask.category).toBe("cell");
     expect(loadedMask.source).toBe("model");
-    expect(loadedMask.frameIdx).toBe(3);
-    expect(loadedMask.video).not.toBeNull();
 
     // Verify RLE round-trips correctly
     const originalData = mask.data;
@@ -216,7 +209,6 @@ describe("SLP ROI/Mask I/O", () => {
       name: "orphan",
       video: null,
       track: null,
-      frameIdx: null,
     });
 
     const labels = new Labels({
@@ -229,9 +221,7 @@ describe("SLP ROI/Mask I/O", () => {
     const loaded = await roundTrip(labels);
     expect(loaded.rois.length).toBe(1);
     const loadedRoi = loaded.rois[0];
-    expect(loadedRoi.video).toBeNull();
     expect(loadedRoi.track).toBeNull();
-    expect(loadedRoi.frameIdx).toBeNull();
     expect(loadedRoi.name).toBe("orphan");
   });
 
@@ -251,11 +241,11 @@ describe("SLP ROI/Mask I/O", () => {
       category: "obj",
     });
 
+    const lfMask = new LabeledFrame({ video, frameIdx: 3, masks: [mask] });
     const labels = new Labels({
-      labeledFrames: [frame],
+      labeledFrames: [frame, lfMask],
       videos: [video],
       skeletons: [skeleton],
-      masks: [mask],
     });
 
     const loaded = await roundTrip(labels);
@@ -275,20 +265,19 @@ describe("SLP BoundingBox I/O", () => {
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     const bb1 = new UserBoundingBox({
-      x1: 0, y1: 20, x2: 100, y2: 100,
-      video, frameIdx: 3, track, category: "animal", name: "bb1", source: "manual",
+      x1: 0, y1: 20, x2: 100, y2: 100, track, category: "animal", name: "bb1", source: "manual",
     });
     const bb2 = new PredictedBoundingBox({
-      x1: 0, y1: 5, x2: 40, y2: 55,
-      score: 0.95, video, frameIdx: 1,
+      x1: 0, y1: 5, x2: 40, y2: 55, score: 0.95,
     });
 
+    const lfBb1 = new LabeledFrame({ video, frameIdx: 3, bboxes: [bb1] });
+    const lfBb2 = new LabeledFrame({ video, frameIdx: 1, bboxes: [bb2] });
     const labels = new Labels({
-      labeledFrames: [frame],
+      labeledFrames: [frame, lfBb1, lfBb2],
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      bboxes: [bb1, bb2],
     });
 
     const loaded = await roundTrip(labels);
@@ -308,8 +297,6 @@ describe("SLP BoundingBox I/O", () => {
     expect(loadedBb1.category).toBe("animal");
     expect(loadedBb1.name).toBe("bb1");
     expect(loadedBb1.source).toBe("manual");
-    expect(loadedBb1.frameIdx).toBe(3);
-    expect(loadedBb1.video).not.toBeNull();
     expect(loadedBb1.track).not.toBeNull();
     expect(loadedBb1.track!.name).toBe("track0");
 
@@ -324,7 +311,6 @@ describe("SLP BoundingBox I/O", () => {
     expect(loadedBb2.height).toBeCloseTo(50);
     expect(loadedBb2.isPredicted).toBe(true);
     expect((loadedBb2 as PredictedBoundingBox).score).toBeCloseTo(0.95);
-    expect(loadedBb2.frameIdx).toBe(1);
   });
 
   it("handles empty bboxes array", async () => {
@@ -337,7 +323,6 @@ describe("SLP BoundingBox I/O", () => {
       labeledFrames: [frame],
       videos: [video],
       skeletons: [skeleton],
-      bboxes: [],
     });
 
     const loaded = await roundTrip(labels);
@@ -355,14 +340,14 @@ describe("SLP ROI instance association (format 1.6)", () => {
 
     const roi = ROI.fromPolygon(
       [[0, 0], [100, 0], [100, 100], [0, 100]],
-      { name: "inst-roi", video, frameIdx: 0, instance: inst1 },
+      { name: "inst-roi", instance: inst1 },
     );
+    frame.rois.push(roi);
 
     const labels = new Labels({
       labeledFrames: [frame],
       videos: [video],
       skeletons: [skeleton],
-      rois: [roi],
     });
 
     const loaded = await roundTrip(labels);
@@ -381,11 +366,11 @@ describe("SLP ROI instance association (format 1.6)", () => {
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     const roi = ROI.fromBbox(0, 0, 50, 50, { name: "no-inst" });
+    frame.rois.push(roi);
     const labels = new Labels({
       labeledFrames: [frame],
       videos: [video],
       skeletons: [skeleton],
-      rois: [roi],
     });
 
     const loaded = await roundTrip(labels);
@@ -432,8 +417,9 @@ describe("SLP Predicted Variant Roundtrips", () => {
       name: "pmask", category: "seg", instance: inst,
     });
 
+    frame.masks.push(mask);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton], masks: [mask],
+      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);
@@ -455,11 +441,12 @@ describe("SLP Predicted Variant Roundtrips", () => {
     data[0] = 1;
     data[4] = 2;
     const li = new PredictedLabelImage({
-      data, height: 3, width: 3, video, frameIdx: 0, score: 0.85,
+      data, height: 3, width: 3, score: 0.85,
     });
 
+    frame.labelImages.push(li);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton], labelImages: [li],
+      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);
@@ -482,8 +469,9 @@ describe("SLP Scale/Offset Roundtrips", () => {
       { video, frameIdx: 0, scale: [2, 3], offset: [10, 20] },
     );
 
+    frame.masks.push(mask);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton], masks: [mask],
+      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);
@@ -503,12 +491,13 @@ describe("SLP Scale/Offset Roundtrips", () => {
     const data = new Int32Array(4);
     data[0] = 1;
     const li = new UserLabelImage({
-      data, height: 2, width: 2, video, frameIdx: 0,
+      data, height: 2, width: 2,
       scale: [0.5, 0.5], offset: [3, 7],
     });
 
+    frame.labelImages.push(li);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton], labelImages: [li],
+      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);

--- a/tests/slp-write.test.ts
+++ b/tests/slp-write.test.ts
@@ -180,15 +180,18 @@ describe("saveSlpToBytes", () => {
     const track = new Track("t1");
 
     const centroids = [
-      new UserCentroid({ x: 10, y: 20, video, frameIdx: 0, track, category: "cell" }),
-      new PredictedCentroid({ x: 50, y: 60, z: 3.5, score: 0.95, video, frameIdx: 1, track, trackingScore: 0.8, name: "spot1", source: "trackmate" }),
+      new UserCentroid({ x: 10, y: 20, track, category: "cell" }),
+      new PredictedCentroid({ x: 50, y: 60, z: 3.5, score: 0.95, track, trackingScore: 0.8, name: "spot1", source: "trackmate" }),
     ];
 
+    const frames = centroids.map((cent, i) =>
+      new LabeledFrame({ video, frameIdx: i, centroids: [cent] })
+    );
     const labels = new Labels({
+      labeledFrames: frames,
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      centroids,
     });
 
     const bytes = await saveSlpToBytes(labels);
@@ -201,7 +204,6 @@ describe("saveSlpToBytes", () => {
     expect(c0.x).toBeCloseTo(10);
     expect(c0.y).toBeCloseTo(20);
     expect(c0.z).toBeNull();
-    expect(c0.frameIdx).toBe(0);
     expect(c0.category).toBe("cell");
     expect(c0.isPredicted).toBe(false);
 
@@ -211,7 +213,6 @@ describe("saveSlpToBytes", () => {
     expect(c1.y).toBeCloseTo(60);
     expect(c1.z).toBeCloseTo(3.5);
     expect(c1.score).toBeCloseTo(0.95);
-    expect(c1.frameIdx).toBe(1);
     expect(c1.trackingScore).toBeCloseTo(0.8);
     expect(c1.name).toBe("spot1");
     expect(c1.source).toBe("trackmate");
@@ -228,15 +229,16 @@ describe("saveSlpToBytes", () => {
     const track = new Track("t1");
 
     const bboxes = [
-      new UserBoundingBox({ x1: 0, y1: 0, x2: 100, y2: 100, video, frameIdx: 0, trackingScore: 0.75 }),
-      new PredictedBoundingBox({ x1: 10, y1: 10, x2: 50, y2: 50, score: 0.9, video, frameIdx: 0, track }),
+      new UserBoundingBox({ x1: 0, y1: 0, x2: 100, y2: 100, trackingScore: 0.75 }),
+      new PredictedBoundingBox({ x1: 10, y1: 10, x2: 50, y2: 50, score: 0.9, track }),
     ];
 
+    const lfBbox = new LabeledFrame({ video, frameIdx: 0, bboxes });
     const labels = new Labels({
+      labeledFrames: [lfBbox],
       videos: [video],
       skeletons: [skeleton],
       tracks: [track],
-      bboxes,
     });
 
     const bytes = await saveSlpToBytes(labels);

--- a/tests/trackmate.test.ts
+++ b/tests/trackmate.test.ts
@@ -79,15 +79,17 @@ describe("readTrackMateCsv", () => {
     expect(c0.x).toBeCloseTo(10.0);
     expect(c0.y).toBeCloseTo(20.0);
     expect(c0.z).toBeNull(); // 0.0 -> null
-    expect(c0.frameIdx).toBe(0);
+    // frameIdx is now on the parent LabeledFrame, not the centroid
     expect(c0.score).toBeCloseTo(5.5);
     expect(c0.name).toBe("ID100");
     expect(c0.source).toBe("trackmate");
     expect(c0.track).not.toBeNull();
     expect(c0.track!.name).toBe("Track_0");
 
-    const c2 = labels.centroids[2] as PredictedCentroid;
-    expect(c2.track!.name).toBe("Track_1");
+    // Centroids are grouped by frame; Track_1 centroid is on frame 0
+    const trackNames = labels.centroids.map((c) => c.track?.name);
+    expect(trackNames).toContain("Track_0");
+    expect(trackNames).toContain("Track_1");
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -145,7 +147,8 @@ describe("readTrackMateCsv", () => {
 
     expect(labels.videos).toHaveLength(1);
     expect(labels.videos[0].filename).toBe("my_video.tif");
-    expect(labels.centroids[0].video).toBe(labels.videos[0]);
+    // centroids no longer have .video; check the parent frame instead
+    expect(labels.labeledFrames[0].video).toBe(labels.videos[0]);
 
     fs.rmSync(dir, { recursive: true });
   });


### PR DESCRIPTION
## Summary

Ports [talmolab/sleap-io#411](https://github.com/talmolab/sleap-io/pull/411) to the JS library and lands four follow-up fixes surfaced during the port review (documented in `scratch/2026-04-12-pr94-design-reassessment/README.md`).

**Core port** — Removes `video` and `frameIdx` attributes from `Centroid`, `BoundingBox`, `SegmentationMask`, and `LabelImage` so annotations derive their spatial-temporal context from the parent `LabeledFrame`. `ROI` keeps `video` (for static ROIs like arena boundaries) but loses `frameIdx`. Eliminates the metadata sync bug where an annotation's own `video`/`frameIdx` could disagree with the `LabeledFrame` it lives in.

**Follow-up fixes** — A post-port design reassessment surfaced one API-contract bug in the ported code and a silent data-loss regression in lazy SLP writes. Both are addressed here so PR #94 lands with the full design intent. See details below.

PR #409 from upstream is docs-only (Python mkdocs) and has no JS-portable code.

## Key Changes

### Model layer (`src/model/`)
- Remove `video`/`frameIdx` from 4 annotation classes; remove `frameIdx` from `ROI`
- Remove `isStatic` getters (no longer meaningful without `frameIdx`)
- Add `LabeledFrame.append(annotation)` — routes by type via `instanceof` checks
- Remove `Labels.addCentroid`/`addBbox`/`addMask`/`addLabelImage`/`addRoi`
- Remove `Labels._distributeAnnotations()` and `_initCentroids`/`_initBboxes`/`_initMasks`/`_initLabelImages`
- Rename `_initRois` → `_staticRois` for static ROIs
- Update flat property getters (`centroids`, `bboxes`, `masks`, `labelImages`) to aggregate only from frames
- Update filter methods (`getRois`, `getMasks`, `getBboxes`, `getCentroids`, `getLabelImages`) to use frame-based lookup
- Update track index sort to derive `frameIdx` from parent `LabeledFrame`
- Update conversion methods (`toRoi`, `toMask`, `toBbox`, `toPolygon`, `resampled`, `explode`) to stop propagating removed fields

### I/O layer
- **SLP reader** (`src/codecs/slp/read.ts`): read functions now return `[annotation, videoIdx, frameIdx]` routing tuples; main reader distributes annotations to `LabeledFrame`s
- **SLP writer** (`src/codecs/slp/write.ts`): write functions accept parallel `contexts: [number, number][]` arrays; main writer builds them by iterating `LabeledFrame`s
- **GeoJSON** (`src/io/geojson.ts`): remove `frameIdx` from ROI import
- **TrackMate** (`src/io/trackmate.ts`): group spots by frame, attach centroids to `LabeledFrame`s during deserialization
- HDF5 column layout unchanged for backward/forward compatibility

## Follow-up Fixes

### Pattern 1 — `getRois({video})` static-ROI leak (JS-only API contract fix)

The initial port added a `_staticRois.filter(...)` line to the `video=v` branch of `getRois` that doesn't appear in any sibling getter (`getMasks`, `getBboxes`, `getCentroids`, `getLabelImages`). This made the filter rule inconsistent with Python and impossible to state in one sentence. Removed.

The rule (now documented in a JSDoc block on `getRois`):

> - Frame-aware filters (`video` or `frameIdx`) walk only `labeledFrames`. Static ROIs are excluded.
> - Otherwise (no filter, or only `category`/`track`/`instance`/`predicted`) the search runs over `this.rois` — the union of static + frame-bound.

To access static ROIs directly, use `Labels.staticRois`. Regression test added in `tests/labels-rois-masks.test.ts`.

### Pattern 2 — `writeSlpToFileLazy` (silent data-loss regression fix)

PR #94's initial diff iterated `labels.labeledFrames` directly in the writer to build routing-context tuples. In lazy mode `labeledFrames` is empty (frames live in `_lazyFrameList`), so `saveSlpToBytes(lazy)` silently produced a file with zero frames and zero annotations. Tests worked around this with explicit `lazy.materialize()` calls.

Ported Python's `_write_labels_lazy` (`sleap_io/io/slp.py:5315-5463`) as `writeSlpToFileLazy` in `src/codecs/slp/write.ts`:

- New helpers: `writeLazyMatrixDataset`, `writeLazyFramesAndInstances`, `writeLazyNegativeFrames` write raw column data from `LazyDataStore` without materializing any frames.
- `writeSlpToFileLazy` builds `(annotation, context)` pairs by iterating `_centroidByFrame`/`_bboxByFrame`/etc. Map keys (format `"vidIdx:frameIdx"`) + `_undistributed*` arrays, then calls the existing `writeRois`/etc. with the routing contexts.
- `saveSlpToBytes` gains a lazy dispatch: fast path for `embed: false`/`undefined`/`"source"`; materialize for embed modes that read pixel data (`"all"`/`"user"`/`"suggestions"`/`"user+suggestions"`).
- `embed: "source"` lazy support via `makeLazySourceLabels` — swaps `videos[]` in place on a shallow Labels copy and remaps `suggestions[].video`. Throws `LazySourceFallback` for multi-camera sessions referencing swapped videos; the dispatch catches it and falls through to materialization.
- Dropped the `lazy.materialize()` workaround in `tests/nested-annotations.test.ts:476`.

### Side fix A — `_instanceIdx` fallback in `writeRois`/`writeBboxes`/`writeCentroids`

`writeMasks` already fell back to `_instanceIdx ?? -1` when `instance === null` (lazy mode). The other three writers did not, silently dropping instance associations. Python's `write_rois` has the fallback at `slp.py:2869`; this brings JS to parity. Affects both lazy writes and any eager use that happens to have `_instanceIdx` set without a live `instance`.

### Side fix B — Preserve static-ROI video association in lazy collector

**This is also a bug in Python** — filed as [talmolab/sleap-io#413](https://github.com/talmolab/sleap-io/issues/413). `_collect_from_lazy` in Python (`sleap_io/io/slp.py:5414-5425`) emits `(-1, -1)` for every undistributed annotation, and `write_rois` reads the context directly with no `roi.video` fallback. For static ROIs, this silently drops the video association on lazy round-trip.

The JS `writeSlpToFileLazy` avoids the bug by looking up `labels.videos.indexOf(roi.video)` for each entry in `_undistributedRois` when building contexts. Regression test at `tests/lazy-write.test.ts` (`preserves static ROI video association`).

### Side fix C — Eager read resolves `_instanceIdx → .instance` for all annotation types

While adding Side-fix-A regression tests I discovered a pre-existing gap: the eager SLP reader only resolved live `.instance` references for ROIs (via the migration path). Bboxes/centroids/masks/labelImages had `_instanceIdx` set but `.instance = null` after eager read — `Labels.materialize()` handles this for lazy→eager but no pass existed for direct eager reads. Added a post-distribution resolution pass in `readSlp` that mirrors `Labels.materialize()`.

## API Changes

| Before | After |
|---|---|
| `new UserCentroid({ x: 1, y: 2, video: v, frameIdx: 5 })` | `new UserCentroid({ x: 1, y: 2 })` |
| `labels.addCentroid(c)` | `lf.append(c)` or `lf.centroids.push(c)` |
| `lf.centroids.push(c)` | `lf.append(c)` (routes by type) |
| `new Labels({ centroids: [c1, c2] })` | Attach to `LabeledFrame`s first, then `new Labels({ labeledFrames: [lf] })` |
| `roi.isStatic` | `labels.staticRois.includes(roi)` |

**Annotations that must always be on a frame:** `Centroid`, `BoundingBox`, `SegmentationMask`, `LabelImage`
**Annotations that can be static or frame-bound:** `ROI` (static via `new Labels({ rois: [...] })`, frame-bound via `lf.append(roi)`)

**Behavioral change introduced by Pattern 1**: `labels.getRois({ video: v })` no longer returns static ROIs whose `video === v`. Use `labels.staticRois` to access them directly.

**Behavioral change introduced by Pattern 2**: `saveSlpToBytes(lazy)` now works without explicit `materialize()`. No API surface change — prior callers that worked via `lazy.materialize()` still work.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 683/683 tests pass across 50 files (up from 668/49 before follow-ups)
- [x] SLP round-trip preserves annotations on `LabeledFrame`s
- [x] Static ROIs preserved through SLP round-trip
- [x] Lazy loading still works (LazyDataStore updated to use routing tuples)
- [x] New test file `tests/lazy-write.test.ts` — 14 tests covering:
  - User/predicted instance round-trip through lazy fast path
  - Frame-bound centroids/bboxes/masks/labelImages round-trip
  - Static ROI video association preserved (Side fix B regression)
  - Negative frames round-trip
  - Instance association preserved on centroids/bboxes/rois via `_instanceIdx` (Side fix A regression)
  - Mixed annotation types in a single frame
  - `embed: "source"` lazy fast path restores source video paths
  - `embed: "all"` in lazy mode triggers materialization
- [x] New regression test for Pattern 1 in `tests/labels-rois-masks.test.ts`
- [x] `nested-annotations.test.ts` lazy write test no longer requires explicit `materialize()`

## References

- Investigation doc: `scratch/2026-04-12-pr94-design-reassessment/README.md`
- Python issue for the cross-library Side fix B bug: talmolab/sleap-io#413
- Python issue also covers the `get_rois` docstring clarification (no behavior change upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)