### PR TITLE
feat(labels): widen lookups to accept Video | string | URL (#107 / Python PR #436)

### DIFF
--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -638,15 +638,29 @@ export class Labels {
     return this.labeledFrames.flatMap((frame) => frame.instances);
   }
 
-  find(options: { video?: Video; frameIdx?: number }): LabeledFrame[] {
+  /**
+   * Search for labeled frames given video and/or frame index.
+   *
+   * A foreign `Video` instance or filename (`string`/`URL`) is resolved to the
+   * matching `Video` in `this.videos` via {@link _resolveVideo} (SYNC; see its
+   * documented divergence from `matchVideo`), so an object created independently
+   * still works. When the video does not resolve to a project video the foreign
+   * reference is used as-is, so identity-based lookups yield no results.
+   */
+  find(options: { video?: Video | string | URL; frameIdx?: number }): LabeledFrame[] {
     if (this._lazyFrameList) this.materialize();
+    // Canonicalize a foreign Video / filename to the matching project Video.
+    const resolved =
+      options.video !== undefined
+        ? this._resolveVideo(options.video) ?? undefined
+        : undefined;
     // Fast path: O(1) lookup when both video and frameIdx are specified
-    if (options.video !== undefined && options.frameIdx !== undefined) {
-      const frame = this.getFrame(options.video, options.frameIdx);
+    if (resolved !== undefined && options.frameIdx !== undefined) {
+      const frame = this.getFrame(resolved, options.frameIdx);
       return frame ? [frame] : [];
     }
     return this.labeledFrames.filter((frame) => {
-      if (options.video && frame.video !== options.video) {
+      if (resolved && frame.video !== resolved) {
         return false;
       }
       if (options.frameIdx !== undefined && frame.frameIdx !== options.frameIdx) {
@@ -711,7 +725,7 @@ export class Labels {
    * ROIs across all frames, use `temporalRois`.
    */
   getRois(filters?: {
-    video?: Video;
+    video?: Video | string | URL;
     frameIdx?: number;
     category?: string;
     track?: Track;
@@ -719,14 +733,20 @@ export class Labels {
     predicted?: boolean;
   }): ROI[] {
     if (!filters) return [...this.rois];
+    // Canonicalize a foreign Video / filename via the SYNC resolver (see
+    // `_resolveVideo` for its documented divergence from `matchVideo`).
+    const video =
+      filters.video !== undefined
+        ? this._resolveVideo(filters.video) ?? undefined
+        : undefined;
     let results: ROI[];
-    if (filters.video !== undefined && filters.frameIdx !== undefined) {
-      const lf = this.getFrame(filters.video, filters.frameIdx);
+    if (video !== undefined && filters.frameIdx !== undefined) {
+      const lf = this.getFrame(video, filters.frameIdx);
       results = lf ? lf.rois : [];
-    } else if (filters.video !== undefined) {
+    } else if (video !== undefined) {
       results = [];
       for (const lf of this.labeledFrames) {
-        if (lf.video === filters.video) results.push(...lf.rois);
+        if (lf.video === video) results.push(...lf.rois);
       }
     } else if (filters.frameIdx !== undefined) {
       results = [];
@@ -752,7 +772,7 @@ export class Labels {
   }
 
   getMasks(filters?: {
-    video?: Video;
+    video?: Video | string | URL;
     frameIdx?: number;
     category?: string;
     track?: Track;
@@ -760,14 +780,20 @@ export class Labels {
     predicted?: boolean;
   }): SegmentationMask[] {
     if (!filters) return [...this.masks];
+    // Canonicalize a foreign Video / filename via the SYNC resolver (see
+    // `_resolveVideo` for its documented divergence from `matchVideo`).
+    const video =
+      filters.video !== undefined
+        ? this._resolveVideo(filters.video) ?? undefined
+        : undefined;
     let results: SegmentationMask[];
-    if (filters.video !== undefined && filters.frameIdx !== undefined) {
-      const lf = this.getFrame(filters.video, filters.frameIdx);
+    if (video !== undefined && filters.frameIdx !== undefined) {
+      const lf = this.getFrame(video, filters.frameIdx);
       results = lf ? lf.masks : [];
-    } else if (filters.video !== undefined) {
+    } else if (video !== undefined) {
       results = [];
       for (const lf of this.labeledFrames) {
-        if (lf.video === filters.video) results.push(...lf.masks);
+        if (lf.video === video) results.push(...lf.masks);
       }
     } else if (filters.frameIdx !== undefined) {
       results = [];
@@ -793,7 +819,7 @@ export class Labels {
   }
 
   getBboxes(filters?: {
-    video?: Video;
+    video?: Video | string | URL;
     frameIdx?: number;
     category?: string;
     track?: Track;
@@ -801,14 +827,20 @@ export class Labels {
     predicted?: boolean;
   }): BoundingBox[] {
     if (!filters) return [...this.bboxes];
+    // Canonicalize a foreign Video / filename via the SYNC resolver (see
+    // `_resolveVideo` for its documented divergence from `matchVideo`).
+    const video =
+      filters.video !== undefined
+        ? this._resolveVideo(filters.video) ?? undefined
+        : undefined;
     let results: BoundingBox[];
-    if (filters.video !== undefined && filters.frameIdx !== undefined) {
-      const lf = this.getFrame(filters.video, filters.frameIdx);
+    if (video !== undefined && filters.frameIdx !== undefined) {
+      const lf = this.getFrame(video, filters.frameIdx);
       results = lf ? lf.bboxes : [];
-    } else if (filters.video !== undefined) {
+    } else if (video !== undefined) {
       results = [];
       for (const lf of this.labeledFrames) {
-        if (lf.video === filters.video) results.push(...lf.bboxes);
+        if (lf.video === video) results.push(...lf.bboxes);
       }
     } else if (filters.frameIdx !== undefined) {
       results = [];
@@ -834,7 +866,7 @@ export class Labels {
   }
 
   getCentroids(filters?: {
-    video?: Video;
+    video?: Video | string | URL;
     frameIdx?: number;
     category?: string;
     track?: Track;
@@ -842,14 +874,20 @@ export class Labels {
     predicted?: boolean;
   }): Centroid[] {
     if (!filters) return [...this.centroids];
+    // Canonicalize a foreign Video / filename via the SYNC resolver (see
+    // `_resolveVideo` for its documented divergence from `matchVideo`).
+    const video =
+      filters.video !== undefined
+        ? this._resolveVideo(filters.video) ?? undefined
+        : undefined;
     let results: Centroid[];
-    if (filters.video !== undefined && filters.frameIdx !== undefined) {
-      const lf = this.getFrame(filters.video, filters.frameIdx);
+    if (video !== undefined && filters.frameIdx !== undefined) {
+      const lf = this.getFrame(video, filters.frameIdx);
       results = lf ? lf.centroids : [];
-    } else if (filters.video !== undefined) {
+    } else if (video !== undefined) {
       results = [];
       for (const lf of this.labeledFrames) {
-        if (lf.video === filters.video) results.push(...lf.centroids);
+        if (lf.video === video) results.push(...lf.centroids);
       }
     } else if (filters.frameIdx !== undefined) {
       results = [];
@@ -875,21 +913,27 @@ export class Labels {
   }
 
   getLabelImages(filters?: {
-    video?: Video;
+    video?: Video | string | URL;
     frameIdx?: number;
     track?: Track;
     category?: string;
     predicted?: boolean;
   }): LabelImage[] {
     if (!filters) return [...this.labelImages];
+    // Canonicalize a foreign Video / filename via the SYNC resolver (see
+    // `_resolveVideo` for its documented divergence from `matchVideo`).
+    const video =
+      filters.video !== undefined
+        ? this._resolveVideo(filters.video) ?? undefined
+        : undefined;
     let results: LabelImage[];
-    if (filters.video !== undefined && filters.frameIdx !== undefined) {
-      const lf = this.getFrame(filters.video, filters.frameIdx);
+    if (video !== undefined && filters.frameIdx !== undefined) {
+      const lf = this.getFrame(video, filters.frameIdx);
       results = lf ? lf.labelImages : [];
-    } else if (filters.video !== undefined) {
+    } else if (video !== undefined) {
       results = [];
       for (const lf of this.labeledFrames) {
-        if (lf.video === filters.video) results.push(...lf.labelImages);
+        if (lf.video === video) results.push(...lf.labelImages);
       }
     } else if (filters.frameIdx !== undefined) {
       results = [];
@@ -1238,11 +1282,25 @@ export class Labels {
    *   Non-finite, non-positive, or fractional values are sanitized via
    *   `Math.floor` and ignored when `<= 0`.
    */
-  numpy(options?: { video?: Video; returnConfidence?: boolean; numFrames?: number }): number[][][][] {
+  /**
+   * Build a dense `(frames, tracks, nodes, channels)` array from instance points.
+   *
+   * A foreign `Video` instance or filename (`string`/`URL`) is resolved to the
+   * matching project `Video` via {@link _resolveVideo} (SYNC; see its documented
+   * divergence from `matchVideo`). When `options.video` is absent, defaults to
+   * `this.video` (the first video).
+   */
+  numpy(options?: {
+    video?: Video | string | URL;
+    returnConfidence?: boolean;
+    numFrames?: number;
+  }): number[][][][] {
+    // Canonicalize a foreign Video / filename to the matching project Video,
+    // defaulting to the first video when absent.
+    const targetVideo = this._resolveVideo(options?.video) ?? this.video;
     if (this._lazyDataStore) {
-      return this._lazyDataStore.toNumpy(options);
+      return this._lazyDataStore.toNumpy({ ...options, video: targetVideo });
     }
-    const targetVideo = options?.video ?? this.video;
     const frames = this.labeledFrames.filter((frame) => frame.video.matchesPath(targetVideo, true));
     if (!frames.length) return [];
 
@@ -1900,6 +1958,76 @@ export class Labels {
   }
 
   /**
+   * Resolve a video argument to the canonical `Video` in this `Labels` (SYNC).
+   *
+   * Mirrors Python `Labels._resolve_video` (labels.py:1346-1374). Used internally
+   * by the video-accepting query methods ({@link find}, {@link numpy},
+   * {@link extract}, and the `get*` family) to canonicalize a foreign `Video`,
+   * filename, or index so that identity-based lookups succeed.
+   *
+   * DOCUMENTED DIVERGENCE (DECISIONS-107): unlike the async {@link matchVideo},
+   * this resolver is SYNCHRONOUS and therefore does NOT perform inode/pose/image
+   * matching. It uses only the synchronous matching subset:
+   *   1. identity (`===`),
+   *   2. unique `v.matchesPath(query, true)` (strict; posix-normalized),
+   *   3. unique `v.matchesPath(query, false)` (basename),
+   * raising on ambiguity (>1 match at a tier) with messages mirroring
+   * {@link matchVideo}. For all in-memory and non-existent-file lookups (the
+   * realistic case) this is observably identical to Python's `match_video`-based
+   * resolution, since strict `matchesPath` already does normalized path equality.
+   *
+   * @param video - A `Video`, filename (`string`/`URL`), integer index into
+   *   `this.videos`, or `null`/`undefined`.
+   * @returns The canonical `Video`, or `null` if `video` is `null`/`undefined`.
+   *   If no video matches, the foreign `Video` is returned unchanged and a
+   *   path is coerced into a new (unopened) `Video`, so identity-based lookups
+   *   simply yield empty results (preserving the "no match" behavior).
+   */
+  private _resolveVideo(
+    video: Video | string | URL | number | null | undefined,
+  ): Video | null {
+    if (video == null) return null;
+    if (typeof video === "number") return this.videos[video];
+
+    // Coerce the query into a Video (path -> unopened Video).
+    const query =
+      video instanceof Video
+        ? video
+        : new Video({ filename: String(video), openBackend: false });
+
+    // Identity short-circuit.
+    for (const v of this.videos) {
+      if (v === query) return v;
+    }
+
+    const ambiguous = (candidates: Video[], by: string): Error => {
+      const names = candidates.map((v) => filenameRepr(v.filename)).join(", ");
+      return new Error(
+        `Ambiguous video match for ${filenameRepr(query.filename)}: matched ` +
+          `${candidates.length} videos ${by}: ${names}.`,
+      );
+    };
+
+    // Tier 1: strict (posix-normalized) path match.
+    const strict = this.videos.filter((v) => v.matchesPath(query, true));
+    if (strict.length > 1) {
+      throw ambiguous(strict, "by file identity");
+    }
+    if (strict.length) return strict[0];
+
+    // Tier 2: basename match.
+    const byBasename = this.videos.filter((v) => v.matchesPath(query, false));
+    if (byBasename.length > 1) {
+      throw ambiguous(byBasename, "by basename");
+    }
+    if (byBasename.length) return byBasename[0];
+
+    // No match: return a usable Video so callers can still attach it to new
+    // frames; identity-based lookups against it simply yield empty results.
+    return query;
+  }
+
+  /**
    * Resolve a foreign `Video` or path to the canonical `Video` in `this.videos`.
    *
    * Faithful port of Python `Labels.match_video` (labels.py:1216-1344). Uses its
@@ -2176,18 +2304,30 @@ export class Labels {
    * for the extracted videos, and records the source labels in provenance.
    *
    * @param inds - Frame selection: an array of integer indices, an array of
-   *   `[Video, frameIdx]` tuples, or a single `Video` (all of its frames).
+   *   `[Video, frameIdx]` tuples, or a single `Video` (all of its frames). A
+   *   foreign `Video`/filename (`string`/`URL`) selector or tuple element is
+   *   resolved to the matching project `Video` via {@link _resolveVideo} (SYNC;
+   *   see its documented divergence from `matchVideo`).
    * @param copy - If `true` (default), deep-copy the frames and containing
    *   objects; otherwise share references with this Labels.
    * @returns A new `Labels` containing the selected frames.
    */
   extract(
-    inds: number[] | Array<[Video, number]> | Video,
+    inds:
+      | number[]
+      | Array<[Video | string | URL, number]>
+      | Video
+      | string
+      | URL,
     copy = true,
   ): Labels {
     if (this._lazyFrameList) this.materialize();
 
-    let lfs = this._selectFrames(inds);
+    // Canonicalize any foreign Video / filename selector or tuple element to the
+    // matching project Video so `_selectFrames` receives canonical Videos.
+    const resolvedInds = this._resolveExtractInds(inds);
+
+    let lfs = this._selectFrames(resolvedInds);
 
     if (copy) {
       lfs = this._deepCopyFrames(lfs);
@@ -2221,7 +2361,7 @@ export class Labels {
     // Copy suggestion frames for the extracted videos. Re-select on the ORIGINAL
     // frames to read their (un-copied) videos for membership.
     const extractedVideos = new Set<Video>(
-      this._selectFrames(inds).map((lf) => lf.video),
+      this._selectFrames(resolvedInds).map((lf) => lf.video),
     );
     let suggestions = this.suggestions.filter((sf) =>
       extractedVideos.has(sf.video),
@@ -2259,12 +2399,46 @@ export class Labels {
   }
 
   /**
+   * Canonicalize an {@link extract} selector, resolving foreign `Video` /
+   * filename references to the matching project `Video` via {@link _resolveVideo}
+   * (SYNC). The `number[]` index-array path is returned unchanged. Returns a
+   * narrowed selector that {@link _selectFrames} can consume directly.
+   */
+  private _resolveExtractInds(
+    inds:
+      | number[]
+      | Array<[Video | string | URL, number]>
+      | Video
+      | string
+      | URL,
+  ): number[] | Array<[Video, number]> | Video {
+    if (inds instanceof Video) {
+      return this._resolveVideo(inds) as Video;
+    }
+    if (typeof inds === "string" || inds instanceof URL) {
+      return this._resolveVideo(inds) as Video;
+    }
+    if (Array.isArray(inds)) {
+      if (inds.length === 0) return inds as number[];
+      if (Array.isArray(inds[0])) {
+        return (inds as Array<[Video | string | URL, number]>).map(
+          ([video, frameIdx]) =>
+            [this._resolveVideo(video) as Video, frameIdx] as [Video, number],
+        );
+      }
+      return inds as number[];
+    }
+    return inds;
+  }
+
+  /**
    * Resolve an extraction selection to a list of LabeledFrame references.
    *
    * Supports the subset of Python `__getitem__` selectors needed by
    * `extract`/`split`: integer index arrays, `[Video, frameIdx]` tuple arrays,
-   * and a single `Video`. (Filename/path resolution requires `matchVideo`,
-   * which is added in a later phase.)
+   * and a single `Video`. Foreign `Video`/filename references are canonicalized
+   * by {@link _resolveExtractInds} before reaching this method, so it receives
+   * canonical project `Video` instances.
    */
   private _selectFrames(
     inds: number[] | Array<[Video, number]> | Video,

--- a/tests/model/labels-lookup-widening.test.ts
+++ b/tests/model/labels-lookup-widening.test.ts
@@ -1,0 +1,347 @@
+/* @vitest-environment node */
+/**
+ * Port of Python PR #436 (sleap-io issue #107): the Labels lookup APIs are
+ * widened to accept a foreign video reference (`Video | string | URL`) and
+ * resolve it to the canonical project `Video` via the SYNC `_resolveVideo`
+ * cascade (identity -> unique strict `matchesPath` -> unique basename
+ * `matchesPath`, raising on ambiguity). `matchVideo` itself already shipped and
+ * is NOT re-tested here.
+ *
+ * These tests are fully programmatic (no FS / real data) so they run anywhere.
+ * Assertions encode the PYTHON-expected behavior; src is untouched.
+ *
+ * Python references (sleap-io @ 054cce39f):
+ *   tests/model/test_labels.py::test_get_queries_foreign_video (542-556)
+ *   tests/model/test_labels.py::test_find_foreign_video        (487-497)
+ *   tests/model/test_labels.py::test_match_video_basename_fallback (373-379)
+ *   tests/model/test_labels.py::test_match_video_definitive_over_basename
+ *   tests/model/test_labels.py::test_match_video_ambiguous_raises (393-400)
+ *   tests/model/test_labels.py::test_extract_foreign_video     (532-539)
+ */
+import { describe, it, expect } from "vitest";
+import {
+  Labels,
+  Video,
+  Skeleton,
+  Instance,
+  Track,
+  ROI,
+  SegmentationMask,
+  UserBoundingBox,
+  UserCentroid,
+  UserLabelImage,
+  LabeledFrame,
+} from "../../src/index.js";
+
+/**
+ * Build a small programmatic Labels with a single canonical Video whose
+ * filename carries a directory prefix (so basename resolution from a bare
+ * "clip.mp4" applies) and one labeled frame at `frameIdx` 10.
+ */
+function buildLabels() {
+  const skeleton = new Skeleton({ nodes: ["A", "B"] });
+  // Canonical video lives under a directory so a bare-basename query must use
+  // the basename tier (not the strict path tier) to resolve.
+  const canonical = new Video({ filename: "path/to/clip.mp4", openBackend: false });
+  const inst = Instance.fromArray(
+    [
+      [1, 2],
+      [3, 4],
+    ],
+    skeleton,
+  );
+  const lf = new LabeledFrame({
+    video: canonical,
+    frameIdx: 10,
+    instances: [inst],
+  });
+  const labels = new Labels({
+    labeledFrames: [lf],
+    videos: [canonical],
+    skeletons: [skeleton],
+  });
+  return { labels, canonical, lf, skeleton, inst };
+}
+
+describe("Labels lookup widening (#107 / Python PR #436)", () => {
+  describe("find()", () => {
+    it("ACCEPTANCE: find({video: 'clip.mp4'}) returns the SAME LabeledFrame as find({video: canonical})", () => {
+      const { labels, canonical, lf } = buildLabels();
+
+      const byString = labels.find({ video: "clip.mp4", frameIdx: 10 });
+      const byCanonical = labels.find({ video: canonical, frameIdx: 10 });
+
+      expect(byCanonical).toHaveLength(1);
+      expect(byCanonical[0]).toBe(lf);
+      expect(byString).toHaveLength(1);
+      // Same object identity, resolved via basename.
+      expect(byString[0]).toBe(byCanonical[0]);
+      expect(byString[0]).toBe(lf);
+    });
+
+    it("resolves a foreign Video (same path, different identity) to itself", () => {
+      const { labels, canonical, lf } = buildLabels();
+      const foreign = new Video({
+        filename: canonical.filename as string,
+        openBackend: false,
+      });
+      expect(foreign).not.toBe(canonical);
+
+      const results = labels.find({ video: foreign });
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBe(lf);
+    });
+
+    it("returns the canonical Video's frames for an identity reference", () => {
+      const { labels, canonical, lf } = buildLabels();
+      const results = labels.find({ video: canonical });
+      expect(results).toEqual([lf]);
+    });
+
+    it("returns empty (no throw) for a non-matching string", () => {
+      const { labels } = buildLabels();
+      let results: LabeledFrame[] = [];
+      expect(() => {
+        results = labels.find({ video: "not_in_project.mp4", frameIdx: 10 });
+      }).not.toThrow();
+      expect(results).toEqual([]);
+    });
+
+    it("resolves a foreign filename that shares only the basename (relocated file)", () => {
+      const { labels, lf } = buildLabels();
+      // Different directory, same basename -> basename tier resolves.
+      const results = labels.find({ video: "/new/location/clip.mp4", frameIdx: 10 });
+      expect(results).toHaveLength(1);
+      expect(results[0]).toBe(lf);
+    });
+  });
+
+  describe("ambiguity", () => {
+    it("throws when a basename query matches two project videos (test_match_video_ambiguous_raises)", () => {
+      const v1 = new Video({ filename: "/dir1/vid.mp4", openBackend: false });
+      const v2 = new Video({ filename: "/dir2/vid.mp4", openBackend: false });
+      const lf1 = new LabeledFrame({ video: v1, frameIdx: 0 });
+      const lf2 = new LabeledFrame({ video: v2, frameIdx: 0 });
+      const labels = new Labels({
+        labeledFrames: [lf1, lf2],
+        videos: [v1, v2],
+      });
+
+      expect(() => labels.find({ video: "/elsewhere/vid.mp4" })).toThrow(
+        /Ambiguous video match/,
+      );
+    });
+
+    it("an exact path wins over a shared basename (no false ambiguity)", () => {
+      const v1 = new Video({ filename: "/dir1/vid.mp4", openBackend: false });
+      const v2 = new Video({ filename: "/dir2/vid.mp4", openBackend: false });
+      const lf1 = new LabeledFrame({ video: v1, frameIdx: 0 });
+      const lf2 = new LabeledFrame({ video: v2, frameIdx: 0 });
+      const labels = new Labels({
+        labeledFrames: [lf1, lf2],
+        videos: [v1, v2],
+      });
+
+      expect(labels.find({ video: "/dir1/vid.mp4" })).toEqual([lf1]);
+      expect(labels.find({ video: "/dir2/vid.mp4" })).toEqual([lf2]);
+    });
+  });
+
+  describe("URL references", () => {
+    it("coerces new URL('file:///x/clip.mp4') to its string and resolves by basename", () => {
+      const { labels, canonical, lf } = buildLabels();
+      const url = new URL("file:///x/clip.mp4");
+
+      const byUrl = labels.find({ video: url, frameIdx: 10 });
+      const byCanonical = labels.find({ video: canonical, frameIdx: 10 });
+
+      expect(byUrl).toHaveLength(1);
+      expect(byUrl[0]).toBe(lf);
+      expect(byUrl[0]).toBe(byCanonical[0]);
+    });
+
+    it("a non-matching URL yields empty results (no throw)", () => {
+      const { labels } = buildLabels();
+      const url = new URL("file:///x/other.mp4");
+      expect(labels.find({ video: url })).toEqual([]);
+    });
+  });
+
+  describe("numpy()", () => {
+    it("widens video to a basename string (test_get_queries_foreign_video)", () => {
+      const { labels, canonical } = buildLabels();
+      const byString = labels.numpy({ video: "clip.mp4" });
+      const byCanonical = labels.numpy({ video: canonical });
+      const byForeign = labels.numpy({
+        video: new Video({ filename: canonical.filename as string, openBackend: false }),
+      });
+
+      // One labeled frame at idx 10 -> 11 frames (shape[0]) since maxFrame == 10.
+      expect(byCanonical.length).toBe(byString.length);
+      expect(byCanonical.length).toBe(byForeign.length);
+      expect(byCanonical.length).toBeGreaterThan(0);
+    });
+
+    it("accepts an integer index to select the video", () => {
+      const { labels, canonical } = buildLabels();
+      const byIndex = labels.numpy({ video: 0 });
+      const byCanonical = labels.numpy({ video: canonical });
+      expect(byIndex.length).toBe(byCanonical.length);
+      expect(byIndex.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("extract()", () => {
+    it("widens a single string selector to the canonical Video (test_extract_foreign_video)", () => {
+      const { labels, canonical } = buildLabels();
+      const byString = labels.extract("clip.mp4");
+      const byCanonical = labels.extract(canonical);
+      expect(byString.labeledFrames).toHaveLength(1);
+      expect(byCanonical.labeledFrames).toHaveLength(1);
+      expect(byString.labeledFrames.length).toBe(byCanonical.labeledFrames.length);
+    });
+
+    it("widens [video, idx] tuple selectors with a foreign Video / string", () => {
+      const { labels, canonical } = buildLabels();
+      const foreign = new Video({
+        filename: canonical.filename as string,
+        openBackend: false,
+      });
+
+      const byForeignTuple = labels.extract([[foreign, 10]]);
+      const byStringTuple = labels.extract([["clip.mp4", 10]]);
+      const byCanonicalTuple = labels.extract([[canonical, 10]]);
+
+      expect(byForeignTuple.labeledFrames).toHaveLength(1);
+      expect(byStringTuple.labeledFrames).toHaveLength(1);
+      expect(byCanonicalTuple.labeledFrames).toHaveLength(1);
+    });
+
+    it("widens a URL selector by basename", () => {
+      const { labels, canonical } = buildLabels();
+      const byUrl = labels.extract(new URL("file:///x/clip.mp4"));
+      const byCanonical = labels.extract(canonical);
+      expect(byUrl.labeledFrames).toHaveLength(byCanonical.labeledFrames.length);
+      expect(byUrl.labeledFrames).toHaveLength(1);
+    });
+  });
+
+  describe("get* family widening", () => {
+    it("getCentroids({video: 'name'}) matches passing the canonical Video", () => {
+      const skeleton = new Skeleton({ nodes: ["A", "B"] });
+      const video = new Video({ filename: "/data/vid.mp4", openBackend: false });
+      const inst = Instance.fromArray(
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        skeleton,
+      );
+      const centroid = new UserCentroid({ x: 5, y: 10 });
+      const lf = new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [inst],
+        centroids: [centroid],
+      });
+      const labels = new Labels({
+        labeledFrames: [lf],
+        videos: [video],
+        skeletons: [skeleton],
+      });
+
+      const foreign = new Video({ filename: "/data/vid.mp4", openBackend: false });
+      expect(labels.getCentroids({ video })).toEqual([centroid]);
+      expect(labels.getCentroids({ video: foreign })).toEqual([centroid]);
+      expect(labels.getCentroids({ video: "/data/vid.mp4" })).toEqual([centroid]);
+      // Bare basename also resolves via the basename tier.
+      expect(labels.getCentroids({ video: "vid.mp4" })).toEqual([centroid]);
+    });
+
+    it("getRois({video: 'name'}) matches passing the canonical Video", () => {
+      const video = new Video({ filename: "/data/v1.mp4", openBackend: false });
+      const roi = ROI.fromBbox(0, 0, 10, 10, { video });
+      const lf = new LabeledFrame({ video, frameIdx: 0, rois: [roi] });
+      const labels = new Labels({ labeledFrames: [lf], videos: [video] });
+
+      const foreign = new Video({ filename: "/data/v1.mp4", openBackend: false });
+      expect(labels.getRois({ video })).toEqual([roi]);
+      expect(labels.getRois({ video: foreign })).toEqual([roi]);
+      expect(labels.getRois({ video: "/data/v1.mp4" })).toEqual([roi]);
+      expect(labels.getRois({ video: "v1.mp4" })).toEqual([roi]);
+    });
+
+    it("getMasks({video: 'name'}) matches passing the canonical Video", () => {
+      const video = new Video({ filename: "/data/m.mp4", openBackend: false });
+      const mask = SegmentationMask.fromArray(new Uint8Array(4), 2, 2);
+      const lf = new LabeledFrame({ video, frameIdx: 0, masks: [mask] });
+      const labels = new Labels({ labeledFrames: [lf], videos: [video] });
+
+      const foreign = new Video({ filename: "/data/m.mp4", openBackend: false });
+      expect(labels.getMasks({ video })).toEqual([mask]);
+      expect(labels.getMasks({ video: foreign })).toEqual([mask]);
+      expect(labels.getMasks({ video: "/data/m.mp4" })).toEqual([mask]);
+      expect(labels.getMasks({ video: "m.mp4" })).toEqual([mask]);
+    });
+
+    it("getBboxes({video: 'name'}) matches passing the canonical Video", () => {
+      const video = new Video({ filename: "/data/b.mp4", openBackend: false });
+      const bbox = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
+      const lf = new LabeledFrame({ video, frameIdx: 0, bboxes: [bbox] });
+      const labels = new Labels({ labeledFrames: [lf], videos: [video] });
+
+      const foreign = new Video({ filename: "/data/b.mp4", openBackend: false });
+      expect(labels.getBboxes({ video })).toEqual([bbox]);
+      expect(labels.getBboxes({ video: foreign })).toEqual([bbox]);
+      expect(labels.getBboxes({ video: "/data/b.mp4" })).toEqual([bbox]);
+      expect(labels.getBboxes({ video: "b.mp4" })).toEqual([bbox]);
+    });
+
+    it("getLabelImages({video: 'name'}) matches passing the canonical Video", () => {
+      const video = new Video({ filename: "/data/li.mp4", openBackend: false });
+      const li = new UserLabelImage({
+        data: new Uint8Array(4),
+        height: 2,
+        width: 2,
+      });
+      const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
+      const labels = new Labels({ labeledFrames: [lf], videos: [video] });
+
+      const foreign = new Video({ filename: "/data/li.mp4", openBackend: false });
+      expect(labels.getLabelImages({ video })).toEqual([li]);
+      expect(labels.getLabelImages({ video: foreign })).toEqual([li]);
+      expect(labels.getLabelImages({ video: "/data/li.mp4" })).toEqual([li]);
+      expect(labels.getLabelImages({ video: "li.mp4" })).toEqual([li]);
+    });
+
+    it("get* widening returns empty for a non-matching string (no throw)", () => {
+      const video = new Video({ filename: "/data/vid.mp4", openBackend: false });
+      const roi = ROI.fromBbox(0, 0, 10, 10, { video });
+      const lf = new LabeledFrame({ video, frameIdx: 0, rois: [roi] });
+      const labels = new Labels({ labeledFrames: [lf], videos: [video] });
+
+      let result: ROI[] = [];
+      expect(() => {
+        result = labels.getRois({ video: "missing.mp4" });
+      }).not.toThrow();
+      expect(result).toEqual([]);
+    });
+
+    it("get* widening throws on an ambiguous basename query", () => {
+      const v1 = new Video({ filename: "/dir1/vid.mp4", openBackend: false });
+      const v2 = new Video({ filename: "/dir2/vid.mp4", openBackend: false });
+      const roi1 = ROI.fromBbox(0, 0, 10, 10, { video: v1 });
+      const roi2 = ROI.fromBbox(0, 0, 10, 10, { video: v2 });
+      const lf1 = new LabeledFrame({ video: v1, frameIdx: 0, rois: [roi1] });
+      const lf2 = new LabeledFrame({ video: v2, frameIdx: 0, rois: [roi2] });
+      const labels = new Labels({
+        labeledFrames: [lf1, lf2],
+        videos: [v1, v2],
+      });
+
+      expect(() => labels.getRois({ video: "/elsewhere/vid.mp4" })).toThrow(
+        /Ambiguous video match/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #107.

`Labels.matchVideo()` shipped with the merge subsystem (#127). This completes Python PR #436 by widening the lookup APIs to resolve foreign video references.

## Changes
- **`Labels._resolveVideo(video)`** (private, sync) — port of Python `_resolve_video`: `null`/`undefined` → `null`; `number` → `videos[index]`; `Video`/`string`/`URL` → coerce a query Video, then resolve **identity → unique `matchesPath(strict)` → unique `matchesPath(basename)`**, throwing on ambiguity (reusing `matchVideo`'s message style). No match returns the foreign/coerced Video so identity-based lookups simply yield empty results.
- **Widened** `find`, `numpy`, `extract` (single selector + `[video, idx]` tuples), and `getRois`/`getMasks`/`getBboxes`/`getCentroids`/`getLabelImages` to accept `Video | string | URL` — resolve at entry, then reuse the existing logic. `getFrame` stays `Video`-only (internal; `find` resolves first).

## Design note (sync, not async)
`matchVideo` is async (its AUTO cascade awaits `isSameFile`/pixel reads). Making the lookups call it would force `find`/`numpy`/`getRois`/etc. to become async — a large breaking change. Instead `_resolveVideo` is **synchronous**: `matchVideo`'s only async step (the `isSameFile` inode check) reduces to posix-normalized path equality for non-existent files, which `matchesPath(strict)` already performs — so resolution is parity-faithful for all in-memory / non-existent-file lookups (the realistic case). The async `matchVideo` remains the full-cascade entry point (inode/pose/image). Documented in `scratch/merge-parity/DECISIONS-107.md`.

## Tests
21 new parity tests in `tests/model/labels-lookup-widening.test.ts` (ported from Python `test_labels.py`): the acceptance case (`find({video:"clip.mp4",...})` ≡ canonical Video), same/foreign-Video, basename resolution, exact-path-over-basename, non-match → empty, ambiguous → throws, integer index, URL refs, and the widening on `numpy`/`extract`/the `get*` family. Full suite **1033 passing, 1 skipped**; tsc clean. No source bugs found.

Acceptance: `labels.find({ video: "my-clip.mp4", frameIdx: 10 })` resolves the same `LabeledFrame` as `labels.find({ video: canonicalVideo, frameIdx: 10 })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)