### PR TITLE
fix: read field_names JSON-string attribute in streaming reader

### DIFF
--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -609,8 +609,28 @@ async function readStructDatasetStreaming(
     const meta = await file.getDatasetMeta(path);
     const data = await file.getDatasetValue(path);
 
-    // Get field names from metadata
-    const fieldNames = getFieldNamesFromMeta(meta);
+    // Get field names: try dtype metadata first, then HDF5 dataset attributes.
+    // Matches main-thread reader's getFieldNames (read.ts:1356-1372).
+    let fieldNames = getFieldNamesFromMeta(meta);
+    if (fieldNames.length === 0) {
+      try {
+        const attrs = await file.getAttrs(path);
+        const fnAttr = attrs.field_names ?? attrs.fieldNames;
+        if (fnAttr) {
+          let raw = Array.isArray(fnAttr) ? fnAttr
+            : (fnAttr as { value?: unknown })?.value;
+          if (typeof raw === "string") {
+            try { raw = JSON.parse(raw); } catch { /* not JSON */ }
+          }
+          if (raw instanceof Uint8Array) {
+            try { raw = JSON.parse(new TextDecoder().decode(raw)); } catch { /* not JSON */ }
+          }
+          if (Array.isArray(raw)) {
+            fieldNames = raw.map(String);
+          }
+        }
+      } catch { /* ignore attribute read errors */ }
+    }
 
     return normalizeStructData(data.value, data.shape, fieldNames);
   } catch {


### PR DESCRIPTION
## Summary

Closes #120

Files written by sleap-io.js store compound data as flat arrays with a `field_names` HDF5 attribute (JSON string, e.g., `'["frame_id","video","frame_idx",...]'`). The streaming reader only checked dtype metadata for field names — never the attribute — causing 0 labeled frames when reopening sleap-app-saved files.

## The problem

Round-trip failure: open a PyQt SLP → save from sleap-app → reopen → 0 labeled frames.

sleap-io.js `write.ts` writes: `setStringAttr(dataset, "field_names", JSON.stringify(fieldNames))`

But `readStructDatasetStreaming` only called `getFieldNamesFromMeta(meta)` which inspects `meta.dtype`. For flat arrays, dtype is just `"<i"` or `[["field", "<Q"], ...]` — no field names there.

### Additional issue: pkg.slp re-save then reopen stalls

Opening a PyQt-generated pkg.slp in sleap-app, saving it, then reopening the saved file causes the app to stall during loading. 
The streaming reader appears to misidentify the re-saved pkg.slp's embedded video as an external mp4 file and tries to create an `Mp4BoxVideoBackend` instead of a `StreamingHdf5VideoBackend`, causing it to hang.

## Fix

Add attribute fallback after `getFieldNamesFromMeta` returns empty:
1. Call `file.getAttrs(path)` to read dataset attributes
2. Extract `field_names` / `fieldNames` attribute
3. Unwrap Worker serialization (`{ value: ... }`)
4. JSON.parse the string (or decode Uint8Array first)

Matches the main-thread reader's `getFieldNames` fallback (read.ts:1356-1372).

The pkg.slp re-save stall is a separate issue related to how sleap-io.js writes embedded video metadata — tracked separately.

## Context

This fix was originally part of PR #106 (closed in favor of #111). The attribute fallback was lost when #106 was closed — #111 and #114 addressed different aspects of the streaming reader but not this case.

## Test plan
- [ ] Open PyQt SLP → labels visible
- [ ] Save from sleap-app → reopen same file → labels still visible
- [ ] Open pkg.slp → labels visible
- [ ] No regression on files with compound dtype (field names from dtype still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)