### PR TITLE
fix: port v0.7.0 correctness bundle (#414, #419, #420, #421)

### DIFF
--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -1102,6 +1102,11 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
   return masks;
 }
 
+// Pixel data is eagerly materialized into a standalone Int32Array per
+// LabelImage; the h5wasm File is closed by readSlp's finally block before
+// Labels is returned. label-image .data therefore has no dependency on the
+// source file lifetime — the Python issue addressed by PR #419 (h5py
+// Dataset closure invalidated by Labels.__del__) does not apply here.
 function readLabelImages(
   file: any,
   _videos: Video[],

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -360,6 +360,9 @@ function writeSlpToFileLazy(file: any, labels: Labels): void {
   // looking up videos.indexOf(roi.video) instead of using -1. The other
   // four undistributed lists shouldn't have annotations with .video after
   // PR #94 (those classes no longer carry video), so they always use -1.
+  // Mirrors the fix from Python sleap-io PR #414 (talmolab/sleap-io); the
+  // JS port already had this in place via Side fix B and is covered by
+  // tests/lazy-write.test.ts "preserves static ROI video association".
   for (const roi of store._undistributedRois) {
     allRois.push(roi);
     const vidIdx = roi.video ? labels.videos.indexOf(roi.video) : -1;

--- a/src/model/mask.ts
+++ b/src/model/mask.ts
@@ -139,6 +139,36 @@ export class SegmentationMask {
   ): UserSegmentationMask {
     let flat: Uint8Array;
     if (mask instanceof Uint8Array) {
+      // Multi-class guard (parity with Python sleap-io PR #421): refuse
+      // arrays with more than one distinct non-zero value to avoid silently
+      // collapsing class labels. Single-non-zero-value arrays like [0, 5, 5]
+      // are allowed and binarized by encodeRle's truthy check. boolean[][]
+      // inputs are inherently binary and bypass this guard, matching
+      // Python's array.astype(bool) opt-in path.
+      const distinct = new Set<number>();
+      let hasMore = false;
+      for (let i = 0; i < mask.length; i++) {
+        const v = mask[i];
+        if (v === 0 || distinct.has(v)) continue;
+        if (distinct.size >= 3) {
+          hasMore = true;
+          break;
+        }
+        distinct.add(v);
+      }
+      if (distinct.size > 1) {
+        const sample = Array.from(distinct).join(", ");
+        const more = hasMore ? "+" : "";
+        throw new Error(
+          `SegmentationMask is binary (one object per mask) but got an ` +
+            `array with ${distinct.size}${more} distinct non-zero values ` +
+            `(e.g. [${sample}]). Use UserLabelImage.fromArray(array) to ` +
+            `keep all classes in one dense array, or ` +
+            `UserLabelImage.fromBinaryMasks([...]) to split per-class ` +
+            `binaries. To opt in to binarization explicitly, pre-binarize ` +
+            `with Uint8Array.from(arr, v => v ? 1 : 0).`,
+        );
+      }
       flat = mask;
     } else {
       flat = new Uint8Array(height * width);

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -70,7 +70,11 @@ export async function renderImage(
   const { instances, skeleton, frameSize, frameIdx, tracks, trackIndexMap } =
     extractSourceData(source, opts);
 
-  if (instances.length === 0 && !opts.image) {
+  if (
+    instances.length === 0 &&
+    !opts.image &&
+    !hasNonInstanceAnnotations(source)
+  ) {
     throw new Error(
       "No instances to render and no background image provided"
     );
@@ -253,6 +257,34 @@ export async function renderImage(
   // Return ImageData
   // Cast to standard ImageData for compatibility
   return ctx.getImageData(0, 0, scaledWidth, scaledHeight) as unknown as ImageData;
+}
+
+/**
+ * Whether `source` carries non-instance annotations (label images, masks,
+ * bboxes, rois, centroids) that should keep renderImage from throwing even
+ * when there are no instances. For Labels, checks the first labeled frame.
+ *
+ * Mirrors Python sleap-io PR #420: renderImage(source=lf) must work on
+ * segmentation-only LabeledFrames. The actual overlay rendering of these
+ * annotations is tracked in issue #96 — this hook is the single place to
+ * extend when that lands.
+ */
+function hasNonInstanceAnnotations(
+  source: Labels | LabeledFrame | (Instance | PredictedInstance)[]
+): boolean {
+  if (Array.isArray(source)) return false;
+  const lf: LabeledFrame | undefined =
+    "labeledFrames" in source
+      ? (source as Labels).labeledFrames[0]
+      : (source as LabeledFrame);
+  if (!lf) return false;
+  return (
+    (lf.labelImages?.length ?? 0) > 0 ||
+    (lf.masks?.length ?? 0) > 0 ||
+    (lf.bboxes?.length ?? 0) > 0 ||
+    (lf.rois?.length ?? 0) > 0 ||
+    (lf.centroids?.length ?? 0) > 0
+  );
 }
 
 /**

--- a/tests/label-image-slp.test.ts
+++ b/tests/label-image-slp.test.ts
@@ -447,4 +447,55 @@ describe("LabelImage SLP I/O", () => {
     expect(obj!.category).toBe("cell");
     expect(obj!.name).toBe("lazy_test");
   });
+
+  it("labelImage.data survives dropping the Labels reference (Python PR #419 parity)", async () => {
+    // The Python bug fixed in PR #419 was that Labels.__del__ closed the
+    // h5py file on GC, invalidating lazy LabelImage.data readers. The JS
+    // port eagerly materializes pixel data into a standalone Int32Array
+    // (see comment on readLabelImages), so the bug shape doesn't exist.
+    // This test locks that behavior in: hold only the LabelImage, drop the
+    // Labels, and confirm data remains readable and intact.
+    const video = new Video({ filename: "v.mp4" });
+    const skeleton = new Skeleton({ nodes: ["a"] });
+    const track = new Track("t");
+
+    const sourceData = new Int32Array(3 * 3);
+    sourceData[0] = 1;
+    sourceData[4] = 1;
+    sourceData[8] = 1;
+
+    const li = new UserLabelImage({
+      data: sourceData,
+      height: 3,
+      width: 3,
+      objects: new Map<number, LabelImageObjectInfo>([
+        [1, { track, category: "cell", name: "diag", instance: null }],
+      ]),
+    });
+    const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [track],
+    });
+
+    const bytes = await saveSlpToBytes(labels);
+
+    // Load, hold only the inner LabelImage, then drop the Labels reference.
+    let labelImage: LabelImage | null;
+    {
+      const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+      labelImage = loaded.labelImages[0];
+    }
+    // `loaded` is now out of scope; only `labelImage` keeps the data alive.
+
+    expect(labelImage).not.toBeNull();
+    expect(labelImage!.data.length).toBe(9);
+    expect(labelImage!.data[0]).toBe(1);
+    expect(labelImage!.data[4]).toBe(1);
+    expect(labelImage!.data[8]).toBe(1);
+    expect(labelImage!.height).toBe(3);
+    expect(labelImage!.width).toBe(3);
+  });
 });

--- a/tests/mask.test.ts
+++ b/tests/mask.test.ts
@@ -142,6 +142,36 @@ describe("SegmentationMask", () => {
     expect(mask.area).toBe(6); // 2 rows * 3 cols
   });
 
+  it("fromArray rejects multi-class Uint8Array (Python PR #421 parity)", () => {
+    // Multi-class label array — silently binarizing this would collapse
+    // classes 1, 2, and 3 into one undifferentiated blob, losing all the
+    // class information the user encoded. The guard fires loudly instead.
+    const multiClass = new Uint8Array([0, 1, 2, 0, 3, 0]);
+    expect(() => SegmentationMask.fromArray(multiClass, 2, 3)).toThrow(
+      /SegmentationMask is binary.*distinct non-zero values/,
+    );
+  });
+
+  it("fromArray accepts single-non-zero-value Uint8Array (one-class mask)", () => {
+    // A binary mask stamped with a class ID (here: 5) is one object — not
+    // multi-class — and should pass the guard, with encodeRle's truthy
+    // collapse handling the binarization downstream.
+    const stamped = new Uint8Array([0, 5, 5, 0, 5, 0]);
+    const mask = SegmentationMask.fromArray(stamped, 2, 3);
+    expect(mask.area).toBe(3);
+  });
+
+  it("fromArray boolean[][] bypasses the multi-class guard", () => {
+    // boolean[][] is the JS analog of Python's array.astype(bool) — the
+    // documented opt-in to binarization. It should never trip the guard.
+    const arr: boolean[][] = [
+      [false, true, true],
+      [true, false, true],
+    ];
+    const mask = SegmentationMask.fromArray(arr, 2, 3);
+    expect(mask.area).toBe(4);
+  });
+
   it("toPolygon creates an ROI", () => {
     const data = makeMask2D(20, 20, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
     const mask = SegmentationMask.fromArray(data, 20, 20, {

--- a/tests/rendering/render.test.ts
+++ b/tests/rendering/render.test.ts
@@ -6,6 +6,7 @@ import { Instance, Track } from "../../src/model/instance";
 import { LabeledFrame } from "../../src/model/labeled-frame";
 import { Labels } from "../../src/model/labels";
 import { Video } from "../../src/model/video";
+import { UserBoundingBox } from "../../src/model/bbox";
 
 // Create a simple skeleton for testing
 function createTestSkeleton(): Skeleton {
@@ -102,6 +103,41 @@ describe("renderImage", () => {
       expect(imageData).toBeDefined();
       expect(imageData.width).toBe(100);
       expect(imageData.height).toBe(100);
+    });
+
+    it("renders an annotation-only LabeledFrame (Python PR #420 parity)", async () => {
+      // A LabeledFrame with no instances but with a non-instance annotation
+      // (here: a bounding box) should render without throwing. Overlay
+      // drawing for these annotations is tracked in issue #96 — for now the
+      // call just returns the canvas at the requested size.
+      const video = createTestVideo();
+      const bbox = new UserBoundingBox({ x: 5, y: 5, width: 20, height: 20 });
+      const frame = new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [],
+        bboxes: [bbox],
+      });
+
+      const imageData = await renderImage(frame, { width: 80, height: 80 });
+      expect(imageData).toBeDefined();
+      expect(imageData.width).toBe(80);
+      expect(imageData.height).toBe(80);
+    });
+
+    it("still throws on a fully-empty LabeledFrame with no image", async () => {
+      // The guard relaxation is annotation-aware, not blanket: an LF with
+      // nothing on it and no image/background still has nothing to render.
+      const video = createTestVideo();
+      const frame = new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [],
+      });
+
+      await expect(
+        renderImage(frame, { width: 80, height: 80 })
+      ).rejects.toThrow("No instances to render");
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #109. Ports the four small correctness fixes from Python sleap-io v0.7.0 (talmolab/sleap-io PRs #414, #419, #420, #421) into a single PR. Two of the four are JS-architectural no-ops; the other two are real fixes with test coverage.

| Python PR | Status in JS | Action this PR |
|---|---|---|
| #414 — static ROI video association on lazy round-trip | Already preserved (Side fix B at `write.ts:359-367`) | Comment cross-references Python PR #414. Existing test at `tests/lazy-write.test.ts:179`. |
| #419 — `LabelImage.data` across `Labels` GC | Not applicable (eager pixel materialization, file closed in `finally`, no `__del__`) | Comment on `readLabelImages`. New regression test pins the behavior. |
| #420 — `renderImage` on segmentation-only `LabeledFrame` | Real fix | `hasNonInstanceAnnotations` helper + relaxed guard. 2 new tests. |
| #421 — `SegmentationMask` multi-class silent binarization | Real fix | Multi-class guard in `fromArray`'s `Uint8Array` branch. 3 new tests. |

## #420 details

`renderImage(source=lf)` previously threw `"No instances to render and no background image provided"` even when the `LabeledFrame` carried `labelImages`, `masks`, `bboxes`, `rois`, or `centroids`. The new guard checks for any of those before throwing. `boolean[]`/empty-array/empty-Labels paths are unchanged.

Overlay rendering of these annotations is still tracked by issue #96 — this PR just removes the false-positive guard. The renderer hook `hasNonInstanceAnnotations` is the single place to extend when #96 lands.

## #421 details

`SegmentationMask.fromArray` on a multi-class `Uint8Array` (e.g. `[0, 5, 17, 99]`) used to silently binarize via `encodeRle`'s truthy check, collapsing all classes into one undifferentiated blob. The new guard throws:

> SegmentationMask is binary (one object per mask) but got an array with 3 distinct non-zero values (e.g. [5, 17, 99]). Use UserLabelImage.fromArray(array) to keep all classes in one dense array, or UserLabelImage.fromBinaryMasks([...]) to split per-class binaries. To opt in to binarization explicitly, pre-binarize with Uint8Array.from(arr, v => v ? 1 : 0).

`boolean[][]` is unaffected (it's the JS analog of Python's `array.astype(bool)` opt-in). Single-non-zero-value inputs like `[0, 5, 5]` (one object stamped at class 5) are still accepted.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 707/707 pass (51 files; +6 new tests across `tests/mask.test.ts`, `tests/rendering/render.test.ts`, `tests/label-image-slp.test.ts`)
- [x] Targeted run of parity tests confirms they exercise the new code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)