### PR TITLE
fix: handle h5wasm 0.10.x array-of-pairs compound dtype format

### DIFF
--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -622,6 +622,10 @@ function getFieldNamesFromMeta(meta: { shape: number[]; dtype: string }): string
     }
   }
 
+  if (Array.isArray(dtype)) {
+    return dtype.map((pair: [string, string]) => pair[0]);
+  }
+
   if (typeof dtype === "object" && dtype !== null) {
     const dtypeObj = dtype as Record<string, unknown>;
     if (dtypeObj.compound_type && typeof dtypeObj.compound_type === "object") {


### PR DESCRIPTION
## Summary

Closes #113

h5wasm 0.10.x changes how compound dataset dtypes are represented — from an object with `compound_type.members` to an **array of [name, type] pairs** (e.g., `[["frame_id", "<Q"], ["video", "<I"], ...]`). The h5wasm 0.8.8 → 0.10.2 bump landed in #111 (now merged), which is what surfaced this bug on `main`.

`getFieldNamesFromMeta` in the streaming reader only handled the older formats (string and object-with-`compound_type`), falling through on the array format and returning `[]`. This caused 0 labeled frames when loading any SLP file with compound datasets (i.e., all files written by Python sleap-io / PyQt SLEAP) via the Worker path.

## Fix

Add an `Array.isArray(dtype)` branch **before** the existing object check (mandatory ordering — `typeof [] === "object"`, so the array check must come first):

```typescript
if (Array.isArray(dtype)) {
  return dtype.map((pair: [string, string]) => pair[0]);
}
```

`pair[0]` is the field name in h5wasm's `CompoundMemberDtype = [string, Dtype]`, yielding the identical name list (in declaration order) to the object branch's `m.name`.

## Test

Adds `tests/streaming-field-names.test.ts` — a unit test feeding the real h5wasm 0.10.x array-of-pairs dtypes (points and frames, as observed against the repo's Python fixtures) into `getFieldNamesFromMeta`, plus regression guards for the legacy string-repr and object-`compound_type` branches. `getFieldNamesFromMeta` is exported test-only to enable this, since the streaming path is browser/Worker-gated and unreachable under the Node test suite (a regression there would *silently* drop all frames/instances/points).

## Scope

This fixes the **array-of-pairs compound-dtype** case — Python sleap-io / PyQt files, the dominant app-breaking case. It does **not** address the separate sleap-io.js-**written**-file case (flat arrays + a `field_names` JSON-string attribute), which the streaming reader structurally cannot read today (the Worker's `getDatasetMeta` returns only `{shape, dtype, metadata}`, no attrs). That is tracked as a follow-up in #120.

> Note: an earlier revision of this description said "needs field_names attribute fallback from PR #111" — that was inaccurate; #111 added no such fallback. See #120.

## Verification
- [x] Merges cleanly on current `main` (post-#111/#115)
- [x] `tsc -p tsconfig.json --noEmit` passes
- [x] Full test suite green (737 tests); new unit test covers the array-of-pairs fix
- [ ] Load PyQt-generated SLP file in Tauri — labeled frames visible
- [ ] Load pkg.slp file in Tauri — embedded frames render, labels visible

## Related

- #105 — h5wasm upgrade that triggers this
- #111 — bumped to h5wasm 0.10.2 (now merged; surfaced this bug)
- #120 — follow-up: streaming reader `field_names` JSON-attribute fallback for sleap-io.js-written files

🤖 Generated with [Claude Code](https://claude.com/claude-code)