### PR TITLE
fix(ci): make release publish robust and re-runnable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag/branch/SHA) to build and publish to npm"
+        required: true
 
 permissions:
   contents: write
@@ -13,15 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

The **v0.3.0 release never made it to npm**. The Release workflow run for `v0.3.0` failed at the `Update npm` step (`npm install -g npm@latest` crashed with `Cannot find module 'promise-retry'` — a broken `npm@latest` at the time), so `npm publish` never ran. npm is still at `0.2.3` even though `package.json` and the GitHub release say `0.3.0`.

This PR makes the publish workflow robust and recoverable:

- **Remove the fragile `npm install -g npm@latest` step.** Node 22 ships npm 10.x, which supports `npm publish --provenance` natively, so the upgrade step is unnecessary — and it was the single point of failure for v0.3.0.
- **Add a `workflow_dispatch` trigger with a `ref` input** and parametrize checkout via `${{ github.event.inputs.ref || github.ref }}`. This lets a failed or missed publish be re-run for any tag, using the (fixed) workflow on the default branch, without having to retag a release. For normal `release: published` events behavior is unchanged (`github.ref` is the release tag).

## Why now

This unblocks backfilling `v0.3.0` to npm and cutting `v0.3.1` without re-hitting the same failure.

## Test plan
- [x] `release.yml` is valid YAML; `release`-event path resolves checkout `ref` to the release tag (unchanged behavior)
- [ ] CI `test` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
