### PR TITLE
feat(rendering): motion trail overlay (port of Python PR #434)

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -377,6 +377,86 @@ await renderVideo(labels, "output.mp4", {
 
 ---
 
+## Motion Trails
+
+Motion trails trace a node or centroid trajectory over the last N frames, so you
+can see how animals moved through the rendered output. Trails are drawn behind
+the poses and fade from faint (oldest) to opaque (newest).
+
+Because trails need temporal context, they are only drawn when the source is a
+`Labels` object (siblings are looked up via `Labels.find`) or when sibling frames
+are supplied via `trailFrames`. They are a no-op for an instance-array source.
+
+### Video with centroid trails
+
+```ts
+await renderVideo(labels, "output.mp4", {
+  showTrails: true,
+  trailLength: 10,        // past frames behind the current frame
+  trailNode: "centroid",  // "centroid", a node name, or a list of node names
+  trailWidth: 2,
+  trailAlphaFade: true,   // fade oldest -> newest
+});
+```
+
+### Single image with trails
+
+```ts
+import { renderImage, saveImage } from "@talmolab/sleap-io.js";
+
+// Trail the head and thorax nodes (one trail per node, sharing the pose color).
+const img = await renderImage(labels, {
+  width: 640,
+  height: 480,
+  background: "black",
+  showTrails: true,
+  trailNode: ["head", "thorax"],
+});
+await saveImage(img, "trails.png");
+```
+
+### Faint, uniform-colored trails
+
+```ts
+await renderVideo(labels, "output.mp4", {
+  showTrails: true,
+  trailColor: "white",    // overrides the per-track palette
+  trailAlpha: 0.5,        // global opacity multiplier
+  trailAlphaFade: false,  // uniform opacity instead of a fade
+});
+```
+
+By default trails are colored to match the poses (by track, or by instance index
+when untracked). Set `trailColor` to any color spec to force a single color.
+
+### Drawing trails on your own canvas (browser)
+
+`renderImage`/`renderVideo` are Node-only (they depend on `skia-canvas`/ffmpeg),
+but the trail building blocks are browser-safe and composable:
+
+```ts
+import {
+  resolveTrailNode,
+  computeTrails,
+  drawTrails,
+} from "@talmolab/sleap-io.js";
+
+const targets = resolveTrailNode("centroid", skeleton);
+const framesByIdx = new Map(labels.find({ video }).map((lf) => [lf.frameIdx, lf]));
+const { trails, colors } = computeTrails({
+  frameIdx: 100,
+  frameIdxToLf: framesByIdx,
+  trailLength: 10,
+  trailTargets: targets,
+  trackIndexMap,
+  paletteColors,
+  hasTracks: true,
+});
+drawTrails(ctx, trails, { colors, lineWidth: 2, alphaFade: true });
+```
+
+---
+
 ## Export Utilities
 
 ### Save to file
@@ -430,6 +510,13 @@ Render poses from a `Labels`, `LabeledFrame`, or array of `Instance`/`PredictedI
 - `options.showNodes`: Draw nodes (default: `true`)
 - `options.showEdges`: Draw edges (default: `true`)
 - `options.scale`: Output scale factor (default: `1`)
+- `options.showTrails`: Draw motion trails (default: `false`; only for a `Labels` source or with `trailFrames`)
+- `options.trailLength`: Past frames behind the current frame (default: `10`)
+- `options.trailNode`: `"centroid"`, a node name, or a list of node names (default: `"centroid"`)
+- `options.trailWidth`: Trail line width in pixels (default: `2`)
+- `options.trailAlphaFade`: Fade oldest → newest (default: `true`)
+- `options.trailAlpha`: Global trail opacity 0-1 (default: `1`)
+- `options.trailColor`: Uniform trail color spec, or `null` to match poses (default: `null`)
 - `options.background`: `"transparent"` or color spec
 - `options.image`: Background `ImageData`
 - `options.preRenderCallback`: `(ctx: RenderContext) => void`

--- a/src/rendering/index.browser.ts
+++ b/src/rendering/index.browser.ts
@@ -30,9 +30,20 @@ export {
   drawDiamond,
   drawTriangle,
   drawCross,
+  drawTrails,
   getMarkerFunction,
   MARKER_FUNCTIONS,
 } from "./shapes.js";
+export type { DrawTrailsOptions } from "./shapes.js";
+
+// Motion-trail helpers (pure / canvas-based; browser-safe)
+export {
+  resolveTrailNode,
+  computeTrails,
+  nTrailPaletteColors,
+  collectTracks,
+} from "./trails.js";
+export type { TrailTarget, Trail } from "./trails.js";
 
 // Context classes
 export { RenderContext, InstanceContext } from "./context.js";

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -29,9 +29,20 @@ export {
   drawDiamond,
   drawTriangle,
   drawCross,
+  drawTrails,
   getMarkerFunction,
   MARKER_FUNCTIONS,
 } from "./shapes.js";
+export type { DrawTrailsOptions } from "./shapes.js";
+
+// Motion-trail helpers
+export {
+  resolveTrailNode,
+  computeTrails,
+  nTrailPaletteColors,
+  collectTracks,
+} from "./trails.js";
+export type { TrailTarget, Trail } from "./trails.js";
 
 // Context classes
 export { RenderContext, InstanceContext } from "./context.js";

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -12,7 +12,14 @@ import {
   determineColorScheme,
   PALETTES,
 } from "./colors.js";
-import { getMarkerFunction } from "./shapes.js";
+import { getMarkerFunction, drawTrails } from "./shapes.js";
+import type { DrawTrailsOptions } from "./shapes.js";
+import {
+  resolveTrailNode,
+  computeTrails,
+  nTrailPaletteColors,
+  collectTracks,
+} from "./trails.js";
 import { RenderContext, InstanceContext } from "./context.js";
 
 // Default options
@@ -25,6 +32,9 @@ const DEFAULT_OPTIONS: Required<
     | "perInstanceCallback"
     | "width"
     | "height"
+    | "trailFrames"
+    | "trailTracks"
+    | "trailPtsCache"
   >
 > = {
   colorBy: "auto",
@@ -37,6 +47,14 @@ const DEFAULT_OPTIONS: Required<
   showEdges: true,
   scale: 1,
   background: "transparent",
+  // Motion trails (off by default; appearance-neutral when enabled).
+  showTrails: false,
+  trailLength: 10,
+  trailNode: "centroid",
+  trailWidth: 2,
+  trailAlphaFade: true,
+  trailAlpha: 1,
+  trailColor: null,
 };
 
 /** Default fallback color */
@@ -70,10 +88,17 @@ export async function renderImage(
   const { instances, skeleton, frameSize, frameIdx, tracks, trackIndexMap } =
     extractSourceData(source, opts);
 
+  // Motion trails can contribute frames even when the current frame is empty
+  // (past frames supply the trail), so they relax the "nothing to render" guard
+  // for a Labels / LabeledFrame source. Mirrors Python PR #434.
+  const trailsPossible =
+    opts.showTrails && opts.trailLength > 0 && !Array.isArray(source);
+
   if (
     instances.length === 0 &&
     !opts.image &&
-    !hasNonInstanceAnnotations(source)
+    !hasNonInstanceAnnotations(source) &&
+    !trailsPossible
   ) {
     throw new Error(
       "No instances to render and no background image provided"
@@ -153,6 +178,69 @@ export async function renderImage(
   // Pre-render callback
   if (opts.preRenderCallback) {
     opts.preRenderCallback(renderCtx);
+  }
+
+  // Draw motion trails behind the poses. Trails need temporal context, so they
+  // are only drawn for a Labels source (siblings come from `find`) or when the
+  // caller passes `trailFrames`; they are skipped for an instance-list source.
+  if (trailsPossible) {
+    const labelsFrame = source as Labels | LabeledFrame;
+    const framesByIdx = resolveTrailFrames(
+      labelsFrame,
+      frameIdx,
+      options.trailFrames
+    );
+    // The current frame may be empty, so fall back to a skeleton from the trail
+    // context for resolving node-name targets.
+    const trailSkeleton = skeleton ?? firstSkeletonIn(framesByIdx);
+    if (framesByIdx && framesByIdx.size > 0 && trailSkeleton) {
+      // Key/color trails off the project track list (matches Python keying off
+      // `Labels.tracks`): full list for a Labels source, the caller-provided
+      // `trailTracks`, or the tracks discovered in the trail context.
+      const trailTracks =
+        "labeledFrames" in labelsFrame
+          ? labelsFrame.tracks
+          : options.trailTracks ?? collectTracks(framesByIdx.values());
+      const trailHasTracks = trailTracks.length > 0;
+      const trailTrackIndexMap = new Map(trailTracks.map((t, i) => [t, i]));
+      const nColors = nTrailPaletteColors(
+        trailHasTracks,
+        trailTracks.length,
+        framesByIdx.values()
+      );
+      const trailPalette = getPalette(opts.palette as PaletteName, nColors);
+      const trailTargets = resolveTrailNode(opts.trailNode, trailSkeleton);
+      const { trails, colors: trailColors } = computeTrails({
+        frameIdx,
+        frameIdxToLf: framesByIdx,
+        trailLength: opts.trailLength,
+        trailTargets,
+        trackIndexMap: trailTrackIndexMap,
+        paletteColors: trailPalette,
+        hasTracks: trailHasTracks,
+        ptsCache: options.trailPtsCache,
+      });
+      if (trails.length > 0) {
+        const trailDrawOpts: DrawTrailsOptions = {
+          lineWidth: opts.trailWidth,
+          alphaFade: opts.trailAlphaFade,
+          alpha: opts.trailAlpha,
+          scale: opts.scale,
+          offset: [0, 0],
+        };
+        // A uniform trailColor overrides the per-track palette colors.
+        if (opts.trailColor != null) {
+          trailDrawOpts.color = resolveColor(opts.trailColor);
+        } else {
+          trailDrawOpts.colors = trailColors;
+        }
+        drawTrails(
+          ctx as unknown as CanvasRenderingContext2D,
+          trails,
+          trailDrawOpts
+        );
+      }
+    }
   }
 
   // Render each instance
@@ -285,6 +373,51 @@ function hasNonInstanceAnnotations(
     (lf.rois?.length ?? 0) > 0 ||
     (lf.centroids?.length ?? 0) > 0
   );
+}
+
+/**
+ * Resolve the temporal frame context used to compute motion trails.
+ *
+ * - For a `Labels` source, gathers all labeled frames of the rendered video
+ *   (the frame at `labeledFrames[0]`), keyed by frame index.
+ * - For a `LabeledFrame` source, uses the caller-supplied `trailFrames` (a `Map`
+ *   keyed by frame index, or an array), falling back to just the rendered frame
+ *   when no context is provided.
+ *
+ * Returns `null` when there is no usable context (e.g. an empty `Labels`).
+ */
+function resolveTrailFrames(
+  source: Labels | LabeledFrame,
+  frameIdx: number,
+  trailFrames?: LabeledFrame[] | Map<number, LabeledFrame>
+): Map<number, LabeledFrame> | null {
+  if ("labeledFrames" in source) {
+    const rendered = source.labeledFrames[0];
+    if (!rendered) return null;
+    const map = new Map<number, LabeledFrame>();
+    for (const lf of source.find({ video: rendered.video })) {
+      map.set(lf.frameIdx, lf);
+    }
+    return map;
+  }
+  if (trailFrames instanceof Map) return trailFrames;
+  if (Array.isArray(trailFrames)) {
+    const map = new Map<number, LabeledFrame>();
+    for (const lf of trailFrames) map.set(lf.frameIdx, lf);
+    return map;
+  }
+  return new Map([[frameIdx, source]]);
+}
+
+/** First instance skeleton found across the trail context frames, or `null`. */
+function firstSkeletonIn(
+  framesByIdx: Map<number, LabeledFrame> | null
+): Skeleton | null {
+  if (!framesByIdx) return null;
+  for (const lf of framesByIdx.values()) {
+    if (lf.instances.length > 0) return lf.instances[0].skeleton;
+  }
+  return null;
 }
 
 /**

--- a/src/rendering/shapes.ts
+++ b/src/rendering/shapes.ts
@@ -1,6 +1,7 @@
 // src/rendering/shapes.ts
 
-import type { MarkerShape } from "./types.js";
+import type { MarkerShape, RGB } from "./types.js";
+import { rgbToCSS } from "./colors.js";
 
 type DrawMarkerFn = (
   ctx: CanvasRenderingContext2D,
@@ -162,4 +163,111 @@ export const MARKER_FUNCTIONS: Record<MarkerShape, DrawMarkerFn> = {
  */
 export function getMarkerFunction(shape: MarkerShape): DrawMarkerFn {
   return MARKER_FUNCTIONS[shape];
+}
+
+/** Options for {@link drawTrails}. */
+export interface DrawTrailsOptions {
+  /** RGB color used when `colors` is not provided. Default `[0, 255, 0]`. */
+  color?: RGB;
+  /** Per-trail RGB colors. If set, must match `trails` in length; overrides `color`. */
+  colors?: RGB[];
+  /** Trail line width in pixels (before `scale`). Default `2`. */
+  lineWidth?: number;
+  /** Fade opacity from faint (oldest segment) to opaque (newest). Default `true`. */
+  alphaFade?: boolean;
+  /** Global opacity multiplier (0–1). Default `1`. */
+  alpha?: number;
+  /** Output scale factor applied to coordinates and line width. Default `1`. */
+  scale?: number;
+  /** `[ox, oy]` offset subtracted from coordinates (for cropped images). Default `[0, 0]`. */
+  offset?: [number, number];
+}
+
+/**
+ * Draw motion trails as fading polylines on a canvas.
+ *
+ * Each trail is a polyline tracing a node or centroid position across past
+ * frames. Segments are drawn individually so opacity can fade from faint
+ * (oldest) to opaque (newest); non-finite points break the line into gaps.
+ *
+ * Port of Python sleap-io `draw_trails` (PR #434). The Python version rasterizes
+ * into a separate `kSrc` buffer so overlapping joints take the newest segment's
+ * alpha instead of accumulating it. This canvas port instead strokes each
+ * segment directly with per-segment alpha — the same approach the pose-edge
+ * renderer already uses — so overlapping joints may blend slightly. The visual
+ * difference is negligible for trails and keeps the implementation idiomatic.
+ *
+ * @param ctx - Canvas 2D context. Coordinates are drawn pre-scaled by `scale`.
+ * @param trails - List of trails, each an array of `[x, y]` points ordered
+ *   oldest → newest. `NaN` rows break the polyline so missing detections leave
+ *   gaps.
+ * @param options - See {@link DrawTrailsOptions}.
+ * @throws If `colors` is provided and its length does not match `trails`.
+ */
+export function drawTrails(
+  ctx: CanvasRenderingContext2D,
+  trails: Array<Array<[number, number] | number[]>>,
+  options: DrawTrailsOptions = {}
+): void {
+  if (trails.length === 0) return;
+
+  const {
+    color = [0, 255, 0],
+    colors,
+    lineWidth = 2,
+    alphaFade = true,
+    alpha = 1,
+    scale = 1,
+    offset = [0, 0],
+  } = options;
+
+  if (colors !== undefined && colors.length !== trails.length) {
+    throw new Error(
+      `colors has length ${colors.length} but there are ${trails.length} ` +
+        "trails; they must be the same length."
+    );
+  }
+
+  const [ox, oy] = offset;
+  const scaledWidth = lineWidth * scale;
+
+  // Save/restore so we don't leak stroke state to later drawing (e.g. poses).
+  const prevLineCap = ctx.lineCap;
+  ctx.lineCap = "round";
+  ctx.lineWidth = scaledWidth;
+
+  for (let i = 0; i < trails.length; i++) {
+    const trail = trails[i];
+    const c = colors !== undefined ? colors[i] : color;
+    const nPoints = trail.length;
+    if (nPoints < 2) continue; // A single point has no segment to draw.
+
+    const nSegments = nPoints - 1;
+    for (let k = 0; k < nSegments; k++) {
+      const [x0, y0] = trail[k];
+      const [x1, y1] = trail[k + 1];
+      if (
+        !Number.isFinite(x0) ||
+        !Number.isFinite(y0) ||
+        !Number.isFinite(x1) ||
+        !Number.isFinite(y1)
+      ) {
+        // Skip segments touching a missing (NaN) position.
+        continue;
+      }
+
+      // Newest segment (k = nSegments - 1) is fully opaque; oldest stays faintly
+      // visible rather than fully transparent.
+      const segFrac = alphaFade ? Math.max((k + 1) / nSegments, 0.05) : 1.0;
+      const segAlpha = Math.max(0, Math.min(1, segFrac * alpha));
+
+      ctx.strokeStyle = rgbToCSS(c as RGB, segAlpha);
+      ctx.beginPath();
+      ctx.moveTo((x0 - ox) * scale, (y0 - oy) * scale);
+      ctx.lineTo((x1 - ox) * scale, (y1 - oy) * scale);
+      ctx.stroke();
+    }
+  }
+
+  ctx.lineCap = prevLineCap;
 }

--- a/src/rendering/trails.ts
+++ b/src/rendering/trails.ts
@@ -1,0 +1,246 @@
+// src/rendering/trails.ts
+//
+// Motion-trail computation helpers. Port of the trail logic in Python sleap-io
+// `rendering/core.py` (`_resolve_trail_node`, `_compute_trails`,
+// `_n_trail_palette_colors`) added in talmolab/sleap-io PR #434.
+//
+// These are pure, browser-safe functions: they build the trail polylines and
+// their colors from a set of LabeledFrames. The actual canvas drawing lives in
+// `drawTrails` (shapes.ts), and the wiring into the render pipeline lives in
+// render.ts / video.ts.
+
+import type { LabeledFrame } from "../model/labeled-frame.js";
+import type { Instance, PredictedInstance, Track } from "../model/instance.js";
+import type { Skeleton } from "../model/skeleton.js";
+import type { RGB } from "./types.js";
+
+/**
+ * A resolved trail target: `null` means the instance centroid, a number is a
+ * node index into the instance's points.
+ */
+export type TrailTarget = number | null;
+
+/** A single trail: `[x, y]` points ordered oldest → newest. `NaN` marks gaps. */
+export type Trail = Array<[number, number]>;
+
+/**
+ * Resolve a `trailNode` specification to a list of trail targets.
+ *
+ * Mirrors Python `_resolve_trail_node`.
+ *
+ * @param trailNode - `"centroid"`, a node name, or a list of node names (one
+ *   trail per node). Matching of `"centroid"` is case-insensitive.
+ * @param skeleton - Skeleton used to resolve node names to indices.
+ * @returns One target per requested node — `null` (centroid) or a node index.
+ * @throws If a node name is not present in the skeleton.
+ */
+export function resolveTrailNode(
+  trailNode: string | string[],
+  skeleton: Skeleton
+): TrailTarget[] {
+  const names = typeof trailNode === "string" ? [trailNode] : [...trailNode];
+
+  return names.map((name) => {
+    if (typeof name === "string" && name.toLowerCase() === "centroid") {
+      return null;
+    }
+    try {
+      return skeleton.index(name);
+    } catch {
+      throw new Error(
+        `Unknown trailNode ${JSON.stringify(name)}; skeleton nodes: ${JSON.stringify(
+          skeleton.nodeNames
+        )}`
+      );
+    }
+  });
+}
+
+/**
+ * Number of palette colors needed for motion trails.
+ *
+ * Mirrors Python `_n_trail_palette_colors`. Trails are colored by track when
+ * tracks are present, otherwise by instance position index; in the latter case
+ * the palette is sized to the largest instance count over the frames so the
+ * coloring stays stable across a render.
+ *
+ * @param hasTracks - Whether the data has track assignments.
+ * @param nTracks - Total number of tracks (used when `hasTracks` is true).
+ * @param frames - Frames to scan for the peak instance count (used when
+ *   `hasTracks` is false).
+ * @returns The palette size, always at least 1.
+ */
+export function nTrailPaletteColors(
+  hasTracks: boolean,
+  nTracks: number,
+  frames: Iterable<LabeledFrame>
+): number {
+  if (hasTracks) {
+    return Math.max(nTracks, 1);
+  }
+  let peak = 1;
+  for (const lf of frames) {
+    peak = Math.max(peak, lf.instances.length);
+  }
+  return Math.max(peak, 1);
+}
+
+/**
+ * Collect the distinct tracks appearing across the given frames, in first-
+ * appearance order.
+ *
+ * Used as the canonical track list for a `LabeledFrame` source (e.g. inside
+ * `renderVideo`) when the project's `Labels.tracks` list is not directly
+ * available. For a `Labels` source the renderer uses `Labels.tracks` instead,
+ * matching how Python keys trails off `source.tracks`.
+ */
+export function collectTracks(frames: Iterable<LabeledFrame>): Track[] {
+  const seen = new Set<Track>();
+  const tracks: Track[] = [];
+  for (const lf of frames) {
+    for (const inst of lf.instances) {
+      if (inst.track != null && !seen.has(inst.track)) {
+        seen.add(inst.track);
+        tracks.push(inst.track);
+      }
+    }
+  }
+  return tracks;
+}
+
+/**
+ * Compute motion-trail polylines ending at a given frame.
+ *
+ * Mirrors Python `_compute_trails`. Trails are keyed by track (tracked data) or
+ * instance position index (untracked) and colored from `paletteColors`.
+ *
+ * @param opts.frameIdx - Current frame index (the trail ends here).
+ * @param opts.frameIdxToLf - Map from frame index to LabeledFrame.
+ * @param opts.trailLength - Number of past frames behind the current frame. The
+ *   trail spans frames `[frameIdx - trailLength, frameIdx]` inclusive.
+ * @param opts.trailTargets - Targets from {@link resolveTrailNode}.
+ * @param opts.trackIndexMap - Track → index map, used to key trails by track
+ *   and to assign colors.
+ * @param opts.paletteColors - Color palette indexed by track index (tracked) or
+ *   instance index (untracked).
+ * @param opts.hasTracks - Whether the data has track assignments. When false,
+ *   trails are keyed by instance position index instead of track.
+ * @param opts.ptsCache - Optional cache from instance to its extracted points,
+ *   reused across the overlapping trail windows of consecutive frames.
+ * @returns `{ trails, colors }` parallel arrays. Each trail has
+ *   `trailLength + 1` points (oldest → newest, `NaN` for missing positions).
+ */
+export function computeTrails(opts: {
+  frameIdx: number;
+  frameIdxToLf: Map<number, LabeledFrame>;
+  trailLength: number;
+  trailTargets: TrailTarget[];
+  trackIndexMap: Map<Track, number>;
+  paletteColors: RGB[];
+  hasTracks: boolean;
+  ptsCache?: Map<Instance | PredictedInstance, number[][]>;
+}): { trails: Trail[]; colors: RGB[] } {
+  const {
+    frameIdx,
+    frameIdxToLf,
+    trailLength,
+    trailTargets,
+    trackIndexMap,
+    paletteColors,
+    hasTracks,
+    ptsCache,
+  } = opts;
+
+  const frameStart = frameIdx - trailLength;
+  const nPoints = trailLength + 1;
+
+  // Map from "keyIdx:targetIdx" -> { arr, keyIdx }, where keyIdx is the track
+  // index (tracked) or instance index (untracked). Insertion order is preserved
+  // so trail/color ordering matches Python's dict iteration.
+  const trailData = new Map<string, { arr: Trail; keyIdx: number }>();
+
+  for (let j = 0; j < nPoints; j++) {
+    const f = frameStart + j;
+    const lf = frameIdxToLf.get(f);
+    if (!lf) continue;
+
+    const insts = lf.instances;
+    for (let instIdx = 0; instIdx < insts.length; instIdx++) {
+      const inst = insts[instIdx];
+
+      let keyIdx: number;
+      if (hasTracks) {
+        if (inst.track == null) continue;
+        const k = trackIndexMap.get(inst.track);
+        if (k === undefined) continue;
+        keyIdx = k;
+      } else {
+        keyIdx = instIdx;
+      }
+
+      // Extract instance points once, reusing the cache across the overlapping
+      // trail windows of consecutive frames when provided.
+      let pts: number[][];
+      if (ptsCache) {
+        const cached = ptsCache.get(inst);
+        if (cached) {
+          pts = cached;
+        } else {
+          pts = inst.numpy();
+          ptsCache.set(inst, pts);
+        }
+      } else {
+        pts = inst.numpy();
+      }
+
+      for (let tIdx = 0; tIdx < trailTargets.length; tIdx++) {
+        const target = trailTargets[tIdx];
+        let coord: [number, number];
+        if (target === null) {
+          // Centroid: mean of visible points (visibility keyed off column 0,
+          // matching Instance.centroidXy and Python's `pts[:, 0]` check).
+          let sumX = 0;
+          let sumY = 0;
+          let count = 0;
+          for (const p of pts) {
+            if (!Number.isNaN(p[0])) {
+              sumX += p[0];
+              sumY += p[1];
+              count++;
+            }
+          }
+          coord = count > 0 ? [sumX / count, sumY / count] : [NaN, NaN];
+        } else if (target < pts.length) {
+          coord = [pts[target][0], pts[target][1]];
+        } else {
+          coord = [NaN, NaN];
+        }
+
+        const dkey = `${keyIdx}:${tIdx}`;
+        let entry = trailData.get(dkey);
+        if (!entry) {
+          const arr: Trail = Array.from(
+            { length: nPoints },
+            () => [NaN, NaN] as [number, number]
+          );
+          entry = { arr, keyIdx };
+          trailData.set(dkey, entry);
+        }
+        entry.arr[j] = coord;
+      }
+    }
+  }
+
+  const trails: Trail[] = [];
+  const colors: RGB[] = [];
+  for (const { arr, keyIdx } of trailData.values()) {
+    // Drop trails with no finite positions at all.
+    if (!arr.some((p) => Number.isFinite(p[0]) || Number.isFinite(p[1]))) {
+      continue;
+    }
+    trails.push(arr);
+    colors.push(paletteColors[keyIdx % paletteColors.length]);
+  }
+
+  return { trails, colors };
+}

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -2,6 +2,8 @@
 
 import type { RenderContext } from "./context.js";
 import type { InstanceContext } from "./context.js";
+import type { LabeledFrame } from "../model/labeled-frame.js";
+import type { Instance, PredictedInstance, Track } from "../model/instance.js";
 
 /** RGB color as [r, g, b] with values 0-255 */
 export type RGB = [number, number, number];
@@ -51,6 +53,38 @@ export interface RenderOptions {
   showNodes?: boolean; // Default: true
   showEdges?: boolean; // Default: true
   scale?: number; // Default: 1.0
+
+  // Motion trails (trace a node/centroid trajectory over the last N frames).
+  // Trails need temporal context, so they are only drawn when `source` is a
+  // `Labels` object or when `trailFrames` provides sibling frames; they are a
+  // no-op for an instance-list source.
+  showTrails?: boolean; // Default: false
+  trailLength?: number; // Default: 10 (past frames behind the current frame)
+  trailNode?: string | string[]; // Default: "centroid" (or a node name / list)
+  trailWidth?: number; // Default: 2.0 (line width in pixels)
+  trailAlphaFade?: boolean; // Default: true (fade oldest -> newest)
+  trailAlpha?: number; // Default: 1.0 (global opacity multiplier, 0-1)
+  trailColor?: ColorSpec | null; // Default: null (match pose colors)
+  /**
+   * Advanced: temporal context for trails when `source` is a single
+   * `LabeledFrame`. Pass all of the video's labeled frames (a `Map` keyed by
+   * frame index is the efficient form; an array is also accepted). Auto-derived
+   * when `source` is a `Labels`, and populated per video by `renderVideo`.
+   */
+  trailFrames?: LabeledFrame[] | Map<number, LabeledFrame>;
+  /**
+   * Advanced: canonical track list used to key and color trails (mirrors
+   * Python keying off `Labels.tracks`). Auto-derived from `Labels.tracks` for a
+   * `Labels` source; populated by `renderVideo` for a `Labels` source. Falls
+   * back to the tracks discovered in `trailFrames` when omitted.
+   */
+  trailTracks?: Track[];
+  /**
+   * Advanced: shared cache mapping an instance to its extracted points, reused
+   * across the overlapping trail windows of consecutive frames. Populated once
+   * per render by `renderVideo` to avoid recomputing instance points.
+   */
+  trailPtsCache?: Map<Instance | PredictedInstance, number[][]>;
 
   // Background
   background?: "transparent" | ColorSpec;

--- a/src/rendering/video.ts
+++ b/src/rendering/video.ts
@@ -3,6 +3,8 @@
 import type { ChildProcess } from "child_process";
 import type { Labels } from "../model/labels.js";
 import type { LabeledFrame } from "../model/labeled-frame.js";
+import type { Video } from "../model/video.js";
+import type { Instance, PredictedInstance } from "../model/instance.js";
 import type { VideoOptions } from "./types.js";
 import { renderImage } from "./render.js";
 
@@ -59,8 +61,39 @@ export async function renderVideo(
     throw new Error("No frames to render");
   }
 
+  // Build per-video temporal context for motion trails once (keyed by frame
+  // index), using ALL source frames so a trail can reach back before the
+  // selected range. Each rendered frame then gets its video's frame map.
+  const framesByVideo = new Map<Video, Map<number, LabeledFrame>>();
+  // Shared points cache + canonical track list (computed once, like Python's
+  // render_video) so trail colors are stable across the whole pass and we avoid
+  // re-extracting instance points across overlapping trail windows.
+  const trailPtsCache = options.showTrails
+    ? new Map<Instance | PredictedInstance, number[][]>()
+    : undefined;
+  const canonicalTracks = Array.isArray(source) ? undefined : source.tracks;
+  if (options.showTrails) {
+    for (const lf of frames) {
+      let videoFrames = framesByVideo.get(lf.video);
+      if (!videoFrames) {
+        videoFrames = new Map<number, LabeledFrame>();
+        framesByVideo.set(lf.video, videoFrames);
+      }
+      videoFrames.set(lf.frameIdx, lf);
+    }
+  }
+  const optsForFrame = (frame: LabeledFrame): VideoOptions =>
+    options.showTrails
+      ? {
+          ...options,
+          trailFrames: framesByVideo.get(frame.video),
+          trailTracks: options.trailTracks ?? canonicalTracks,
+          trailPtsCache,
+        }
+      : options;
+
   // Get frame dimensions from first frame
-  const firstImage = await renderImage(selectedFrames[0], options);
+  const firstImage = await renderImage(selectedFrames[0], optsForFrame(selectedFrames[0]));
   const width = firstImage.width;
   const height = firstImage.height;
 
@@ -121,7 +154,7 @@ export async function renderVideo(
     }
 
     const frame = selectedFrames[i];
-    const imageData = await renderImage(frame, options);
+    const imageData = await renderImage(frame, optsForFrame(frame));
 
     // Write raw RGBA data to ffmpeg stdin
     const buffer = Buffer.from(imageData.data.buffer);

--- a/tests/rendering/trails.test.ts
+++ b/tests/rendering/trails.test.ts
@@ -1,0 +1,750 @@
+import { describe, it, expect } from "../bun-test";
+import { renderImage } from "../../src/rendering/render";
+import { drawTrails } from "../../src/rendering/shapes";
+import {
+  resolveTrailNode,
+  computeTrails,
+  nTrailPaletteColors,
+  collectTracks,
+} from "../../src/rendering/trails";
+import { Skeleton } from "../../src/model/skeleton";
+import { Instance, PredictedInstance, Track } from "../../src/model/instance";
+import { LabeledFrame } from "../../src/model/labeled-frame";
+import { Labels } from "../../src/model/labels";
+import { Video } from "../../src/model/video";
+import type { RGB } from "../../src/rendering/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Single-node skeleton: centroid == that node, so trail geometry is exact. */
+function dotSkeleton(): Skeleton {
+  return new Skeleton({ nodes: ["c"] });
+}
+
+/** Two-node skeleton for node-target tests. */
+function twoNodeSkeleton(): Skeleton {
+  return new Skeleton({ nodes: ["head", "tail"], edges: [["head", "tail"]] });
+}
+
+function makeInstance(
+  skeleton: Skeleton,
+  points: Record<string, number[]>,
+  track?: Track
+): Instance {
+  return new Instance({ points, skeleton, track });
+}
+
+function makeFrame(
+  video: Video,
+  frameIdx: number,
+  instances: Instance[]
+): LabeledFrame {
+  return new LabeledFrame({ video, frameIdx, instances });
+}
+
+async function makeCtx(
+  w: number,
+  h: number
+): Promise<{ ctx: CanvasRenderingContext2D; read: () => ImageData }> {
+  const { Canvas } = await import("skia-canvas");
+  const canvas = new Canvas(w, h);
+  const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+  return {
+    ctx,
+    read: () => ctx.getImageData(0, 0, w, h) as unknown as ImageData,
+  };
+}
+
+function alphaAt(img: ImageData, w: number, x: number, y: number): number {
+  return img.data[(y * w + x) * 4 + 3];
+}
+
+function rgbaAt(
+  img: ImageData,
+  w: number,
+  x: number,
+  y: number
+): [number, number, number, number] {
+  const i = (y * w + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2], img.data[i + 3]];
+}
+
+// ---------------------------------------------------------------------------
+// resolveTrailNode
+// ---------------------------------------------------------------------------
+
+describe("resolveTrailNode", () => {
+  it("maps 'centroid' to null (case-insensitive)", () => {
+    const skel = twoNodeSkeleton();
+    expect(resolveTrailNode("centroid", skel)).toEqual([null]);
+    expect(resolveTrailNode("Centroid", skel)).toEqual([null]);
+    expect(resolveTrailNode("CENTROID", skel)).toEqual([null]);
+  });
+
+  it("maps a node name to its index", () => {
+    const skel = twoNodeSkeleton();
+    expect(resolveTrailNode("head", skel)).toEqual([0]);
+    expect(resolveTrailNode("tail", skel)).toEqual([1]);
+  });
+
+  it("maps a list of node names to one target each", () => {
+    const skel = twoNodeSkeleton();
+    expect(resolveTrailNode(["head", "tail"], skel)).toEqual([0, 1]);
+    expect(resolveTrailNode(["centroid", "tail"], skel)).toEqual([null, 1]);
+  });
+
+  it("throws on an unknown node name", () => {
+    const skel = twoNodeSkeleton();
+    expect(() => resolveTrailNode("nope", skel)).toThrow("Unknown trailNode");
+    expect(() => resolveTrailNode(["head", "nope"], skel)).toThrow(
+      "Unknown trailNode"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nTrailPaletteColors / collectTracks
+// ---------------------------------------------------------------------------
+
+describe("nTrailPaletteColors", () => {
+  it("uses track count when tracked (min 1)", () => {
+    expect(nTrailPaletteColors(true, 3, [])).toBe(3);
+    expect(nTrailPaletteColors(true, 0, [])).toBe(1);
+  });
+
+  it("uses peak instance count when untracked (min 1)", () => {
+    const skel = dotSkeleton();
+    const video = new Video({ filename: "v.mp4" });
+    const frames = [
+      makeFrame(video, 0, [
+        makeInstance(skel, { c: [1, 1] }),
+        makeInstance(skel, { c: [2, 2] }),
+      ]),
+      makeFrame(video, 1, [makeInstance(skel, { c: [3, 3] })]),
+    ];
+    expect(nTrailPaletteColors(false, 0, frames)).toBe(2);
+    expect(nTrailPaletteColors(false, 0, [])).toBe(1);
+  });
+});
+
+describe("collectTracks", () => {
+  it("collects distinct tracks in first-appearance order", () => {
+    const skel = dotSkeleton();
+    const video = new Video({ filename: "v.mp4" });
+    const a = new Track("A");
+    const b = new Track("B");
+    const frames = [
+      makeFrame(video, 0, [makeInstance(skel, { c: [1, 1] }, b)]), // B first
+      makeFrame(video, 1, [
+        makeInstance(skel, { c: [2, 2] }, a),
+        makeInstance(skel, { c: [3, 3] }, b), // dedup
+      ]),
+      makeFrame(video, 2, [makeInstance(skel, { c: [4, 4] })]), // untracked ignored
+    ];
+    expect(collectTracks(frames)).toEqual([b, a]);
+    expect(collectTracks([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTrails
+// ---------------------------------------------------------------------------
+
+describe("computeTrails", () => {
+  const skel = dotSkeleton();
+  const video = new Video({ filename: "v.mp4" });
+
+  it("builds one polyline per track across the window", () => {
+    const track = new Track("A");
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [makeInstance(skel, { c: [10, 10] }, track)])],
+      [1, makeFrame(video, 1, [makeInstance(skel, { c: [10, 20] }, track)])],
+      [2, makeFrame(video, 2, [makeInstance(skel, { c: [10, 30] }, track)])],
+    ]);
+    const { trails, colors } = computeTrails({
+      frameIdx: 2,
+      frameIdxToLf: frames,
+      trailLength: 2,
+      trailTargets: [null],
+      trackIndexMap: new Map([[track, 0]]),
+      paletteColors: [[7, 8, 9]],
+      hasTracks: true,
+    });
+    expect(trails.length).toBe(1);
+    expect(trails[0]).toEqual([
+      [10, 10],
+      [10, 20],
+      [10, 30],
+    ]);
+    expect(colors).toEqual([[7, 8, 9]]);
+  });
+
+  it("leaves NaN gaps for missing frames", () => {
+    const track = new Track("A");
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [makeInstance(skel, { c: [10, 10] }, track)])],
+      // frame 1 missing
+      [2, makeFrame(video, 2, [makeInstance(skel, { c: [10, 30] }, track)])],
+    ]);
+    const { trails } = computeTrails({
+      frameIdx: 2,
+      frameIdxToLf: frames,
+      trailLength: 2,
+      trailTargets: [null],
+      trackIndexMap: new Map([[track, 0]]),
+      paletteColors: [[1, 2, 3]],
+      hasTracks: true,
+    });
+    expect(trails[0][0]).toEqual([10, 10]);
+    expect(Number.isNaN(trails[0][1][0])).toBe(true);
+    expect(Number.isNaN(trails[0][1][1])).toBe(true);
+    expect(trails[0][2]).toEqual([10, 30]);
+  });
+
+  it("emits one trail per node when given a node list", () => {
+    const skel2 = twoNodeSkeleton();
+    const track = new Track("A");
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [makeInstance(skel2, { head: [5, 5], tail: [7, 7] }, track)])],
+    ]);
+    const { trails } = computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [0, 1],
+      trackIndexMap: new Map([[track, 0]]),
+      paletteColors: [[1, 2, 3]],
+      hasTracks: true,
+    });
+    expect(trails.length).toBe(2);
+    expect(trails[0]).toEqual([[5, 5]]);
+    expect(trails[1]).toEqual([[7, 7]]);
+  });
+
+  it("keys untracked instances by position index", () => {
+    const frames = new Map<number, LabeledFrame>([
+      [
+        0,
+        makeFrame(video, 0, [
+          makeInstance(skel, { c: [1, 1] }),
+          makeInstance(skel, { c: [2, 2] }),
+        ]),
+      ],
+    ]);
+    const { trails, colors } = computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [null],
+      trackIndexMap: new Map(),
+      paletteColors: [
+        [10, 10, 10],
+        [20, 20, 20],
+      ],
+      hasTracks: false,
+    });
+    expect(trails).toEqual([[[1, 1]], [[2, 2]]]);
+    expect(colors).toEqual([
+      [10, 10, 10],
+      [20, 20, 20],
+    ]);
+  });
+
+  it("skips untracked instances when hasTracks is true", () => {
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [makeInstance(skel, { c: [1, 1] })])],
+    ]);
+    const { trails } = computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [null],
+      trackIndexMap: new Map(),
+      paletteColors: [[1, 2, 3]],
+      hasTracks: true,
+    });
+    expect(trails.length).toBe(0);
+  });
+
+  it("keeps tracked and skips untracked in a mixed frame when hasTracks", () => {
+    const a = new Track("A");
+    const b = new Track("B");
+    const frames = new Map<number, LabeledFrame>([
+      [
+        0,
+        makeFrame(video, 0, [
+          makeInstance(skel, { c: [1, 1] }, a),
+          makeInstance(skel, { c: [2, 2] }), // untracked -> skipped
+          makeInstance(skel, { c: [3, 3] }, b),
+        ]),
+      ],
+    ]);
+    const { trails, colors } = computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [null],
+      trackIndexMap: new Map([
+        [a, 0],
+        [b, 1],
+      ]),
+      paletteColors: [
+        [10, 10, 10],
+        [20, 20, 20],
+      ],
+      hasTracks: true,
+    });
+    expect(trails).toEqual([[[1, 1]], [[3, 3]]]); // A and B, not the untracked
+    expect(colors).toEqual([
+      [10, 10, 10],
+      [20, 20, 20],
+    ]);
+  });
+
+  it("reuses a shared points cache across calls (renderVideo path)", () => {
+    const track = new Track("A");
+    const inst = makeInstance(skel, { c: [10, 10] }, track);
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [inst])],
+      [1, makeFrame(video, 1, [makeInstance(skel, { c: [10, 20] }, track)])],
+    ]);
+    const cache = new Map();
+    const common = {
+      frameIdxToLf: frames,
+      trailLength: 1,
+      trailTargets: [null] as (number | null)[],
+      trackIndexMap: new Map([[track, 0]]),
+      paletteColors: [[1, 2, 3] as RGB],
+      hasTracks: true,
+      ptsCache: cache,
+    };
+    const first = computeTrails({ ...common, frameIdx: 0 });
+    const second = computeTrails({ ...common, frameIdx: 1 });
+    expect(cache.get(inst)).toBeDefined(); // cached the shared frame-0 instance
+    // Frame 0 ends its trail at (10,10); frame 1 extends through it.
+    expect(first.trails[0][first.trails[0].length - 1]).toEqual([10, 10]);
+    expect(second.trails[0]).toEqual([
+      [10, 10],
+      [10, 20],
+    ]);
+  });
+
+  it("computes the centroid as the mean of visible nodes", () => {
+    const skel2 = twoNodeSkeleton();
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [makeInstance(skel2, { head: [10, 20], tail: [30, 40] })])],
+    ]);
+    const { trails } = computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [null],
+      trackIndexMap: new Map(),
+      paletteColors: [[1, 2, 3]],
+      hasTracks: false,
+    });
+    expect(trails[0]).toEqual([[20, 30]]);
+  });
+
+  it("drops trails with no finite positions (all-invisible instance)", () => {
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [Instance.fromArray([[NaN, NaN]], skel)])],
+    ]);
+    const { trails } = computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [null],
+      trackIndexMap: new Map(),
+      paletteColors: [[1, 2, 3]],
+      hasTracks: false,
+    });
+    expect(trails.length).toBe(0);
+  });
+
+  it("yields NaN for a node index beyond the instance points", () => {
+    const skel2 = twoNodeSkeleton();
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [makeInstance(skel2, { head: [5, 5], tail: [7, 7] })])],
+    ]);
+    const { trails } = computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [1, 99], // 99 is out of range -> dropped (all-NaN)
+      trackIndexMap: new Map(),
+      paletteColors: [[1, 2, 3]],
+      hasTracks: false,
+    });
+    expect(trails.length).toBe(1); // only the valid tail target survives
+    expect(trails[0]).toEqual([[7, 7]]);
+  });
+
+  it("populates and reuses the points cache when provided", () => {
+    const track = new Track("A");
+    const inst = makeInstance(skel, { c: [10, 10] }, track);
+    const frames = new Map<number, LabeledFrame>([
+      [0, makeFrame(video, 0, [inst])],
+    ]);
+    const cache = new Map();
+    computeTrails({
+      frameIdx: 0,
+      frameIdxToLf: frames,
+      trailLength: 0,
+      trailTargets: [null],
+      trackIndexMap: new Map([[track, 0]]),
+      paletteColors: [[1, 2, 3]],
+      hasTracks: true,
+      ptsCache: cache,
+    });
+    expect(cache.has(inst)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// drawTrails (canvas)
+// ---------------------------------------------------------------------------
+
+describe("drawTrails", () => {
+  it("draws a polyline (covered pixels become opaque)", async () => {
+    const { ctx, read } = await makeCtx(40, 40);
+    drawTrails(ctx, [[[10, 10], [10, 30]]], { lineWidth: 6, alphaFade: false });
+    const img = read();
+    expect(alphaAt(img, 40, 10, 20)).toBeGreaterThan(200); // on the line
+    expect(alphaAt(img, 40, 0, 0)).toBe(0); // corner untouched
+  });
+
+  it("is a no-op for empty input", async () => {
+    const { ctx, read } = await makeCtx(20, 20);
+    drawTrails(ctx, []);
+    const img = read();
+    expect(alphaAt(img, 20, 10, 10)).toBe(0);
+  });
+
+  it("is a no-op for single-point trails", async () => {
+    const { ctx, read } = await makeCtx(20, 20);
+    drawTrails(ctx, [[[10, 10]]], { lineWidth: 6 });
+    expect(alphaAt(read(), 20, 10, 10)).toBe(0);
+  });
+
+  it("breaks the line at NaN gaps", async () => {
+    const { ctx, read } = await makeCtx(40, 60);
+    // segment 0: (10,10)-(10,20) drawn; segments touching NaN skipped.
+    drawTrails(ctx, [[[10, 10], [10, 20], [NaN, NaN], [10, 40]]], {
+      lineWidth: 6,
+      alphaFade: false,
+    });
+    const img = read();
+    expect(alphaAt(img, 40, 10, 15)).toBeGreaterThan(200); // drawn segment
+    expect(alphaAt(img, 40, 10, 40)).toBe(0); // isolated point: no segment
+  });
+
+  it("fades opacity from oldest to newest segment", async () => {
+    const { ctx, read } = await makeCtx(40, 80);
+    drawTrails(ctx, [[[10, 10], [10, 40], [10, 70]]], { lineWidth: 6 });
+    const img = read();
+    const older = alphaAt(img, 40, 10, 25); // segment 0 (frac 0.5)
+    const newer = alphaAt(img, 40, 10, 55); // segment 1 (frac 1.0)
+    expect(older).toBeGreaterThan(0);
+    expect(newer).toBeGreaterThan(older);
+  });
+
+  it("applies the global alpha multiplier", async () => {
+    const half = await makeCtx(40, 40);
+    drawTrails(half.ctx, [[[10, 10], [10, 30]]], {
+      lineWidth: 6,
+      alphaFade: false,
+      alpha: 0.5,
+    });
+    const full = await makeCtx(40, 40);
+    drawTrails(full.ctx, [[[10, 10], [10, 30]]], {
+      lineWidth: 6,
+      alphaFade: false,
+      alpha: 1,
+    });
+    expect(alphaAt(half.read(), 40, 10, 20)).toBeLessThan(
+      alphaAt(full.read(), 40, 10, 20)
+    );
+  });
+
+  it("honors per-trail colors", async () => {
+    const { ctx, read } = await makeCtx(50, 40);
+    const red: RGB = [255, 0, 0];
+    const blue: RGB = [0, 0, 255];
+    drawTrails(
+      ctx,
+      [
+        [[10, 10], [10, 30]],
+        [[30, 10], [30, 30]],
+      ],
+      { lineWidth: 6, alphaFade: false, colors: [red, blue] }
+    );
+    const img = read();
+    const [r1, , b1] = rgbaAt(img, 50, 10, 20);
+    const [r2, , b2] = rgbaAt(img, 50, 30, 20);
+    expect(r1).toBeGreaterThan(b1); // first trail red
+    expect(b2).toBeGreaterThan(r2); // second trail blue
+  });
+
+  it("throws when colors length does not match trails", async () => {
+    const { ctx } = await makeCtx(20, 20);
+    expect(() =>
+      drawTrails(ctx, [[[1, 1], [2, 2]], [[3, 3], [4, 4]]], {
+        colors: [[255, 0, 0]],
+      })
+    ).toThrow("must be the same length");
+  });
+
+  it("applies the offset", async () => {
+    const { ctx, read } = await makeCtx(40, 40);
+    drawTrails(ctx, [[[20, 10], [20, 30]]], {
+      lineWidth: 6,
+      alphaFade: false,
+      offset: [10, 0],
+    });
+    const img = read();
+    expect(alphaAt(img, 40, 10, 20)).toBeGreaterThan(200); // shifted left by 10
+    expect(alphaAt(img, 40, 20, 20)).toBe(0); // original position empty
+  });
+
+  it("applies the scale factor", async () => {
+    const { ctx, read } = await makeCtx(40, 40);
+    drawTrails(ctx, [[[5, 5], [5, 15]]], {
+      lineWidth: 4,
+      alphaFade: false,
+      scale: 2,
+    });
+    const img = read();
+    expect(alphaAt(img, 40, 10, 20)).toBeGreaterThan(200); // scaled to (10,10)-(10,30)
+  });
+
+  it("widens the stroke with lineWidth", async () => {
+    const thin = await makeCtx(40, 40);
+    drawTrails(thin.ctx, [[[10, 5], [10, 35]]], { lineWidth: 1, alphaFade: false });
+    const thick = await makeCtx(40, 40);
+    drawTrails(thick.ctx, [[[10, 5], [10, 35]]], { lineWidth: 9, alphaFade: false });
+    // A pixel offset from the line center is covered only by the thick stroke.
+    expect(alphaAt(thin.read(), 40, 13, 20)).toBe(0);
+    expect(alphaAt(thick.read(), 40, 13, 20)).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderImage integration
+// ---------------------------------------------------------------------------
+
+describe("renderImage with motion trails", () => {
+  const skel = dotSkeleton();
+
+  /** Build a Labels whose rendered frame (labeledFrames[0]) is the newest. */
+  function makeTrailLabels(track?: Track): Labels {
+    const video = new Video({ filename: "v.mp4" });
+    const f0 = makeFrame(video, 0, [makeInstance(skel, { c: [20, 20] }, track)]);
+    const f1 = makeFrame(video, 1, [makeInstance(skel, { c: [20, 40] }, track)]);
+    const f2 = makeFrame(video, 2, [makeInstance(skel, { c: [20, 60] }, track)]);
+    // labeledFrames[0] is the current (newest) frame; trail reaches back to f0.
+    return new Labels({ labeledFrames: [f2, f1, f0] });
+  }
+
+  it("draws a trail behind the pose for a Labels source", async () => {
+    const labels = makeTrailLabels(new Track("A"));
+    const withTrails = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 2,
+      trailWidth: 5,
+    });
+    const withoutTrails = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: false,
+    });
+    // (20,30) sits on the f0->f1 trail segment, away from the f2 pose marker.
+    expect(alphaAt(withTrails, 80, 20, 30)).toBeGreaterThan(0);
+    expect(alphaAt(withoutTrails, 80, 20, 30)).toBe(0);
+  });
+
+  it("overrides trail color when trailColor is set", async () => {
+    const labels = makeTrailLabels(new Track("A"));
+    const def = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 2,
+      trailWidth: 5,
+    });
+    const red = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 2,
+      trailWidth: 5,
+      trailColor: "red",
+    });
+    const [, , bDef] = rgbaAt(def, 80, 20, 30);
+    const [rRed, , bRed] = rgbaAt(red, 80, 20, 30);
+    expect(bDef).toBeGreaterThan(0); // default palette color is blue-ish
+    expect(rRed).toBeGreaterThan(bRed); // explicit red dominates
+  });
+
+  it("is a no-op for an instance-array source (no temporal context)", async () => {
+    const inst = makeInstance(skel, { c: [40, 40] });
+    const img = await renderImage([inst], {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 5,
+    });
+    expect(img.width).toBe(80);
+    expect(img.height).toBe(80);
+  });
+
+  it("uses caller-provided trailFrames for a LabeledFrame source", async () => {
+    const track = new Track("A");
+    const video = new Video({ filename: "v.mp4" });
+    const f0 = makeFrame(video, 0, [makeInstance(skel, { c: [20, 20] }, track)]);
+    const f1 = makeFrame(video, 1, [makeInstance(skel, { c: [20, 40] }, track)]);
+    const f2 = makeFrame(video, 2, [makeInstance(skel, { c: [20, 60] }, track)]);
+    const img = await renderImage(f2, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 2,
+      trailWidth: 5,
+      trailFrames: [f0, f1, f2],
+    });
+    expect(alphaAt(img, 80, 20, 30)).toBeGreaterThan(0);
+  });
+
+  it("supports trailing a named node", async () => {
+    const skel2 = twoNodeSkeleton();
+    const video = new Video({ filename: "v.mp4" });
+    const f0 = makeFrame(video, 0, [
+      Instance.fromArray([[20, 20], [60, 60]], skel2),
+    ]);
+    const f1 = makeFrame(video, 1, [
+      Instance.fromArray([[20, 40], [60, 60]], skel2),
+    ]);
+    const labels = new Labels({ labeledFrames: [f1, f0] });
+    const img = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 1,
+      trailNode: "head",
+      trailWidth: 5,
+    });
+    // head trail runs along x=20; tail is static at (60,60) so no trail there.
+    expect(alphaAt(img, 80, 20, 30)).toBeGreaterThan(0);
+  });
+
+  it("draws one trail per node for a node-name list", async () => {
+    const skel2 = twoNodeSkeleton();
+    const video = new Video({ filename: "v.mp4" });
+    // head sweeps down x=20; tail sweeps down x=60.
+    const f0 = makeFrame(video, 0, [
+      Instance.fromArray([[20, 20], [60, 20]], skel2),
+    ]);
+    const f1 = makeFrame(video, 1, [
+      Instance.fromArray([[20, 50], [60, 50]], skel2),
+    ]);
+    const labels = new Labels({ labeledFrames: [f1, f0] });
+    const img = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 1,
+      trailNode: ["head", "tail"],
+      trailWidth: 5,
+    });
+    expect(alphaAt(img, 80, 20, 35)).toBeGreaterThan(0); // head trail
+    expect(alphaAt(img, 80, 60, 35)).toBeGreaterThan(0); // tail trail
+  });
+
+  it("accepts a numeric (grayscale) trailColor", async () => {
+    const labels = makeTrailLabels(new Track("A"));
+    const img = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 2,
+      trailWidth: 5,
+      trailColor: 200,
+    });
+    const [r, g, b] = rgbaAt(img, 80, 20, 30);
+    expect(r).toBeGreaterThan(150);
+    expect(Math.abs(r - g)).toBeLessThan(20);
+    expect(Math.abs(r - b)).toBeLessThan(20);
+  });
+
+  it("renders trails on an empty current frame (Python PR #434 parity)", async () => {
+    const track = new Track("A");
+    const video = new Video({ filename: "v.mp4" });
+    const f1 = makeFrame(video, 1, [makeInstance(skel, { c: [20, 30] }, track)]);
+    const f2 = makeFrame(video, 2, [makeInstance(skel, { c: [20, 50] }, track)]);
+    const f3 = makeFrame(video, 3, []); // current frame is empty
+    const labels = new Labels({
+      labeledFrames: [f3, f2, f1],
+      videos: [video],
+      skeletons: [skel],
+      tracks: [track],
+    });
+    // Without trails this would throw ("No instances to render"); trails relax it.
+    const img = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 3,
+      trailWidth: 5,
+    });
+    expect(alphaAt(img, 80, 20, 40)).toBeGreaterThan(0); // on the f1->f2 segment
+  });
+
+  it("trails predicted instances", async () => {
+    const track = new Track("A");
+    const video = new Video({ filename: "v.mp4" });
+    const f0 = makeFrame(video, 0, [
+      new PredictedInstance({ points: { c: [20, 20] }, skeleton: skel, track, score: 0.9 }),
+    ]);
+    const f1 = makeFrame(video, 1, [
+      new PredictedInstance({ points: { c: [20, 50] }, skeleton: skel, track, score: 0.8 }),
+    ]);
+    const labels = new Labels({ labeledFrames: [f1, f0] });
+    const img = await renderImage(labels, {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 1,
+      trailWidth: 5,
+    });
+    expect(alphaAt(img, 80, 20, 35)).toBeGreaterThan(0);
+  });
+
+  it("honors trailTracks ordering (the renderVideo per-frame contract)", async () => {
+    // Render the same LabeledFrame twice with different canonical track orders;
+    // the trail color must follow the track's index in trailTracks.
+    const a = new Track("A");
+    const b = new Track("B");
+    const video = new Video({ filename: "v.mp4" });
+    const f0 = makeFrame(video, 0, [makeInstance(skel, { c: [20, 20] }, a)]);
+    const f1 = makeFrame(video, 1, [makeInstance(skel, { c: [20, 50] }, a)]);
+    const common = {
+      width: 80,
+      height: 80,
+      showTrails: true,
+      trailLength: 1,
+      trailWidth: 5,
+      trailFrames: [f0, f1],
+    } as const;
+    // trailTracks [A, B]: A -> palette index 0.
+    const aFirst = await renderImage(f1, { ...common, trailTracks: [a, b] });
+    // trailTracks [B, A]: A -> palette index 1 (different color).
+    const bFirst = await renderImage(f1, { ...common, trailTracks: [b, a] });
+    const c0 = rgbaAt(aFirst, 80, 20, 35);
+    const c1 = rgbaAt(bFirst, 80, 20, 35);
+    expect(c0[0] !== c1[0] || c0[1] !== c1[1] || c0[2] !== c1[2]).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the **motion trail overlay** from Python sleap-io [PR #434](https://github.com/talmolab/sleap-io/pull/434) (closes the upstream issue #428). A trail traces a node or centroid trajectory over the last *N* frames so you can see how animals moved through rendered output. Trails are drawn behind the poses and fade from faint (oldest) to opaque (newest).

This was the **main unported gap** remaining in the v0.4.0 release-tracking issue #110. An audit of the other open items there found they are already implemented in the JS port (`matchVideo` #436, `isNegative` merge #432, lazy-ROI-video #414, render-no-instances #420, the `SegmentationMask` multi-class guard from #421, and the #386 lazy relinking spot-check) or not applicable to JS (`Labels.__del__` #419, `merge_label_images` #400). The still-missing items beyond this PR are the larger stretch ports: Norpix `.seq` (#95), TIFF `loadLabelImages` (#421 part A), and the `fromArray` `createTracks` harmonization (#387).

## What's included

- **`src/rendering/trails.ts`** (new, pure & browser-safe): `resolveTrailNode`, `computeTrails`, `nTrailPaletteColors`, `collectTracks` — ports of Python `_resolve_trail_node` / `_compute_trails` / `_n_trail_palette_colors`. Trails are keyed by track (tracked data) or instance index (untracked) and colored to match the poses; missing detections / frames leave `NaN` gaps.
- **`drawTrails`** in `shapes.ts`: canvas polyline overlay with per-segment alpha fade, NaN gaps, `scale`, `offset`, and per-trail colors. Validates a `colors`/`trails` length mismatch.
- **`renderImage` / `renderVideo`** gain new keyword-only options (all optional, off / appearance-neutral by default): `showTrails`, `trailLength`, `trailNode`, `trailWidth`, `trailAlphaFade`, `trailAlpha`, `trailColor`.
  - Trails key off the project track list (`Labels.tracks`), matching Python.
  - They render even when the current frame is empty (past frames supply the trail) — the "nothing to render" guard is relaxed for a trail-capable source.
  - `renderVideo` builds the per-video temporal context once and shares a single points cache + canonical track list across the whole pass, so trail colors are stable and instance points aren't re-extracted per frame.
- **Public API**: `drawTrails`, `resolveTrailNode`, `computeTrails`, `nTrailPaletteColors`, `collectTracks` exported (Node + browser entrypoints).
- **Docs**: new "Motion Trails" section + API-reference entries in `docs/rendering.md`.

## Example

```ts
await renderVideo(labels, "output.mp4", {
  showTrails: true,
  trailLength: 10,
  trailNode: "centroid",   // or a node name / list of node names
  trailWidth: 2,
  trailAlphaFade: true,
});

// Single image, faint uniform-colored trails for two named nodes:
const img = await renderImage(labels, {
  width: 640, height: 480, background: "black",
  showTrails: true, trailNode: ["head", "thorax"],
  trailColor: "white", trailAlpha: 0.5, trailAlphaFade: false,
});
```

## Design decisions / divergences from Python

Intentional, JS-idiomatic divergences (documented in code):
- **Canvas per-segment alpha** instead of skia's `kSrc` buffer — overlapping joints may blend slightly, same as the existing pose-edge renderer. Visually negligible for trails.
- **No CLI** — the JS port has no `sio render` CLI, so the `--trail-*` flags are not ported.

`trailNode` list → one trail per node (each sharing the instance/track color). A `trailColor` overrides the palette with one uniform color. Untracked data keys trails by instance index. Trails are skipped (not errored) for an instance-array source with no temporal context.

## Testing

- New `tests/rendering/trails.test.ts` (39 tests): `resolveTrailNode`, `nTrailPaletteColors`, `collectTracks`, `computeTrails` (track/instance keying, NaN gaps, centroid mean, node lists, out-of-range nodes, all-NaN drop, mixed tracked/untracked, shared cache), `drawTrails` pixel checks (fade, global alpha, per-trail colors, offset, scale, line width, NaN gaps, length-mismatch throw), and `renderImage` integration (Labels/LabeledFrame sources, `trailColor` override incl. numeric grayscale, node-name list, empty current frame, predicted instances, `trailTracks` ordering).
- Full suite: **1230 pass, 1 skip, 0 fail**; `tsc` lint clean; build green.
- Findings from an adversarial multi-agent review were folded in before this PR: project-level track keying/palette sizing, the empty-current-frame guard relaxation, the shared `renderVideo` points cache, and the extra coverage tests above.

`renderVideo` end-to-end encoding is ffmpeg-gated and (consistent with the repo having no `renderVideo` tests) is covered indirectly: each frame renders via `renderImage` with the exact `trailFrames` + `trailTracks` context `renderVideo` supplies, which is tested directly.

Part of the v0.4.0 catch-up to Python sleap-io v0.7.1 (#110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
