### PR TITLE
docs: Minor cleanups from v0.3.0 audit

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -357,6 +357,8 @@ const mask = roi.toMask(480, 640);
 
 > **Note:** `ROI.fromBbox()` and `ROI.fromXyxy()` are deprecated. Use `BoundingBox.fromXywh()` or `BoundingBox.fromXyxy()` instead.
 
+> **Note:** `ROI.video` is retained for static ROIs (arena boundaries, chamber outlines stored on `labels.staticRois`); `ROI.frameIdx` was removed in v0.3.0. Frame-bound ROIs derive their frame from the parent `LabeledFrame` — attach them with `lf.append(roi)`.
+
 ### `SegmentationMask`
 RLE-encoded binary mask. `SegmentationMask` is abstract; use `UserSegmentationMask` or `PredictedSegmentationMask` for direct construction. The `fromArray()` factory returns `UserSegmentationMask`.
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -14,3 +14,5 @@ The embedded viewer below loads `.slp` files entirely in the browser. It streams
   loading="lazy"
 ></iframe>
 
+Source: [`docs/assets/demo/demo.js`](https://github.com/talmolab/sleap-io.js/blob/main/docs/assets/demo/demo.js) · [`index.html`](https://github.com/talmolab/sleap-io.js/blob/main/docs/assets/demo/index.html)
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ await saveSlp(labels, "/tmp/session-roundtrip.slp", { embed: false });
 ## Features
 
 - SLP read/write with embedded frame support (format 1.0–2.2).
-- ROI and segmentation mask annotations (format 1.5), ROI-instance associations (format 1.6), bounding boxes (format 1.7), label images (format 1.8), identities (format 1.9), spatial metadata (format 2.1).
+- ROI and segmentation mask annotations (format 1.5), ROI-instance associations (format 1.6), bounding boxes (format 1.7), label images (format 1.8), identities (format 1.9), corner-based bounding boxes (format 2.0), spatial metadata (format 2.1), chunked label image storage (format 2.2).
 - Browser-compatible SLP writing via `saveSlpToBytes()`.
 - Streaming inputs (URL, `File`, `FileSystemFileHandle`, `Blob`).
 - Data model types (`Labels`, `LabeledFrame`, `Instance`, `Skeleton`, `Video`, `ROI`, `SegmentationMask`, `BoundingBox`, `Centroid`, `LabelImage`, `Identity`, `Instance3D`).

--- a/docs/lite.md
+++ b/docs/lite.md
@@ -176,6 +176,8 @@ interface VideoMetadata {
 | Skeleton parsing | ✅ | ✅ |
 | Metadata | ✅ | ✅ |
 
+> **Dependencies:** The full entry point pulls in `pako` (^2.1.0) for label image zlib compression, but lite mode does not import it — the `/lite` bundle stays free of `pako` and `h5wasm`.
+
 ## Example: File Upload Validation
 
 ```ts


### PR DESCRIPTION
## Summary

PR 2 of 2 from the v0.3.0 docs audit (see `scratch/2026-04-06-release-prep/docs-audit-report.md`). PR 1 (#101) landed every critical fix and missing-coverage addition; this one is the non-blocking cleanup pass.

- **`docs/api.md`**: Note in the ROI section clarifying that `ROI.video` is retained for static ROIs while `ROI.frameIdx` was removed in v0.3.0. Frame-bound ROIs derive their frame from the parent `LabeledFrame`.
- **`docs/index.md`**: Format version feature list skipped 2.0 and 2.2 while listing 1.5–2.1. Filled in the gaps (corner-based bboxes for 2.0, chunked label image storage for 2.2) so the per-version detail matches the "1.0–2.2" range claim above it.
- **`docs/lite.md`**: Added a dependency note under the Full vs Lite comparison clarifying that `pako` (added as a v0.3.0 dep for label image zlib I/O) is not imported by lite mode — the `/lite` bundle stays free of `pako` and `h5wasm`. Verified by grepping `src/lite.ts` (no `pako` import).
- **`docs/demo.md`**: Added a one-line source footer linking to `docs/assets/demo/demo.js` and `index.html` on GitHub so readers can learn from the implementation without hunting for it.

## Test plan

- [x] `rg 'ROI\.video|ROI\.frameIdx' docs/api.md` — note appears near the ROI constructor section
- [x] `rg 'format 2\.0|format 2\.2' docs/index.md` — both format versions documented
- [x] `rg 'pako' src/lite.ts` — confirms lite mode does not import pako (no hits)
- [x] Visual review of each edited file
- [ ] Docs site preview builds cleanly (mkdocs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)