### PR TITLE
fix(label-image): no tracks by default in LabelImage.fromArray (port of Python PR #387)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -627,12 +627,18 @@ Dense integer label images for instance segmentation workflows (Cellpose, StarDi
 ### Creating Label Images
 
 ```ts
-// From a 2D integer array
+// From a 2D integer array. Tracks are NOT created by default — pass them
+// explicitly, or set `createTracks: true` to auto-create one per label ID.
 const li = LabelImage.fromArray(
   new Int32Array([0, 0, 1, 1, 0, 2, 2, 0, 0]),
   3, 3,  // height, width
   { tracks: [trackA, trackB] },
 );
+
+// Pure segmentation (no tracking): omit tracks (objects carry track = null).
+const segLi = LabelImage.fromArray(maskData, 480, 640);
+// Opt in to auto-created tracks named by label ID:
+const trackedLi = LabelImage.fromArray(maskData, 480, 640, { createTracks: true });
 
 // From segmentation masks (composites multiple binary masks)
 const li2 = LabelImage.fromMasks(masks);

--- a/src/model/label-image.ts
+++ b/src/model/label-image.ts
@@ -245,8 +245,13 @@ export class LabelImage {
   /**
    * Create a LabelImage from a flat Int32Array or 2D number array.
    *
-   * Tracks are auto-created when not provided. When provided as an array,
-   * they are assigned positionally starting at label ID 1.
+   * Tracks are NOT created by default (mirrors Python `LabelImage.from_numpy`
+   * after sleap-io PR #387): pure segmentation workflows (e.g. Cellpose) produce
+   * instances that don't need tracking. Pass `createTracks: true` to auto-create
+   * one Track per unique non-zero label ID, or provide `tracks` explicitly. When
+   * provided as an array, tracks are assigned positionally starting at label
+   * ID 1; as a `Map`, by label ID. Providing `tracks` takes precedence over
+   * `createTracks`.
    */
   static fromArray(
     data: Int32Array | number[][],
@@ -255,6 +260,7 @@ export class LabelImage {
     options?: {
       tracks?: Track[] | Map<number, Track>;
       categories?: string[] | Map<number, string>;
+      createTracks?: boolean;
       source?: string;
     },
   ): UserLabelImage {
@@ -282,9 +288,11 @@ export class LabelImage {
     const trackMap = new Map<number, Track>();
     const tracks = options?.tracks;
     if (tracks === undefined) {
-      // Auto-create tracks
-      for (const lid of sortedIds) {
-        trackMap.set(lid, new Track(String(lid)));
+      // No tracks by default; opt in via `createTracks` (PR #387 parity).
+      if (options?.createTracks) {
+        for (const lid of sortedIds) {
+          trackMap.set(lid, new Track(String(lid)));
+        }
       }
     } else if (Array.isArray(tracks)) {
       for (let i = 0; i < tracks.length; i++) {

--- a/tests/label-image.test.ts
+++ b/tests/label-image.test.ts
@@ -328,14 +328,21 @@ describe("LabelImage", () => {
   });
 
   describe("fromArray", () => {
-    it("creates from Int32Array with auto-created tracks", () => {
+    it("creates from Int32Array with no tracks by default (PR #387 parity)", () => {
       const flat = new Int32Array([0, 1, 2, 0, 3, 0]);
       const li = LabelImage.fromArray(flat, 2, 3);
       expect(li.height).toBe(2);
       expect(li.width).toBe(3);
       expect(li.labelIds).toEqual([1, 2, 3]);
       expect(li.nObjects).toBe(3);
-      // Auto-created tracks should have string names
+      // Objects exist but carry no tracks unless opted in.
+      expect(li.tracks).toEqual([]);
+      expect(li.objects.get(1)!.track).toBeNull();
+    });
+
+    it("auto-creates tracks when createTracks is true", () => {
+      const flat = new Int32Array([0, 1, 2, 0, 3, 0]);
+      const li = LabelImage.fromArray(flat, 2, 3, { createTracks: true });
       const tracks = li.tracks;
       expect(tracks).toHaveLength(3);
       expect(tracks[0].name).toBe("1");
@@ -582,9 +589,9 @@ describe("LabelImage", () => {
       expect(li.labelIds).toEqual([3, 7, 15]);
     });
 
-    it("fromArray with sparse IDs auto-creates tracks", () => {
+    it("fromArray with createTracks names tracks by sparse label ID", () => {
       const flat = new Int32Array([0, 3, 7, 0, 15, 0]);
-      const li = LabelImage.fromArray(flat, 2, 3);
+      const li = LabelImage.fromArray(flat, 2, 3, { createTracks: true });
       expect(li.labelIds).toEqual([3, 7, 15]);
       const tracks = li.tracks;
       expect(tracks).toHaveLength(3);
@@ -639,6 +646,10 @@ describe("LabelImage.fromStack", () => {
     expect(result).toHaveLength(2);
     expect(result[0].height).toBe(2);
     expect(result[0].width).toBe(2);
+    // No tracks by default (the createTracks:false default is honored through
+    // the fromArray delegation; PR #387 parity).
+    expect(result[0].tracks).toEqual([]);
+    expect(result[1].tracks).toEqual([]);
   });
 
   it("createTracks auto-creates shared Track objects", () => {


### PR DESCRIPTION
## Summary

Completes the JS port of Python sleap-io [PR #387](https://github.com/talmolab/sleap-io/pull/387)'s label-image change (the verification spot-check on issue #110 flagged this as the last incomplete piece).

`LabelImage.fromArray` — the JS counterpart of Python `LabelImage.from_numpy` — auto-created one `Track` per label ID whenever `tracks` was omitted. PR #387 removed that default: pure segmentation workflows (e.g. Cellpose, SAM) produce instances that don't need tracking. The sibling factories `fromBinaryMasks` and `fromStack` were already ported with the opt-in `createTracks` flag, leaving `fromArray` as the only holdout still auto-creating tracks.

## Changes

- **`fromArray` no longer creates tracks by default.** Pass `createTracks: true` to auto-create one `Track` per unique non-zero label ID (named by ID), or provide `tracks` explicitly. Objects are still created for every label — they simply carry `track: null` unless tracks are requested. Providing `tracks` takes precedence over `createTracks`.
- **Also fixes `fromStack`.** It delegates to `fromArray` (passing the shared track map, or `undefined`), so its own `createTracks: false` default was silently overridden by `fromArray`'s auto-creation. `fromStack` without `createTracks` now correctly yields no tracks (locked in with a regression assertion).
- No other code paths are affected: `fromStack` is the only internal `fromArray` caller, and the SLP read/write paths construct label images from their `objects` map directly (not via `fromArray`).

## Before / after

```ts
// before: 3 auto-created tracks named "1","2","3"
// after:  no tracks (objects carry track = null)
const li = LabelImage.fromArray(maskData, 480, 640);

// opt in to the old behavior:
const tracked = LabelImage.fromArray(maskData, 480, 640, { createTracks: true });
```

## Testing

- Updated the `fromArray` default test to assert **no tracks by default**, added an explicit **`createTracks` opt-in** test, repurposed the sparse-ID test under `createTracks`, and added a **`fromStack` no-tracks-by-default** regression assertion.
- Full suite: **1252 pass, 1 skip, 0 fail**; `tsc` lint clean.
- Docs: the `fromArray` example in `docs/api.md` now notes the default and the opt-in.

Part of the v0.4.0 catch-up to Python sleap-io v0.7.1 (#110) — the #386/#387/#400 verification spot-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
