### PR TITLE
fix(ci): pin npm 11.16.0 for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      # npm trusted publishing (OIDC, tokenless) requires npm >= 11.5.1.
+      # Node 22 bundles npm 10.x, which can sign provenance but cannot
+      # authenticate via OIDC, so publish 404s. Pin an exact known-good
+      # version rather than @latest (a broken @latest sank the v0.3.0 publish).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.16.0
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary

Follow-up to #124. That PR removed the npm upgrade step, assuming it was unnecessary — but it was **load-bearing**.

This repo publishes via **npm trusted publishing (OIDC, tokenless)** — there is no `NODE_AUTH_TOKEN`/`NPM_TOKEN` wired into the workflow. OIDC-based trusted publishing requires **npm ≥ 11.5.1**. Node 22 bundles npm **10.x**, which can *sign provenance* but **cannot authenticate via OIDC**, so `npm publish` fails the PUT with a `404` (npm's auth-failure response). Verified against a `workflow_dispatch` backfill run of `v0.3.0`:

```
npm notice publish Signed provenance statement ...
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@talmolab%2fsleap-io.js
```

## Fix

Restore the npm upgrade step, but **pin an exact version (`11.16.0`)** instead of `@latest`. The original v0.3.0 failure was a transiently broken `npm@latest` (`Cannot find module 'promise-retry'`); pinning makes the publish reproducible and immune to bad `@latest` releases while satisfying the trusted-publishing version requirement.

## Test plan
- [ ] CI `test` check passes
- [ ] After merge: re-dispatch the release workflow for `v0.3.0` and confirm it publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)
