### PR TITLE
feat(numpy): add numFrames option to Labels.numpy() and toNumpy()

### DIFF
--- a/src/codecs/numpy.ts
+++ b/src/codecs/numpy.ts
@@ -12,7 +12,8 @@ import { Video } from "../model/video.js";
  *   Useful when `video.shape` is null — for example, Mp4Box-backed browser
  *   videos — and you still want a video-length-sized array. If smaller than
  *   `maxLabeledFrame + 1`, it is clamped up so no labeled frames are dropped.
- *   Values `<= 0` are ignored.
+ *   Non-finite, non-positive, or fractional values are sanitized via
+ *   `Math.floor` and ignored when `<= 0`.
  */
 export function toNumpy(
   labels: Labels,

--- a/src/codecs/numpy.ts
+++ b/src/codecs/numpy.ts
@@ -4,8 +4,25 @@ import { PredictedInstance, Track, predictedPointsFromArray } from "../model/ins
 import { Skeleton } from "../model/skeleton.js";
 import { Video } from "../model/video.js";
 
-export function toNumpy(labels: Labels, options?: { returnConfidence?: boolean; video?: Video }): number[][][][] {
-  return labels.numpy({ returnConfidence: options?.returnConfidence, video: options?.video });
+/**
+ * Convert labels to a dense `[frames, tracks, nodes, coords]` array.
+ *
+ * @param options.numFrames Optional explicit length of the output's frame
+ *   dimension. Takes precedence over `video.shape[0]` (the inferred fallback).
+ *   Useful when `video.shape` is null — for example, Mp4Box-backed browser
+ *   videos — and you still want a video-length-sized array. If smaller than
+ *   `maxLabeledFrame + 1`, it is clamped up so no labeled frames are dropped.
+ *   Values `<= 0` are ignored.
+ */
+export function toNumpy(
+  labels: Labels,
+  options?: { returnConfidence?: boolean; video?: Video; numFrames?: number }
+): number[][][][] {
+  return labels.numpy({
+    returnConfidence: options?.returnConfidence,
+    video: options?.video,
+    numFrames: options?.numFrames,
+  });
 }
 
 export function fromNumpy(

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -1037,7 +1037,8 @@ export class Labels {
    *   Useful when `video.shape` is null — for example, Mp4Box-backed browser
    *   videos — and you still want a video-length-sized array. If smaller than
    *   `maxLabeledFrame + 1`, it is clamped up so no labeled frames are dropped.
-   *   Values `<= 0` are ignored.
+   *   Non-finite, non-positive, or fractional values are sanitized via
+   *   `Math.floor` and ignored when `<= 0`.
    */
   numpy(options?: { video?: Video; returnConfidence?: boolean; numFrames?: number }): number[][][][] {
     if (this._lazyDataStore) {
@@ -1048,7 +1049,8 @@ export class Labels {
     if (!frames.length) return [];
 
     let maxFrame = Math.max(...frames.map((frame) => frame.frameIdx));
-    const override = options?.numFrames && options.numFrames > 0 ? options.numFrames : 0;
+    const rawOverride = options?.numFrames;
+    const override = Number.isFinite(rawOverride) && (rawOverride as number) > 0 ? Math.floor(rawOverride as number) : 0;
     const effectiveLength = override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
     if (effectiveLength > 0) {
       maxFrame = Math.max(maxFrame, effectiveLength - 1);

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -1029,7 +1029,17 @@ export class Labels {
     });
   }
 
-  numpy(options?: { video?: Video; returnConfidence?: boolean }): number[][][][] {
+  /**
+   * Convert labels to a dense `[frames, tracks, nodes, coords]` array.
+   *
+   * @param options.numFrames Optional explicit length of the output's frame
+   *   dimension. Takes precedence over `video.shape[0]` (the inferred fallback).
+   *   Useful when `video.shape` is null — for example, Mp4Box-backed browser
+   *   videos — and you still want a video-length-sized array. If smaller than
+   *   `maxLabeledFrame + 1`, it is clamped up so no labeled frames are dropped.
+   *   Values `<= 0` are ignored.
+   */
+  numpy(options?: { video?: Video; returnConfidence?: boolean; numFrames?: number }): number[][][][] {
     if (this._lazyDataStore) {
       return this._lazyDataStore.toNumpy(options);
     }
@@ -1038,9 +1048,10 @@ export class Labels {
     if (!frames.length) return [];
 
     let maxFrame = Math.max(...frames.map((frame) => frame.frameIdx));
-    const videoLength = targetVideo.shape?.[0] ?? 0;
-    if (videoLength > 0) {
-      maxFrame = Math.max(maxFrame, videoLength - 1);
+    const override = options?.numFrames && options.numFrames > 0 ? options.numFrames : 0;
+    const effectiveLength = override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
+    if (effectiveLength > 0) {
+      maxFrame = Math.max(maxFrame, effectiveLength - 1);
     }
     const tracks = this.tracks.length ? this.tracks.length : Math.max(1, ...frames.map((frame) => frame.instances.length));
     const nodes = this.skeletons[0]?.nodes.length ?? 0;

--- a/src/model/lazy.ts
+++ b/src/model/lazy.ts
@@ -215,7 +215,17 @@ export class LazyDataStore {
    * Returns [frames, tracks/instances, nodes, coords] where coords is
    * [x, y] or [x, y, score] when returnConfidence is true.
    */
-  toNumpy(options?: { video?: Video; returnConfidence?: boolean }): number[][][][] {
+  /**
+   * Convert lazy-mode labels to a dense `[frames, tracks, nodes, coords]` array.
+   *
+   * @param options.numFrames Optional explicit length of the output's frame
+   *   dimension. Takes precedence over `video.shape[0]` (the inferred fallback).
+   *   Useful when `video.shape` is null — for example, Mp4Box-backed browser
+   *   videos — and you still want a video-length-sized array. If smaller than
+   *   `maxLabeledFrame + 1`, it is clamped up so no labeled frames are dropped.
+   *   Values `<= 0` are ignored.
+   */
+  toNumpy(options?: { video?: Video; returnConfidence?: boolean; numFrames?: number }): number[][][][] {
     const targetVideo = options?.video ?? this.videos[0];
     if (!targetVideo) return [];
 
@@ -252,9 +262,10 @@ export class LazyDataStore {
     }
     if (!matchingFrames.length) return [];
 
-    const videoLength = targetVideo.shape?.[0] ?? 0;
-    if (videoLength > 0) {
-      maxFrameIdx = Math.max(maxFrameIdx, videoLength - 1);
+    const override = options?.numFrames && options.numFrames > 0 ? options.numFrames : 0;
+    const effectiveLength = override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
+    if (effectiveLength > 0) {
+      maxFrameIdx = Math.max(maxFrameIdx, effectiveLength - 1);
     }
 
     const nodeCount = this.skeletons[0]?.nodes.length ?? 0;

--- a/src/model/lazy.ts
+++ b/src/model/lazy.ts
@@ -209,21 +209,18 @@ export class LazyDataStore {
   }
 
   /**
-   * Build a 4D numpy-like array directly from raw column data without
-   * materializing any LabeledFrame or Instance objects.
-   *
-   * Returns [frames, tracks/instances, nodes, coords] where coords is
-   * [x, y] or [x, y, score] when returnConfidence is true.
-   */
-  /**
-   * Convert lazy-mode labels to a dense `[frames, tracks, nodes, coords]` array.
+   * Convert lazy-mode labels to a dense `[frames, tracks, nodes, coords]` array
+   * directly from raw column data without materializing any LabeledFrame or
+   * Instance objects. Coords is `[x, y]` or `[x, y, score]` when
+   * `returnConfidence` is true.
    *
    * @param options.numFrames Optional explicit length of the output's frame
    *   dimension. Takes precedence over `video.shape[0]` (the inferred fallback).
    *   Useful when `video.shape` is null — for example, Mp4Box-backed browser
    *   videos — and you still want a video-length-sized array. If smaller than
    *   `maxLabeledFrame + 1`, it is clamped up so no labeled frames are dropped.
-   *   Values `<= 0` are ignored.
+   *   Non-finite, non-positive, or fractional values are sanitized via
+   *   `Math.floor` and ignored when `<= 0`.
    */
   toNumpy(options?: { video?: Video; returnConfidence?: boolean; numFrames?: number }): number[][][][] {
     const targetVideo = options?.video ?? this.videos[0];
@@ -262,7 +259,8 @@ export class LazyDataStore {
     }
     if (!matchingFrames.length) return [];
 
-    const override = options?.numFrames && options.numFrames > 0 ? options.numFrames : 0;
+    const rawOverride = options?.numFrames;
+    const override = Number.isFinite(rawOverride) && (rawOverride as number) > 0 ? Math.floor(rawOverride as number) : 0;
     const effectiveLength = override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
     if (effectiveLength > 0) {
       maxFrameIdx = Math.max(maxFrameIdx, effectiveLength - 1);

--- a/tests/codecs/numpy.test.ts
+++ b/tests/codecs/numpy.test.ts
@@ -3,7 +3,8 @@ import { describe, it, expect } from "vitest";
 import { loadSlp } from "../../src/io/main.js";
 import { toNumpy, fromNumpy } from "../../src/codecs/numpy.js";
 import { Labels } from "../../src/model/labels.js";
-import { PredictedInstance } from "../../src/model/instance.js";
+import { Instance, PredictedInstance } from "../../src/model/instance.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
 import { Skeleton } from "../../src/model/skeleton.js";
 import { Video } from "../../src/model/video.js";
 import { fileURLToPath } from "node:url";
@@ -13,6 +14,21 @@ const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 
 async function loadFixture(filename: string) {
   return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+}
+
+function buildSparseLabels(options: {
+  shape?: [number, number, number, number] | null;
+  labeledFrameIdx: number;
+}): Labels {
+  const video = new Video({ filename: "sparse.mp4" });
+  if (options.shape !== undefined) video.shape = options.shape;
+  const skeleton = new Skeleton(["a", "b"]);
+  const frame = new LabeledFrame({
+    video,
+    frameIdx: options.labeledFrameIdx,
+    instances: [Instance.fromArray([[1, 2], [3, 4]], skeleton)],
+  });
+  return new Labels({ labeledFrames: [frame], videos: [video], skeletons: [skeleton] });
 }
 
 describe("numpy codec", () => {
@@ -121,5 +137,55 @@ describe("numpy codec", () => {
     expect(() => fromNumpy([[[[0, 0]]]] as any, { skeleton })).toThrow(/video/);
     expect(() => fromNumpy([[[[0, 0]]]] as any, { video })).toThrow(/skeleton/);
     expect(() => fromNumpy([[[[0, 0]]]] as any, { video, videos: [video], skeleton })).toThrow(/both/);
+  });
+
+  it("sizes output to video.shape[0] when known and labels are sparse", () => {
+    const labels = buildSparseLabels({ shape: [10, 1, 1, 1], labeledFrameIdx: 3 });
+    const arr = labels.numpy();
+    expect(arr.length).toBe(10);
+    expect(arr[3][0][0]).toEqual([1, 2]);
+    expect(Number.isNaN(arr[9][0][0][0])).toBe(true);
+  });
+
+  it("falls back to last labeled frame + 1 when video.shape is null", () => {
+    const labels = buildSparseLabels({ shape: null, labeledFrameIdx: 3 });
+    const arr = labels.numpy();
+    expect(arr.length).toBe(4);
+  });
+
+  it("uses numFrames override when video.shape is null", () => {
+    const labels = buildSparseLabels({ shape: null, labeledFrameIdx: 3 });
+    const arr = labels.numpy({ numFrames: 10 });
+    expect(arr.length).toBe(10);
+    expect(arr[3][0][0]).toEqual([1, 2]);
+  });
+
+  it("numFrames overrides video.shape[0] when both provided", () => {
+    const labels = buildSparseLabels({ shape: [5, 1, 1, 1], labeledFrameIdx: 1 });
+    const arr = labels.numpy({ numFrames: 12 });
+    expect(arr.length).toBe(12);
+  });
+
+  it("clamps numFrames up to maxLabeledFrame + 1", () => {
+    const labels = buildSparseLabels({ shape: null, labeledFrameIdx: 7 });
+    const arr = labels.numpy({ numFrames: 3 });
+    expect(arr.length).toBe(8);
+    expect(arr[7][0][0]).toEqual([1, 2]);
+    expect(Number.isNaN(arr[0][0][0][0])).toBe(true);
+    expect(Number.isNaN(arr[6][0][0][0])).toBe(true);
+  });
+
+  it("ignores numFrames <= 0", () => {
+    const labels = buildSparseLabels({ shape: [6, 1, 1, 1], labeledFrameIdx: 1 });
+    const arr = labels.numpy({ numFrames: 0 });
+    expect(arr.length).toBe(6);
+  });
+
+  it("threads numFrames through the toNumpy codec wrapper", () => {
+    const labels = buildSparseLabels({ shape: null, labeledFrameIdx: 2 });
+    const viaCodec = toNumpy(labels, { numFrames: 9 });
+    const viaMethod = labels.numpy({ numFrames: 9 });
+    expect(viaCodec).toEqual(viaMethod);
+    expect(viaCodec.length).toBe(9);
   });
 });

--- a/tests/codecs/numpy.test.ts
+++ b/tests/codecs/numpy.test.ts
@@ -181,6 +181,14 @@ describe("numpy codec", () => {
     expect(arr.length).toBe(6);
   });
 
+  it("floors fractional numFrames and ignores non-finite values", () => {
+    const labels = buildSparseLabels({ shape: null, labeledFrameIdx: 2 });
+    expect(labels.numpy({ numFrames: 9.7 }).length).toBe(9);
+    expect(labels.numpy({ numFrames: Number.NaN }).length).toBe(3);
+    expect(labels.numpy({ numFrames: Number.POSITIVE_INFINITY }).length).toBe(3);
+    expect(labels.numpy({ numFrames: -2.5 }).length).toBe(3);
+  });
+
   it("threads numFrames through the toNumpy codec wrapper", () => {
     const labels = buildSparseLabels({ shape: null, labeledFrameIdx: 2 });
     const viaCodec = toNumpy(labels, { numFrames: 9 });

--- a/tests/lazy.test.ts
+++ b/tests/lazy.test.ts
@@ -242,3 +242,52 @@ describe("Lazy auto-materialization", () => {
     expect(lazyNumpy.length).toBeGreaterThan(0);
   });
 });
+
+describe("LazyDataStore.toNumpy numFrames", () => {
+  async function loadLazyWithMaxFrame(filename: string) {
+    const lazy = await loadFixtureLazy(filename);
+    const eager = await loadFixture(filename);
+    const targetVideo = eager.videos[0];
+    const maxLabeledFrame = Math.max(
+      ...eager.labeledFrames
+        .filter((f) => f.video.matchesPath(targetVideo, true))
+        .map((f) => f.frameIdx)
+    );
+    return { lazy, eager, maxLabeledFrame };
+  }
+
+  it("toNumpy sizes to video.shape[0] when known", async () => {
+    const { lazy, maxLabeledFrame } = await loadLazyWithMaxFrame("typical.slp");
+    const knownLength = maxLabeledFrame + 25;
+    lazy.videos[0].shape = [knownLength, 384, 384, 1];
+    expect(lazy.numpy().length).toBe(knownLength);
+  });
+
+  it("toNumpy falls back to last labeled frame + 1 when shape is null", async () => {
+    const { lazy, maxLabeledFrame } = await loadLazyWithMaxFrame("typical.slp");
+    lazy.videos[0].shape = null;
+    expect(lazy.numpy().length).toBe(maxLabeledFrame + 1);
+  });
+
+  it("toNumpy respects numFrames override when shape is null", async () => {
+    const { lazy, maxLabeledFrame } = await loadLazyWithMaxFrame("typical.slp");
+    lazy.videos[0].shape = null;
+    const override = maxLabeledFrame + 50;
+    expect(lazy.numpy({ numFrames: override }).length).toBe(override);
+  });
+
+  it("toNumpy numFrames takes precedence over video.shape[0]", async () => {
+    const { lazy, maxLabeledFrame } = await loadLazyWithMaxFrame("typical.slp");
+    const shapeLength = maxLabeledFrame + 10;
+    lazy.videos[0].shape = [shapeLength, 384, 384, 1];
+    const override = shapeLength + 100;
+    expect(lazy.numpy({ numFrames: override }).length).toBe(override);
+  });
+
+  it("toNumpy clamps numFrames up to cover all labeled frames", async () => {
+    const { lazy, maxLabeledFrame } = await loadLazyWithMaxFrame("typical.slp");
+    lazy.videos[0].shape = null;
+    // numFrames=1 is below maxLabeledFrame + 1; expect clamping up.
+    expect(lazy.numpy({ numFrames: 1 }).length).toBe(maxLabeledFrame + 1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds optional `numFrames?: number` to `Labels.numpy()`, `LazyDataStore.toNumpy()`, and the `toNumpy` codec wrapper.
- Override takes precedence over `video.shape[0]`; clamps up to `maxLabeledFrame + 1` so labels are never dropped; sanitizes non-finite / fractional / non-positive values.
- Closes the JS gap to Python sleap-io PR #368 for the common browser case where `Video.shape` is `null` (e.g. Mp4Box-backed videos pre-decode).

Closes #98.

## Pinned semantics

1. **Length formula**: `length = max(maxLabeledFrame + 1, effectiveLength)`, where `effectiveLength = floor(numFrames)` (if finite and > 0) else `video.shape?.[0] ?? 0`.
2. **Precedence**: explicit `numFrames` wins over inferred `video.shape[0]`.
3. **Under-sized override**: clamped up — never lose labels (matches Python's invariant).
4. **Invalid `numFrames`**: `NaN`, `Infinity`, negative, zero, and fractional values are floored / ignored (avoids a `numFrames: 0` footgun and `Array.from({ length: Infinity })` blowups).

## Test plan

- [x] `npm run lint` — clean
- [x] `npx vitest run tests/codecs/numpy.test.ts tests/lazy.test.ts` — 43 passed
- [x] `npm test -- --run` — 720 passed across 51 files
- [x] New eager-path tests cover: shape-known, shape-null fallback, numFrames override (with/without shape), clamping, ignore <= 0, non-finite/fractional sanitization, codec-wrapper threading
- [x] New lazy-path tests cover: shape-known, shape-null fallback, numFrames override, precedence, clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)