### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@talmolab/sleap-io.js",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "h5wasm": "^0.10.2",
         "jsfive": "^0.3.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Version bump from `0.3.0` to `0.3.1`.

Patch release: fixes several streaming SLP reader regressions plus two small enhancements.

### Bug fixes
- **Streaming reader loaded 0 frames under h5wasm 0.10.x** ([#114](https://github.com/talmolab/sleap-io.js/pull/114)) — handle the new array-of-`[name, type]` compound-dtype shape.
- **Streaming reader returned 0 frames for sleap-app-saved files** ([#122](https://github.com/talmolab/sleap-io.js/pull/122)) — read the `field_names` JSON-string attribute as a fallback.
- **Missing video shape for embedded `pkg.slp` videos** ([#119](https://github.com/talmolab/sleap-io.js/pull/119)) — read dataset attributes and lazily probe the first embedded frame.
- **Reading `pkg.slp` embedded video frames in the browser** ([#111](https://github.com/talmolab/sleap-io.js/pull/111)) — fix HDF5 checksum/Worker MEMFS errors; report the full source frame count.
- **`renderImage` on annotation-only frames + silent multi-class mask binarization** ([#115](https://github.com/talmolab/sleap-io.js/pull/115)).

### Enhancements
- **`Labels.dedupSkeletons()`** opt-in helper to collapse duplicate skeletons ([#118](https://github.com/talmolab/sleap-io.js/pull/118)).
- **`numFrames` option** for `Labels.numpy()` / `toNumpy()` ([#116](https://github.com/talmolab/sleap-io.js/pull/116)).

Full notes will ship with the `v0.3.1` GitHub release. **Full Changelog**: https://github.com/talmolab/sleap-io.js/compare/v0.3.0...v0.3.1

## Test plan
- [x] `npm version patch` updated `package.json` and `package-lock.json` to `0.3.1`
- [ ] CI `test` check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
