### PR TITLE
feat(video): Norpix .seq video backend (port of Python PR #380)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -4,10 +4,11 @@
 # Register the Node-side I/O backends before any test file runs, replacing the
 # old vitest `setupFiles`. `h5-node.ts` wires up the h5wasm/node HDF5 backend
 # and the SLP file writer; `node-fs-resolver.ts` installs the node:fs resolver
-# used by the merge/matching subsystem. The suite runs with `bun test --parallel`
+# used by the merge/matching subsystem; `seq-node.ts` installs the node:fs byte
+# source for reading .seq video files. The suite runs with `bun test --parallel`
 # (each file in its own worker process, implying `--isolate`); these preloads run
 # per worker, so the registrations are present in every test file.
-preload = ["./src/codecs/slp/h5-node.ts", "./src/model/node-fs-resolver.ts"]
+preload = ["./src/codecs/slp/h5-node.ts", "./src/model/node-fs-resolver.ts", "./src/video/seq-node.ts"]
 
 # Coverage (emitted only when `--coverage` is passed, e.g. `bun test --coverage`).
 # Write an lcov report into `coverage/` so CI can upload it as an artifact, and

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,6 +37,33 @@ const video = await loadVideo("path/to/video.mp4");
 const frame = await video.getFrame(0);  // Returns ImageData or raw bytes
 ```
 
+#### Norpix `.seq` files
+
+Norpix StreamPix `.seq` files (common in behavioral neuroscience) are supported
+natively — no conversion needed. Uncompressed (raw grayscale / BGR) and
+compressed (JPEG, PNG) codecs are read; Bayer codecs are not supported. Decoding
+JPEG/PNG frames requires an image decoder (a browser, or the optional
+`skia-canvas` package on Node).
+
+```ts
+import { loadVideo, SeqVideoBackend } from "@talmolab/sleap-io.js";
+
+const video = await loadVideo("recording.seq");
+const frame = await video.getFrame(0);        // ImageData (RGBA)
+console.log(video.shape);                      // [frames, height, width, channels]
+console.log(video.fps);                        // auto-computed from frame timestamps
+
+// Per-frame timestamps (seconds since the Unix epoch):
+const seq = video.backend as SeqVideoBackend;
+const timestamps = await seq.getTimestamps();
+```
+
+In the browser, pass a `File`/`Blob` instead of a path:
+
+```ts
+const video = await loadVideo(fileFromInput); // fileFromInput: File ending in .seq
+```
+
 ### Server-Side Rendering
 
 For server-side skeleton rendering (e.g., generating thumbnails):

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -23,6 +23,13 @@ export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
 export * from "./video/streaming-hdf5-video.js";
+export {
+  SeqVideoBackend,
+  SeqHeader,
+  SeqIndex,
+  BlobByteSource,
+  type ByteSource,
+} from "./video/seq-video.js";
 export { createVideoBackend, type VideoBackendType } from "./video/factory.js";
 export * from "./io/main.js";
 export * from "./io/geojson.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import "./codecs/slp/h5-node.js";
 // Register the Node `fs`-backed default resolver for merge/matching video
 // file-identity checks (kept out of the browser-reachable graph; issue #70).
 import "./model/node-fs-resolver.js";
+// Register the Node `fs`-backed byte source for reading .seq files from a path.
+import "./video/seq-node.js";
 
 export * from "./model/labels.js";
 export * from "./model/labeled-frame.js";
@@ -26,6 +28,13 @@ export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
 export * from "./video/streaming-hdf5-video.js";
+export {
+  SeqVideoBackend,
+  SeqHeader,
+  SeqIndex,
+  BlobByteSource,
+  type ByteSource,
+} from "./video/seq-video.js";
 export { createVideoBackend, type VideoBackendType } from "./video/factory.js";
 export * from "./io/main.js";
 export * from "./io/geojson.js";

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -3,6 +3,7 @@ import { Hdf5VideoBackend } from "./hdf5-video.js";
 import { MediaVideoBackend } from "./media-video.js";
 import { Mp4BoxVideoBackend } from "./mp4box-video.js";
 import { MediaBunnyVideoBackend } from "./mediabunny-video.js";
+import { SeqVideoBackend } from "./seq-video.js";
 import { openH5File } from "../codecs/slp/h5.js";
 
 /** Supported video backend identifiers for user selection. */
@@ -47,6 +48,12 @@ export async function createVideoBackend(
       shape: options?.shape,
       fps: options?.fps,
     });
+  }
+
+  // Norpix .seq files use the dedicated SeqVideo backend (not overridable; no
+  // other backend can read the format).
+  if (ext === "seq") {
+    return SeqVideoBackend.create(source);
   }
 
   // User-specified backend override

--- a/src/video/seq-node.ts
+++ b/src/video/seq-node.ts
@@ -1,0 +1,57 @@
+// src/video/seq-node.ts
+//
+// Node-only registration of a `node:fs`-backed byte source for `.seq` files.
+//
+// Imported by the Node entry point (`src/index.ts`) and the bun test preload
+// (`bunfig.toml`), but NEVER by the browser entry (`src/index.browser.ts`).
+// Keeping the `node:fs` reference out of the browser-reachable `seq-video.ts`
+// ensures the browser module graph contains no Node-only imports (issue #70).
+
+import * as fs from "node:fs";
+import { setSeqFileByteSourceFactory, type ByteSource } from "./seq-video.js";
+
+/** Random-access `.seq` byte source backed by a `node:fs` file descriptor. */
+class NodeFileByteSource implements ByteSource {
+  private path: string;
+  private fd: number | null = null;
+  private fileSize: number | null = null;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  private ensureOpen(): number {
+    if (this.fd === null) {
+      this.fd = fs.openSync(this.path, "r");
+    }
+    return this.fd;
+  }
+
+  async size(): Promise<number> {
+    if (this.fileSize === null) {
+      this.fileSize = fs.statSync(this.path).size;
+    }
+    return this.fileSize;
+  }
+
+  async read(offset: number, length: number): Promise<Uint8Array> {
+    if (length <= 0) return new Uint8Array(0);
+    const fd = this.ensureOpen();
+    const buf = Buffer.alloc(length);
+    const bytesRead = fs.readSync(fd, buf, 0, length, offset);
+    // Copy into a standalone, exactly-sized Uint8Array (buf is not pooled here,
+    // but a fresh buffer keeps byteOffset 0 for safe DataView construction).
+    return new Uint8Array(buf.subarray(0, bytesRead));
+  }
+
+  close(): void {
+    if (this.fd !== null) {
+      fs.closeSync(this.fd);
+      this.fd = null;
+    }
+  }
+}
+
+setSeqFileByteSourceFactory((path) => new NodeFileByteSource(path));
+
+export { NodeFileByteSource };

--- a/src/video/seq-video.ts
+++ b/src/video/seq-video.ts
@@ -1,0 +1,657 @@
+// src/video/seq-video.ts
+//
+// Backend for reading Norpix StreamPix `.seq` video files.
+//
+// The `.seq` format is used by StreamPix / Norpix for high-speed video recording
+// in behavioral neuroscience. This is a faithful port of Python sleap-io's
+// `sleap_io/io/seq.py` (PR #380), adapted to the JS `VideoBackend` interface.
+//
+// Format overview:
+//   - 1024-byte little-endian binary header (magic 0xFEED)
+//   - Uncompressed (raw grayscale / BGR) and compressed (JPEG, PNG) codecs
+//   - Per-frame timestamps (seconds + milliseconds + optional microseconds)
+//   - Compressed formats use variable-length frames requiring a seek index
+//
+// This module is browser-reachable (via the video factory), so it must not
+// statically import `node:fs`. File access on Node is provided through an
+// injected byte-source factory (see `seq-node.ts`); browsers use a `Blob`.
+
+import { VideoBackend, VideoFrame } from "./backend.js";
+
+/** Numeric image-format code → codec name (Python `_IMAGE_FORMAT_CODES`). */
+const IMAGE_FORMAT_CODES: Record<number, string> = {
+  100: "monoraw", // Grayscale uncompressed
+  200: "raw", // Color BGR uncompressed
+  101: "brgb8", // Bayer pattern raw
+  102: "monojpg", // Grayscale JPEG compressed
+  201: "jpg", // Color JPEG compressed
+  103: "jbrgb", // Bayer JPEG compressed
+  1: "monopng", // Grayscale PNG compressed
+  2: "png", // Color PNG compressed
+};
+
+const COMPRESSED_CODECS = new Set(["monojpg", "jpg", "jbrgb", "monopng", "png"]);
+const BAYER_CODECS = new Set(["brgb8", "jbrgb"]);
+
+const HEADER_SIZE = 1024;
+const MAGIC = 0xfeed;
+
+// =============================================================================
+// Byte source abstraction
+// =============================================================================
+
+/**
+ * Random-access reader over the bytes of a `.seq` file. Implementations: a
+ * `Blob` (browser) and an injected `node:fs`-backed source (Node, registered by
+ * `seq-node.ts`).
+ */
+export interface ByteSource {
+  /** Total size of the source in bytes. */
+  size(): Promise<number>;
+  /** Read `length` bytes starting at `offset` (clamped to EOF). */
+  read(offset: number, length: number): Promise<Uint8Array>;
+  /** Release any underlying handle. */
+  close(): void;
+}
+
+/** `Blob`/`File`-backed byte source (browser-safe). */
+export class BlobByteSource implements ByteSource {
+  private blob: Blob;
+  constructor(blob: Blob) {
+    this.blob = blob;
+  }
+  async size(): Promise<number> {
+    return this.blob.size;
+  }
+  async read(offset: number, length: number): Promise<Uint8Array> {
+    const end = Math.min(offset + length, this.blob.size);
+    if (end <= offset) return new Uint8Array(0);
+    const buf = await this.blob.slice(offset, end).arrayBuffer();
+    return new Uint8Array(buf);
+  }
+  close(): void {
+    // Nothing to release for a Blob.
+  }
+}
+
+/** Factory for a file-path byte source; registered by the Node entry point. */
+export type FileByteSourceFactory = (path: string) => ByteSource;
+
+let fileByteSourceFactory: FileByteSourceFactory | null = null;
+
+/** Register the Node `node:fs`-backed byte source factory (see `seq-node.ts`). */
+export function setSeqFileByteSourceFactory(
+  factory: FileByteSourceFactory | null
+): void {
+  fileByteSourceFactory = factory;
+}
+
+function createFileByteSource(path: string): ByteSource {
+  if (!fileByteSourceFactory) {
+    throw new Error(
+      "Reading .seq files from a path requires the Node entry point " +
+        "(`@talmolab/sleap-io.js`). In the browser, pass a File/Blob instead."
+    );
+  }
+  return fileByteSourceFactory(path);
+}
+
+// =============================================================================
+// Header
+// =============================================================================
+
+/** Parsed header of a Norpix `.seq` file (port of Python `SeqHeader`). */
+export class SeqHeader {
+  magic = MAGIC;
+  name = "Norpix seq";
+  version = 0;
+  headerSize = HEADER_SIZE;
+  description = "";
+  width = 0;
+  height = 0;
+  bitDepth = 8;
+  bitDepthReal = 8;
+  imageSizeBytes = 0;
+  imageFormat = 100;
+  numFrames = 0;
+  trueImageSize = 0;
+  fps = 30.0;
+  codec = "";
+
+  /** Human-readable codec name (e.g. `"monoraw"`). */
+  get codecName(): string {
+    return IMAGE_FORMAT_CODES[this.imageFormat] ?? `unknown(${this.imageFormat})`;
+  }
+
+  /** Whether frames use variable-length compression (JPEG/PNG). */
+  get isCompressed(): boolean {
+    return COMPRESSED_CODECS.has(this.codecName);
+  }
+
+  /** Number of color channels (`bitDepth / bitDepthReal`). */
+  get numChannels(): number {
+    return Math.floor(this.bitDepth / (this.bitDepthReal || 8));
+  }
+
+  /**
+   * Parse the 1024-byte header from a byte buffer.
+   *
+   * @throws If the buffer is too small or has an invalid magic number.
+   */
+  static fromBytes(raw: Uint8Array): SeqHeader {
+    if (raw.length < HEADER_SIZE) {
+      throw new Error("File too small to contain a valid .seq header");
+    }
+    const dv = new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
+
+    const magic = dv.getUint32(0, true);
+    if (magic !== MAGIC) {
+      throw new Error(
+        `Invalid .seq magic: 0x${magic.toString(16).toUpperCase()} ` +
+          `(expected 0x${MAGIC.toString(16).toUpperCase()})`
+      );
+    }
+
+    const readU16String = (start: number, count: number): string => {
+      let s = "";
+      for (let i = 0; i < count; i++) {
+        const c = dv.getUint16(start + i * 2, true);
+        if (c > 0 && c < 128) s += String.fromCharCode(c);
+      }
+      return s.trim();
+    };
+
+    const header = new SeqHeader();
+    header.magic = magic;
+    header.name = readU16String(4, 10); // bytes 4-23
+    header.version = dv.getInt32(28, true);
+    header.headerSize = dv.getUint32(32, true);
+    header.description = readU16String(36, 256); // bytes 36-547
+
+    // 9 uint32 fields starting at byte 548.
+    header.width = dv.getUint32(548, true);
+    header.height = dv.getUint32(552, true);
+    header.bitDepth = dv.getUint32(556, true);
+    header.bitDepthReal = dv.getUint32(560, true);
+    header.imageSizeBytes = dv.getUint32(564, true);
+    header.imageFormat = dv.getUint32(568, true);
+    header.numFrames = dv.getUint32(572, true);
+    // field[7] @576 is unused.
+    header.trueImageSize = dv.getUint32(580, true);
+
+    header.fps = dv.getFloat64(584, true);
+    header.codec = `imageFormat${String(header.imageFormat).padStart(3, "0")}`;
+
+    return header;
+  }
+}
+
+// =============================================================================
+// Seek index
+// =============================================================================
+
+const JPEG_SOI = [0xff, 0xd8];
+const PNG_SIG = [0x89, 0x50];
+
+/** Frame seek index for a `.seq` file (port of Python `SeqIndex`). */
+export class SeqIndex {
+  offsets: number[];
+  numFrames: number;
+  /** Per-frame timestamp size in bytes (6 for version < 5, else 8). */
+  timestampSize: number;
+
+  constructor(offsets: number[], numFrames: number, timestampSize: number) {
+    this.offsets = offsets;
+    this.numFrames = numFrames;
+    this.timestampSize = timestampSize;
+  }
+
+  /** Byte offset for a frame. @throws If out of range. */
+  frameOffset(frame: number): number {
+    if (frame < 0 || frame >= this.numFrames) {
+      throw new Error(`Frame ${frame} out of range [0, ${this.numFrames})`);
+    }
+    return this.offsets[frame];
+  }
+
+  /** Build the index for uncompressed formats (constant frame stride). */
+  static buildUncompressed(header: SeqHeader): SeqIndex {
+    const offsets: number[] = [];
+    for (let i = 0; i < header.numFrames; i++) {
+      offsets.push(HEADER_SIZE + i * header.trueImageSize);
+    }
+    return new SeqIndex(offsets, header.numFrames, header.version >= 5 ? 8 : 6);
+  }
+
+  /**
+   * Build the index for compressed formats by scanning the file.
+   *
+   * Compressed frames are variable-length, so the file is scanned sequentially:
+   * each frame begins with a uint32 size; the next frame is located by probing
+   * for the next `size + magic` past the timestamp, allowing small even padding.
+   */
+  static async buildCompressed(
+    source: ByteSource,
+    header: SeqHeader
+  ): Promise<SeqIndex> {
+    const fileSize = await source.size();
+    const nMax = header.numFrames > 0 ? header.numFrames : 10_000_000;
+    const tsSize = header.version >= 5 ? 8 : 6;
+    let extra: number | null = null;
+
+    const readU32 = async (pos: number): Promise<number | null> => {
+      const b = await source.read(pos, 4);
+      if (b.length < 4) return null;
+      return new DataView(b.buffer, b.byteOffset, 4).getUint32(0, true);
+    };
+
+    const offsets: number[] = [HEADER_SIZE];
+
+    for (let i = 1; i < nMax; i++) {
+      const prev = offsets[i - 1];
+      const frameSize = await readU32(prev);
+      if (frameSize === null) break;
+      if (frameSize === 0 || frameSize > fileSize) break;
+
+      let nextOffset: number;
+      if (extra !== null) {
+        nextOffset = prev + frameSize + extra;
+      } else {
+        const searchStart = prev + frameSize + tsSize;
+        let found = false;
+        nextOffset = 0;
+        for (let pad = 0; pad < 32; pad += 2) {
+          const candidate = searchStart + pad;
+          if (candidate + 6 > fileSize) break;
+          const probe = await source.read(candidate, 6);
+          if (probe.length < 6) break;
+          const candSize = new DataView(
+            probe.buffer,
+            probe.byteOffset,
+            6
+          ).getUint32(0, true);
+          const m0 = probe[4];
+          const m1 = probe[5];
+          const isMagic =
+            (m0 === JPEG_SOI[0] && m1 === JPEG_SOI[1]) ||
+            (m0 === PNG_SIG[0] && m1 === PNG_SIG[1]);
+          if (candSize > 0 && candSize < fileSize && isMagic) {
+            extra = tsSize + pad;
+            nextOffset = candidate;
+            found = true;
+            break;
+          }
+        }
+        if (!found) break;
+      }
+
+      if (nextOffset >= fileSize) break;
+
+      // Validate the next frame begins with a plausible size field. Read 6 bytes
+      // (size + magic) and require all 6 to be present, matching Python's scan.
+      const check = await source.read(nextOffset, 6);
+      if (check.length < 6) break;
+      const checkSize = new DataView(check.buffer, check.byteOffset, 6).getUint32(
+        0,
+        true
+      );
+      if (checkSize === 0 || checkSize > fileSize) break;
+
+      offsets.push(nextOffset);
+    }
+
+    return new SeqIndex(offsets, offsets.length, tsSize);
+  }
+}
+
+// =============================================================================
+// Image decoding helpers
+// =============================================================================
+
+const hasGlobalImageData = typeof globalThis !== "undefined" &&
+  typeof (globalThis as { ImageData?: unknown }).ImageData !== "undefined";
+
+/** Construct an `ImageData` from RGBA bytes, in browser or Node (skia-canvas). */
+async function makeImageData(
+  rgba: Uint8ClampedArray<ArrayBuffer>,
+  width: number,
+  height: number
+): Promise<ImageData> {
+  if (hasGlobalImageData) {
+    return new ImageData(rgba, width, height);
+  }
+  try {
+    const sc = await import("skia-canvas");
+    return new (sc as unknown as {
+      ImageData: new (
+        d: Uint8ClampedArray<ArrayBuffer>,
+        w: number,
+        h: number
+      ) => ImageData;
+    }).ImageData(rgba, width, height);
+  } catch {
+    // Last-resort duck-typed frame: consumers only read width/height/data.
+    return { data: rgba, width, height, colorSpace: "srgb" } as unknown as ImageData;
+  }
+}
+
+/** Decode a JPEG/PNG byte buffer to an RGBA `ImageData`. */
+async function decodeEncoded(bytes: Uint8Array): Promise<ImageData> {
+  // Browser: createImageBitmap + canvas.
+  if (
+    typeof createImageBitmap !== "undefined" &&
+    typeof OffscreenCanvas !== "undefined"
+  ) {
+    const safe = new Uint8Array(bytes);
+    const bitmap = await createImageBitmap(new Blob([safe.buffer]));
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Failed to get 2D context for .seq frame decode");
+    ctx.drawImage(bitmap, 0, 0);
+    return ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+  }
+  // Node: skia-canvas loadImage + canvas. skia-canvas's loadImage wants a Node
+  // Buffer (a bare Uint8Array is misread as a path), so wrap the bytes.
+  try {
+    const sc = await import("skia-canvas");
+    const src =
+      typeof Buffer !== "undefined" ? Buffer.from(bytes) : (bytes as unknown);
+    const img = await (
+      sc as unknown as { loadImage: (b: unknown) => Promise<{ width: number; height: number }> }
+    ).loadImage(src);
+    const Canvas = (sc as unknown as { Canvas: new (w: number, h: number) => unknown })
+      .Canvas;
+    const canvas = new Canvas(img.width, img.height) as {
+      getContext: (t: string) => {
+        drawImage: (i: unknown, x: number, y: number) => void;
+        getImageData: (x: number, y: number, w: number, h: number) => ImageData;
+      };
+    };
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+    return ctx.getImageData(0, 0, img.width, img.height);
+  } catch (err) {
+    throw new Error(
+      "Decoding JPEG/PNG frames in .seq files requires an image decoder " +
+        "(a browser, or the optional `skia-canvas` package on Node). " +
+        `Original error: ${(err as Error).message}`
+    );
+  }
+}
+
+// =============================================================================
+// Backend
+// =============================================================================
+
+/**
+ * Video backend for reading Norpix `.seq` files.
+ *
+ * Supported codecs: `monoraw` (grayscale raw), `raw` (BGR raw → RGB),
+ * `monojpg`/`jpg` (JPEG), `monopng`/`png` (PNG). Bayer codecs are unsupported.
+ *
+ * Construct via {@link SeqVideoBackend.create} (async; parses the header, builds
+ * the seek index, and computes FPS from timestamps).
+ */
+export class SeqVideoBackend implements VideoBackend {
+  filename: string;
+  dataset?: string | null = null;
+  shape: [number, number, number, number];
+  fps?: number;
+
+  private source: ByteSource;
+  private headerData: SeqHeader;
+  private index: SeqIndex;
+
+  private constructor(
+    filename: string,
+    source: ByteSource,
+    header: SeqHeader,
+    index: SeqIndex,
+    fps: number | undefined
+  ) {
+    this.filename = filename;
+    this.source = source;
+    this.headerData = header;
+    this.index = index;
+    this.fps = fps;
+    const channels = header.numChannels === 1 ? 1 : 3;
+    this.shape = [index.numFrames, header.height, header.width, channels];
+  }
+
+  /** Open a `.seq` file from a path (Node) or a `File`/`Blob` (browser). */
+  static async create(source: string | File | Blob): Promise<SeqVideoBackend> {
+    const isBlob = typeof Blob !== "undefined" && source instanceof Blob;
+    const filename = isBlob ? ((source as File).name ?? "") : (source as string);
+    const byteSource = isBlob
+      ? new BlobByteSource(source as Blob)
+      : createFileByteSource(source as string);
+
+    try {
+      const header = SeqHeader.fromBytes(await byteSource.read(0, HEADER_SIZE));
+      if (BAYER_CODECS.has(header.codecName)) {
+        throw new Error(
+          `Bayer codec '${header.codecName}' is not supported in .seq files. ` +
+            "Convert the file to a standard format first."
+        );
+      }
+      const index = header.isCompressed
+        ? await SeqIndex.buildCompressed(byteSource, header)
+        : SeqIndex.buildUncompressed(header);
+      const fps = await computeFps(byteSource, header, index, (i, h) =>
+        readTimestamp(byteSource, h, index, i)
+      );
+      return new SeqVideoBackend(filename, byteSource, header, index, fps);
+    } catch (err) {
+      byteSource.close();
+      throw err;
+    }
+  }
+
+  /** The parsed `.seq` header. */
+  get header(): SeqHeader {
+    return this.headerData;
+  }
+
+  /** Number of frames in the video. */
+  get numFrames(): number {
+    return this.index.numFrames;
+  }
+
+  async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+    let idx = frameIndex;
+    if (idx < 0) idx = this.index.numFrames + idx;
+    if (idx < 0 || idx >= this.index.numFrames) return null;
+
+    const data = await readFrameData(this.source, this.headerData, this.index, idx);
+    return decodeFrame(this.headerData, data);
+  }
+
+  /**
+   * Absolute per-frame timestamps as seconds since the Unix epoch (Python
+   * `get_timestamps` parity).
+   */
+  async getTimestamps(): Promise<number[]> {
+    const out: number[] = [];
+    for (let i = 0; i < this.index.numFrames; i++) {
+      out.push(await readTimestamp(this.source, this.headerData, this.index, i));
+    }
+    return out;
+  }
+
+  /** Absolute timestamp (seconds since epoch) for a single frame. */
+  async getTimestamp(frameIndex: number): Promise<number> {
+    let idx = frameIndex;
+    if (idx < 0) idx = this.index.numFrames + idx;
+    if (idx < 0 || idx >= this.index.numFrames) {
+      throw new Error(
+        `Frame ${frameIndex} out of range [0, ${this.index.numFrames})`
+      );
+    }
+    return readTimestamp(this.source, this.headerData, this.index, idx);
+  }
+
+  /**
+   * Presentation times in seconds relative to the first frame (consistent with
+   * the other backends' {@link VideoBackend.getFrameTimes}). For absolute
+   * timestamps use {@link getTimestamps}.
+   */
+  async getFrameTimes(): Promise<number[] | null> {
+    const ts = await this.getTimestamps();
+    if (ts.length === 0) return null;
+    const t0 = ts[0];
+    return ts.map((t) => t - t0);
+  }
+
+  close(): void {
+    this.source.close();
+  }
+}
+
+// =============================================================================
+// Frame / timestamp / fps helpers (free functions; operate on a ByteSource)
+// =============================================================================
+
+/** Read the compressed frame's leading 4-byte size field (includes itself). */
+async function readCompressedFrameSize(
+  source: ByteSource,
+  offset: number
+): Promise<number> {
+  const sizeBytes = await source.read(offset, 4);
+  return new DataView(sizeBytes.buffer, sizeBytes.byteOffset, 4).getUint32(0, true);
+}
+
+/** Read the raw (possibly compressed) bytes of a frame. */
+async function readFrameData(
+  source: ByteSource,
+  header: SeqHeader,
+  index: SeqIndex,
+  frameIdx: number
+): Promise<Uint8Array> {
+  const offset = index.frameOffset(frameIdx);
+  if (header.isCompressed) {
+    const nbytes = await readCompressedFrameSize(source, offset);
+    return source.read(offset + 4, nbytes - 4);
+  }
+  return source.read(offset, header.imageSizeBytes);
+}
+
+/** Read the timestamp (seconds since epoch) for a frame. */
+async function readTimestamp(
+  source: ByteSource,
+  header: SeqHeader,
+  index: SeqIndex,
+  frameIdx: number
+): Promise<number> {
+  // The timestamp directly follows the image data. Its position is nominal in
+  // both cases (matching Python's value for well-formed files) — no need to read
+  // the frame data: uncompressed is a fixed stride; compressed uses the leading
+  // 4-byte size field (which includes itself), so the timestamp is at
+  // `offset + frameSize`. This keeps timestamp/FPS reads cheap.
+  const offset = index.frameOffset(frameIdx);
+  const tsPos = header.isCompressed
+    ? offset + (await readCompressedFrameSize(source, offset))
+    : offset + header.imageSizeBytes;
+
+  const buf = await source.read(tsPos, index.timestampSize);
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  const sec = dv.getUint32(0, true);
+  const ms = dv.getUint16(4, true);
+  let result = sec + ms / 1000.0;
+  if (index.timestampSize === 8) {
+    const us = dv.getUint16(6, true);
+    result += us / 1_000_000.0;
+  }
+  return result;
+}
+
+/** Decode raw frame bytes into an RGBA `ImageData`. */
+async function decodeFrame(header: SeqHeader, data: Uint8Array): Promise<ImageData> {
+  const codec = header.codecName;
+  const h = header.height;
+  const w = header.width;
+  const nch = header.numChannels;
+
+  if (codec === "monoraw" || codec === "raw") {
+    const rgba = new Uint8ClampedArray(w * h * 4);
+    if (nch === 1) {
+      for (let i = 0; i < w * h; i++) {
+        const gray = data[i] ?? 0;
+        const o = i * 4;
+        rgba[o] = gray;
+        rgba[o + 1] = gray;
+        rgba[o + 2] = gray;
+        rgba[o + 3] = 255;
+      }
+    } else {
+      // BGR -> RGBA.
+      for (let i = 0; i < w * h; i++) {
+        const base = i * nch;
+        const o = i * 4;
+        rgba[o] = data[base + 2] ?? 0; // R <- B
+        rgba[o + 1] = data[base + 1] ?? 0; // G
+        rgba[o + 2] = data[base] ?? 0; // B <- R
+        rgba[o + 3] = 255;
+      }
+    }
+    return makeImageData(rgba, w, h);
+  }
+
+  if (
+    codec === "monojpg" ||
+    codec === "jpg" ||
+    codec === "monopng" ||
+    codec === "png"
+  ) {
+    return decodeEncoded(data);
+  }
+
+  throw new Error(`Unsupported .seq codec: ${codec}`);
+}
+
+/**
+ * Recompute FPS from actual frame timestamps using the first 100 frames (robust
+ * median-filtered estimate). Falls back to the header FPS (if >= 1) else
+ * `undefined`. Mirrors Python `_recompute_fps`.
+ */
+async function computeFps(
+  source: ByteSource,
+  header: SeqHeader,
+  index: SeqIndex,
+  read: (i: number, h: SeqHeader) => Promise<number>
+): Promise<number | undefined> {
+  const fallback = header.fps >= 1.0 ? header.fps : undefined;
+  try {
+    const n = Math.min(100, index.numFrames);
+    if (n < 2) return fallback;
+
+    const ts: number[] = [];
+    for (let i = 0; i < n; i++) ts.push(await read(i, header));
+
+    const ds: number[] = [];
+    for (let i = 1; i < ts.length; i++) ds.push(ts[i] - ts[i - 1]);
+
+    const median = medianOf(ds);
+    // 5ms tolerance — tuned for high-speed video (>100 fps); slower framerates
+    // with larger jitter fall back to the header FPS.
+    const filtered = ds.filter((d) => Math.abs(d - median) < 0.005);
+    if (filtered.length > 0) {
+      const mean = filtered.reduce((a, b) => a + b, 0) / filtered.length;
+      const computed = 1.0 / mean;
+      if (Number.isFinite(computed) && computed >= 1.0) {
+        return computed;
+      }
+    }
+  } catch {
+    // fall through to fallback
+  }
+  return fallback;
+}
+
+function medianOf(values: number[]): number {
+  if (values.length === 0) return NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}

--- a/tests/video/seq.test.ts
+++ b/tests/video/seq.test.ts
@@ -1,0 +1,628 @@
+import { describe, it, expect } from "../bun-test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  SeqVideoBackend,
+  SeqHeader,
+  SeqIndex,
+} from "../../src/video/seq-video";
+import "../../src/video/seq-node"; // register node:fs byte source
+import { loadVideo } from "../../src/io/main";
+
+const HEADER_SIZE = 1024;
+const MAGIC = 0xfeed;
+
+interface Timestamp {
+  sec: number;
+  ms: number;
+  us?: number;
+}
+
+function tsValue(ts: Timestamp, size: number): number {
+  let v = ts.sec + ts.ms / 1000.0;
+  if (size === 8) v += (ts.us ?? 0) / 1_000_000.0;
+  return v;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function makeHeader(opts: {
+  width: number;
+  height: number;
+  imageFormat: number;
+  version: number;
+  fps: number;
+  numFrames: number;
+  bitDepth: number;
+  bitDepthReal?: number;
+  imageSizeBytes: number;
+  trueImageSize: number;
+}): Uint8Array {
+  const buf = new Uint8Array(HEADER_SIZE);
+  const dv = new DataView(buf.buffer);
+  dv.setUint32(0, MAGIC, true);
+  dv.setInt32(28, opts.version, true);
+  dv.setUint32(32, HEADER_SIZE, true);
+  dv.setUint32(548, opts.width, true);
+  dv.setUint32(552, opts.height, true);
+  dv.setUint32(556, opts.bitDepth, true);
+  dv.setUint32(560, opts.bitDepthReal ?? 8, true);
+  dv.setUint32(564, opts.imageSizeBytes, true);
+  dv.setUint32(568, opts.imageFormat, true);
+  dv.setUint32(572, opts.numFrames, true);
+  dv.setUint32(580, opts.trueImageSize, true);
+  dv.setFloat64(584, opts.fps, true);
+  return buf;
+}
+
+function encodeTimestamp(ts: Timestamp, size: number): Uint8Array {
+  const buf = new Uint8Array(size);
+  const dv = new DataView(buf.buffer);
+  dv.setUint32(0, ts.sec, true);
+  dv.setUint16(4, ts.ms, true);
+  if (size === 8) dv.setUint16(6, ts.us ?? 0, true);
+  return buf;
+}
+
+/** Build an uncompressed (mono or BGR) .seq file. */
+function buildUncompressed(opts: {
+  width: number;
+  height: number;
+  color: boolean;
+  version: number;
+  fps: number;
+  frames: Uint8Array[]; // raw image bytes per frame
+  timestamps: Timestamp[];
+}): Uint8Array {
+  const nch = opts.color ? 3 : 1;
+  const imageSizeBytes = opts.width * opts.height * nch;
+  const tsSize = opts.version >= 5 ? 8 : 6;
+  const trueImageSize = imageSizeBytes + tsSize;
+  const header = makeHeader({
+    width: opts.width,
+    height: opts.height,
+    imageFormat: opts.color ? 200 : 100,
+    version: opts.version,
+    fps: opts.fps,
+    numFrames: opts.frames.length,
+    bitDepth: opts.color ? 24 : 8,
+    imageSizeBytes,
+    trueImageSize,
+  });
+  const parts: Uint8Array[] = [header];
+  for (let i = 0; i < opts.frames.length; i++) {
+    parts.push(opts.frames[i]);
+    parts.push(encodeTimestamp(opts.timestamps[i], tsSize));
+  }
+  return concat(parts);
+}
+
+/** Build a compressed (JPEG/PNG) .seq file from encoded payloads. */
+function buildCompressed(opts: {
+  width: number;
+  height: number;
+  imageFormat: number; // 201 jpg, 2 png, etc.
+  version: number;
+  fps: number;
+  numFramesHeader: number;
+  payloads: Uint8Array[]; // encoded image bytes (must start with the magic)
+  timestamps: Timestamp[];
+}): Uint8Array {
+  const tsSize = opts.version >= 5 ? 8 : 6;
+  const header = makeHeader({
+    width: opts.width,
+    height: opts.height,
+    imageFormat: opts.imageFormat,
+    version: opts.version,
+    fps: opts.fps,
+    numFrames: opts.numFramesHeader,
+    bitDepth: opts.imageFormat === 2 || opts.imageFormat === 201 ? 24 : 8,
+    imageSizeBytes: 0,
+    trueImageSize: 0,
+  });
+  const parts: Uint8Array[] = [header];
+  for (let i = 0; i < opts.payloads.length; i++) {
+    const payload = opts.payloads[i];
+    const sizeField = new Uint8Array(4);
+    new DataView(sizeField.buffer).setUint32(0, 4 + payload.length, true);
+    parts.push(sizeField);
+    parts.push(payload);
+    parts.push(encodeTimestamp(opts.timestamps[i], tsSize));
+  }
+  return concat(parts);
+}
+
+function fakeJpeg(len: number, seed: number): Uint8Array {
+  const b = new Uint8Array(len);
+  b[0] = 0xff;
+  b[1] = 0xd8; // SOI
+  for (let i = 2; i < len - 2; i++) b[i] = (seed + i) & 0xff;
+  b[len - 2] = 0xff;
+  b[len - 1] = 0xd9; // EOI
+  return b;
+}
+
+async function encodePng(
+  width: number,
+  height: number,
+  rgb: [number, number, number]
+): Promise<Uint8Array> {
+  const sc = await import("skia-canvas");
+  const canvas = new sc.Canvas(width, height);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  ctx.fillRect(0, 0, width, height);
+  const buf = await canvas.toBuffer("png");
+  return new Uint8Array(buf);
+}
+
+async function encodeJpeg(
+  width: number,
+  height: number,
+  rgb: [number, number, number]
+): Promise<Uint8Array> {
+  const sc = await import("skia-canvas");
+  const canvas = new sc.Canvas(width, height);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  ctx.fillRect(0, 0, width, height);
+  const buf = await canvas.toBuffer("jpeg", { quality: 1 });
+  return new Uint8Array(buf);
+}
+
+function px(img: ImageData, x: number, y: number): [number, number, number, number] {
+  const i = (y * img.width + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2], img.data[i + 3]];
+}
+
+const blobOf = (bytes: Uint8Array): Blob => new Blob([bytes.buffer as ArrayBuffer]);
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+describe("SeqHeader", () => {
+  it("parses a valid header", () => {
+    const bytes = buildUncompressed({
+      width: 4,
+      height: 3,
+      color: false,
+      version: 4,
+      fps: 25,
+      frames: [new Uint8Array(12)],
+      timestamps: [{ sec: 1, ms: 0 }],
+    });
+    const h = SeqHeader.fromBytes(bytes.slice(0, HEADER_SIZE));
+    expect(h.magic).toBe(MAGIC);
+    expect(h.width).toBe(4);
+    expect(h.height).toBe(3);
+    expect(h.imageFormat).toBe(100);
+    expect(h.codecName).toBe("monoraw");
+    expect(h.numChannels).toBe(1);
+    expect(h.isCompressed).toBe(false);
+    expect(h.fps).toBeCloseTo(25, 5);
+  });
+
+  it("reports color channels and compression for color JPEG", () => {
+    const bytes = buildCompressed({
+      width: 2,
+      height: 2,
+      imageFormat: 201,
+      version: 5,
+      fps: 30,
+      numFramesHeader: 1,
+      payloads: [fakeJpeg(20, 1)],
+      timestamps: [{ sec: 1, ms: 0, us: 0 }],
+    });
+    const h = SeqHeader.fromBytes(bytes.slice(0, HEADER_SIZE));
+    expect(h.codecName).toBe("jpg");
+    expect(h.numChannels).toBe(3);
+    expect(h.isCompressed).toBe(true);
+  });
+
+  it("throws on invalid magic", () => {
+    const bytes = new Uint8Array(HEADER_SIZE);
+    new DataView(bytes.buffer).setUint32(0, 0x1234, true);
+    expect(() => SeqHeader.fromBytes(bytes)).toThrow("Invalid .seq magic");
+  });
+
+  it("throws when too small", () => {
+    expect(() => SeqHeader.fromBytes(new Uint8Array(10))).toThrow("too small");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SeqIndex
+// ---------------------------------------------------------------------------
+
+describe("SeqIndex.buildUncompressed", () => {
+  it("computes analytic offsets and timestamp size", () => {
+    const h = new SeqHeader();
+    h.numFrames = 3;
+    h.trueImageSize = 50;
+    h.version = 4;
+    const idx = SeqIndex.buildUncompressed(h);
+    expect(idx.numFrames).toBe(3);
+    expect(idx.offsets).toEqual([1024, 1074, 1124]);
+    expect(idx.timestampSize).toBe(6);
+
+    h.version = 5;
+    expect(SeqIndex.buildUncompressed(h).timestampSize).toBe(8);
+  });
+
+  it("frameOffset throws out of range", () => {
+    const idx = new SeqIndex([1024], 1, 6);
+    expect(() => idx.frameOffset(1)).toThrow("out of range");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Uncompressed reading
+// ---------------------------------------------------------------------------
+
+describe("SeqVideoBackend — uncompressed mono", () => {
+  it("reads frames, shape, and handles indexing", async () => {
+    // 3x2 mono, 2 frames with distinct pixel values.
+    const f0 = new Uint8Array([10, 20, 30, 40, 50, 60]);
+    const f1 = new Uint8Array([100, 110, 120, 130, 140, 150]);
+    const bytes = buildUncompressed({
+      width: 3,
+      height: 2,
+      color: false,
+      version: 4,
+      fps: 30,
+      frames: [f0, f1],
+      timestamps: [
+        { sec: 1000, ms: 0 },
+        { sec: 1000, ms: 100 },
+      ],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    expect(be.shape).toEqual([2, 2, 3, 1]); // [frames, height, width, channels]
+    expect(be.numFrames).toBe(2);
+
+    const img0 = (await be.getFrame(0)) as ImageData;
+    expect(img0.width).toBe(3);
+    expect(img0.height).toBe(2);
+    // mono replicates gray across RGB, alpha 255.
+    expect(px(img0, 0, 0)).toEqual([10, 10, 10, 255]);
+    expect(px(img0, 2, 1)).toEqual([60, 60, 60, 255]);
+
+    const img1 = (await be.getFrame(1)) as ImageData;
+    expect(px(img1, 0, 0)).toEqual([100, 100, 100, 255]);
+
+    // Negative index resolves from the end.
+    const imgNeg = (await be.getFrame(-1)) as ImageData;
+    expect(px(imgNeg, 0, 0)).toEqual([100, 100, 100, 255]);
+
+    // Out of range -> null.
+    expect(await be.getFrame(99)).toBeNull();
+    expect(await be.getFrame(-99)).toBeNull();
+    be.close();
+  });
+});
+
+describe("SeqVideoBackend — uncompressed color (BGR -> RGB)", () => {
+  it("swaps BGR to RGB", async () => {
+    // 1x1 color: BGR bytes [b=30, g=20, r=10] -> RGBA [10,20,30,255].
+    const f0 = new Uint8Array([30, 20, 10]);
+    const bytes = buildUncompressed({
+      width: 1,
+      height: 1,
+      color: true,
+      version: 4,
+      fps: 30,
+      frames: [f0],
+      timestamps: [{ sec: 5, ms: 0 }],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    expect(be.shape).toEqual([1, 1, 1, 3]);
+    const img = (await be.getFrame(0)) as ImageData;
+    expect(px(img, 0, 0)).toEqual([10, 20, 30, 255]);
+    be.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timestamps & FPS
+// ---------------------------------------------------------------------------
+
+describe("SeqVideoBackend — timestamps", () => {
+  it("reads absolute timestamps (version 4, 6-byte)", async () => {
+    const bytes = buildUncompressed({
+      width: 1,
+      height: 1,
+      color: false,
+      version: 4,
+      fps: 30,
+      frames: [new Uint8Array([0]), new Uint8Array([1])],
+      timestamps: [
+        { sec: 1000, ms: 250 },
+        { sec: 1000, ms: 500 },
+      ],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    expect(await be.getTimestamp(0)).toBeCloseTo(1000.25, 6);
+    expect(await be.getTimestamp(1)).toBeCloseTo(1000.5, 6);
+    expect(await be.getTimestamps()).toEqual([1000.25, 1000.5]);
+    // getFrameTimes is relative to the first frame.
+    const rel = await be.getFrameTimes();
+    expect(rel![0]).toBeCloseTo(0, 6);
+    expect(rel![1]).toBeCloseTo(0.25, 6);
+    be.close();
+  });
+
+  it("reads microsecond precision (version 5, 8-byte)", async () => {
+    const bytes = buildUncompressed({
+      width: 1,
+      height: 1,
+      color: false,
+      version: 5,
+      fps: 30,
+      frames: [new Uint8Array([0])],
+      timestamps: [{ sec: 10, ms: 500, us: 250 }],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    expect(await be.getTimestamp(0)).toBeCloseTo(10.50025, 6);
+    be.close();
+  });
+
+  it("getTimestamp throws out of range", async () => {
+    const bytes = buildUncompressed({
+      width: 1,
+      height: 1,
+      color: false,
+      version: 4,
+      fps: 30,
+      frames: [new Uint8Array([0])],
+      timestamps: [{ sec: 1, ms: 0 }],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    await expect(be.getTimestamp(5)).rejects.toThrow("out of range");
+    be.close();
+  });
+});
+
+describe("SeqVideoBackend — fps", () => {
+  it("computes fps from uniform timestamps", async () => {
+    // 10 frames spaced 10ms apart -> 100 fps.
+    const frames: Uint8Array[] = [];
+    const timestamps: Timestamp[] = [];
+    for (let i = 0; i < 10; i++) {
+      frames.push(new Uint8Array([i]));
+      timestamps.push({ sec: 100, ms: i * 10 });
+    }
+    const be = await SeqVideoBackend.create(
+      blobOf(
+        buildUncompressed({
+          width: 1,
+          height: 1,
+          color: false,
+          version: 4,
+          fps: 5, // header fps deliberately wrong
+          frames,
+          timestamps,
+        })
+      )
+    );
+    expect(be.fps).toBeCloseTo(100, 1);
+    be.close();
+  });
+
+  it("uses only the first 100 frames to estimate fps", async () => {
+    // 150 frames at 10ms spacing -> 100 fps; exercises the min(100, n) window.
+    const frames: Uint8Array[] = [];
+    const timestamps: Timestamp[] = [];
+    for (let i = 0; i < 150; i++) {
+      frames.push(new Uint8Array([i & 0xff]));
+      timestamps.push({ sec: 50, ms: i * 10 });
+    }
+    const be = await SeqVideoBackend.create(
+      blobOf(
+        buildUncompressed({
+          width: 1,
+          height: 1,
+          color: false,
+          version: 4,
+          fps: 5,
+          frames,
+          timestamps,
+        })
+      )
+    );
+    expect(be.numFrames).toBe(150);
+    expect(be.fps).toBeCloseTo(100, 1);
+    be.close();
+  });
+
+  it("falls back to header fps for a single frame", async () => {
+    const be = await SeqVideoBackend.create(
+      blobOf(
+        buildUncompressed({
+          width: 1,
+          height: 1,
+          color: false,
+          version: 4,
+          fps: 24,
+          frames: [new Uint8Array([0])],
+          timestamps: [{ sec: 1, ms: 0 }],
+        })
+      )
+    );
+    expect(be.fps).toBe(24);
+    be.close();
+  });
+
+  it("falls back to header fps when intervals are too irregular", async () => {
+    // Diffs alternate 2s / 3s: filtered set is empty -> fallback to header fps.
+    const frames: Uint8Array[] = [];
+    const timestamps: Timestamp[] = [];
+    let t = 0;
+    for (let i = 0; i < 5; i++) {
+      frames.push(new Uint8Array([i]));
+      timestamps.push({ sec: t, ms: 0 });
+      t += i % 2 === 0 ? 2 : 3;
+    }
+    const be = await SeqVideoBackend.create(
+      blobOf(
+        buildUncompressed({
+          width: 1,
+          height: 1,
+          color: false,
+          version: 4,
+          fps: 7,
+          frames,
+          timestamps,
+        })
+      )
+    );
+    expect(be.fps).toBe(7);
+    be.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compressed
+// ---------------------------------------------------------------------------
+
+describe("SeqVideoBackend — compressed index scan", () => {
+  it("scans variable-length frames and reads timestamps", async () => {
+    const payloads = [fakeJpeg(20, 1), fakeJpeg(30, 2), fakeJpeg(25, 3)];
+    const bytes = buildCompressed({
+      width: 4,
+      height: 4,
+      imageFormat: 201,
+      version: 4,
+      fps: 30,
+      numFramesHeader: 3,
+      payloads,
+      timestamps: [
+        { sec: 1, ms: 0 },
+        { sec: 1, ms: 20 },
+        { sec: 1, ms: 40 },
+      ],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    expect(be.numFrames).toBe(3);
+    expect(be.shape[0]).toBe(3);
+    expect(await be.getTimestamp(0)).toBeCloseTo(1.0, 6);
+    expect(await be.getTimestamp(2)).toBeCloseTo(1.04, 6);
+    be.close();
+  });
+});
+
+describe("SeqVideoBackend — compressed PNG decode", () => {
+  it("decodes a real PNG frame to pixels", async () => {
+    const png = await encodePng(2, 1, [10, 20, 30]);
+    const bytes = buildCompressed({
+      width: 2,
+      height: 1,
+      imageFormat: 2, // png
+      version: 4,
+      fps: 30,
+      numFramesHeader: 1,
+      payloads: [png],
+      timestamps: [{ sec: 1, ms: 0 }],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    expect(be.numFrames).toBe(1);
+    const img = (await be.getFrame(0)) as ImageData;
+    expect(img.width).toBe(2);
+    expect(img.height).toBe(1);
+    expect(px(img, 0, 0)).toEqual([10, 20, 30, 255]);
+    be.close();
+  });
+});
+
+describe("SeqVideoBackend — compressed JPEG decode", () => {
+  it("decodes a real color JPEG frame to pixels (within lossy tolerance)", async () => {
+    const jpeg = await encodeJpeg(4, 2, [200, 100, 50]);
+    const bytes = buildCompressed({
+      width: 4,
+      height: 2,
+      imageFormat: 201, // jpg (color)
+      version: 4,
+      fps: 30,
+      numFramesHeader: 1,
+      payloads: [jpeg],
+      timestamps: [{ sec: 1, ms: 0 }],
+    });
+    const be = await SeqVideoBackend.create(blobOf(bytes));
+    const img = (await be.getFrame(0)) as ImageData;
+    expect(img.width).toBe(4);
+    expect(img.height).toBe(2);
+    const [r, g, b, a] = px(img, 0, 0);
+    expect(Math.abs(r - 200)).toBeLessThan(12);
+    expect(Math.abs(g - 100)).toBeLessThan(12);
+    expect(Math.abs(b - 50)).toBeLessThan(12);
+    expect(a).toBe(255);
+    be.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Errors & factory routing
+// ---------------------------------------------------------------------------
+
+describe("SeqVideoBackend — errors", () => {
+  it("rejects Bayer codecs", async () => {
+    const bytes = buildCompressed({
+      width: 2,
+      height: 2,
+      imageFormat: 101, // brgb8 (bayer)
+      version: 4,
+      fps: 30,
+      numFramesHeader: 1,
+      payloads: [fakeJpeg(20, 1)],
+      timestamps: [{ sec: 1, ms: 0 }],
+    });
+    await expect(SeqVideoBackend.create(blobOf(bytes))).rejects.toThrow("Bayer");
+  });
+
+  it("rejects a missing file path", async () => {
+    const missing = path.join(os.tmpdir(), "seq-does-not-exist-xyz123.seq");
+    await expect(SeqVideoBackend.create(missing)).rejects.toThrow();
+  });
+});
+
+describe("loadVideo with a .seq path (node:fs byte source)", () => {
+  it("routes .seq through the SeqVideo backend from a file path", async () => {
+    const f0 = new Uint8Array([11, 22, 33, 44]);
+    const f1 = new Uint8Array([55, 66, 77, 88]);
+    const bytes = buildUncompressed({
+      width: 2,
+      height: 2,
+      color: false,
+      version: 4,
+      fps: 30,
+      frames: [f0, f1],
+      timestamps: [
+        { sec: 2000, ms: 0 },
+        { sec: 2000, ms: 33 },
+      ],
+    });
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "seq-test-"));
+    const file = path.join(dir, "recording.seq");
+    fs.writeFileSync(file, bytes);
+    try {
+      const video = await loadVideo(file);
+      expect(video.shape).toEqual([2, 2, 2, 1]);
+      const img = (await video.getFrame(0)) as ImageData;
+      expect(px(img, 0, 0)).toEqual([11, 11, 11, 255]);
+      expect(px(img, 1, 1)).toEqual([44, 44, 44, 255]);
+      video.close();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds native read support for **Norpix StreamPix `.seq`** video files — a high-speed format common in behavioral neuroscience — porting Python sleap-io [PR #380](https://github.com/talmolab/sleap-io/pull/380) (closes #95). `loadVideo("recording.seq")` works directly on Node (by path), and a browser `File`/`Blob` works too; no conversion needed.

## What's included

- **`src/video/seq-video.ts`** (browser-reachable; no static `node:fs`):
  - **`SeqHeader`** — 1024-byte little-endian header parser (magic `0xFEED`): name, version, description, dimensions, bit depth, codec, frame count, FPS.
  - **`SeqIndex`** — analytic frame offsets for uncompressed formats; a file-scanning seek index for variable-length compressed formats (locates each frame via its `size` field + a JPEG/PNG magic probe with padding tolerance).
  - **`ByteSource`** abstraction with a browser-safe **`BlobByteSource`** and an injectable file-source factory.
  - **`SeqVideoBackend implements VideoBackend`**:
    - `getFrame` → decoded RGBA `ImageData`
    - `shape` = `[frames, height, width, channels]`
    - per-frame timestamps: `getTimestamps()` / `getTimestamp(i)` (absolute epoch seconds, Python parity) and `getFrameTimes()` (relative seconds, consistent with the mp4/mediabunny backends)
    - `fps` auto-computed from a median-filtered estimate over the first 100 frame timestamps (falls back to the header FPS)
  - **Codecs**: `monoraw`, `raw` (BGR→RGB), `monojpg`/`jpg`, `monopng`/`png`. Bayer codecs raise a descriptive error. JPEG/PNG decode via the browser (`createImageBitmap`) or the optional `skia-canvas` package on Node.
- **`src/video/seq-node.ts`** (Node-only; imported by the Node entry + bun preload) registers a `node:fs`-backed byte source. Keeps `node:fs` **out of the browser module graph** (issue #70) — verified: the browser bundle contains zero `node:fs`/`seq-node` references.
- **Wiring**: `factory.ts` routes `.seq`; `SeqVideoBackend`/`SeqHeader`/`SeqIndex`/`BlobByteSource` exported from both entry points; a "Norpix `.seq` files" section in `docs/usage.md`.

## Example

```ts
import { loadVideo, SeqVideoBackend } from "@talmolab/sleap-io.js";

const video = await loadVideo("recording.seq");
const frame = await video.getFrame(0);   // ImageData (RGBA)
console.log(video.shape, video.fps);      // [frames, h, w, channels], auto fps

const seq = video.backend as SeqVideoBackend;
const timestamps = await seq.getTimestamps();   // seconds since epoch
```

In the browser, pass a `File`/`Blob` ending in `.seq` instead of a path.

## Testing

`tests/video/seq.test.ts` — **21 tests** over synthetic `.seq` files (no data files needed):
- header parsing (valid / bad magic / too small / color-channel + compression detection)
- `SeqIndex` uncompressed offsets + timestamp size; out-of-range guard
- uncompressed mono frames (pixel checks, negative index, out-of-range → null) and color BGR→RGB
- timestamps: 6-byte (v4) and 8-byte microsecond (v5); relative `getFrameTimes`; out-of-range throw
- fps: uniform, single-frame fallback, irregular-interval fallback, and a **>100-frame window** test
- compressed index scan (variable-length frames + timestamps)
- real **PNG** and **color JPEG** decode (via skia-canvas)
- errors: Bayer codec, missing file path
- `loadVideo(path)` end-to-end through the `node:fs` byte source

Full suite: **1251 pass, 1 skip, 0 fail**; `tsc` lint clean; build green with no Node-only leakage into the browser bundle.

Findings from an adversarial multi-agent review were folded in before this PR: `readTimestamp` now derives the timestamp position from the leading 4-byte size field instead of reading the whole frame (cheaper FPS/timestamp reads, consistent nominal positions in both codecs), and the color-JPEG / file-not-found / >100-frame-fps coverage gaps were closed.

## Divergences from Python (intentional)

- No on-disk `.seq-index.json` cache — the compressed seek index is rebuilt on each open (keeps the browser path filesystem-free; can be added for Node later).
- No `grayscale` force option.

Part of the v0.4.0 catch-up to Python sleap-io v0.7.1 (#110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
