### PR TITLE
fix: lazy video shape probing for pkg.slp embedded videos

### DIFF
--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -230,6 +230,18 @@ async function readVideosStreaming(
           if (framesNum !== undefined && framesNum > 0) {
             frameCountFromAttrs = framesNum;
           }
+          // Read height/width/channels from dataset attributes when JSON metadata
+          // is missing (common for pkg.slp files)
+          const readNumAttr = (attr: unknown): number | undefined => {
+            if (attr === undefined || attr === null) return undefined;
+            const v = typeof attr === "object" && attr !== null && "value" in attr
+              ? (attr as { value: unknown }).value : attr;
+            const n = Number(v);
+            return Number.isFinite(n) && n > 0 ? n : undefined;
+          };
+          if (!meta.height) meta.height = readNumAttr(attrs.height);
+          if (!meta.width) meta.width = readNumAttr(attrs.width);
+          if (!meta.channels) meta.channels = readNumAttr(attrs.channels);
         } catch {
           // Ignore attribute read errors
         }
@@ -237,8 +249,8 @@ async function readVideosStreaming(
 
       const frameCount = frameCountFromAttrs ?? meta.frameCount;
       const shape: [number, number, number, number] | undefined =
-        frameCount && meta.height && meta.width && meta.channels
-          ? [frameCount, meta.height, meta.width, meta.channels]
+        (meta.height && meta.width && meta.channels)
+          ? [frameCount ?? 0, meta.height, meta.width, meta.channels]
           : undefined;
 
       // Determine channel order with priority:
@@ -263,6 +275,10 @@ async function readVideosStreaming(
           shape,
           fps: meta.fps,
         });
+
+        if (!shape || shape[0] === 0) {
+          await backend.probeShape(frameCount ?? undefined);
+        }
       }
 
       videos.push(new Video({

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -112,6 +112,47 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     return image ?? rawBytes;
   }
 
+  async probeShape(sourceFrameCount?: number): Promise<void> {
+    if (this.shape && this.shape[0] > 0) return;
+    try {
+      // Reuse the same loading path as getFrame — populates cachedData
+      if (!this.cachedData) {
+        const data = await this.h5file.getDatasetValue(this.datasetPath);
+        this.cachedData = normalizeVideoData(data.value, data.shape);
+
+        if (isContiguousEncodedBuffer(this.cachedData, this.format, this.shape)) {
+          this.frameOffsets = findEncodedFrameOffsets(
+            this.cachedData as unknown as Uint8Array,
+            this.format,
+            this.shape?.[0] ?? 0
+          );
+        }
+      }
+
+      // Decode first entry to get image dimensions
+      const entry = Array.isArray(this.cachedData) ? this.cachedData[0] : null;
+      if (!entry) return;
+      const rawBytes = toUint8Array(entry);
+      if (!rawBytes || rawBytes.length === 0) return;
+
+      if (isEncodedFormat(this.format)) {
+        const decoded = await decodeImageBytes(rawBytes, this.format, this.channelOrder);
+        if (decoded && "width" in decoded && "height" in decoded) {
+          // Use source frame count if available, otherwise infer from max frame number
+          let fc = sourceFrameCount ?? 0;
+          if (!fc && this.frameNumberToIndex.size > 0) {
+            let maxIdx = 0;
+            for (const key of this.frameNumberToIndex.keys()) {
+              if (key > maxIdx) maxIdx = key;
+            }
+            fc = maxIdx + 1;
+          }
+          this.shape = [fc, decoded.height, decoded.width, 4];
+        }
+      }
+    } catch { /* probe failed, shape stays undefined */ }
+  }
+
   close(): void {
     this.cachedData = null;
     this.frameOffsets = null;


### PR DESCRIPTION
## Summary

Closes #117

Matches Python sleap-io's lazy video shape behavior for embedded videos in pkg.slp files. Without this, `video.shape` is null for pkg.slp videos (no JSON shape metadata), causing missing frame counts, missing resolution display, and broken seekbar navigation.

## Changes

### 1. Read height/width/channels from HDF5 dataset attributes (`read-streaming.ts`)

pkg.slp embedded video datasets have `height`, `width`, `channels` as HDF5 attributes, but the streaming reader only read `format`, `channel_order`, and `frames` attributes. Now reads all dimension attributes when JSON metadata is missing, allowing `shape` to be partially constructed as `[0, H, W, C]`.

### 2. Add `probeShape()` to `StreamingHdf5VideoBackend` (`streaming-hdf5-video.ts`)

Lazy shape probe called after backend creation when `shape[0] === 0`:
- Loads the embedded dataset into `cachedData` (same code path as `getFrame`, so no double-load on later rendering)
- Decodes the first entry to get image dimensions
- Uses `max(frame_numbers) + 1` as frame count for correct seekbar source range
- Skips gracefully for empty videos (0 embedded frames)

## How Python does it

Python's `VideoBackend.shape` is a cached property that calls `read_test_frame()` → `_read_frame(0)` to decode one frame for dimensions, and `num_frames` → `dataset.shape[0]` for frame count. Each operation opens a fresh file handle. The JS approach achieves the same result within the Worker-based streaming architecture.

## Test plan
- [ ] pkg.slp: all videos show correct resolution (1024x1024)
- [ ] pkg.slp: videos with data show source frame range (e.g., 269326)
- [ ] pkg.slp: empty videos show 0 frames with correct resolution
- [ ] pkg.slp: seekbar shows labeled frame marks at correct positions
- [ ] pkg.slp: clicking labeled frame marks navigates correctly
- [ ] Regular SLP: no regression (shape from JSON metadata, no probing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)