### PR TITLE
feat(labels): add dedupSkeletons() helper (#103)

### DIFF
--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -328,6 +328,11 @@ export class Labels {
    *
    * Note: skeleton `name` is not part of `matches()` — the canonical's name wins.
    *
+   * Note: `matches()` compares only node count and node names in order — it does
+   * NOT compare `edges` or `symmetries`. If matched skeletons differ in topology,
+   * the canonical (first) skeleton's edges/symmetries are kept and the others are
+   * discarded.
+   *
    * Legacy `.slp` files often carry content-duplicate skeletons (a pre-1.5 Python
    * sleap quirk). Call this method after `loadSlp` if you want them collapsed —
    * it is not run automatically on load.

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -316,6 +316,57 @@ export class Labels {
     this._invalidateIndices();
   }
 
+  /**
+   * Collapse structurally-equal skeletons into a single canonical entry.
+   *
+   * Skeletons are partitioned via {@link Skeleton.matches} (same node count and
+   * node names in the same order). The first member of each equivalence class
+   * is kept as canonical; the rest are removed from `this.skeletons` and every
+   * instance referencing a non-canonical skeleton is reassigned to the canonical
+   * via direct property assignment. Points are positional, so reassignment is
+   * safe and does not change any point coordinates.
+   *
+   * Note: skeleton `name` is not part of `matches()` — the canonical's name wins.
+   *
+   * Legacy `.slp` files often carry content-duplicate skeletons (a pre-1.5 Python
+   * sleap quirk). Call this method after `loadSlp` if you want them collapsed —
+   * it is not run automatically on load.
+   *
+   * In lazy mode this forces full materialization, consistent with other Labels
+   * mutators.
+   *
+   * @returns Number of duplicate skeletons collapsed (0 if none).
+   */
+  dedupSkeletons(): { canonicalized: number } {
+    if (this._lazyFrameList) this.materialize();
+    if (this.skeletons.length <= 1) return { canonicalized: 0 };
+
+    const canonicals: Skeleton[] = [];
+    const canonicalFor = new Map<Skeleton, Skeleton>();
+    for (const skel of this.skeletons) {
+      const existing = canonicals.find((c) => skel.matches(c));
+      if (existing) {
+        canonicalFor.set(skel, existing);
+      } else {
+        canonicals.push(skel);
+        canonicalFor.set(skel, skel);
+      }
+    }
+
+    const canonicalized = this.skeletons.length - canonicals.length;
+    if (canonicalized === 0) return { canonicalized: 0 };
+
+    this.skeletons = canonicals;
+    for (const frame of this.labeledFrames) {
+      for (const inst of frame.instances) {
+        const canon = canonicalFor.get(inst.skeleton);
+        if (canon && inst.skeleton !== canon) inst.skeleton = canon;
+      }
+    }
+
+    return { canonicalized };
+  }
+
   /** Flat view of all centroids across all frames. */
   get centroids(): Centroid[] {
     if (this._lazyFrameList && this._lazyDataStore) {

--- a/tests/model/labels-dedup-skeletons.test.ts
+++ b/tests/model/labels-dedup-skeletons.test.ts
@@ -1,0 +1,219 @@
+/* @vitest-environment node */
+import { describe, it, expect } from "vitest";
+import { Labels } from "../../src/model/labels.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { Instance, PredictedInstance } from "../../src/model/instance.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { Video } from "../../src/model/video.js";
+import { loadSlp, saveSlpToBytes } from "../../src/io/main.js";
+
+function skel(names: string[], name?: string): Skeleton {
+  return new Skeleton({ nodes: names, name });
+}
+
+describe("Labels.dedupSkeletons", () => {
+  it("returns 0 on empty Labels", () => {
+    const labels = new Labels({});
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 0 });
+    expect(labels.skeletons).toHaveLength(0);
+  });
+
+  it("returns 0 with a single skeleton", () => {
+    const s = skel(["a", "b"]);
+    const labels = new Labels({ skeletons: [s] });
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 0 });
+    expect(labels.skeletons).toEqual([s]);
+  });
+
+  it("collapses two equal-but-distinct skeletons and reassigns instances", () => {
+    const sA = skel(["head", "thorax"], "A");
+    const sB = skel(["head", "thorax"], "B");
+    const video = new Video({ filename: "v.mp4" });
+    const instA = Instance.fromArray([[1, 2], [3, 4]], sA);
+    const instB = Instance.fromArray([[5, 6], [7, 8]], sB);
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA, instB],
+    });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [sA, sB],
+    });
+
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 1 });
+    expect(labels.skeletons).toEqual([sA]);
+    expect(instA.skeleton).toBe(sA);
+    expect(instB.skeleton).toBe(sA);
+    // Point coords unchanged
+    expect(instA.points[0].xy).toEqual([1, 2]);
+    expect(instB.points[0].xy).toEqual([5, 6]);
+    expect(instB.points[1].xy).toEqual([7, 8]);
+  });
+
+  it("partitions three equivalence classes with multiple members", () => {
+    const a1 = skel(["x", "y"], "a1");
+    const a2 = skel(["x", "y"], "a2");
+    const b1 = skel(["p", "q", "r"], "b1");
+    const b2 = skel(["p", "q", "r"], "b2");
+    const c1 = skel(["m"], "c1");
+    const c2 = skel(["m"], "c2");
+    const video = new Video({ filename: "v.mp4" });
+    const instances = [
+      Instance.fromArray([[1, 1], [2, 2]], a2),
+      Instance.fromArray([[3, 3], [4, 4], [5, 5]], b2),
+      Instance.fromArray([[6, 6]], c2),
+    ];
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [a1, a2, b1, b2, c1, c2],
+    });
+
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 3 });
+    expect(labels.skeletons).toEqual([a1, b1, c1]);
+    expect(instances[0].skeleton).toBe(a1);
+    expect(instances[1].skeleton).toBe(b1);
+    expect(instances[2].skeleton).toBe(c1);
+  });
+
+  it("does not merge skeletons with different node names", () => {
+    const s1 = skel(["a", "b"]);
+    const s2 = skel(["a", "c"]);
+    const labels = new Labels({ skeletons: [s1, s2] });
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 0 });
+    expect(labels.skeletons).toEqual([s1, s2]);
+  });
+
+  it("does not merge skeletons with same names in different order (matches() is order-sensitive)", () => {
+    const s1 = skel(["a", "b"]);
+    const s2 = skel(["b", "a"]);
+    const labels = new Labels({ skeletons: [s1, s2] });
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 0 });
+    expect(labels.skeletons).toEqual([s1, s2]);
+  });
+
+  it("dedups unreferenced skeletons against their peers", () => {
+    const s1 = skel(["a", "b"], "s1");
+    const s2 = skel(["a", "b"], "s2");
+    const labels = new Labels({ skeletons: [s1, s2] });
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 1 });
+    expect(labels.skeletons).toEqual([s1]);
+  });
+
+  it("is idempotent", () => {
+    const sA = skel(["head", "thorax"]);
+    const sB = skel(["head", "thorax"]);
+    const labels = new Labels({ skeletons: [sA, sB] });
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 1 });
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 0 });
+    expect(labels.skeletons).toEqual([sA]);
+  });
+
+  it("is a no-op on a copied Labels (clones are 1-per-equivalence-class)", () => {
+    const s = skel(["head", "thorax"], "fly");
+    const video = new Video({ filename: "v.mp4" });
+    const instance = Instance.fromArray([[1, 2], [3, 4]], s);
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instance],
+    });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [s],
+    });
+    const copy = labels.copy();
+    expect(copy.skeletons).toHaveLength(1);
+    expect(copy.dedupSkeletons()).toEqual({ canonicalized: 0 });
+    expect(copy.skeletons).toHaveLength(1);
+  });
+
+  it("handles predicted instances", () => {
+    const sA = skel(["head", "thorax"], "A");
+    const sB = skel(["head", "thorax"], "B");
+    const video = new Video({ filename: "v.mp4" });
+    const pred = PredictedInstance.fromArray([[1, 2], [3, 4]], sB, 0.9);
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [pred],
+    });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [sA, sB],
+    });
+
+    expect(labels.dedupSkeletons()).toEqual({ canonicalized: 1 });
+    expect(labels.skeletons).toEqual([sA]);
+    expect(pred.skeleton).toBe(sA);
+  });
+});
+
+describe("loadSlp does not auto-dedup skeletons (helper is opt-in)", () => {
+  it("preserves duplicate skeletons through save+load, then collapses on explicit call", async () => {
+    const sA = skel(["head", "thorax"], "A");
+    const sB = skel(["head", "thorax"], "B");
+    const video = new Video({ filename: "v.mp4" });
+    const instA = Instance.fromArray([[1, 2], [3, 4]], sA);
+    const instB = Instance.fromArray([[5, 6], [7, 8]], sB);
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA, instB],
+    });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [sA, sB],
+    });
+
+    const bytes = await saveSlpToBytes(labels);
+    const loaded = await loadSlp(bytes, { openVideos: false });
+
+    // Auto-dedup is intentionally NOT performed on load.
+    expect(loaded.skeletons).toHaveLength(2);
+
+    // Explicit call collapses them.
+    expect(loaded.dedupSkeletons()).toEqual({ canonicalized: 1 });
+    expect(loaded.skeletons).toHaveLength(1);
+    for (const inst of loaded.instances) {
+      expect(loaded.skeletons).toContain(inst.skeleton);
+    }
+  });
+
+  it("materializes lazy mode before deduping", async () => {
+    const sA = skel(["head", "thorax"], "A");
+    const sB = skel(["head", "thorax"], "B");
+    const video = new Video({ filename: "v.mp4" });
+    const instA = Instance.fromArray([[1, 2], [3, 4]], sA);
+    const instB = Instance.fromArray([[5, 6], [7, 8]], sB);
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA, instB],
+    });
+    const source = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [sA, sB],
+    });
+    const bytes = await saveSlpToBytes(source);
+    const lazy = await loadSlp(bytes, { openVideos: false, lazy: true });
+
+    expect(lazy.isLazy).toBe(true);
+    expect(lazy.skeletons).toHaveLength(2);
+
+    expect(lazy.dedupSkeletons()).toEqual({ canonicalized: 1 });
+
+    expect(lazy.isLazy).toBe(false);
+    expect(lazy.skeletons).toHaveLength(1);
+    for (const inst of lazy.instances) {
+      expect(lazy.skeletons).toContain(inst.skeleton);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `Labels.dedupSkeletons()` — opt-in helper that collapses structurally-equal `Skeleton`s in `Labels.skeletons` and reassigns every instance's `.skeleton` to the canonical. Returns `{ canonicalized: number }`.
- Partitioning uses the existing `Skeleton.matches()` (same node count + node names in order). Points are positional, so reassignment is safe.
- **Not** auto-called from `loadSlp` / `readSlp` / `readSlpLazy` / `readSlpStreaming` — loaders stay verbatim-faithful to file contents; users opt in when they want the cleanup. JSDoc documents the recipe.
- Force-materializes lazy mode (matches the existing mutator pattern: `removePredictions`, etc.).

Closes #103 (one of the v0.4.0 must-haves in #110).

## Why opt-in (not auto-called on load)

Auto-mutation on load would add latency every user pays whether they need cleanup or not, and silently rewriting file contents on read is a surprise. The Python sleap-io v0.7.0 changelog suggested considering auto-call; we deliberately diverge here.

## Test plan

- [x] 12 new tests in `tests/model/labels-dedup-skeletons.test.ts`:
  - empty Labels / single skeleton — return 0
  - two equal-but-distinct skeletons → collapses to 1, instances reassigned, points unchanged
  - three equivalence classes with multiple members each (6 → 3)
  - structurally distinct skeletons NOT merged (different names; same names in different order, since `matches()` is order-sensitive)
  - unreferenced skeleton still deduped against its peers
  - idempotency (second call returns 0)
  - `copy()` round-trip → no-op (clones are 1-per-class)
  - predicted instances handled
  - SLP round-trip via `saveSlpToBytes` + `loadSlp` preserves duplicates (no auto-call), then explicit call collapses
  - lazy-mode load → `dedupSkeletons()` triggers `materialize()` and collapses correctly
- [x] Full suite (`npx vitest run`) — 732/732 passing
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)