### PR TITLE
fix: preserve isNegative flag when merging frames

### DIFF
--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -327,6 +327,7 @@ export class LabeledFrame {
     threshold: number = 5.0,
   ): void {
     if (strategy === "keep_original") {
+      this._resolveNegativeFlag(other);
       return;
     }
 
@@ -334,6 +335,7 @@ export class LabeledFrame {
       for (const attr of ANNOTATION_ATTRS) {
         this[attr] = (other[attr] as Annotation[]).map(_shallowCopy) as any;
       }
+      this._resolveNegativeFlag(other);
       return;
     }
 
@@ -347,6 +349,7 @@ export class LabeledFrame {
         }
         (this as any)[attr] = kept;
       }
+      this._resolveNegativeFlag(other);
       return;
     }
 
@@ -359,6 +362,7 @@ export class LabeledFrame {
           threshold,
         );
       }
+      this._resolveNegativeFlag(other);
       return;
     }
 
@@ -371,6 +375,7 @@ export class LabeledFrame {
           threshold,
         );
       }
+      this._resolveNegativeFlag(other);
       return;
     }
 
@@ -383,6 +388,11 @@ export class LabeledFrame {
         }
       }
     }
+    this._resolveNegativeFlag(other);
+  }
+
+  private _resolveNegativeFlag(other: LabeledFrame): void {
+    this.isNegative = (this.isNegative || other.isNegative) && !this.hasUserInstances;
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #108

`LabeledFrame.mergeAnnotations()` silently dropped the `isNegative` flag during all merge strategies. Frames explicitly marked as negative (hard negatives for training) lost their flag after any merge operation.

## Example

You mark frame 500 as negative ("no animals here"). A collaborator sends predictions. You merge them in. Frame 500 had no predictions (correct — no animals), but the merge dropped `isNegative`. Your training pipeline no longer knows it's a hard negative.

## Fix

Add `_resolveNegativeFlag(other)` call after every merge strategy:

```typescript
isNegative = (self.isNegative || other.isNegative) && !hasUserInstances
```

- Either side was negative → flag preserved
- User instance present in result → flag cancelled (user pose vetoes)
- Neither side negative → stays not negative

## Test plan
- [x] Both negative, no user instances → stays negative
- [x] One negative, no user instances → stays negative  
- [x] Negative + user instance on frame → cancelled
- [x] Neither negative → stays not negative
- [x] All strategies tested: keep_original, keep_new, keep_both, replace_predictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)