### PR TITLE
docs: Refresh for v0.3.0 API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,8 @@ JavaScript/TypeScript utilities for reading and writing SLEAP `.slp` files with 
 
 ## Quickstart
 
-Install from npm:
-
 ```bash
 npm install @talmolab/sleap-io.js
-```
-
-To build from source (for contributors):
-
-```bash
-npm install
-npm run build
 ```
 
 ### Load and save SLP

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ JavaScript/TypeScript utilities for reading and writing SLEAP `.slp` files with 
 - SLP read/write with format compatibility (format 1.0–2.2, including embedded frames via HDF5 video datasets).
 - Browser-compatible SLP writing via `saveSlpToBytes()`.
 - Streaming-friendly file access (URL, `File`, `FileSystemFileHandle`, `Blob`).
-- Core data model (`Labels`, `LabeledFrame`, `Instance`, `Skeleton`, `Video`, `Identity`, `Instance3D`, etc.).
+- Core data model (`Labels`, `LabeledFrame`, `Instance`, `Skeleton`, `Video`, `Centroid`, `Identity`, `Instance3D`, etc.).
 - ROI, segmentation mask, bounding box, and label image annotations with GeoJSON I/O.
 - 3D pose data structures with cross-library interop (Python sleap-io, luc3d).
 - Video backends accept `string`, `File`, or `Blob` sources.
@@ -24,6 +24,14 @@ JavaScript/TypeScript utilities for reading and writing SLEAP `.slp` files with 
 
 ## Quickstart
 
+Install from npm:
+
+```bash
+npm install @talmolab/sleap-io.js
+```
+
+To build from source (for contributors):
+
 ```bash
 npm install
 npm run build
@@ -32,7 +40,7 @@ npm run build
 ### Load and save SLP
 
 ```ts
-import { loadSlp, saveSlp, saveSlpToBytes } from "sleap-io.js";
+import { loadSlp, saveSlp, saveSlpToBytes } from "@talmolab/sleap-io.js";
 
 const labels = await loadSlp("/path/to/session.slp", { openVideos: false });
 
@@ -46,7 +54,7 @@ const bytes: Uint8Array = await saveSlpToBytes(labels);
 ### Load video
 
 ```ts
-import { loadVideo, Mp4BoxVideoBackend } from "sleap-io.js";
+import { loadVideo, Mp4BoxVideoBackend } from "@talmolab/sleap-io.js";
 
 // From file path (Node.js) or URL (browser)
 const video = await loadVideo("/path/to/video.mp4", { openBackend: false });

--- a/docs/api.md
+++ b/docs/api.md
@@ -242,13 +242,13 @@ labels.replaceVideos({ videoMap: new Map([[oldVid, newVid]]) });
 
 ### Frame merging
 
-Merge annotations from one `LabeledFrame` into another with strategy-aware handling. `LabeledFrame._mergeAnnotations(other, strategy?, threshold?)` supports six strategies, applied across all annotation modalities (centroids, bboxes, masks, label images, ROIs):
+Merge annotations from one `LabeledFrame` into another with strategy-aware handling. `LabeledFrame.mergeAnnotations(other, strategy?, threshold?)` supports six strategies, applied across all annotation modalities (centroids, bboxes, masks, label images, ROIs):
 
 | Strategy | Behavior |
 |---|---|
 | `"keep_original"` | Keep self only, discard everything from `other` |
 | `"keep_new"` | Replace self's annotations with (copies of) `other`'s |
-| `"keep_both"` *(default)* | Deduplicate by object identity, union both sets |
+| `"keep_both"` *(default)* | Deduplicate by object identity, union both sets (items from `other` are shallow-copied before insertion) |
 | `"replace_predictions"` | Keep user annotations from self; drop self's predicted and take all predicted from `other` |
 | `"auto"` | Spatially match by centroid distance; user beats predicted; add unmatched |
 | `"update_tracks"` | Spatially match and cascade track assignments only |
@@ -257,13 +257,13 @@ The `auto` and `update_tracks` strategies compare centroid distances against `th
 
 ```ts
 // Default behavior (keep_both): dedupe by identity, union everything
-lfA._mergeAnnotations(lfB);
+lfA.mergeAnnotations(lfB);
 
 // Spatial auto merge with a 3 px threshold
-lfA._mergeAnnotations(lfB, "auto", 3.0);
+lfA.mergeAnnotations(lfB, "auto", 3.0);
 
 // Keep only predicted updates from other, leave user annotations alone
-lfA._mergeAnnotations(lfB, "replace_predictions");
+lfA.mergeAnnotations(lfB, "replace_predictions");
 ```
 
 ## Lazy Loading
@@ -288,15 +288,20 @@ Key classes:
 - **`LazyDataStore`**: Holds raw HDF5 column data; supports `materializeFrame(idx)`, `materializeAll()`, `copy()`, and `toNumpy()` fast path.
 - **`LazyFrameList`**: Array-like container with `at(idx)`, `length`, `toArray()`, `[Symbol.iterator]()`, and `materializedCount`.
 
-> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale or partial results. Call `labels.materialize()` first, or use `labels.find({ video, frameIdx })` which handles both lazy and eager modes transparently (it returns `LabeledFrame[]` — take the first element).
+> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale or partial results. You have two options, both of which trigger full materialization under the hood:
+>
+> 1. Call `labels.materialize()` explicitly, then use the O(1) lookups.
+> 2. Call `labels.find({ video, frameIdx })`, which materializes internally on first call and then uses the same O(1) index. It returns `LabeledFrame[]` — take the first element.
+>
+> Both paths do the same amount of work on the first call; there's no cheap "lazy-preserving" variant of frame lookup by `(video, frameIdx)`.
 
 ```ts
-// Safe patterns for lazy Labels
-const [frame] = labels.find({ video, frameIdx: 42 });   // LabeledFrame | undefined
-
-// Or materialize first for O(1) lookups
+// Option 1: materialize first, then O(1) lookup
 labels.materialize();
-const lf = labels.getFrame(video, 42);  // now safe
+const lf = labels.getFrame(video, 42);
+
+// Option 2: find() — equivalent, materializes on first call
+const [frame] = labels.find({ video, frameIdx: 42 });   // LabeledFrame | undefined
 ```
 
 ## ROI & Segmentation Masks
@@ -389,31 +394,42 @@ Axis-aligned or rotated bounding box for detection/tracking workflows. `Bounding
 
 Bounding boxes use corner coordinates (`x1`, `y1`, `x2`, `y2`) as their primary storage. Center-based properties (`xCenter`, `yCenter`, `width`, `height`) are available as computed getters.
 
+Construct a user-annotated bbox and attach it to a frame:
+
 ```ts
-// Create user-annotated bbox from corners
 const bbox = new UserBoundingBox({
   x1: 0, y1: 20, x2: 100, y2: 100,
   category: "animal",
 });
 
-// Attach to a frame (the parent LabeledFrame provides video + frameIdx context)
+// The parent LabeledFrame provides video + frameIdx context
 let lf = labels.getFrame(labels.videos[0], 3);
 if (!lf) {
   lf = new LabeledFrame({ video: labels.videos[0], frameIdx: 3 });
   labels.append(lf);
 }
 lf.append(bbox);
+```
 
-// Create predicted bbox with confidence score
-const pred = new PredictedBoundingBox({
+Construct a predicted bbox with confidence score:
+
+```ts
+const predBbox = new PredictedBoundingBox({
   x1: 0, y1: 20, x2: 100, y2: 100,
   score: 0.95,
 });
+```
 
-// Factory methods (return UserBoundingBox)
-const bbox2 = BoundingBox.fromXyxy(10, 20, 110, 100);  // corner coords
-const bbox3 = BoundingBox.fromXywh(10, 20, 100, 80);   // top-left + size
+Factory methods (return `UserBoundingBox`):
 
+```ts
+const fromCorners = BoundingBox.fromXyxy(10, 20, 110, 100);  // corner coords
+const fromTopLeft = BoundingBox.fromXywh(10, 20, 100, 80);   // top-left + size
+```
+
+Properties and conversions:
+
+```ts
 // Stored properties
 bbox.x1; bbox.y1; bbox.x2; bbox.y2;  // corner coordinates
 bbox.angle;      // rotation in radians (default 0)

--- a/docs/api.md
+++ b/docs/api.md
@@ -242,7 +242,7 @@ labels.replaceVideos({ videoMap: new Map([[oldVid, newVid]]) });
 
 ### Frame merging
 
-Merge annotations from one `LabeledFrame` into another with strategy-aware handling. `LabeledFrame.mergeAnnotations(other, strategy?, threshold?)` supports six strategies, applied across all annotation modalities (centroids, bboxes, masks, label images, ROIs):
+Merge annotations from one `LabeledFrame` into another with strategy-aware handling. `LabeledFrame.mergeAnnotations(other, strategy?, threshold?)` supports six strategies, applied across all annotation modalities (centroids, bboxes, masks, label images, ROIs). To populate a single `LabeledFrame` in the first place, see [Adding annotations to frames](#adding-annotations-to-frames) below.
 
 | Strategy | Behavior |
 |---|---|
@@ -254,6 +254,15 @@ Merge annotations from one `LabeledFrame` into another with strategy-aware handl
 | `"update_tracks"` | Spatially match and cascade track assignments only |
 
 The `auto` and `update_tracks` strategies compare centroid distances against `threshold` (default `5.0` px). Empty masks and ROIs whose centroid is `null` are skipped by the matcher.
+
+The strategy argument is typed as `MergeStrategy`, re-exported from the package root for type-safe call sites:
+
+```ts
+import type { MergeStrategy } from "@talmolab/sleap-io.js";
+
+const strategy: MergeStrategy = "auto";
+lfA.mergeAnnotations(lfB, strategy, 3.0);
+```
 
 ```ts
 // Default behavior (keep_both): dedupe by identity, union everything

--- a/docs/api.md
+++ b/docs/api.md
@@ -249,7 +249,7 @@ Merge annotations from one `LabeledFrame` into another with strategy-aware handl
 | `"keep_original"` | Keep self only, discard everything from `other` |
 | `"keep_new"` | Replace self's annotations with (copies of) `other`'s |
 | `"keep_both"` *(default)* | Deduplicate by object identity, union both sets |
-| `"replace_predictions"` | Keep user annotations from self, replace predicted entries with `other`'s |
+| `"replace_predictions"` | Keep user annotations from self; drop self's predicted and take all predicted from `other` |
 | `"auto"` | Spatially match by centroid distance; user beats predicted; add unmatched |
 | `"update_tracks"` | Spatially match and cascade track assignments only |
 
@@ -288,11 +288,11 @@ Key classes:
 - **`LazyDataStore`**: Holds raw HDF5 column data; supports `materializeFrame(idx)`, `materializeAll()`, `copy()`, and `toNumpy()` fast path.
 - **`LazyFrameList`**: Array-like container with `at(idx)`, `length`, `toArray()`, `[Symbol.iterator]()`, and `materializedCount`.
 
-> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale or partial results. Call `labels.materialize()` first, or use `labels.find(video, frameIdx)` which handles both lazy and eager modes transparently.
+> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale or partial results. Call `labels.materialize()` first, or use `labels.find({ video, frameIdx })` which handles both lazy and eager modes transparently (it returns `LabeledFrame[]` — take the first element).
 
 ```ts
 // Safe patterns for lazy Labels
-const frame = labels.find(video, 42);   // works in both modes
+const [frame] = labels.find({ video, frameIdx: 42 });   // LabeledFrame | undefined
 
 // Or materialize first for O(1) lookups
 labels.materialize();
@@ -400,7 +400,7 @@ const bbox = new UserBoundingBox({
 let lf = labels.getFrame(labels.videos[0], 3);
 if (!lf) {
   lf = new LabeledFrame({ video: labels.videos[0], frameIdx: 3 });
-  labels.labeledFrames.push(lf);
+  labels.append(lf);
 }
 lf.append(bbox);
 
@@ -446,7 +446,7 @@ const c = new UserCentroid({ x: 100, y: 200, track });
 let lf = labels.getFrame(video, 0);
 if (!lf) {
   lf = new LabeledFrame({ video, frameIdx: 0 });
-  labels.labeledFrames.push(lf);
+  labels.append(lf);
 }
 lf.append(c);
 
@@ -461,7 +461,7 @@ const pc = new PredictedCentroid({
 let lf1 = labels.getFrame(video, 1);
 if (!lf1) {
   lf1 = new LabeledFrame({ video, frameIdx: 1 });
-  labels.labeledFrames.push(lf1);
+  labels.append(lf1);
 }
 lf1.append(pc);
 
@@ -527,6 +527,8 @@ labels.addVideo(video);
 
 Use `LabeledFrame.append(annotation)` to add any annotation type. It routes by runtime type to the appropriate per-frame list (`lf.centroids`, `.bboxes`, `.masks`, `.labelImages`, `.rois`) and handles `Instance` and `PredictedInstance` as well. If you know the target list at the call site, you can also push directly.
 
+> **Note:** `Labels` and `LabeledFrame` each have an `append()` method. `labels.append(lf)` adds a `LabeledFrame` to a `Labels` (and also registers its video and tracks). `lf.append(annotation)` adds an annotation to a single `LabeledFrame`. They're different operations at different levels of the hierarchy.
+
 ```ts
 import {
   Labels,
@@ -552,7 +554,7 @@ const labels = new Labels({ labeledFrames: [lf], videos: [video], skeletons: [sk
 let existing = labels.getFrame(video, 5);
 if (!existing) {
   existing = new LabeledFrame({ video, frameIdx: 5 });
-  labels.labeledFrames.push(existing);
+  labels.append(existing);
 }
 existing.append(anotherBbox);
 ```
@@ -617,7 +619,7 @@ labelImages.forEach((li, i) => {
   let lf = labels.getFrame(video, i);
   if (!lf) {
     lf = new LabeledFrame({ video, frameIdx: i });
-    labels.labeledFrames.push(lf);
+    labels.append(lf);
   }
   lf.append(li);
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -198,6 +198,74 @@ const labels = new Labels({ labeledFrames: [frame], skeletons: [skeleton], video
 labels.addVideo(video); // no-op if already present
 ```
 
+### Frame and track index lookups
+
+`Labels` builds lazy `Map` indices for O(1) frame and track lookups, replacing linear scans through `labeledFrames`. The frame-aware `find()` / `getCentroids()` / `getBboxes()` / `getMasks()` / `getLabelImages()` / `getRois()` methods use these indices internally when both `video` and `frameIdx` are passed.
+
+```ts
+// O(1) frame lookup
+const lf = labels.getFrame(video, 42);  // LabeledFrame | null
+
+// O(1) track annotation lookup, sorted by frameIdx
+const annotations = labels.getTrackAnnotations(video, track);
+
+// Force index rebuild after external mutations
+labels.reindex();
+```
+
+Indices are built lazily on first access and auto-invalidated when frames are added or videos replaced. See the [Lazy Loading](#lazy-loading) section below for the caveat that applies when the `Labels` is lazy.
+
+### Deep copy and video remapping
+
+`Labels.copy()` produces a fully independent copy of a `Labels` object with consistent internal references — frame videos point to the copy's video objects, instance skeletons point to the copy's skeletons, etc. Both eager and lazy `Labels` are supported.
+
+`Labels.replaceVideos()` rewrites video references across every collection in one call: `labeledFrames`, `suggestions`, `sessions`, `staticRois`, `temporalRois`, `masks`, `labelImages`, and `centroids`.
+
+```ts
+// Deep copy (eager or lazy — matches the original)
+const copy = labels.copy();
+
+// Suppress backend auto-opening on the new copy (faster, safer for bulk ops)
+const detached = labels.copy({ openVideos: false });
+
+// Replace video references — specify both old and new
+labels.replaceVideos({ oldVideos: [oldVid], newVideos: [newVid] });
+
+// Or infer old from current
+labels.replaceVideos({ newVideos: [newVid] });
+
+// Or pass a Map
+labels.replaceVideos({ videoMap: new Map([[oldVid, newVid]]) });
+```
+
+`LazyDataStore.copy()` duplicates the underlying HDF5 column arrays so that two `Labels` wrapping the same source file can diverge safely.
+
+### Frame merging
+
+Merge annotations from one `LabeledFrame` into another with strategy-aware handling. `LabeledFrame._mergeAnnotations(other, strategy?, threshold?)` supports six strategies, applied across all annotation modalities (centroids, bboxes, masks, label images, ROIs):
+
+| Strategy | Behavior |
+|---|---|
+| `"keep_original"` | Keep self only, discard everything from `other` |
+| `"keep_new"` | Replace self's annotations with (copies of) `other`'s |
+| `"keep_both"` *(default)* | Deduplicate by object identity, union both sets |
+| `"replace_predictions"` | Keep user annotations from self, replace predicted entries with `other`'s |
+| `"auto"` | Spatially match by centroid distance; user beats predicted; add unmatched |
+| `"update_tracks"` | Spatially match and cascade track assignments only |
+
+The `auto` and `update_tracks` strategies compare centroid distances against `threshold` (default `5.0` px). Empty masks and ROIs whose centroid is `null` are skipped by the matcher.
+
+```ts
+// Default behavior (keep_both): dedupe by identity, union everything
+lfA._mergeAnnotations(lfB);
+
+// Spatial auto merge with a 3 px threshold
+lfA._mergeAnnotations(lfB, "auto", 3.0);
+
+// Keep only predicted updates from other, leave user annotations alone
+lfA._mergeAnnotations(lfB, "replace_predictions");
+```
+
 ## Lazy Loading
 
 Load SLP files with on-demand frame materialization for better performance on large datasets.
@@ -217,8 +285,19 @@ console.log(labels.isLazy);  // false
 
 Key classes:
 
-- **`LazyDataStore`**: Holds raw HDF5 column data; supports `materializeFrame(idx)`, `materializeAll()`, and `toNumpy()` fast path.
+- **`LazyDataStore`**: Holds raw HDF5 column data; supports `materializeFrame(idx)`, `materializeAll()`, `copy()`, and `toNumpy()` fast path.
 - **`LazyFrameList`**: Array-like container with `at(idx)`, `length`, `toArray()`, `[Symbol.iterator]()`, and `materializedCount`.
+
+> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale or partial results. Call `labels.materialize()` first, or use `labels.find(video, frameIdx)` which handles both lazy and eager modes transparently.
+
+```ts
+// Safe patterns for lazy Labels
+const frame = labels.find(video, 42);   // works in both modes
+
+// Or materialize first for O(1) lookups
+labels.materialize();
+const lf = labels.getFrame(video, 42);  // now safe
+```
 
 ## ROI & Segmentation Masks
 
@@ -314,18 +393,26 @@ Bounding boxes use corner coordinates (`x1`, `y1`, `x2`, `y2`) as their primary 
 // Create user-annotated bbox from corners
 const bbox = new UserBoundingBox({
   x1: 0, y1: 20, x2: 100, y2: 100,
-  video: labels.videos[0], frameIdx: 3, category: "animal",
+  category: "animal",
 });
 
+// Attach to a frame (the parent LabeledFrame provides video + frameIdx context)
+let lf = labels.getFrame(labels.videos[0], 3);
+if (!lf) {
+  lf = new LabeledFrame({ video: labels.videos[0], frameIdx: 3 });
+  labels.labeledFrames.push(lf);
+}
+lf.append(bbox);
+
 // Create predicted bbox with confidence score
-const bbox = new PredictedBoundingBox({
+const pred = new PredictedBoundingBox({
   x1: 0, y1: 20, x2: 100, y2: 100,
   score: 0.95,
 });
 
 // Factory methods (return UserBoundingBox)
-const bbox = BoundingBox.fromXyxy(10, 20, 110, 100);  // corner coords
-const bbox = BoundingBox.fromXywh(10, 20, 100, 80);   // top-left + size
+const bbox2 = BoundingBox.fromXyxy(10, 20, 110, 100);  // corner coords
+const bbox3 = BoundingBox.fromXywh(10, 20, 100, 80);   // top-left + size
 
 // Stored properties
 bbox.x1; bbox.y1; bbox.x2; bbox.y2;  // corner coordinates
@@ -343,7 +430,6 @@ bbox.bounds;     // { minX, minY, maxX, maxY }
 bbox.area;       // width * height
 bbox.centroidXy; // [x, y]
 bbox.isPredicted; // true for PredictedBoundingBox
-bbox.isStatic;   // true if no frameIdx
 bbox.isRotated;  // true if angle != 0
 
 // Conversion
@@ -355,24 +441,35 @@ const mask = bbox.toMask(480, 640);    // SegmentationMask
 Point representing the center of an object. `Centroid` is abstract; use `UserCentroid` or `PredictedCentroid`.
 
 ```ts
-// Create user centroid
-const c = new UserCentroid({ x: 100, y: 200, video, frameIdx: 0, track });
+// Create user centroid (attach to a frame to provide video + frameIdx context)
+const c = new UserCentroid({ x: 100, y: 200, track });
+let lf = labels.getFrame(video, 0);
+if (!lf) {
+  lf = new LabeledFrame({ video, frameIdx: 0 });
+  labels.labeledFrames.push(lf);
+}
+lf.append(c);
 
 // Create predicted centroid with confidence
 const pc = new PredictedCentroid({
   x: 50, y: 60, z: 3.5,
   score: 0.95,
   trackingScore: 0.8,
-  video, frameIdx: 1, track,
+  track,
   name: "spot1", source: "trackmate",
 });
+let lf1 = labels.getFrame(video, 1);
+if (!lf1) {
+  lf1 = new LabeledFrame({ video, frameIdx: 1 });
+  labels.labeledFrames.push(lf1);
+}
+lf1.append(pc);
 
 // Properties
 c.xy;           // [x, y]
 c.yx;           // [y, x] (row, col)
 c.xyz;          // [x, y, z | null]
 c.isPredicted;  // false for User, true for Predicted
-c.isStatic;     // true if no frameIdx
 
 // Convert to single-node Instance
 const inst = pc.toInstance();  // PredictedInstance with centroid skeleton
@@ -399,6 +496,8 @@ CENTROID_SKELETON === getCentroidSkeleton();  // true (singleton)
 
 ### `Labels` Annotation Access
 
+Annotations (`Centroid`, `BoundingBox`, `SegmentationMask`, `LabelImage`, frame-bound `ROI`) live on individual `LabeledFrame` instances, not on `Labels`. The `Labels` getters return flattened read-only views across all frames; mutation always goes through the owning frame.
+
 ```ts
 // Read-only property getters (flat views across all frames)
 labels.rois;           // ROI[]
@@ -407,32 +506,62 @@ labels.bboxes;         // BoundingBox[]
 labels.centroids;      // Centroid[]
 labels.labelImages;    // LabelImage[]
 labels.identities;     // Identity[]
-labels.staticRois;     // ROIs without frame index
-labels.temporalRois;   // ROIs with frame index
-labels.staticBboxes;   // BBoxes without frame index
-labels.temporalBboxes; // BBoxes with frame index
+labels.staticRois;     // Static (video-level) ROIs, e.g. arena boundaries
+labels.temporalRois;   // Frame-bound ROIs (flat view across frames)
 
-// Mutation (adds to the appropriate LabeledFrame)
-labels.addRoi(roi);
-labels.addMask(mask);
-labels.addBbox(bbox);
-labels.addCentroid(centroid);
-labels.addLabelImage(labelImage);
-
-// Filtered queries (all support `predicted` filter)
+// Filtered queries (all support `predicted` filter; frame-aware filters use O(1) indices)
 labels.getRois({ video, frameIdx: 0, category: "arena", predicted: false });
 labels.getMasks({ video, category: "segmentation", predicted: true });
 labels.getBboxes({ video, frameIdx: 0, predicted: true });
 labels.getCentroids({ video, frameIdx: 0, track, predicted: true });
 labels.getLabelImages({ video, frameIdx: 0, track, category: "cell" });
 
+// Note: getRois({ video }) returns only frame-bound ROIs for that video.
+// For static ROIs, use labels.staticRois directly.
+
 // Add a video (deduplicates automatically)
 labels.addVideo(video);
 ```
 
-Annotations are stored per-frame on `LabeledFrame`. The `Labels` property getters return
-flattened views across all frames. When constructing `Labels` with flat annotation lists,
-they are automatically distributed to matching frames.
+#### Adding annotations to frames
+
+Use `LabeledFrame.append(annotation)` to add any annotation type. It routes by runtime type to the appropriate per-frame list (`lf.centroids`, `.bboxes`, `.masks`, `.labelImages`, `.rois`) and handles `Instance` and `PredictedInstance` as well. If you know the target list at the call site, you can also push directly.
+
+```ts
+import {
+  Labels,
+  LabeledFrame,
+  UserCentroid,
+  UserBoundingBox,
+  UserSegmentationMask,
+} from "@talmolab/sleap-io.js";
+
+// Build a frame with mixed annotations
+const lf = new LabeledFrame({ video, frameIdx: 5 });
+lf.append(new UserCentroid({ x: 100, y: 200, track }));
+lf.append(new UserBoundingBox({ x1: 50, y1: 50, x2: 150, y2: 150 }));
+lf.append(UserSegmentationMask.fromArray(maskData, 480, 640));
+
+// Or push directly if you know the type
+lf.centroids.push(new UserCentroid({ x: 10, y: 20 }));
+
+// Pass frames as labeledFrames when constructing Labels
+const labels = new Labels({ labeledFrames: [lf], videos: [video], skeletons: [skeleton] });
+
+// To mutate an existing Labels, look up the target frame first
+let existing = labels.getFrame(video, 5);
+if (!existing) {
+  existing = new LabeledFrame({ video, frameIdx: 5 });
+  labels.labeledFrames.push(existing);
+}
+existing.append(anotherBbox);
+```
+
+Static ROIs (video-level, e.g. arena boundaries) live on `labels.staticRois` and can be mutated directly:
+
+```ts
+labels.staticRois.push(arenaRoi);
+```
 
 The SLP format version is set automatically based on content:
 
@@ -460,14 +589,14 @@ Dense integer label images for instance segmentation workflows (Cellpose, StarDi
 const li = LabelImage.fromArray(
   new Int32Array([0, 0, 1, 1, 0, 2, 2, 0, 0]),
   3, 3,  // height, width
-  { tracks: [trackA, trackB], video, frameIdx: 0 },
+  { tracks: [trackA, trackB] },
 );
 
 // From segmentation masks (composites multiple binary masks)
-const li = LabelImage.fromMasks(masks, { video, frameIdx: 0 });
+const li2 = LabelImage.fromMasks(masks);
 
 // From per-object binary masks (SAM / Mask R-CNN output)
-const li = LabelImage.fromBinaryMasks(
+const li3 = LabelImage.fromBinaryMasks(
   [mask1_2d, mask2_2d, mask3_2d],
   {
     tracks: [trackA, trackB, trackC],
@@ -481,10 +610,20 @@ const labelImages = LabelImage.fromStack({
   data: [frame0_2d, frame1_2d, frame2_2d],
   tracks: new Map([[1, trackA], [2, trackB]]),
   createTracks: true,  // auto-create Track objects from label IDs
-  video,
-  frameIdx: [0, 1, 2],
+});
+
+// Attach each label image to its frame
+labelImages.forEach((li, i) => {
+  let lf = labels.getFrame(video, i);
+  if (!lf) {
+    lf = new LabeledFrame({ video, frameIdx: i });
+    labels.labeledFrames.push(lf);
+  }
+  lf.append(li);
 });
 ```
+
+Frame and video context for label images comes from the parent `LabeledFrame`. Factory methods return plain `UserLabelImage` objects; use `lf.append(li)` to attach them to a frame.
 
 ### Properties and Methods
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -559,10 +559,10 @@ if (!existing) {
 existing.append(anotherBbox);
 ```
 
-Static ROIs (video-level, e.g. arena boundaries) live on `labels.staticRois` and can be mutated directly:
+Static ROIs (video-level, e.g. arena boundaries) live on `labels.staticRois`. Use `labels.addStaticRoi(roi)` to add one — the method also registers the ROI's track on `labels.tracks` if present:
 
 ```ts
-labels.staticRois.push(arenaRoi);
+labels.addStaticRoi(arenaRoi);
 ```
 
 The SLP format version is set automatically based on content:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -258,11 +258,11 @@ const array = labels.numpy();
 labels.materialize();
 ```
 
-> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale results. Use `labels.find(video, frameIdx)` (which handles both modes) or call `labels.materialize()` before using `getFrame` / `getTrackAnnotations`.
+> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale results. Use `labels.find({ video, frameIdx })` (which handles both modes and returns `LabeledFrame[]`) or call `labels.materialize()` before using `getFrame` / `getTrackAnnotations`.
 >
 > ```ts
 > // Works for both lazy and eager Labels
-> const frame = labels.find(video, 42);
+> const [frame] = labels.find({ video, frameIdx: 42 });   // LabeledFrame | undefined
 >
 > // Or materialize first, then use O(1) lookups
 > labels.materialize();
@@ -328,7 +328,7 @@ const c = new UserCentroid({ x: 100, y: 200 });
 let lf = labels.getFrame(video, 5);
 if (!lf) {
   lf = new LabeledFrame({ video, frameIdx: 5 });
-  labels.labeledFrames.push(lf);
+  labels.append(lf);
 }
 lf.append(c);
 ```
@@ -366,7 +366,7 @@ const frameRoi = ROI.fromPolygon([[10,10], [50,10], [50,50], [10,50]], {
 let lf = labels.getFrame(labels.videos[0], 0);
 if (!lf) {
   lf = new LabeledFrame({ video: labels.videos[0], frameIdx: 0 });
-  labels.labeledFrames.push(lf);
+  labels.append(lf);
 }
 lf.append(frameRoi);
 
@@ -414,7 +414,7 @@ const li = LabelImage.fromBinaryMasks(
 let lf = labels.getFrame(video, 0);
 if (!lf) {
   lf = new LabeledFrame({ video, frameIdx: 0 });
-  labels.labeledFrames.push(lf);
+  labels.append(lf);
 }
 lf.append(li);
 
@@ -442,7 +442,7 @@ labelImages.forEach((li, frameIdx) => {
   let lf = labels.getFrame(video, frameIdx);
   if (!lf) {
     lf = new LabeledFrame({ video, frameIdx });
-    labels.labeledFrames.push(lf);
+    labels.append(lf);
   }
   lf.append(li);
 });

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -258,6 +258,17 @@ const array = labels.numpy();
 labels.materialize();
 ```
 
+> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale results. Use `labels.find(video, frameIdx)` (which handles both modes) or call `labels.materialize()` before using `getFrame` / `getTrackAnnotations`.
+>
+> ```ts
+> // Works for both lazy and eager Labels
+> const frame = labels.find(video, 42);
+>
+> // Or materialize first, then use O(1) lookups
+> labels.materialize();
+> const lf = labels.getFrame(video, 42);
+> ```
+
 ## Saving with Embedded Frames
 
 Embed video frames directly into the SLP file:
@@ -305,9 +316,28 @@ await saveSlpSet(set);
 
 SLP format 1.5+ supports spatial annotations alongside pose data.
 
+### Working with annotations
+
+Annotations (`Centroid`, `BoundingBox`, `SegmentationMask`, `LabelImage`, and frame-bound `ROI`) live on individual `LabeledFrame` instances — not on `Labels`. The parent frame provides `video` and `frameIdx` context; annotation constructors no longer take those fields.
+
+The primary mutation API is `LabeledFrame.append(annotation)`, which routes by runtime type to the correct per-frame list (`lf.centroids`, `lf.bboxes`, `lf.masks`, `lf.labelImages`, `lf.rois`). It also handles `Instance` and `PredictedInstance`.
+
+```ts
+// The mental model: create annotation → attach to frame → frame lives in Labels
+const c = new UserCentroid({ x: 100, y: 200 });
+let lf = labels.getFrame(video, 5);
+if (!lf) {
+  lf = new LabeledFrame({ video, frameIdx: 5 });
+  labels.labeledFrames.push(lf);
+}
+lf.append(c);
+```
+
+Static ROIs (e.g., arena boundaries that apply to an entire video rather than a specific frame) are the one exception — they live on `labels.staticRois` and can be mutated directly.
+
 ```ts
 import {
-  loadSlp, ROI, SegmentationMask,
+  loadSlp, LabeledFrame, ROI, SegmentationMask,
   UserBoundingBox, PredictedBoundingBox, BoundingBox,
   writeGeoJSON, readGeoJSON,
 } from "@talmolab/sleap-io.js";
@@ -322,19 +352,30 @@ const frameRois = labels.getRois({ video: labels.videos[0], frameIdx: 0 });
 const predMasks = labels.getMasks({ predicted: true });
 const frameBboxes = labels.getBboxes({ video: labels.videos[0], frameIdx: 0 });
 
-// Create ROIs
-const roi = ROI.fromPolygon([[0,0], [100,0], [100,100], [0,100]], {
+// Create a static arena ROI (video-level, not tied to a frame)
+const arena = ROI.fromPolygon([[0,0], [100,0], [100,100], [0,100]], {
   category: "arena",
   video: labels.videos[0],
 });
-labels.addRoi(roi);
+labels.staticRois.push(arena);
 
-// Create bounding boxes (corner coordinates)
+// Or create a frame-bound ROI and attach it to a LabeledFrame
+const frameRoi = ROI.fromPolygon([[10,10], [50,10], [50,50], [10,50]], {
+  category: "crop",
+});
+let lf = labels.getFrame(labels.videos[0], 0);
+if (!lf) {
+  lf = new LabeledFrame({ video: labels.videos[0], frameIdx: 0 });
+  labels.labeledFrames.push(lf);
+}
+lf.append(frameRoi);
+
+// Create a bounding box and attach it to the same frame
 const bbox = new UserBoundingBox({
   x1: 125, y1: 200, x2: 175, y2: 280,
-  category: "animal", video: labels.videos[0], frameIdx: 0,
+  category: "animal",
 });
-labels.addBbox(bbox);
+lf.append(bbox);
 
 // Query centroids
 const frameCentroids = labels.getCentroids({ video: labels.videos[0], frameIdx: 0 });
@@ -354,7 +395,7 @@ For dense instance segmentation workflows (Cellpose, StarDist, SAM, Mask R-CNN),
 ### From Segmentation Model Output
 
 ```ts
-import { LabelImage, Track } from "@talmolab/sleap-io.js";
+import { LabeledFrame, LabelImage, Track } from "@talmolab/sleap-io.js";
 
 // Create from per-object binary masks (e.g., SAM output)
 const trackA = new Track({ name: "cell_1" });
@@ -366,9 +407,16 @@ const li = LabelImage.fromBinaryMasks(
     height: 480, width: 640,  // required for Uint8Array input
     tracks: [trackA, trackB],
     categories: ["cell", "cell"],
-    video, frameIdx: 0,
   },
 );
+
+// Attach to a frame — video/frameIdx come from the parent LabeledFrame
+let lf = labels.getFrame(video, 0);
+if (!lf) {
+  lf = new LabeledFrame({ video, frameIdx: 0 });
+  labels.labeledFrames.push(lf);
+}
+lf.append(li);
 
 // Extract individual masks
 const cellMask = li.getTrackMask(trackA);  // Uint8Array
@@ -378,23 +426,26 @@ const allCells = li.getCategoryMask("cell");
 ### Batch Processing Video Frames
 
 ```ts
-import { LabelImage, normalizeLabelIds } from "@talmolab/sleap-io.js";
+import { LabeledFrame, LabelImage, normalizeLabelIds } from "@talmolab/sleap-io.js";
 
 // Create label images for each frame from a stack of 2D arrays
 const labelImages = LabelImage.fromStack({
   data: [frame0, frame1, frame2],  // number[][][] (per-frame 2D label arrays)
   createTracks: true,  // auto-create Track objects from label IDs
-  video,
-  frameIdx: [0, 1, 2],
 });
 
 // Normalize IDs so the same track gets the same label ID across all frames
 const trackMap = normalizeLabelIds(labelImages);
 
-// Add to labels
-for (const li of labelImages) {
-  labels.addLabelImage(li);
-}
+// Attach each label image to its corresponding frame
+labelImages.forEach((li, frameIdx) => {
+  let lf = labels.getFrame(video, frameIdx);
+  if (!lf) {
+    lf = new LabeledFrame({ video, frameIdx });
+    labels.labeledFrames.push(lf);
+  }
+  lf.append(li);
+});
 ```
 
 ### Spatial Transforms

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -258,15 +258,15 @@ const array = labels.numpy();
 labels.materialize();
 ```
 
-> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale results. Use `labels.find({ video, frameIdx })` (which handles both modes and returns `LabeledFrame[]`) or call `labels.materialize()` before using `getFrame` / `getTrackAnnotations`.
+> **Note:** `labels.getFrame()` and `labels.getTrackAnnotations()` **throw** on lazy `Labels`. These O(1) lookups rely on fully materialized frame/track indices and would otherwise silently return stale results. Either call `labels.materialize()` first, or use `labels.find({ video, frameIdx })`, which also materializes internally on the first call and then uses the O(1) index. Both paths do the same amount of work — there is no cheap lazy-preserving variant.
 >
 > ```ts
-> // Works for both lazy and eager Labels
-> const [frame] = labels.find({ video, frameIdx: 42 });   // LabeledFrame | undefined
->
-> // Or materialize first, then use O(1) lookups
+> // Option 1: materialize first, then O(1) lookup
 > labels.materialize();
 > const lf = labels.getFrame(video, 42);
+>
+> // Option 2: find() — equivalent, materializes on first call
+> const [frame] = labels.find({ video, frameIdx: 42 });   // LabeledFrame | undefined
 > ```
 
 ## Saving with Embedded Frames

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -333,7 +333,7 @@ if (!lf) {
 lf.append(c);
 ```
 
-Static ROIs (e.g., arena boundaries that apply to an entire video rather than a specific frame) are the one exception — they live on `labels.staticRois` and can be mutated directly.
+Static ROIs (e.g., arena boundaries that apply to an entire video rather than a specific frame) are the one exception — they live on `labels.staticRois` and are added via `labels.addStaticRoi(roi)`.
 
 ```ts
 import {
@@ -357,7 +357,7 @@ const arena = ROI.fromPolygon([[0,0], [100,0], [100,100], [0,100]], {
   category: "arena",
   video: labels.videos[0],
 });
-labels.staticRois.push(arena);
+labels.addStaticRoi(arena);
 
 // Or create a frame-bound ROI and attach it to a LabeledFrame
 const frameRoi = ROI.fromPolygon([[10,10], [50,10], [50,50], [10,50]], {

--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -321,7 +321,7 @@ export class LabeledFrame {
    * @param threshold - Maximum centroid distance (pixels) for spatial matching
    *   in "auto" and "update_tracks" strategies.
    */
-  _mergeAnnotations(
+  mergeAnnotations(
     other: LabeledFrame,
     strategy: MergeStrategy = "keep_both",
     threshold: number = 5.0,

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -472,6 +472,19 @@ export class Labels {
     this._collectAnnotationTracks(frame);
   }
 
+  /**
+   * Add a static ROI (not tied to any specific frame, e.g., an arena boundary).
+   *
+   * Registers the ROI's track (if any) on `this.tracks`. Use
+   * `lf.append(roi)` on a `LabeledFrame` to add a frame-bound ROI instead.
+   */
+  addStaticRoi(roi: ROI): void {
+    this._staticRois.push(roi);
+    if (roi.track && !this.tracks.includes(roi.track)) {
+      this.tracks.push(roi.track);
+    }
+  }
+
   toDict(options?: { video?: Video | number; skipEmptyFrames?: boolean }) {
     if (this._lazyFrameList) this.materialize();
     return toDict(this, options);

--- a/tests/labels-rois-masks.test.ts
+++ b/tests/labels-rois-masks.test.ts
@@ -45,6 +45,25 @@ describe("Labels ROI and Mask integration", () => {
     expect(labels.temporalRois[0]).toBe(temporalRoi);
   });
 
+  it("addStaticRoi appends to _staticRois and registers the track", () => {
+    const video = new Video({ filename: "arena.mp4" });
+    const track = new Track("animal");
+    const arena = ROI.fromBbox(0, 0, 100, 100, { video, track });
+    const labels = new Labels({ videos: [video] });
+
+    labels.addStaticRoi(arena);
+
+    expect(labels.staticRois).toHaveLength(1);
+    expect(labels.staticRois[0]).toBe(arena);
+    expect(labels.tracks).toContain(track);
+
+    // Second call with the same track should not duplicate it.
+    const arena2 = ROI.fromBbox(0, 0, 50, 50, { video, track });
+    labels.addStaticRoi(arena2);
+    expect(labels.staticRois).toHaveLength(2);
+    expect(labels.tracks.filter((t) => t === track)).toHaveLength(1);
+  });
+
   it("getRois filters by video", () => {
     const v1 = new Video({ filename: "a.mp4" });
     const v2 = new Video({ filename: "b.mp4" });

--- a/tests/labels-rois-masks.test.ts
+++ b/tests/labels-rois-masks.test.ts
@@ -64,6 +64,22 @@ describe("Labels ROI and Mask integration", () => {
     expect(labels.tracks.filter((t) => t === track)).toHaveLength(1);
   });
 
+  it("addStaticRoi does not duplicate a track already registered via the constructor", () => {
+    const video = new Video({ filename: "arena.mp4" });
+    const track = new Track("animal");
+    // Track is registered via a frame annotation before addStaticRoi runs.
+    const bbox = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, track });
+    const lf = new LabeledFrame({ video, frameIdx: 0, bboxes: [bbox] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [video] });
+    expect(labels.tracks).toEqual([track]);
+
+    const arena = ROI.fromBbox(0, 0, 100, 100, { video, track });
+    labels.addStaticRoi(arena);
+
+    expect(labels.staticRois).toHaveLength(1);
+    expect(labels.tracks.filter((t) => t === track)).toHaveLength(1);
+  });
+
   it("getRois filters by video", () => {
     const v1 = new Video({ filename: "a.mp4" });
     const v2 = new Video({ filename: "b.mp4" });

--- a/tests/nested-annotations.test.ts
+++ b/tests/nested-annotations.test.ts
@@ -64,7 +64,7 @@ describe("LabeledFrame annotation fields", () => {
     expect(lf.bboxes[0]).toBe(bUser);
   });
 
-  it("_mergeAnnotations merges, deduplicates, and copies new items", () => {
+  it("mergeAnnotations merges, deduplicates, and copies new items", () => {
     const video = new Video({ filename: "test.mp4" });
     const shared = new UserCentroid({ x: 1, y: 2});
     const unique = new UserCentroid({ x: 3, y: 4});
@@ -72,7 +72,7 @@ describe("LabeledFrame annotation fields", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [shared] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [shared, unique] });
 
-    lf1._mergeAnnotations(lf2);
+    lf1.mergeAnnotations(lf2);
 
     // shared should not be duplicated (same identity already in lf1)
     expect(lf1.centroids).toHaveLength(2);
@@ -484,7 +484,7 @@ describe("Lazy read with annotations", () => {
   });
 });
 
-describe("_mergeAnnotations strategies", () => {
+describe("mergeAnnotations strategies", () => {
   it("keep_original keeps self's annotations and discards other's", () => {
     const video = new Video({ filename: "test.mp4" });
     const selfC = new UserCentroid({ x: 1, y: 2});
@@ -493,7 +493,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
 
-    lf1._mergeAnnotations(lf2, "keep_original");
+    lf1.mergeAnnotations(lf2, "keep_original");
 
     expect(lf1.centroids).toHaveLength(1);
     expect(lf1.centroids[0]).toBe(selfC);
@@ -507,7 +507,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
 
-    lf1._mergeAnnotations(lf2, "keep_new");
+    lf1.mergeAnnotations(lf2, "keep_new");
 
     expect(lf1.centroids).toHaveLength(1);
     expect(lf1.centroids[0]).not.toBe(otherC); // copied, not same object
@@ -525,7 +525,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred, otherUser] });
 
-    lf1._mergeAnnotations(lf2, "replace_predictions");
+    lf1.mergeAnnotations(lf2, "replace_predictions");
 
     // selfUser kept, selfPred removed, otherPred added (copied), otherUser ignored
     expect(lf1.centroids).toHaveLength(2);
@@ -544,7 +544,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     expect(lf1.centroids).toHaveLength(2);
     expect(lf1.centroids[0]).toBe(selfUser);
@@ -561,7 +561,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Both should be present: self's user kept + other's user added (unmatched)
     expect(lf1.centroids).toHaveLength(2);
@@ -578,7 +578,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Prediction replaced by user
     expect(lf1.centroids).toHaveLength(1);
@@ -595,7 +595,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Self's prediction kept (unmatched) + other's user added (unmatched)
     expect(lf1.centroids).toHaveLength(2);
@@ -615,7 +615,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, bboxes: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, bboxes: [otherUser] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Centroid distance ~1.4px, well within threshold — prediction replaced by user
     expect(lf1.bboxes).toHaveLength(1);
@@ -647,7 +647,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [otherUser] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Bbox centroids are close — prediction replaced by user
     expect(lf1.masks).toHaveLength(1);
@@ -665,7 +665,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUserA, otherUserB] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // One replaces prediction via match, other added as unmatched — neither dropped
     expect(lf1.centroids).toHaveLength(2);
@@ -694,7 +694,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [emptyMask] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [normalMask] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Both kept: empty mask has no centroid so it's unmatched
     expect(lf1.masks).toHaveLength(2);
@@ -711,7 +711,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
 
-    lf1._mergeAnnotations(lf2, "update_tracks");
+    lf1.mergeAnnotations(lf2, "update_tracks");
 
     // Self's centroid track updated to other's track
     expect(lf1.centroids).toHaveLength(1);
@@ -730,7 +730,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
 
-    lf1._mergeAnnotations(lf2, "update_tracks");
+    lf1.mergeAnnotations(lf2, "update_tracks");
 
     expect(lf1.centroids[0].track).toBe(trackA); // unchanged
   });
@@ -760,7 +760,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liSelf] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liOther] });
 
-    lf1._mergeAnnotations(lf2, "update_tracks");
+    lf1.mergeAnnotations(lf2, "update_tracks");
 
     // Label image track should be unchanged
     expect(lf1.labelImages[0].objects.get(1)!.track).toBe(trackA);
@@ -791,7 +791,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liSelf] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liOther] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // User from self kept, prediction from other ignored (user beats predicted)
     expect(lf1.labelImages).toHaveLength(1);
@@ -822,7 +822,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, rois: [selfPred] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, rois: [otherUser] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Centroids are ~1.4px apart — prediction replaced by user
     expect(lf1.rois).toHaveLength(1);
@@ -849,7 +849,7 @@ describe("_mergeAnnotations strategies", () => {
     const lf1 = new LabeledFrame({ video, frameIdx: 0, rois: [emptyRoi] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, rois: [normalRoi] });
 
-    lf1._mergeAnnotations(lf2, "auto");
+    lf1.mergeAnnotations(lf2, "auto");
 
     // Both kept: empty ROI has no centroid so it's unmatched
     expect(lf1.rois).toHaveLength(2);


### PR DESCRIPTION
## Summary

Refreshes `README.md`, `docs/api.md`, and `docs/usage.md` to match the v0.3.0 API surface. Fixes **12 critical copy-paste bugs**, adds **4 missing coverage sections**, and fills **2 narrative gaps** flagged by the docs audit in `scratch/2026-04-06-release-prep/docs-audit-report.md`. This is PR 1 of 2 from that audit — PR 2 handles minor cleanups.

Two systemic patterns from PR #94 had stale examples that would error at runtime:
1. `video` / `frameIdx` on annotation constructors and factories (removed in v0.3.0 — those fields come from the parent `LabeledFrame` now).
2. `Labels.addCentroid()` / `.addBbox()` / `.addMask()` / `.addLabelImage()` / `.addRoi()` methods (removed in favor of `LabeledFrame.append()`).

Four major v0.3.0 features had zero documentation: `Labels.copy()` / `replaceVideos()` (#87), O(1) frame/track index lookups (#89), `LabeledFrame.append()` as a first-class mutation API, and `_mergeAnnotations()` with its six merge strategies (#93).

## Changes

**README.md** (4 fixes)
- Fix 2 broken imports (`"sleap-io.js"` → `"@talmolab/sleap-io.js"`)
- Add `npm install @talmolab/sleap-io.js` to quickstart
- Add `Centroid` to the core data model features list

**docs/api.md** — critical fixes
- Strip `video`/`frameIdx` from `UserBoundingBox`, 2× `UserCentroid`, and `LabelImage.fromArray` / `fromMasks` / `fromStack` examples
- Replace removed `Labels.addRoi/.addMask/.addBbox/.addCentroid/.addLabelImage` block with the `LabeledFrame.append()` pattern
- Delete stale `staticBboxes` / `temporalBboxes` getters and two `.isStatic` property lines

**docs/api.md** — new sections
- **Frame and track index lookups** — documents O(1) `getFrame()` / `getTrackAnnotations()` / `reindex()`
- **Deep copy and video remapping** — documents `Labels.copy()` / `replaceVideos()` / `LazyDataStore.copy()`
- **Frame merging** — documents `_mergeAnnotations()` with a strategy table for all six modes
- **Adding annotations to frames** subsection under Annotation Access — formalizes `LabeledFrame.append()` as the primary mutation API
- **Lazy-mode throw callout** in Lazy Loading — warns that `getFrame()`/`getTrackAnnotations()` throw on lazy `Labels`, with `find()` / `materialize()` workarounds

**docs/usage.md** — critical fixes
- Same two sweeps (`video`/`frameIdx` stripping, `.add*()` → `.append()` replacement)

**docs/usage.md** — narrative additions
- **Working with annotations** intro under the spatial annotations heading — explains the frame-based model, `LabeledFrame.append()`, and the static-ROI exception
- **Lazy-mode throw note** in the Lazy Loading section
- Clarified ROI example with explicit static-vs-frame-bound distinction

## Source change: `Labels.addStaticRoi()`

During review, the ``labels.staticRois.push(arena)`` pattern the docs prescribed for static ROIs turned out to be a silent no-op: ``staticRois`` is a getter returning a defensive copy (``return [...this._staticRois];`` at `src/model/labels.ts:481`), so pushes landed on a throwaway array. v0.3.0 shipped no public mutation API for static ROIs.

Rather than either (a) documenting the private ``_staticRois`` field or (b) restricting static ROIs to construction time only, this PR adds a small public method:

```ts
// src/model/labels.ts
addStaticRoi(roi: ROI): void {
  this._staticRois.push(roi);
  if (roi.track && !this.tracks.includes(roi.track)) {
    this.tracks.push(roi.track);
  }
}
```

The track-registration side effect mirrors the constructor's handling of ``options.rois`` (``labels.ts:117–121``), so a ROI added at construction time and one added via ``addStaticRoi`` are observationally identical. Added a unit test in ``tests/labels-rois-masks.test.ts`` covering the happy path and track dedup. Both ``docs/api.md`` and ``docs/usage.md`` now use ``labels.addStaticRoi(arena)`` instead of the broken ``.push`` pattern.

## Latent bug caught mid-flight

While eyeballing a usage.md example, I noticed that the ``labels.getFrame(video, i) ?? new LabeledFrame(...)`` idiom has a subtle bug: a newly-created ``LabeledFrame`` is **not** automatically attached to ``labels.labeledFrames``, so annotations appended to it would silently fail to persist. All 8 occurrences across both files were expanded to explicit lookup + ``labels.append(lf)`` + ``lf.append(annotation)`` form:

```ts
let lf = labels.getFrame(video, frameIdx);
if (!lf) {
  lf = new LabeledFrame({ video, frameIdx });
  labels.append(lf);
}
lf.append(annotation);
```

``Labels.append(lf)`` (``src/model/labels.ts:467``) does strictly more than a raw ``labeledFrames.push``: it invalidates the frame index, registers the video, and collects annotation tracks. Using it in docs keeps the examples aligned with the recommended mutation path.

## Out of scope (deferred to PR 2)

- Minor cleanups: ``ROI.video`` clarification note, format version detail list in ``docs/index.md``, ``pako`` dep note in ``docs/lite.md``, source link in ``docs/demo.md``

## Review follow-ups (addressed in a second commit)

- Renamed ``LabeledFrame._mergeAnnotations`` → ``mergeAnnotations``. The underscore prefix implied internal use, but the method is documented here as a first-class public API; renaming pre-release is cheaper than locking the underscore name in. Updated ``src/model/labeled-frame.ts``, all 22 references in ``tests/nested-annotations.test.ts``, and the three call sites in ``docs/api.md``.
- Softened the "``find()`` handles both lazy and eager modes" wording in both ``docs/api.md`` and ``docs/usage.md``. ``find()`` at ``src/model/labels.ts:444`` materializes unconditionally when lazy, so it's equivalent in work to ``materialize() + getFrame()`` — not a lightweight bypass. The callout now presents both options as equal-cost paths.
- Clarified the ``keep_both`` row in the merge strategy table to note that items from ``other`` are shallow-copied before insertion (the dedup is identity-based against self).
- Restructured the ``BoundingBox`` code block in ``docs/api.md`` into four focused sub-blocks (construct + attach, predicted, factories, properties) with headings, dropping the ``bbox2`` / ``bbox3`` numeric suffixes in favor of descriptive names (``fromCorners`` / ``fromTopLeft``).
- Added a second unit test in ``tests/labels-rois-masks.test.ts`` covering the case where a track is already registered via a constructor-passed frame annotation before ``addStaticRoi`` is called — verifies no double-registration on this code path too.

**Correction on ``MergeStrategy`` export**: the original PR description noted PR 2 would need to verify whether ``MergeStrategy`` is re-exported from ``src/index.ts``. It already is, via ``export * from "./model/labeled-frame.js"`` at ``src/index.ts:7``. No action needed; the deferred item is removed.

## Test plan

- [ ] ``rg '\.add(Centroid|Bbox|Mask|LabelImage)\b' docs/`` returns zero hits (``addStaticRoi`` and ``addVideo`` are the only surviving ``add*`` methods)
- [ ] ``rg '\.isStatic|staticBboxes|temporalBboxes|staticLabelImages|temporalLabelImages' docs/`` returns zero hits
- [ ] ``rg 'staticRois\.push' docs/`` returns zero hits (all replaced with ``addStaticRoi``)
- [ ] ``rg '"sleap-io\.js"' README.md`` returns zero hits (all imports use ``@talmolab/sleap-io.js``)
- [ ] ``rg '\?\?\s*new LabeledFrame' docs/`` returns zero hits (no latent buggy idiom)
- [ ] ``npx tsc --noEmit`` on ``src/`` is clean
- [ ] ``npx vitest run tests/labels-rois-masks.test.ts`` passes (19 tests, includes the new ``addStaticRoi`` test)
- [ ] All documented APIs exist in source (verified: ``copy``, ``replaceVideos``, ``reindex``, ``removePredictions``, ``addVideo``, ``addStaticRoi``, ``mergeAnnotations``, ``append``)
- [ ] Read through edited sections linearly — narrative flows from concept → per-type examples
- [ ] Build the docs site and spot-check that the new anchors (``#lazy-loading``) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
