### PR TITLE
fix: Worker streaming reader parity and pkg.slp support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@talmolab/sleap-io.js",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "dependencies": {
-        "h5wasm": "^0.8.8",
+        "h5wasm": "^0.9.0",
         "jsfive": "^0.3.10",
         "mediabunny": "^1.30.0",
         "mp4box": "^0.5.4",
@@ -996,7 +996,6 @@
       "integrity": "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1448,7 +1447,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1609,9 +1607,9 @@
       }
     },
     "node_modules/h5wasm": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/h5wasm/-/h5wasm-0.8.11.tgz",
-      "integrity": "sha512-oZ/sZA155VVQl6d37Gay6RnjwGTrS63Lm8wZzhrbRdJr0nAswr9KCmu8qSUMlQn1TSOIK1kEBnpmH2XztwFq6w==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/h5wasm/-/h5wasm-0.9.0.tgz",
+      "integrity": "sha512-Wci6p5GpjN8BYdcBZu0ypPK1r7sictFMKgCMzc2WeBdwK9qhJCdYEkwimnv4tfCaaIV7ZC/PfaVSyLEp3dzMFA==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/has-flag": {
@@ -2020,7 +2018,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2070,7 +2067,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2621,7 +2617,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2650,7 +2645,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3171,7 +3165,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -3375,7 +3368,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "h5wasm": "^0.8.8",
+    "h5wasm": "^0.9.0",
     "jsfive": "^0.3.10",
     "mediabunny": "^1.30.0",
     "mp4box": "^0.5.4",

--- a/src/codecs/slp/h5-worker.ts
+++ b/src/codecs/slp/h5-worker.ts
@@ -108,7 +108,7 @@ async function initH5Wasm(h5wasmUrl) {
   if (h5wasmModule) return;
 
   // Default to CDN if no URL provided
-  const url = h5wasmUrl || 'https://cdn.jsdelivr.net/npm/h5wasm@0.8.8/dist/iife/h5wasm.js';
+  const url = h5wasmUrl || 'https://cdn.jsdelivr.net/npm/h5wasm@0.9.0/dist/iife/h5wasm.js';
 
   // Import h5wasm IIFE
   importScripts(url);
@@ -187,7 +187,8 @@ async function openBufferFile(buffer, filename = 'data.h5') {
 
   // Write buffer to virtual filesystem
   const data = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
-  mountPath = '/buffer-' + Date.now() + '/' + filename;
+  const basename = filename.split('/').pop().split('\\\\').pop() || 'data.h5';
+  mountPath = '/buffer-' + Date.now() + '/' + basename;
 
   // Create parent directory
   const dir = mountPath.substring(0, mountPath.lastIndexOf('/'));

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -146,6 +146,23 @@ async function readFromStreamingFile(
     formatId,
   });
 
+  // Read negative frames
+  const negFramesData = await readStructDatasetStreaming(file, "negative_frames");
+  if (negFramesData && Object.keys(negFramesData).length > 0) {
+    const videoIds = (negFramesData.video_id ?? negFramesData.video ?? []) as number[];
+    const frameIdxs = (negFramesData.frame_idx ?? []) as number[];
+    const negativeSet = new Set<string>();
+    for (let i = 0; i < frameIdxs.length; i++) {
+      negativeSet.add(`${Number(videoIds[i])}:${Number(frameIdxs[i])}`);
+    }
+    for (const frame of labeledFrames) {
+      const videoIndex = Math.max(0, videos.indexOf(frame.video));
+      if (negativeSet.has(`${videoIndex}:${frame.frameIdx}`)) {
+        frame.isNegative = true;
+      }
+    }
+  }
+
   // Read identities
   const identities = await readIdentitiesStreaming(file);
 
@@ -617,8 +634,11 @@ async function readStructDatasetStreaming(
         const attrs = await file.getAttrs(path);
         const fnAttr = attrs.field_names ?? attrs.fieldNames;
         if (fnAttr) {
-          const raw = Array.isArray(fnAttr) ? fnAttr
+          let raw = Array.isArray(fnAttr) ? fnAttr
             : (fnAttr as { value?: unknown })?.value;
+          if (typeof raw === "string") {
+            try { raw = JSON.parse(raw); } catch { /* not JSON */ }
+          }
           if (Array.isArray(raw)) {
             fieldNames = raw.map(String);
           }

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -608,8 +608,25 @@ async function readStructDatasetStreaming(
     const meta = await file.getDatasetMeta(path);
     const data = await file.getDatasetValue(path);
 
-    // Get field names from metadata
-    const fieldNames = getFieldNamesFromMeta(meta);
+    // Get field names: try dtype metadata first, then HDF5 dataset attributes
+    // (matches main-thread reader's getFieldNames which checks dtype.fields,
+    // metadata.compound_type.members, then attrs.field_names)
+    let fieldNames = getFieldNamesFromMeta(meta);
+    if (fieldNames.length === 0) {
+      try {
+        const attrs = await file.getAttrs(path);
+        const fnAttr = attrs.field_names ?? attrs.fieldNames;
+        if (fnAttr) {
+          const raw = Array.isArray(fnAttr) ? fnAttr
+            : (fnAttr as { value?: unknown })?.value;
+          if (Array.isArray(raw)) {
+            fieldNames = raw.map(String);
+          }
+        }
+      } catch {
+        // Ignore attribute read errors
+      }
+    }
 
     return normalizeStructData(data.value, data.shape, fieldNames);
   } catch {

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -207,50 +207,65 @@ async function readVideosStreaming(
           ? [meta.frameCount, meta.height, meta.width, meta.channels]
           : undefined;
 
-      // Auto-detect dataset path when embedded but not specified in metadata
+      // Auto-detect dataset path and read attributes only when we need them
+      // (openVideos or metadata is incomplete). Probing embedded video datasets
+      // can crash h5wasm on some pkg.slp files, so skip when not needed.
       let datasetPath: string | undefined = meta.dataset;
-      if (meta.embedded && !datasetPath) {
-        datasetPath = (await findVideoDatasetStreaming(file, videoIndex)) ?? undefined;
-      }
-
-      // Read format and channel_order from HDF5 dataset attributes if available
-      // This matches Python sleap-io behavior (video_reading.py:987-1006)
       let format = meta.format;
       let channelOrderFromAttrs: string | undefined;
-      if (datasetPath) {
-        try {
-          const attrs = await file.getAttrs(datasetPath);
-          // Read format attribute
-          if (!format) {
-            const formatAttr = attrs.format;
-            if (formatAttr) {
-              format = typeof formatAttr === "string"
-                ? formatAttr
-                : (formatAttr as { value?: string })?.value;
+      let sourceFrameCount: number | undefined;
+
+      if (openVideos || !format) {
+        if (meta.embedded && !datasetPath) {
+          datasetPath = (await findVideoDatasetStreaming(file, videoIndex)) ?? undefined;
+        }
+
+        if (datasetPath) {
+          try {
+            const attrs = await file.getAttrs(datasetPath);
+            if (!format) {
+              const formatAttr = attrs.format;
+              if (formatAttr) {
+                format = typeof formatAttr === "string"
+                  ? formatAttr
+                  : (formatAttr as { value?: string })?.value;
+              }
             }
+            const channelOrderAttr = attrs.channel_order;
+            if (channelOrderAttr) {
+              channelOrderFromAttrs = typeof channelOrderAttr === "string"
+                ? channelOrderAttr
+                : (channelOrderAttr as { value?: string })?.value;
+            }
+            // Read source video total frame count for embedded videos.
+            // This is the full frame count of the original video, not the
+            // number of embedded frames. Used so the seekbar shows the full
+            // source video range (matching Python SLEAP behavior).
+            if (meta.embedded) {
+              const framesAttr = attrs.frames;
+              if (framesAttr != null) {
+                const val = typeof framesAttr === "object" && framesAttr !== null && "value" in framesAttr
+                  ? (framesAttr as { value: unknown }).value
+                  : framesAttr;
+                sourceFrameCount = Number(val);
+              }
+            }
+          } catch {
+            // Ignore attribute read errors — h5wasm may not support this dataset
           }
-          // Read channel_order attribute (like Python does)
-          const channelOrderAttr = attrs.channel_order;
-          if (channelOrderAttr) {
-            channelOrderFromAttrs = typeof channelOrderAttr === "string"
-              ? channelOrderAttr
-              : (channelOrderAttr as { value?: string })?.value;
-          }
-        } catch {
-          // Ignore attribute read errors
         }
       }
 
-      // Determine channel order with priority:
-      // 1. JSON metadata (meta.channelOrder)
-      // 2. HDF5 dataset attribute (channelOrderFromAttrs)
-      // 3. Legacy fallback based on format_id (BGR for < 1.4)
       const channelOrder = meta.channelOrder ?? channelOrderFromAttrs ?? (formatId < 1.4 ? "BGR" : "RGB");
+
+      const videoShape: [number, number, number, number] | undefined =
+        (sourceFrameCount ?? meta.frameCount) && meta.height && meta.width && meta.channels
+          ? [(sourceFrameCount ?? meta.frameCount)!, meta.height, meta.width, meta.channels]
+          : shape;
 
       // Create streaming backend for embedded videos when openVideos is true
       let backend = null;
       if (openVideos && meta.embedded && datasetPath) {
-        // Read frame_numbers for this video
         const frameNumbers = await readFrameNumbersStreaming(file, datasetPath);
 
         backend = new StreamingHdf5VideoBackend({
@@ -260,7 +275,7 @@ async function readVideosStreaming(
           frameNumbers,
           format: format ?? "png",
           channelOrder,
-          shape,
+          shape: videoShape,
           fps: meta.fps,
         });
       }
@@ -271,7 +286,7 @@ async function readVideosStreaming(
         backendMetadata: {
           dataset: datasetPath,
           format,
-          shape,
+          shape: videoShape,
           fps: meta.fps,
           channel_order: channelOrder,
         },


### PR DESCRIPTION
## Summary

Closes #105

Enables reading embedded video frames from `.pkg.slp` files in the browser, and fixes critical bugs where the Worker-based streaming reader returned 0 labeled frames and silently dropped negative frame metadata.

## Background

The Worker streaming reader (`readSlpStreaming`) is the default code path in browser/Tauri environments. Previously, it always crashed with `errno:44` in Tauri (due to a MEMFS path bug), silently falling back to the main-thread reader which worked correctly. Users never noticed because the fallback was transparent.

Fixing the Worker crash (the basename fix below) revealed two more bugs:

1. **field_names parsing**: `readStructDatasetStreaming` read field_names from HDF5 dataset attributes, but the values are stored as JSON strings (e.g., `'["frame_id","video","frame_idx",...]'`). The code extracted the string but never JSON-parsed it, so `Array.isArray()` was always false — returning empty column mappings and producing Labels with 0 labeled frames.

2. **negative frames**: The streaming reader never read the `/negative_frames` dataset, so `LabeledFrame.isNegative` was never set, affecting training data selection.

## Changes

### h5wasm upgrade (`package.json`)
- `^0.8.8` → `^0.9.0` — upgrades underlying C library from HDF5 1.14.6 to HDF5 2.0.0
- Fixes checksum buffer overflow (`H5F_get_checksums`, HDF5 #4434) that caused `"incorrect metadata checksum after all read attempts"`
- Fixes object header version bug (`H5Ocopy`, HDF5 #2653) that caused `"bad object header version number"`

### Worker fixes (`h5-worker.ts`)
- Updated CDN URL from `h5wasm@0.8.8` to `h5wasm@0.9.0`
- Fixed `openBufferFile()` path construction: extracts basename from filename before creating MEMFS mount path, preventing `errno:44` when `filenameHint` is a full filesystem path

### Streaming reader fixes (`read-streaming.ts`)
- **field_names attribute parsing**: `readStructDatasetStreaming` now reads `field_names` from HDF5 dataset attributes AND JSON-parses the string value — matching the main-thread reader's `getFieldNames` fallback chain
- **negative frames**: Added `/negative_frames` dataset reading after `buildLabeledFrames()`, marking `frame.isNegative = true` for negative frames — matching the main-thread reader's behavior
- **Source video frame count**: Reads the `frames` HDF5 attribute from embedded video datasets to get the source video's total frame count instead of using the embedded frame count

## Known gaps (streaming reader vs main-thread)

The streaming reader does not yet support these annotation types (tracked in #107):
- ROIs and bounding boxes (`/rois`, `/roi_wkb`, `/bboxes`)
- Segmentation masks (`/masks`, `/mask_rle`)
- Label images (`/label_images`, `/label_image_data`)
- Centroids (`/centroids`)

These features are not currently used by sleap-app.

## Test plan
- [ ] Tauri: load normal .slp file — labeled frames, instances, and predictions visible
- [ ] Tauri: load pkg.slp file — embedded video frames render
- [ ] Browser: load pkg.slp files — frames render
- [ ] Seekbar shows full source video range, not just embedded frame count
- [ ] Negative frames correctly marked as `isNegative`
- [ ] Node.js: `loadSlp()` — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)