### PR TITLE
fix(video): slice one embedded frame instead of reading whole dataset (#135)

### DIFF
--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -262,14 +262,18 @@ async function readVideosStreaming(
       // Create streaming backend for embedded videos when openVideos is true
       let backend = null;
       if (openVideos && meta.embedded && datasetPath) {
-        // Read frame_numbers for this video
+        // Read frame_numbers (and frame_sizes when present) for this video.
+        // frame_sizes lets the 1D-concatenated layout (JS writer) byte-range
+        // slice exactly, mirroring the sync reader (read.ts) — see issue #135.
         const frameNumbers = await readFrameNumbersStreaming(file, datasetPath);
+        const frameSizes = await readFrameSizesStreaming(file, datasetPath);
 
         backend = new StreamingHdf5VideoBackend({
           filename: meta.filename,
           h5file: file,
           datasetPath,
           frameNumbers,
+          frameSizes,
           format: format ?? "png",
           channelOrder,
           shape,
@@ -338,6 +342,43 @@ async function readFrameNumbersStreaming(
     return [];
   } catch {
     return [];
+  }
+}
+
+/**
+ * Read the frame_sizes dataset for a video, if present.
+ *
+ * frame_sizes records the encoded byte length of each embedded frame and is
+ * written by the JS writer (1D concatenated layout). When available it lets the
+ * backend byte-range slice an exact frame instead of scanning. Returns undefined
+ * when the dataset is absent (e.g. Python-written 2D padded files).
+ */
+async function readFrameSizesStreaming(
+  file: StreamingH5File,
+  datasetPath: string
+): Promise<number[] | undefined> {
+  try {
+    const groupPath = datasetPath.endsWith("/video")
+      ? datasetPath.slice(0, -6)
+      : datasetPath;
+
+    const groupKeys = await file.getKeys(groupPath);
+    if (!groupKeys.includes("frame_sizes")) {
+      return undefined;
+    }
+
+    const data = await file.getDatasetValue(`${groupPath}/frame_sizes`);
+    const values = data.value;
+
+    if (Array.isArray(values)) {
+      return values.map((v: unknown) => Number(v));
+    }
+    if (ArrayBuffer.isView(values)) {
+      return Array.from(values as unknown as ArrayLike<number>).map(Number);
+    }
+    return undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/video/embedded-frame.ts
+++ b/src/video/embedded-frame.ts
@@ -1,0 +1,276 @@
+/**
+ * Shared helpers for reading a single embedded frame out of an HDF5 video
+ * dataset without materializing (and caching) the whole per-video dataset.
+ *
+ * Used by both the synchronous {@link Hdf5VideoBackend} (Node/Bun) and the
+ * streaming {@link StreamingHdf5VideoBackend} (browser Web Worker) so the two
+ * stay in lockstep. See issue #135 for the motivation and measurements: reading
+ * the entire dataset to display one frame took 0.5–3.3 s per video switch and
+ * retained tens of MB per video; slicing one frame takes ~tens of ms and retains
+ * effectively nothing.
+ *
+ * Supported storage layouts (classified from the dataset shape + embedded frame
+ * count, never from `video.shape`):
+ *  - `padded`  — 2D `[N, M]` (Python writer): row `i` is one encoded image plus
+ *                trailing zero padding. Slice row `i`, trim the padding.
+ *  - `vlen`    — 1D `[N]` variable-length blobs (legacy pkg.slp): element `i` is
+ *                one encoded image. h5wasm slices a single element directly.
+ *  - `concat`  — 1D `[totalBytes]` (JS writer): all frames concatenated. Needs
+ *                `frame_sizes` to byte-range slice; otherwise the legacy
+ *                magic-byte scan fallback applies.
+ *
+ * @module
+ */
+
+/** A hyperslab selection: one `[start, stop]` pair (or `[]` = full) per dim. */
+export type Hdf5Slice = Array<[number, number] | []>;
+
+// PNG magic bytes: 0x89 P N G \r \n 0x1A \n
+export const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// JPEG magic bytes: 0xFF 0xD8 0xFF
+export const JPEG_MAGIC = new Uint8Array([0xff, 0xd8, 0xff]);
+
+/** Whether a format string denotes an encoded image (PNG/JPEG) vs raw pixels. */
+export function isEncodedFormat(format: string): boolean {
+  const n = format.toLowerCase();
+  return n === "png" || n === "jpg" || n === "jpeg";
+}
+
+/** Magic-byte signature for an encoded format (defaults to JPEG when unknown). */
+export function magicFor(format: string): Uint8Array {
+  return format.toLowerCase() === "png" ? PNG_MAGIC : JPEG_MAGIC;
+}
+
+/**
+ * Whether `magic` appears at `pos` in `buffer`, using an indexed compare.
+ *
+ * This deliberately avoids `buffer.subarray(pos)` (which allocates a throwaway
+ * view at every byte position — the ~30× self-inflicted cost in the old scan).
+ */
+export function matchesMagicAt(buffer: Uint8Array, pos: number, magic: Uint8Array): boolean {
+  if (pos + magic.length > buffer.length) return false;
+  for (let k = 0; k < magic.length; k++) {
+    if (buffer[pos + k] !== magic[k]) return false;
+  }
+  return true;
+}
+
+/** Whether the buffer starts with a PNG or JPEG signature. */
+export function startsWithImageMagic(buffer: Uint8Array): boolean {
+  return matchesMagicAt(buffer, 0, PNG_MAGIC) || matchesMagicAt(buffer, 0, JPEG_MAGIC);
+}
+
+/**
+ * Scan a contiguous buffer for encoded-frame start offsets.
+ *
+ * Used only by the legacy fallback (1D concatenated buffer without
+ * `frame_sizes`). Uses the indexed compare and exits once `expectedFrameCount`
+ * frames are found. NOTE: the 3-byte JPEG magic can occur inside entropy-coded
+ * data, so this is only reliable for PNG; prefer `frame_sizes` / slicing.
+ */
+export function findEncodedFrameOffsets(
+  buffer: Uint8Array,
+  format: string,
+  expectedFrameCount: number
+): number[] {
+  const magic = magicFor(format);
+  const m0 = magic[0];
+  const L = magic.length;
+  const limit = buffer.length - L;
+  const offsets: number[] = [];
+  for (let i = 0; i <= limit; i++) {
+    if (buffer[i] !== m0) continue;
+    let ok = true;
+    for (let k = 1; k < L; k++) {
+      if (buffer[i + k] !== magic[k]) {
+        ok = false;
+        break;
+      }
+    }
+    if (!ok) continue;
+    offsets.push(i);
+    i += L - 1;
+    if (expectedFrameCount > 0 && offsets.length >= expectedFrameCount) break;
+  }
+  return offsets;
+}
+
+/** Cumulative byte offsets from per-frame sizes (valid for `concat` only). */
+export function computeOffsetsFromSizes(sizes: number[]): number[] {
+  const offsets: number[] = new Array(sizes.length);
+  let off = 0;
+  for (let i = 0; i < sizes.length; i++) {
+    offsets[i] = off;
+    off += sizes[i];
+  }
+  return offsets;
+}
+
+/**
+ * Trim a sliced 2D padded row (one encoded image + trailing zero padding) down
+ * to just the encoded image bytes.
+ *
+ * When the exact byte length is known (`frame_sizes`) it is used directly.
+ * Otherwise trailing zero bytes are stripped — valid because PNG streams end in
+ * the IEND CRC (`…0x60 0x82`) and JPEG streams end in EOI (`0xFF 0xD9`), so an
+ * encoded image never ends in `0x00`; any trailing zeros are pure padding.
+ */
+export function trimPaddedRow(row: Uint8Array, size?: number): Uint8Array {
+  if (size != null && size >= 0 && size <= row.length) {
+    return size === row.length ? row : row.subarray(0, size);
+  }
+  let end = row.length;
+  while (end > 0 && row[end - 1] === 0) end--;
+  return end === row.length ? row : row.subarray(0, end);
+}
+
+/** Storage layout of an embedded-image dataset. */
+export type EmbeddedLayout = "padded" | "vlen" | "concat" | "ambiguous1d";
+
+/**
+ * Classify the dataset layout from its shape and the embedded frame count.
+ *
+ * A 2D+ dataset is always `padded` (slice the first dim). A 1D dataset whose
+ * length equals the embedded frame count is `vlen` (one blob per element);
+ * otherwise it is `concat` (bytes). When the frame count is unknown the 1D case
+ * is `ambiguous1d` and must be resolved by reading the value.
+ */
+export function classifyLayout(shape: number[], frameCount: number): EmbeddedLayout {
+  if (shape.length >= 2) return "padded";
+  if (shape.length === 1) {
+    if (frameCount > 0) return shape[0] === frameCount ? "vlen" : "concat";
+    return "ambiguous1d";
+  }
+  return "ambiguous1d";
+}
+
+/** Build a hyperslab slice selecting only row `index` along the first dim. */
+export function rowSlice(shape: number[], index: number): Hdf5Slice {
+  return shape.map(
+    (dim, d) => (d === 0 ? [index, index + 1] : [0, dim]) as [number, number]
+  );
+}
+
+/**
+ * Reinterpret a value read from HDF5 as a `Uint8Array` view without copying when
+ * possible. Crucially this reinterprets the bytes of an `Int8Array` (h5wasm
+ * dtype `<b`) as unsigned, matching how the image bytes were originally written.
+ */
+export function asUint8Array(value: unknown): Uint8Array | null {
+  if (value == null) return null;
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    const v = value as ArrayBufferView;
+    return new Uint8Array(v.buffer, v.byteOffset, v.byteLength);
+  }
+  if (Array.isArray(value)) {
+    return Uint8Array.from(value as number[]);
+  }
+  if (typeof value === "object" && "buffer" in (value as Record<string, unknown>)) {
+    return new Uint8Array((value as { buffer: ArrayBuffer }).buffer);
+  }
+  return null;
+}
+
+/** Result of reading a (possibly sliced) dataset value. */
+export interface SliceReadResult {
+  value: unknown;
+  shape: number[];
+}
+
+/** Mutable per-backend cache for the legacy whole-buffer fallback path. */
+export interface LegacyFrameCache {
+  whole: Uint8Array | unknown[] | null;
+  offsets: number[] | null;
+}
+
+/**
+ * The minimal capabilities a backend must provide for {@link readEmbeddedFrameBytes}.
+ */
+export interface EmbeddedFrameReader {
+  /** Number of embedded frames (length of `frame_numbers`); 0 if unknown. */
+  frameCount: number;
+  /** Image format ("png" | "jpg" | "jpeg" | raw). */
+  format: string;
+  /** Per-frame byte sizes when available (enables exact byte-range slicing). */
+  frameSizes?: number[];
+  /** Read dataset metadata (cheap; the caller should memoize across frames). */
+  getMeta(): Promise<{ shape: number[]; dtype: string }>;
+  /** Read a hyperslab slice; omit `slice` to read the whole dataset. */
+  readSlice(slice?: Hdf5Slice): Promise<SliceReadResult>;
+  /** Mutable cache shared across calls for the legacy fallback path. */
+  legacy: LegacyFrameCache;
+}
+
+/**
+ * Read the raw bytes (encoded image or raw pixels) of the embedded frame stored
+ * at `index`, slicing only that frame from the dataset wherever the layout
+ * allows. Returns `null` if the frame cannot be located.
+ */
+export async function readEmbeddedFrameBytes(
+  reader: EmbeddedFrameReader,
+  index: number
+): Promise<Uint8Array | null> {
+  if (index < 0) return null;
+  const meta = await reader.getMeta();
+  const shape = meta.shape ?? [];
+  const layout = classifyLayout(shape, reader.frameCount);
+  const encoded = isEncodedFormat(reader.format);
+
+  // 2D padded (and N-D raw): slice the requested row only.
+  if (layout === "padded") {
+    const { value } = await reader.readSlice(rowSlice(shape, index));
+    const row = asUint8Array(value);
+    if (!row) return null;
+    // Raw pixels are trimmed downstream by decodeRawFrame using the shape.
+    return encoded ? trimPaddedRow(row, reader.frameSizes?.[index]) : row;
+  }
+
+  // vlen: h5wasm slices a single element -> an array holding one blob.
+  if (layout === "vlen") {
+    const { value } = await reader.readSlice([[index, index + 1]]);
+    const entry = Array.isArray(value) ? value[0] : value;
+    return asUint8Array(entry);
+  }
+
+  // 1D concatenated with known sizes: exact byte-range slice.
+  if (layout === "concat" && reader.frameSizes && reader.frameSizes.length > index) {
+    const offsets = (reader.legacy.offsets ??= computeOffsetsFromSizes(reader.frameSizes));
+    const start = offsets[index];
+    const end = start + reader.frameSizes[index];
+    const { value } = await reader.readSlice([[start, end]]);
+    return asUint8Array(value);
+  }
+
+  // Legacy fallback: read the whole dataset once, cache it, and index into it.
+  // Covers 1D concatenated without frame_sizes (magic-byte scan) and the
+  // ambiguous 1D case (which may resolve to a vlen array).
+  if (!reader.legacy.whole) {
+    const { value } = await reader.readSlice();
+    if (Array.isArray(value)) {
+      reader.legacy.whole = value;
+    } else {
+      const buf = asUint8Array(value);
+      if (!buf) return null;
+      reader.legacy.whole = buf;
+      if (encoded && startsWithImageMagic(buf)) {
+        reader.legacy.offsets = findEncodedFrameOffsets(buf, reader.format, reader.frameCount);
+      }
+    }
+  }
+
+  const whole = reader.legacy.whole;
+  if (Array.isArray(whole)) {
+    return asUint8Array(whole[index]);
+  }
+  const buf = whole as Uint8Array;
+  const offsets = reader.legacy.offsets;
+  if (offsets && offsets.length > index) {
+    const start = offsets[index];
+    const end = index + 1 < offsets.length ? offsets[index + 1] : buf.length;
+    return buf.slice(start, end);
+  }
+  return null;
+}

--- a/src/video/hdf5-video.ts
+++ b/src/video/hdf5-video.ts
@@ -1,19 +1,22 @@
 import { VideoBackend, VideoFrame } from "./backend.js";
+import {
+  type EmbeddedFrameReader,
+  type Hdf5Slice,
+  type LegacyFrameCache,
+  type SliceReadResult,
+  isEncodedFormat,
+  readEmbeddedFrameBytes,
+} from "./embedded-frame.js";
 
 const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
 
-// PNG magic bytes: 0x89 P N G \r \n 0x1A \n
-const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-
-// JPEG magic bytes: 0xFF 0xD8 0xFF
-const JPEG_MAGIC = new Uint8Array([0xff, 0xd8, 0xff]);
-
 /**
- * Video backend for embedded images in HDF5 files.
+ * Video backend for embedded images in HDF5 files (synchronous h5wasm).
  *
- * Supports two data storage formats:
- * 1. vlen-encoded: Array of individual frame blobs (each index = one frame)
- * 2. Contiguous buffer: Single buffer with all frames concatenated
+ * Reads a single frame at a time via hyperslab slicing rather than loading and
+ * caching the entire per-video dataset. Supports 2D padded, 1D concatenated
+ * (with `frame_sizes`), and variable-length (vlen) blob layouts. See issue #135
+ * and {@link readEmbeddedFrameBytes} for details.
  */
 export class Hdf5VideoBackend implements VideoBackend {
   filename: string;
@@ -25,9 +28,8 @@ export class Hdf5VideoBackend implements VideoBackend {
   private frameNumberToIndex: Map<number, number>;
   private format: string;
   private channelOrder: string;
-  private cachedData: unknown[] | Uint8Array | null;
-  private frameOffsets: number[] | null;
   private frameSizes: number[] | undefined;
+  private legacy: LegacyFrameCache;
 
   constructor(options: {
     filename: string;
@@ -51,9 +53,8 @@ export class Hdf5VideoBackend implements VideoBackend {
     this.channelOrder = options.channelOrder ?? "RGB";
     this.shape = options.shape;
     this.fps = options.fps;
-    this.cachedData = null;
-    this.frameOffsets = null;
     this.frameSizes = options.frameSizes;
+    this.legacy = { whole: null, offsets: null };
   }
 
   async getFrame(frameIndex: number): Promise<VideoFrame | null> {
@@ -65,40 +66,7 @@ export class Hdf5VideoBackend implements VideoBackend {
       : frameIndex;
     if (index === undefined) return null;
 
-    if (!this.cachedData) {
-      const value = dataset.value;
-      this.cachedData = normalizeVideoData(value);
-
-      // Use frame_sizes for reliable frame boundary detection if available
-      if (this.frameSizes && this.frameSizes.length > 0 && this.cachedData instanceof Uint8Array) {
-        this.frameOffsets = computeOffsetsFromSizes(this.frameSizes);
-      } else if (isContiguousEncodedBuffer(this.cachedData, this.format, this.shape)) {
-        // Fall back to magic byte scanning for old files without frame_sizes
-        this.frameOffsets = findEncodedFrameOffsets(
-          this.cachedData as Uint8Array,
-          this.format,
-          this.shape?.[0] ?? 0
-        );
-      }
-    }
-
-    let rawBytes: Uint8Array | null;
-
-    // Handle contiguous buffer with computed frame offsets
-    if (this.frameOffsets && this.frameOffsets.length > index) {
-      const buffer = this.cachedData as Uint8Array;
-      const start = this.frameOffsets[index];
-      const end = index + 1 < this.frameOffsets.length
-        ? this.frameOffsets[index + 1]
-        : buffer.length;
-      rawBytes = buffer.slice(start, end);
-    } else {
-      // Standard vlen-encoded array: each index is a frame blob
-      const entry = (this.cachedData as unknown[])[index];
-      if (entry == null) return null;
-      rawBytes = toUint8Array(entry);
-    }
-
+    const rawBytes = await readEmbeddedFrameBytes(this.buildReader(dataset), index);
     if (!rawBytes || rawBytes.length === 0) return null;
 
     if (isEncodedFormat(this.format)) {
@@ -110,111 +78,25 @@ export class Hdf5VideoBackend implements VideoBackend {
     return image ?? rawBytes;
   }
 
+  /** Build a single-frame reader bound to an open h5wasm dataset object. */
+  private buildReader(dataset: any): EmbeddedFrameReader {
+    return {
+      frameCount: this.frameNumberToIndex.size,
+      format: this.format,
+      frameSizes: this.frameSizes,
+      legacy: this.legacy,
+      getMeta: async () => ({ shape: dataset.shape ?? [], dtype: dataset.dtype }),
+      readSlice: async (slice?: Hdf5Slice): Promise<SliceReadResult> => {
+        const value = slice ? dataset.slice(slice) : dataset.value;
+        return { value, shape: dataset.shape ?? [] };
+      },
+    };
+  }
+
   close(): void {
-    this.cachedData = null;
-    this.frameOffsets = null;
+    this.legacy.whole = null;
+    this.legacy.offsets = null;
   }
-}
-
-/**
- * Normalize video data to a consistent format.
- */
-function normalizeVideoData(value: unknown): unknown[] | Uint8Array {
-  if (Array.isArray(value)) {
-    return value;
-  }
-  if (ArrayBuffer.isView(value)) {
-    const arr = value as ArrayBufferView;
-    return new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
-  }
-  return [];
-}
-
-/**
- * Check if the data is a contiguous buffer of encoded (PNG/JPEG) images.
- */
-function isContiguousEncodedBuffer(
-  data: unknown[] | Uint8Array,
-  format: string,
-  shape?: [number, number, number, number]
-): boolean {
-  if (!isEncodedFormat(format)) return false;
-  if (!(data instanceof Uint8Array)) return false;
-  if (data.length < 8) return false;
-
-  const isPng = matchesMagic(data, PNG_MAGIC);
-  const isJpeg = matchesMagic(data, JPEG_MAGIC);
-
-  if (!isPng && !isJpeg) return false;
-
-  if (shape) {
-    const frameCount = shape[0];
-    if (frameCount > 1 && data.length > 10000) {
-      return true;
-    }
-  }
-
-  return true;
-}
-
-function matchesMagic(buffer: Uint8Array, magic: Uint8Array): boolean {
-  if (buffer.length < magic.length) return false;
-  for (let i = 0; i < magic.length; i++) {
-    if (buffer[i] !== magic[i]) return false;
-  }
-  return true;
-}
-
-/**
- * Find byte offsets of each encoded frame in a contiguous buffer.
- */
-function findEncodedFrameOffsets(
-  buffer: Uint8Array,
-  format: string,
-  expectedFrameCount: number
-): number[] {
-  const offsets: number[] = [];
-  const magic = format.toLowerCase() === "png" ? PNG_MAGIC : JPEG_MAGIC;
-
-  for (let i = 0; i <= buffer.length - magic.length; i++) {
-    if (matchesMagic(buffer.subarray(i), magic)) {
-      offsets.push(i);
-      i += magic.length - 1;
-
-      if (expectedFrameCount > 0 && offsets.length >= expectedFrameCount) {
-        break;
-      }
-    }
-  }
-
-  return offsets;
-}
-
-/**
- * Compute byte offsets from an array of frame sizes (cumulative sum).
- */
-function computeOffsetsFromSizes(sizes: number[]): number[] {
-  const offsets: number[] = new Array(sizes.length);
-  let offset = 0;
-  for (let i = 0; i < sizes.length; i++) {
-    offsets[i] = offset;
-    offset += sizes[i];
-  }
-  return offsets;
-}
-
-function toUint8Array(entry: any): Uint8Array | null {
-  if (entry instanceof Uint8Array) return entry;
-  if (entry instanceof ArrayBuffer) return new Uint8Array(entry);
-  if (ArrayBuffer.isView(entry)) return new Uint8Array(entry.buffer, entry.byteOffset, entry.byteLength);
-  if (Array.isArray(entry)) return new Uint8Array(entry.flat());
-  if (entry?.buffer) return new Uint8Array(entry.buffer);
-  return null;
-}
-
-function isEncodedFormat(format: string): boolean {
-  const normalized = format.toLowerCase();
-  return normalized === "png" || normalized === "jpg" || normalized === "jpeg";
 }
 
 async function decodeImageBytes(

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -1,13 +1,15 @@
 import { VideoBackend, VideoFrame } from "./backend.js";
 import type { StreamingH5File } from "../codecs/slp/h5-streaming.js";
+import {
+  type EmbeddedFrameReader,
+  type Hdf5Slice,
+  type LegacyFrameCache,
+  type SliceReadResult,
+  isEncodedFormat,
+  readEmbeddedFrameBytes,
+} from "./embedded-frame.js";
 
 const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
-
-// PNG magic bytes: 0x89 P N G \r \n 0x1A \n
-const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-
-// JPEG magic bytes: 0xFF 0xD8 0xFF
-const JPEG_MAGIC = new Uint8Array([0xff, 0xd8, 0xff]);
 
 /**
  * Video backend for embedded images in HDF5 files accessed via streaming.
@@ -16,9 +18,10 @@ const JPEG_MAGIC = new Uint8Array([0xff, 0xd8, 0xff]);
  * a synchronous h5wasm File object, making it suitable for browser environments
  * where the SLP file is loaded via HTTP range requests.
  *
- * Supports two data storage formats:
- * 1. vlen-encoded: Array of individual frame blobs (each index = one frame)
- * 2. Contiguous buffer: Single buffer with all frames concatenated
+ * Reads one frame at a time via hyperslab slicing (issue #135) rather than
+ * loading and caching the entire per-video dataset. Supports 2D padded, 1D
+ * concatenated (with `frame_sizes`), and variable-length (vlen) blob layouts;
+ * see {@link readEmbeddedFrameBytes}.
  */
 export class StreamingHdf5VideoBackend implements VideoBackend {
   filename: string;
@@ -30,14 +33,16 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
   private frameNumberToIndex: Map<number, number>;
   private format: string;
   private channelOrder: string;
-  private cachedData: unknown[] | Uint8Array | null;
-  private frameOffsets: number[] | null;  // For contiguous buffer: byte offsets of each frame
+  private frameSizes: number[] | undefined;
+  private legacy: LegacyFrameCache;
+  private metaCache: { shape: number[]; dtype: string } | null;
 
   constructor(options: {
     filename: string;
     h5file: StreamingH5File;
     datasetPath: string;
     frameNumbers?: number[];
+    frameSizes?: number[];
     format?: string;
     channelOrder?: string;
     shape?: [number, number, number, number];
@@ -52,10 +57,11 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     this.frameNumberToIndex = new Map(frameNumbers.map((num, idx) => [num, idx]));
     this.format = options.format ?? "png";
     this.channelOrder = options.channelOrder ?? "RGB";
+    this.frameSizes = options.frameSizes;
     this.shape = options.shape;
     this.fps = options.fps;
-    this.cachedData = null;
-    this.frameOffsets = null;
+    this.legacy = { whole: null, offsets: null };
+    this.metaCache = null;
   }
 
   async getFrame(frameIndex: number): Promise<VideoFrame | null> {
@@ -65,42 +71,12 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
       : frameIndex;
     if (index === undefined) return null;
 
-    // Load data if not cached
-    if (!this.cachedData) {
-      try {
-        const data = await this.h5file.getDatasetValue(this.datasetPath);
-        this.cachedData = normalizeVideoData(data.value, data.shape);
-
-        // Detect if this is a contiguous buffer of encoded images
-        if (isContiguousEncodedBuffer(this.cachedData, this.format, this.shape)) {
-          this.frameOffsets = findEncodedFrameOffsets(
-            this.cachedData as unknown as Uint8Array,
-            this.format,
-            this.shape?.[0] ?? 0
-          );
-        }
-      } catch {
-        return null;
-      }
-    }
-
     let rawBytes: Uint8Array | null;
-
-    // Handle contiguous buffer with computed frame offsets
-    if (this.frameOffsets && this.frameOffsets.length > index) {
-      const buffer = this.cachedData as unknown as Uint8Array;
-      const start = this.frameOffsets[index];
-      const end = index + 1 < this.frameOffsets.length
-        ? this.frameOffsets[index + 1]
-        : buffer.length;
-      rawBytes = buffer.slice(start, end);
-    } else {
-      // Standard vlen-encoded array: each index is a frame blob
-      const entry = (this.cachedData as unknown[])[index];
-      if (entry == null) return null;
-      rawBytes = toUint8Array(entry);
+    try {
+      rawBytes = await readEmbeddedFrameBytes(this.buildReader(), index);
+    } catch {
+      return null;
     }
-
     if (!rawBytes || rawBytes.length === 0) return null;
 
     if (isEncodedFormat(this.format)) {
@@ -115,24 +91,8 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
   async probeShape(sourceFrameCount?: number): Promise<void> {
     if (this.shape && this.shape[0] > 0) return;
     try {
-      // Reuse the same loading path as getFrame — populates cachedData
-      if (!this.cachedData) {
-        const data = await this.h5file.getDatasetValue(this.datasetPath);
-        this.cachedData = normalizeVideoData(data.value, data.shape);
-
-        if (isContiguousEncodedBuffer(this.cachedData, this.format, this.shape)) {
-          this.frameOffsets = findEncodedFrameOffsets(
-            this.cachedData as unknown as Uint8Array,
-            this.format,
-            this.shape?.[0] ?? 0
-          );
-        }
-      }
-
-      // Decode first entry to get image dimensions
-      const entry = Array.isArray(this.cachedData) ? this.cachedData[0] : null;
-      if (!entry) return;
-      const rawBytes = toUint8Array(entry);
+      // Slice and decode only the first stored frame to recover H/W.
+      const rawBytes = await readEmbeddedFrameBytes(this.buildReader(), 0);
       if (!rawBytes || rawBytes.length === 0) return;
 
       if (isEncodedFormat(this.format)) {
@@ -153,122 +113,32 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     } catch { /* probe failed, shape stays undefined */ }
   }
 
+  /** Build a single-frame reader bound to the streaming worker file. */
+  private buildReader(): EmbeddedFrameReader {
+    return {
+      frameCount: this.frameNumberToIndex.size,
+      format: this.format,
+      frameSizes: this.frameSizes,
+      legacy: this.legacy,
+      getMeta: async () => {
+        if (!this.metaCache) {
+          this.metaCache = await this.h5file.getDatasetMeta(this.datasetPath);
+        }
+        return this.metaCache;
+      },
+      readSlice: async (slice?: Hdf5Slice): Promise<SliceReadResult> => {
+        const data = await this.h5file.getDatasetValue(this.datasetPath, slice);
+        return { value: data.value, shape: data.shape };
+      },
+    };
+  }
+
   close(): void {
-    this.cachedData = null;
-    this.frameOffsets = null;
+    this.legacy.whole = null;
+    this.legacy.offsets = null;
+    this.metaCache = null;
     // Note: We don't close the h5file here as it may be shared across multiple backends
   }
-}
-
-/**
- * Normalize video data to a consistent format.
- * Handles both TypedArrays (contiguous) and regular arrays (vlen-encoded).
- */
-function normalizeVideoData(value: unknown, _shape: number[]): unknown[] | Uint8Array {
-  // Already an array of frame blobs
-  if (Array.isArray(value)) {
-    return value;
-  }
-
-  // TypedArray - could be contiguous buffer or raw pixel data
-  if (ArrayBuffer.isView(value)) {
-    // Return as Uint8Array for further processing
-    const arr = value as ArrayBufferView;
-    return new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
-  }
-
-  // Fallback
-  return [];
-}
-
-/**
- * Check if the data is a contiguous buffer of encoded (PNG/JPEG) images.
- */
-function isContiguousEncodedBuffer(
-  data: unknown[] | Uint8Array,
-  format: string,
-  shape?: [number, number, number, number]
-): boolean {
-  if (!isEncodedFormat(format)) return false;
-  if (!(data instanceof Uint8Array)) return false;
-
-  // If it's a Uint8Array and format is PNG/JPEG, check for magic bytes
-  if (data.length < 8) return false;
-
-  // Check if buffer starts with PNG or JPEG magic bytes
-  const isPng = matchesMagic(data, PNG_MAGIC);
-  const isJpeg = matchesMagic(data, JPEG_MAGIC);
-
-  if (!isPng && !isJpeg) return false;
-
-  // If we have shape info, check if buffer is much larger than a single frame
-  // (indicating multiple concatenated frames)
-  if (shape) {
-    const frameCount = shape[0];
-    if (frameCount > 1 && data.length > 10000) {
-      return true;
-    }
-  }
-
-  return true;
-}
-
-/**
- * Check if buffer starts with magic bytes.
- */
-function matchesMagic(buffer: Uint8Array, magic: Uint8Array): boolean {
-  if (buffer.length < magic.length) return false;
-  for (let i = 0; i < magic.length; i++) {
-    if (buffer[i] !== magic[i]) return false;
-  }
-  return true;
-}
-
-/**
- * Find byte offsets of each encoded frame in a contiguous buffer.
- * Scans for PNG/JPEG magic bytes to find frame boundaries.
- */
-function findEncodedFrameOffsets(
-  buffer: Uint8Array,
-  format: string,
-  expectedFrameCount: number
-): number[] {
-  const offsets: number[] = [];
-  const magic = format.toLowerCase() === "png" ? PNG_MAGIC : JPEG_MAGIC;
-
-  // Scan for magic bytes
-  for (let i = 0; i <= buffer.length - magic.length; i++) {
-    if (matchesMagic(buffer.subarray(i), magic)) {
-      offsets.push(i);
-      // Skip ahead to avoid finding embedded magic bytes
-      // For PNG, skip at least the header (8 bytes)
-      // For JPEG, we need to be more careful as magic is only 3 bytes
-      i += magic.length - 1;
-
-      // Early exit if we found expected number of frames
-      if (expectedFrameCount > 0 && offsets.length >= expectedFrameCount) {
-        break;
-      }
-    }
-  }
-
-  return offsets;
-}
-
-function toUint8Array(entry: unknown): Uint8Array | null {
-  if (entry instanceof Uint8Array) return entry;
-  if (entry instanceof ArrayBuffer) return new Uint8Array(entry);
-  if (ArrayBuffer.isView(entry)) return new Uint8Array(entry.buffer, entry.byteOffset, entry.byteLength);
-  if (Array.isArray(entry)) return new Uint8Array(entry.flat());
-  if (entry && typeof entry === "object" && "buffer" in entry) {
-    return new Uint8Array((entry as { buffer: ArrayBuffer }).buffer);
-  }
-  return null;
-}
-
-function isEncodedFormat(format: string): boolean {
-  const normalized = format.toLowerCase();
-  return normalized === "png" || normalized === "jpg" || normalized === "jpeg";
 }
 
 async function decodeImageBytes(

--- a/tests/video/embedded-frame.test.ts
+++ b/tests/video/embedded-frame.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect } from "../bun-test";
+import {
+  type EmbeddedFrameReader,
+  type Hdf5Slice,
+  PNG_MAGIC,
+  JPEG_MAGIC,
+  asUint8Array,
+  classifyLayout,
+  computeOffsetsFromSizes,
+  findEncodedFrameOffsets,
+  readEmbeddedFrameBytes,
+  rowSlice,
+  trimPaddedRow,
+} from "../../src/video/embedded-frame.js";
+import { Hdf5VideoBackend } from "../../src/video/hdf5-video.js";
+import { getH5Module, ensureH5StagingDir, openH5File } from "../../src/codecs/slp/h5.js";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Test doubles for the shared reader
+// ---------------------------------------------------------------------------
+
+/** An int8 view over the given byte values — mimics h5wasm dtype `<b`. */
+function int8(bytes: number[]): Int8Array {
+  return new Int8Array(Uint8Array.from(bytes).buffer);
+}
+
+function fakeReader(opts: {
+  shape: number[];
+  frameCount: number;
+  format: string;
+  frameSizes?: number[];
+  onSlice: (slice: Hdf5Slice | undefined) => unknown;
+}): { reader: EmbeddedFrameReader; calls: Array<Hdf5Slice | undefined> } {
+  const calls: Array<Hdf5Slice | undefined> = [];
+  const reader: EmbeddedFrameReader = {
+    frameCount: opts.frameCount,
+    format: opts.format,
+    frameSizes: opts.frameSizes,
+    legacy: { whole: null, offsets: null },
+    getMeta: async () => ({ shape: opts.shape, dtype: "<b" }),
+    readSlice: async (slice?: Hdf5Slice) => {
+      calls.push(slice);
+      return { value: opts.onSlice(slice), shape: opts.shape };
+    },
+  };
+  return { reader, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("embedded-frame helpers", () => {
+  it("classifies layouts from shape + frame count", () => {
+    expect(classifyLayout([3, 100], 3)).toBe("padded");
+    expect(classifyLayout([3, 100], 0)).toBe("padded");
+    expect(classifyLayout([5], 5)).toBe("vlen"); // length == frame count
+    expect(classifyLayout([5000], 5)).toBe("concat"); // length >> frame count
+    expect(classifyLayout([5], 0)).toBe("ambiguous1d"); // unknown count
+  });
+
+  it("rowSlice selects only the first dim", () => {
+    expect(rowSlice([3, 100], 1)).toEqual([[1, 2], [0, 100]]);
+    expect(rowSlice([3, 4, 5], 2)).toEqual([[2, 3], [0, 4], [0, 5]]);
+  });
+
+  it("computeOffsetsFromSizes is a cumulative sum", () => {
+    expect(computeOffsetsFromSizes([10, 20, 5])).toEqual([0, 10, 30]);
+  });
+
+  it("trimPaddedRow strips trailing zeros (PNG/JPEG never end in 0x00)", () => {
+    const row = Uint8Array.from([1, 2, 3, 0, 0, 0]);
+    expect(Array.from(trimPaddedRow(row))).toEqual([1, 2, 3]);
+  });
+
+  it("trimPaddedRow uses an exact size when provided", () => {
+    const row = Uint8Array.from([1, 2, 3, 4, 5]); // no trailing zeros
+    expect(Array.from(trimPaddedRow(row, 2))).toEqual([1, 2]);
+  });
+
+  it("asUint8Array reinterprets int8 bytes as unsigned", () => {
+    const i8 = int8([0x89, 0xff, 0x00, 0x50]);
+    const u8 = asUint8Array(i8)!;
+    expect(Array.from(u8)).toEqual([0x89, 0xff, 0x00, 0x50]);
+  });
+
+  it("findEncodedFrameOffsets uses indexed compare + exits at expected count", () => {
+    const frameA = Uint8Array.from([...PNG_MAGIC, 1, 2]);
+    const frameB = Uint8Array.from([...PNG_MAGIC, 3, 4, 5]);
+    const buf = Uint8Array.from([...frameA, ...frameB]);
+    expect(findEncodedFrameOffsets(buf, "png", 2)).toEqual([0, frameA.length]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readEmbeddedFrameBytes — layout-aware single-frame slicing
+// ---------------------------------------------------------------------------
+
+describe("readEmbeddedFrameBytes", () => {
+  it("padded 2D: slices one row, trims padding, reinterprets int8", async () => {
+    const M = 8;
+    const { reader, calls } = fakeReader({
+      shape: [3, M],
+      frameCount: 3,
+      format: "png",
+      onSlice: () => int8([0x89, 0x50, 0x4e, 0x47, 0x01, 0, 0, 0]), // 5 real + 3 pad
+    });
+    const out = await readEmbeddedFrameBytes(reader, 1);
+    expect(out).not.toBeNull();
+    expect(Array.from(out!)).toEqual([0x89, 0x50, 0x4e, 0x47, 0x01]);
+    // Exactly one slice, targeting only row 1 — never the whole dataset.
+    expect(calls).toEqual([[[1, 2], [0, M]]]);
+  });
+
+  it("padded 2D: trims to frame_sizes[index] when present", async () => {
+    const { reader } = fakeReader({
+      shape: [2, 10],
+      frameCount: 2,
+      format: "jpg",
+      frameSizes: [4, 7],
+      onSlice: () => int8(new Array(10).fill(0xff)), // no trailing zeros
+    });
+    const out = await readEmbeddedFrameBytes(reader, 0);
+    expect(out!.length).toBe(4);
+  });
+
+  it("concat 1D + frame_sizes: byte-range slice, no whole read", async () => {
+    const { reader, calls } = fakeReader({
+      shape: [30],
+      frameCount: 2, // != 30 -> concat
+      format: "png",
+      frameSizes: [10, 20],
+      onSlice: (slice) => {
+        expect(slice).toEqual([[10, 30]]);
+        return new Uint8Array(20).fill(7);
+      },
+    });
+    const out = await readEmbeddedFrameBytes(reader, 1);
+    expect(out!.length).toBe(20);
+    expect(calls.length).toBe(1);
+  });
+
+  it("vlen: slices a single element and unwraps the blob", async () => {
+    const { reader, calls } = fakeReader({
+      shape: [2],
+      frameCount: 2, // == 2 -> vlen
+      format: "png",
+      onSlice: (slice) => {
+        expect(slice).toEqual([[1, 2]]);
+        return [int8([0x89, 0x50, 0xff])]; // array holding one blob
+      },
+    });
+    const out = await readEmbeddedFrameBytes(reader, 1);
+    expect(Array.from(out!)).toEqual([0x89, 0x50, 0xff]);
+    expect(calls.length).toBe(1);
+  });
+
+  it("legacy fallback: 1D concat without frame_sizes scans once and caches", async () => {
+    const frameA = Uint8Array.from([...PNG_MAGIC, 11, 22]);
+    const frameB = Uint8Array.from([...PNG_MAGIC, 33, 44, 55]);
+    const whole = Uint8Array.from([...frameA, ...frameB]);
+    const { reader, calls } = fakeReader({
+      shape: [whole.length],
+      frameCount: 2, // != length -> concat; no frameSizes -> fallback
+      format: "png",
+      onSlice: (slice) => {
+        expect(slice).toBeUndefined(); // whole-dataset read
+        return whole;
+      },
+    });
+    const a = await readEmbeddedFrameBytes(reader, 0);
+    const b = await readEmbeddedFrameBytes(reader, 1);
+    expect(Array.from(a!)).toEqual(Array.from(frameA));
+    expect(Array.from(b!)).toEqual(Array.from(frameB));
+    // The whole buffer is read once and reused, not re-read per frame.
+    expect(calls.length).toBe(1);
+  });
+
+  it("ambiguous 1D (unknown frame count) resolves a vlen array", async () => {
+    const { reader } = fakeReader({
+      shape: [2],
+      frameCount: 0, // unknown
+      format: "png",
+      onSlice: (slice) => {
+        expect(slice).toBeUndefined();
+        return [int8([1, 2]), int8([3, 4, 5])];
+      },
+    });
+    const out = await readEmbeddedFrameBytes(reader, 1);
+    expect(Array.from(out!)).toEqual([3, 4, 5]);
+  });
+
+  it("ambiguous 1D (unknown frame count) resolves a contiguous buffer via magic scan", async () => {
+    const frameA = Uint8Array.from([...PNG_MAGIC, 0xaa]);
+    const frameB = Uint8Array.from([...PNG_MAGIC, 0xbb, 0xcc]);
+    const whole = Uint8Array.from([...frameA, ...frameB]);
+    const { reader, calls } = fakeReader({
+      shape: [whole.length],
+      frameCount: 0, // unknown -> ambiguous1d
+      format: "png",
+      onSlice: (slice) => {
+        expect(slice).toBeUndefined();
+        return whole; // TypedArray -> magic-scan branch
+      },
+    });
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual(Array.from(frameA));
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 1))!)).toEqual(Array.from(frameB));
+    expect(calls.length).toBe(1); // read whole once, cached
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: synthetic 2D-padded fixtures through the real sync backend
+// ---------------------------------------------------------------------------
+
+/**
+ * Create an in-wasm HDF5 file with a 2D int8 padded `video0/video` dataset and
+ * a `frame_numbers` dataset, then reopen it read-only. Returns the h5wasm File
+ * plus an access counter proxy so tests can assert slicing vs whole reads.
+ */
+async function makePaddedFixture(frames: Uint8Array[]): Promise<{
+  file: any;
+  spy: { value: number; slice: number };
+}> {
+  const mod: any = await getH5Module();
+  await mod.ready;
+  ensureH5StagingDir(mod);
+  const path = `/tmp/issue135-${Math.floor(performance.now())}-${frames.length}.h5`;
+  const N = frames.length;
+  const M = Math.max(...frames.map((f) => f.length)) + 8; // guarantee padding
+  const flat = new Uint8Array(N * M); // zero-filled => trailing padding
+  for (let i = 0; i < N; i++) flat.set(frames[i], i * M);
+
+  const wf = new mod.File(path, "w");
+  wf.create_group("video0");
+  wf.create_dataset({
+    name: "video0/video",
+    data: new Int8Array(flat.buffer), // store as signed bytes like Python
+    shape: [N, M],
+    dtype: "<b",
+  });
+  wf.create_dataset({
+    name: "video0/frame_numbers",
+    data: Int32Array.from(frames.map((_, i) => i)),
+    shape: [N],
+    dtype: "<i4",
+  });
+  wf.close();
+
+  const rf = new mod.File(path, "r");
+  return wrapWithSpy(rf, () => rf.close());
+}
+
+/**
+ * Wrap an h5wasm File so accesses to a dataset's `.value` (whole read) and
+ * `.slice` (hyperslab read) are counted, letting tests assert that slicing —
+ * not whole-dataset reads — is used. frame_numbers/frame_sizes are passed
+ * through unwrapped (the backend reads those eagerly and small).
+ */
+function wrapWithSpy(rf: any, close: () => void): { file: any; spy: { value: number; slice: number } } {
+  const spy = { value: 0, slice: 0 };
+  const file = {
+    get(p: string) {
+      const ds = rf.get(p);
+      if (!ds || p.endsWith("frame_numbers") || p.endsWith("frame_sizes")) return ds;
+      return new Proxy(ds, {
+        get(target, prop, recv) {
+          if (prop === "value") {
+            spy.value++;
+            return target.value;
+          }
+          if (prop === "slice") {
+            spy.slice++;
+            return target.slice.bind(target);
+          }
+          return Reflect.get(target, prop, recv);
+        },
+      });
+    },
+    keys: () => rf.keys(),
+    _close: close,
+  };
+  return { file, spy };
+}
+
+describe("Hdf5VideoBackend single-frame slicing (2D padded)", () => {
+  it("slices a PNG frame, trims padding, and never reads the whole dataset", async () => {
+    const frameA = Uint8Array.from([...PNG_MAGIC, 0xde, 0xad, 0xbe, 0xef]);
+    const frameB = Uint8Array.from([...PNG_MAGIC, 0x01, 0x02]);
+    const { file, spy } = await makePaddedFixture([frameA, frameB]);
+
+    const backend = new Hdf5VideoBackend({
+      filename: ".",
+      file,
+      datasetPath: "video0/video",
+      frameNumbers: [0, 1],
+      format: "png",
+      channelOrder: "BGR",
+    });
+
+    // Node has no createImageBitmap -> getFrame returns the raw (sliced) bytes.
+    const out0 = (await backend.getFrame(0)) as Uint8Array;
+    expect(Array.from(out0)).toEqual(Array.from(frameA)); // trimmed, padding gone
+    const out1 = (await backend.getFrame(1)) as Uint8Array;
+    expect(Array.from(out1)).toEqual(Array.from(frameB));
+
+    // The whole-dataset read path (`dataset.value`) is never taken.
+    expect(spy.value).toBe(0);
+    expect(spy.slice).toBeGreaterThan(0);
+
+    file._close();
+  });
+
+  it("0x89/0xFF bytes round-trip (int8 -> uint8) and JPEG with embedded magic slices exactly", async () => {
+    // A JPEG payload that contains the 3-byte JPEG magic (FF D8 FF) mid-stream,
+    // which would defeat the old magic-byte scan but is irrelevant to slicing.
+    const frame = Uint8Array.from([
+      0xff, 0xd8, 0xff, 0xe0, // SOI + APP0
+      0x12, 0xff, 0xd8, 0xff, 0x34, // embedded false-positive magic
+      0xff, 0xd9, // EOI
+    ]);
+    const { file, spy } = await makePaddedFixture([frame]);
+
+    const backend = new Hdf5VideoBackend({
+      filename: ".",
+      file,
+      datasetPath: "video0/video",
+      frameNumbers: [0],
+      format: "jpg",
+      channelOrder: "RGB",
+    });
+
+    const out = (await backend.getFrame(0)) as Uint8Array;
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(Array.from(out)).toEqual(Array.from(frame)); // exact, padding trimmed
+    expect(spy.value).toBe(0);
+
+    file._close();
+  });
+
+  it("maps sparse, non-identity frame numbers to the right storage row", async () => {
+    const frame10 = Uint8Array.from([...PNG_MAGIC, 0x10, 0x11]);
+    const frame20 = Uint8Array.from([...PNG_MAGIC, 0x20, 0x21, 0x22]);
+    const { file, spy } = await makePaddedFixture([frame10, frame20]);
+
+    // frame numbers 10 and 20 -> storage indices 0 and 1.
+    const backend = new Hdf5VideoBackend({
+      filename: ".",
+      file,
+      datasetPath: "video0/video",
+      frameNumbers: [10, 20],
+      format: "png",
+      channelOrder: "RGB",
+    });
+
+    expect(Array.from((await backend.getFrame(20)) as Uint8Array)).toEqual(Array.from(frame20));
+    expect(Array.from((await backend.getFrame(10)) as Uint8Array)).toEqual(Array.from(frame10));
+    expect(await backend.getFrame(15)).toBeNull(); // not an embedded frame number
+    expect(spy.value).toBe(0);
+
+    file._close();
+  });
+});
+
+describe("Hdf5VideoBackend single-frame slicing (real vlen pkg.slp)", () => {
+  it("slices a single vlen element without reading the whole dataset", async () => {
+    const bytes = fs.readFileSync(path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"));
+    const { file: rawFile, close } = await openH5File(new Uint8Array(bytes));
+    const { file, spy } = wrapWithSpy(rawFile, close);
+
+    const frameNumbers = Array.from(rawFile.get("video0/frame_numbers").value).map((v: any) => Number(v));
+    const backend = new Hdf5VideoBackend({
+      filename: ".",
+      file,
+      datasetPath: "video0/video",
+      frameNumbers,
+      format: "png",
+      channelOrder: "BGR",
+    });
+
+    const out = (await backend.getFrame(frameNumbers[0])) as Uint8Array;
+    expect(out).toBeInstanceOf(Uint8Array);
+    expect(out.length).toBeGreaterThan(0);
+    // It is a real PNG blob, sliced — and the whole vlen array was never read.
+    expect(Array.from(out.subarray(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    expect(spy.value).toBe(0);
+    expect(spy.slice).toBeGreaterThan(0);
+
+    file._close();
+  });
+});


### PR DESCRIPTION
## Problem

Switching between videos in a `.slp` with embedded images froze the UI for
0.5–3.3 s per switch. Both HDF5 embedded-image backends read, transferred, and
magic-byte-scanned the **entire per-video image dataset** to display a **single
frame**, then cached the whole decompressed buffer forever:

1. **Whole-dataset read** instead of a per-frame slice.
2. **O(N·M) main-thread magic-byte scan** with a ~30× allocation bug
   (`buffer.subarray(i)` at every byte) and a dead early-exit.
3. **`cachedData` never evicted** → unbounded heap growth while browsing.

## Fix

Read only the requested frame via the hyperslab `slice` that `getDatasetValue`
already supports, in **both** backends, driven by a new shared module
`src/video/embedded-frame.ts` so the sync (`Hdf5VideoBackend`) and streaming
(`StreamingHdf5VideoBackend`) paths stay in lockstep. Layout is classified from
the **dataset** shape + embedded frame count:

| layout | producer | read |
|---|---|---|
| 2D padded `[N, M]` int8 | Python writer | slice row `i`, trim trailing zero padding (or `frame_sizes[i]`) |
| vlen `[N]` blobs | legacy pkg.slp | slice element `i` (h5wasm returns one blob) |
| 1D concat `[totalBytes]` uint8 | JS writer | byte-range slice via `frame_sizes` |
| 1D concat without `frame_sizes` | old files | legacy whole-read + **fixed** indexed scan (fallback only) |

Also:
- Slicing makes the magic scan — and the JPEG `FF D8 FF` false-positive landmine
  — moot for the 2D / vlen / sized-concat cases.
- The whole-dataset cache is gone; nothing large is retained per video.
- The streaming reader now reads `frame_sizes` (mirroring the sync reader) so
  JS-writer files byte-range slice exactly.
- `probeShape` slices/decodes only row 0 (it was previously **broken** for the
  2D contiguous layout — it only handled vlen arrays).
- Reinterprets `int8` (`<b`) bytes as unsigned, matching how images were written.

No public API change → consumers pick it up with no app change.

## Measurements

Real 470 MB Python-written `.slp` (23 videos, 2D padded PNG/BGR, no `frame_sizes`),
measured against the actual library backend (local benchmark):

| metric | before | after | improvement |
|---|---|---|---|
| cold getFrame, worst video | 3344 ms | 18 ms | **189×** |
| cold getFrame, sum of 23 videos | 25613 ms | 140 ms | **183×** |
| heap retained after touching all 23 videos | 871 MB | 0 MB | **eliminated** |

Per-video cold speedups range 60×–296×. Warm revisits are now uncached (re-slice
from disk: ~3–11 ms in Node; the browser worker path ~20–45 ms vs the old ~20 ms
cached) — an accepted trade for removing the multi-second cold stall and the
unbounded retention. An optional decoded-frame cache remains a possible
follow-up if scrubbing ever regresses.

## Tests

- New `tests/video/embedded-frame.test.ts`: layout classification, exact slice
  specs per layout, padding trim, `int8 → uint8`, the legacy + ambiguous scan
  branches, plus integration through the real sync backend — synthetic
  2D-padded PNG/JPEG fixtures (including a **JPEG payload with an embedded
  `FF D8 FF`**, proving slicing sidesteps the old scan false-positive), sparse
  non-identity frame-number mapping, and a **real vlen `pkg.slp`** — each
  asserting the whole-dataset read (`dataset.value`) is **never** taken.
- Full suite: 1191 pass / 1 skip / 0 fail; lint + build clean.

An adversarial multi-agent review (5 dimensions × 2 independent skeptics) found
**no confirmed correctness defects**; the test additions above address the
coverage gaps it surfaced.

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
