### PR TITLE
test: cover h5wasm 0.10.x array-of-pairs compound dtype branch (follow-up to #114)

### DIFF
--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -621,7 +621,10 @@ async function readStructDatasetStreaming(
 /**
  * Extract field names from dataset metadata.
  */
-function getFieldNamesFromMeta(meta: { shape: number[]; dtype: string }): string[] {
+export function getFieldNamesFromMeta(meta: {
+  shape: number[];
+  dtype: string;
+}): string[] {
   // dtype might be a string like "{'names':['x','y','visible','complete'],...}"
   // or an object with compound type info
   const dtype = meta.dtype;

--- a/tests/streaming-field-names.test.ts
+++ b/tests/streaming-field-names.test.ts
@@ -1,0 +1,75 @@
+/* @vitest-environment node */
+/**
+ * Regression tests for the streaming reader's compound-dtype field-name
+ * extraction (issues #113 / PR #114).
+ *
+ * h5wasm 0.10.x (bumped in PR #111) represents compound dataset dtypes as an
+ * array of [name, type] pairs, e.g. [["frame_id", "<Q"], ["video", "<I"], ...].
+ * `getFieldNamesFromMeta` previously only handled the legacy string-repr and
+ * object-with-`compound_type` shapes, falling through to `[]` on the array
+ * format. That silently dropped every frame/instance/point when loading
+ * Python sleap-io / PyQt SLP files via the Worker path (0 labeled frames).
+ *
+ * The streaming path is browser/Worker-gated (loadSlp routes to readSlp under
+ * Node), so it is unreachable from the all-Node suite. This unit test imports
+ * the (test-only exported) function directly to lock in the fix and guard the
+ * pre-existing branches against regression. The array-of-pairs fixtures below
+ * are the exact shapes h5wasm 0.10.x emits for the repo's Python .slp fixtures.
+ */
+import { describe, it, expect } from "vitest";
+import { getFieldNamesFromMeta } from "../src/codecs/slp/read-streaming.js";
+
+describe("getFieldNamesFromMeta — h5wasm 0.10.x array-of-pairs compound dtype (#113/#114)", () => {
+  it("extracts field names from array-of-[name,type] pairs (points)", () => {
+    const dtype = [
+      ["x", "<d"],
+      ["y", "<d"],
+      ["visible", "unknown"],
+      ["complete", "unknown"],
+    ] as unknown as string;
+    expect(getFieldNamesFromMeta({ shape: [10, 4], dtype })).toEqual([
+      "x",
+      "y",
+      "visible",
+      "complete",
+    ]);
+  });
+
+  it("handles the frames compound dtype", () => {
+    const dtype = [
+      ["frame_id", "<Q"],
+      ["video", "<I"],
+      ["frame_idx", "<Q"],
+      ["instance_id_start", "<Q"],
+      ["instance_id_end", "<Q"],
+    ] as unknown as string;
+    expect(getFieldNamesFromMeta({ shape: [5, 5], dtype })).toEqual([
+      "frame_id",
+      "video",
+      "frame_idx",
+      "instance_id_start",
+      "instance_id_end",
+    ]);
+  });
+
+  it("still handles the legacy string-repr dtype", () => {
+    expect(
+      getFieldNamesFromMeta({
+        shape: [1, 4],
+        dtype:
+          "{'names':['x','y','visible','complete'],'formats':['<d','<d','|b1','|b1']}",
+      })
+    ).toEqual(["x", "y", "visible", "complete"]);
+  });
+
+  it("still handles the object compound_type.members shape", () => {
+    const dtype = {
+      compound_type: { members: [{ name: "a" }, { name: "b" }] },
+    } as unknown as string;
+    expect(getFieldNamesFromMeta({ shape: [1, 2], dtype })).toEqual(["a", "b"]);
+  });
+
+  it("returns [] for an unrecognized dtype", () => {
+    expect(getFieldNamesFromMeta({ shape: [1], dtype: "<i" })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #114, which fixed `getFieldNamesFromMeta` to handle h5wasm 0.10.x's array-of-pairs compound dtype but merged **without test coverage** (it merged at the original commit while the test was being prepared). This adds the regression test it should have shipped with.

The `Array.isArray(dtype)` branch guards a **silent-failure** path: if it regresses, the streaming reader drops *all* frames/instances/points with no thrown error and no CI signal. The streaming path is browser/Worker-gated and unreachable from the all-Node test suite, so there is currently zero coverage of this fix.

## Changes

- **Export `getFieldNamesFromMeta`** (test-only) so the unit test can import it without a browser/Worker harness.
- **Add `tests/streaming-field-names.test.ts`** — feeds the exact array-of-pairs dtypes h5wasm 0.10.x emits for the repo's Python fixtures (`points`, `frames`) into `getFieldNamesFromMeta`, plus regression guards for the legacy string-repr and object-`compound_type` branches and the empty-on-unrecognized case.

## Verification
- [x] `tsc -p tsconfig.json --noEmit` passes
- [x] Full suite green (737 → 742 tests); 5 new tests pass

## Related
- #114 — the fix this covers
- #113 — original report
- #120 — separate follow-up: streaming reader `field_names` JSON-attribute fallback for sleap-io.js-written files

🤖 Generated with [Claude Code](https://claude.com/claude-code)