### PR TITLE
feat(io): TIFF label-image reader loadLabelImages() (port Python PR #421)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
       },
       "optionalDependencies": {
         "skia-canvas": "^3.0.8",
+        "tiff": "^7.1.3",
       },
     },
   },
@@ -179,6 +180,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
@@ -188,6 +191,8 @@
     "h5wasm": ["h5wasm@0.10.2", "", {}, "sha512-TeuuGEII+9o9rRNQ3Mr1XidStL6lj4eTqBuYrquOxzXtZLyEYAyffa4gh7kc/fdS8nXhQHtxQK61KwdUn31uEQ=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iobuffer": ["iobuffer@6.0.1", "", {}, "sha512-SZWYkWNfjIXIBYSDpXDYIgshqtbOPsi4lviawAEceR1Kqk+sHDlcQjWrzNQsii80AyBY0q5c8HCTNjqo74ul+Q=="],
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
@@ -252,6 +257,8 @@
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tiff": ["tiff@7.1.3", "", { "dependencies": { "fflate": "^0.8.2", "iobuffer": "^6.0.0" } }, "sha512-YEEq3fT++2pdta/9P/vGG4QRMdZQoe6W6JNaWnIi6NvAsbeNITwFCtmWwL/BZvOi+uo2I3ohyOkD3sZfme+c6g=="],
 
     "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -8,7 +8,7 @@
 # source for reading .seq video files. The suite runs with `bun test --parallel`
 # (each file in its own worker process, implying `--isolate`); these preloads run
 # per worker, so the registrations are present in every test file.
-preload = ["./src/codecs/slp/h5-node.ts", "./src/model/node-fs-resolver.ts", "./src/video/seq-node.ts"]
+preload = ["./src/codecs/slp/h5-node.ts", "./src/model/node-fs-resolver.ts", "./src/video/seq-node.ts", "./src/io/label-images-node.ts"]
 
 # Coverage (emitted only when `--coverage` is passed, e.g. `bun test --coverage`).
 # Write an lcov report into `coverage/` so CI can upload it as an artifact, and

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/talmolab/sleap-io.js.git"
   },
   "scripts": {
-    "build": "tsup src/index.ts src/index.browser.ts src/lite.ts --format esm --dts --external skia-canvas --external mediabunny",
+    "build": "tsup src/index.ts src/index.browser.ts src/lite.ts --format esm --dts --external skia-canvas --external mediabunny --external tiff",
     "test": "bun test --parallel",
     "test:coverage": "bun test --parallel --coverage",
     "lint": "tsc -p tsconfig.json --noEmit"
@@ -42,7 +42,8 @@
     "yaml": "^2.6.1"
   },
   "optionalDependencies": {
-    "skia-canvas": "^3.0.8"
+    "skia-canvas": "^3.0.8",
+    "tiff": "^7.1.3"
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import "./codecs/slp/h5-node.js";
 import "./model/node-fs-resolver.js";
 // Register the Node `fs`-backed byte source for reading .seq files from a path.
 import "./video/seq-node.js";
+// Register the Node `fs`-backed TIFF reader for loadLabelImages() path inputs.
+import "./io/label-images-node.js";
 
 export * from "./model/labels.js";
 export * from "./model/labeled-frame.js";

--- a/src/io/label-images-node.ts
+++ b/src/io/label-images-node.ts
@@ -1,0 +1,37 @@
+// src/io/label-images-node.ts
+//
+// Node-only registration of a `node:fs`-backed TIFF reader for `loadLabelImages`.
+//
+// Imported by the Node entry point (`src/index.ts`) and the bun test preload
+// (`bunfig.toml`), but NEVER by the browser entry. Keeps `node:fs` out of the
+// browser module graph (issue #70), mirroring `seq-node.ts` / `node-fs-resolver.ts`.
+
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
+import { setLabelImageFileReader } from "./label-images.js";
+
+/**
+ * Read a `.tif`/`.tiff` path. A file → its bytes; a directory → the bytes of its
+ * `*.tif`/`*.tiff` entries, sorted alphanumerically (one file per frame),
+ * matching Python `read_label_images`.
+ */
+async function readTiffPath(
+  path: string
+): Promise<Uint8Array | { files: Uint8Array[] }> {
+  const stat = fs.statSync(path);
+  if (stat.isDirectory()) {
+    const entries = fs
+      .readdirSync(path)
+      .filter((name) => /\.tiff?$/i.test(name))
+      .sort();
+    const files = entries.map(
+      (name) => new Uint8Array(fs.readFileSync(nodePath.join(path, name)))
+    );
+    return { files };
+  }
+  return new Uint8Array(fs.readFileSync(path));
+}
+
+setLabelImageFileReader(readTiffPath);
+
+export { readTiffPath };

--- a/src/io/label-images.ts
+++ b/src/io/label-images.ts
@@ -1,0 +1,426 @@
+// src/io/label-images.ts
+//
+// Reader for dense integer LABEL-IMAGE TIFFs (one label ID per pixel), produced
+// by segmentation tools (Cellpose, StarDist, ImageJ, ilastik, ...). Port of the
+// read path of Python sleap-io's `sleap_io/io/tiff.py` `read_label_images`
+// (talmolab/sleap-io PR #421); see issue #140 for scope/decisions.
+//
+// Browser-reachable: this module must NOT statically import `node:fs`. Decoding
+// uses the optional `tiff` package (lazy-imported). Path reading on Node is
+// provided through an injected reader (see `label-images-node.ts`); browsers
+// pass a `File`/`Blob`.
+
+import { LabelImage, UserLabelImage } from "../model/label-image.js";
+import type { Track } from "../model/instance.js";
+
+/** How TIFF pages map onto LabelImage frames. Mirrors Python `pages_as`. */
+export type PagesAs = "auto" | "time" | "classes";
+
+export interface LoadLabelImagesOptions {
+  /** Page→frame mapping. Default `"auto"` (parity with Python). */
+  pagesAs?: PagesAs;
+  /**
+   * Auto-create one Track per unique non-zero label ID (shared across frames).
+   * Default `false` — pure-segmentation parity with `LabelImage.fromArray`
+   * (PR #387). Ignored in `classes` mode (matches Python). Time mode only.
+   */
+  createTracks?: boolean;
+  /** Explicit Track assignment by label ID (`Map`) or positional (`Track[]`). Time mode. */
+  tracks?: Map<number, Track> | Track[] | null;
+  /**
+   * Explicit category assignment. `Map<id,string>` (by label ID) in time mode;
+   * `string[]` (positional, one per class) in classes mode.
+   */
+  categories?: Map<number, string> | string[] | null;
+  /** Decode only this subset of pages (0-based), in order. Default: all pages. */
+  frames?: number[] | null;
+  /** Source string stored on each LabelImage. Defaults to filename / blob name. */
+  source?: string;
+}
+
+/**
+ * Reader for a `.tif`/`.tiff` path (Node only). Returns the file bytes, or a
+ * list of per-file byte arrays for a directory. Registered by
+ * `label-images-node.ts`; absent in the browser graph (issue #70).
+ */
+export type LabelImageFileReader = (
+  path: string
+) => Promise<Uint8Array | { files: Uint8Array[] }>;
+
+let fileReader: LabelImageFileReader | null = null;
+
+/** Register the Node `node:fs`-backed TIFF path reader. */
+export function setLabelImageFileReader(fn: LabelImageFileReader | null): void {
+  fileReader = fn;
+}
+
+// Minimal shape of a decoded TIFF IFD from the `tiff` package.
+interface TiffIfdLike {
+  width: number;
+  height: number;
+  bitsPerSample: number;
+  samplesPerPixel: number;
+  sampleFormat?: number;
+  imageDescription?: string;
+  data: ArrayLike<number>;
+}
+
+type Layout = "YX" | "TYX" | "CYX" | "TCYX" | "unknown";
+
+// One-shot ambiguous-multipage warnings, deduped by message text (Python relies
+// on the stdlib `warnings` once-per-site filter; JS has no equivalent).
+const warnedMessages = new Set<string>();
+
+async function decodeTiff(
+  bytes: Uint8Array,
+  opts?: { pages?: number[]; ignoreImageData?: boolean }
+): Promise<TiffIfdLike[]> {
+  // `tiff` is an optionalDependency (issue #140 decision 3): externalized in the
+  // tsup build and lazy-imported here so it resolves from the consumer's install
+  // at runtime (skia-canvas pattern) and never lands in bundles that don't read
+  // TIFFs. A missing package surfaces the actionable error below.
+  let mod: { decode: (b: Uint8Array, o?: unknown) => TiffIfdLike[] };
+  try {
+    mod = (await import("tiff")) as unknown as typeof mod;
+  } catch {
+    throw new Error(
+      "Reading TIFF label images requires the optional `tiff` package. " +
+        "Install it with: npm install tiff"
+    );
+  }
+  try {
+    return mod.decode(bytes, opts);
+  } catch (err) {
+    // `tiff` throws "Unsupported bitDepth: 32" for 32/64-bit INTEGER rasters.
+    // Surface a clear, actionable message (also caught proactively in
+    // validatePageDtype when headers are readable).
+    const m = String((err as Error)?.message ?? "");
+    if (/bit\s*depth/i.test(m) && /(32|64)/.test(m)) {
+      throw new Error(
+        `32-bit integer TIFFs are not yet supported (${m}). Re-export the label ` +
+          "image as uint16, or split into <=65535 objects."
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * Load dense integer label images from a TIFF file (or a directory of TIFFs on
+ * Node). Mirrors Python `read_label_images`.
+ *
+ * @param source Node: a path string (file or directory). Browser: a `File`/`Blob`.
+ * @returns One `UserLabelImage` per page in `time`/`auto`(→time) mode, or a
+ *   single-element array in `classes` mode.
+ */
+export async function loadLabelImages(
+  source: string | File | Blob,
+  options: LoadLabelImagesOptions = {}
+): Promise<UserLabelImage[]> {
+  const pagesAs: PagesAs = options.pagesAs ?? "auto";
+  if (pagesAs !== "auto" && pagesAs !== "time" && pagesAs !== "classes") {
+    throw new Error(
+      `pagesAs must be 'auto', 'time', or 'classes'; got ${JSON.stringify(pagesAs)}.`
+    );
+  }
+
+  const isBlob = typeof Blob !== "undefined" && source instanceof Blob;
+  if (isBlob) {
+    const bytes = new Uint8Array(await (source as Blob).arrayBuffer());
+    const src = options.source ?? (source as File).name ?? "";
+    return decodeSingleFile(bytes, pagesAs, options, src);
+  }
+
+  if (!fileReader) {
+    throw new Error(
+      "Reading TIFF label images from a path requires the Node entry point " +
+        "(`@talmolab/sleap-io.js`). In the browser, pass a File/Blob instead."
+    );
+  }
+  const read = await fileReader(source as string);
+  const src = options.source ?? (source as string);
+  if (read instanceof Uint8Array) {
+    return decodeSingleFile(read, pagesAs, options, src);
+  }
+  return decodeDirectory(read.files, pagesAs, options, src);
+}
+
+/** Decode a single multi-page TIFF buffer. */
+async function decodeSingleFile(
+  bytes: Uint8Array,
+  pagesAs: PagesAs,
+  options: LoadLabelImagesOptions,
+  source: string
+): Promise<UserLabelImage[]> {
+  // Cheap header scan: validate dtype, count pages, read page-0 metadata.
+  const meta = await decodeTiff(bytes, { ignoreImageData: true });
+  const nPages = meta.length;
+  if (nPages === 0) return [];
+  for (const ifd of meta) validatePageDtype(ifd);
+
+  // Resolve layout (priority: explicit pagesAs -> tag-270 metadata -> fallback).
+  let layout: Layout;
+  if (pagesAs === "time") layout = "TYX";
+  else if (pagesAs === "classes") layout = "CYX";
+  else layout = inferAxes(meta[0].imageDescription, nPages);
+
+  if (layout === "TCYX") {
+    throw new Error(
+      "4D TCYX (time + channel) TIFF stacks are not yet supported. Pass " +
+        "pagesAs: 'time' or 'classes' explicitly, or split the stack by channel."
+    );
+  }
+
+  // Page subset (0-based). Free via the decoder's `pages` option.
+  const pageIndices = normalizeFrames(options.frames, nPages);
+  if (pageIndices.length === 0) return [];
+
+  const ifds = await decodeTiff(bytes, { pages: pageIndices });
+  const pages = ifds.map(pageTo2D);
+
+  if (layout === "CYX") {
+    return [buildClassStack(pages, options, source)];
+  }
+
+  // YX / TYX / unknown -> time.
+  if (
+    pagesAs === "auto" &&
+    layout === "unknown" &&
+    nPages > 1 &&
+    pagesCouldBeClassStack(pages)
+  ) {
+    warnAmbiguous(source, nPages, dtypeName(meta[0]));
+  }
+  return buildTimeStack(pages, options, source);
+}
+
+/** Decode a directory of single-frame TIFFs (Node only). One file per frame. */
+async function decodeDirectory(
+  files: Uint8Array[],
+  pagesAs: PagesAs,
+  options: LoadLabelImagesOptions,
+  source: string
+): Promise<UserLabelImage[]> {
+  if (files.length === 0) return [];
+  const fileIndices = normalizeFrames(options.frames, files.length);
+  const pages: number[][][] = [];
+  for (const i of fileIndices) {
+    const ifds = await decodeTiff(files[i], { pages: [0] });
+    if (ifds.length === 0) continue;
+    validatePageDtype(ifds[0]);
+    pages.push(pageTo2D(ifds[0]));
+  }
+  if (pages.length === 0) return [];
+  // Directories never inspect metadata and never emit the ambiguous warning.
+  if (pagesAs === "classes") return [buildClassStack(pages, options, source)];
+  return buildTimeStack(pages, options, source);
+}
+
+// --- dtype / geometry validation -------------------------------------------
+
+function validatePageDtype(ifd: TiffIfdLike): void {
+  if (ifd.samplesPerPixel !== 1) {
+    throw new Error(
+      `Expected a single-channel (2D) label-image page, got ${ifd.samplesPerPixel} ` +
+        "samples per pixel. Multi-channel/RGB TIFFs are not supported."
+    );
+  }
+  // MVP supports only unsigned 8/16-bit label rasters. Float, signed, and 32-bit
+  // integer are deferred (issue #140) and rejected with a clear, actionable error
+  // rather than silently truncated.
+  const fmt = ifd.sampleFormat ?? 1; // 1=uint, 2=int, 3=float
+  if (fmt === 3) {
+    throw new Error(
+      `Floating-point TIFFs are not supported as label images (bitsPerSample=${ifd.bitsPerSample}). ` +
+        "Re-export as uint8 or uint16."
+    );
+  }
+  if (fmt === 2) {
+    throw new Error(
+      "Signed-integer TIFFs are not supported as label images. Re-export as uint8 or uint16."
+    );
+  }
+  if (ifd.bitsPerSample !== 8 && ifd.bitsPerSample !== 16) {
+    throw new Error(
+      `Only 8- and 16-bit unsigned label images are supported (got ${ifd.bitsPerSample}-bit). ` +
+        "Re-export as uint16, or split into <=65535 objects."
+    );
+  }
+}
+
+function dtypeName(ifd: TiffIfdLike): string {
+  const fmt = ifd.sampleFormat ?? 1;
+  const kind = fmt === 3 ? "float" : fmt === 2 ? "int" : "uint";
+  return `${kind}${ifd.bitsPerSample}`;
+}
+
+// --- axis inference from tag-270 metadata ----------------------------------
+
+/**
+ * Infer the page layout from the page-0 `ImageDescription` (tag 270). Only
+ * ImageJ-hyperstack and OME-XML metadata are authoritative; a plain multi-page
+ * TIFF reports `"unknown"`. A single page is always `"YX"`.
+ */
+export function inferAxes(description: string | undefined, nPages: number): Layout {
+  if (nPages === 1) return "YX";
+  if (!description) return "unknown";
+
+  const dims = parseImageJDims(description) ?? parseOmeDims(description);
+  if (!dims) return "unknown";
+  return dimsToLayout(dims.c, dims.z, dims.t);
+}
+
+function dimsToLayout(c: number, z: number, t: number): Layout {
+  const time = Math.max(z, 1) * Math.max(t, 1);
+  if (c > 1 && time <= 1) return "CYX";
+  if (c <= 1 && time > 1) return "TYX";
+  if (c > 1 && time > 1) return "TCYX";
+  return "unknown";
+}
+
+/** Parse ImageJ-hyperstack `key=value` ImageDescription. */
+function parseImageJDims(
+  desc: string
+): { c: number; z: number; t: number } | null {
+  if (!/(^|\n)ImageJ=/.test(desc)) return null;
+  const get = (key: string): number => {
+    const m = desc.match(new RegExp(`(?:^|\\n)${key}=(\\d+)`));
+    return m ? parseInt(m[1], 10) : 1;
+  };
+  return { c: get("channels"), z: get("slices"), t: get("frames") };
+}
+
+/** Parse OME-XML `<Pixels SizeC/SizeT/SizeZ=...>` ImageDescription. */
+function parseOmeDims(desc: string): { c: number; z: number; t: number } | null {
+  if (!/<\s*OME[\s>]|openmicroscopy\.org/i.test(desc)) return null;
+  const pixels = desc.match(/<\s*Pixels\b[^>]*>/i);
+  const attrs = pixels ? pixels[0] : desc;
+  const get = (attr: string): number => {
+    const m = attrs.match(new RegExp(`${attr}\\s*=\\s*["'](\\d+)["']`, "i"));
+    return m ? parseInt(m[1], 10) : 1;
+  };
+  return { c: get("SizeC"), z: get("SizeZ"), t: get("SizeT") };
+}
+
+// --- label-ID inference (classes mode) -------------------------------------
+
+/**
+ * If every page is a single-class binary (exactly one distinct positive value)
+ * and those per-page values are all distinct, return them (COCO-style ID
+ * preservation). Otherwise return `null` (positional `1..N`). Mirrors Python
+ * `_infer_label_ids_from_pages`.
+ */
+export function inferLabelIdsFromPages(pages: number[][][]): number[] | null {
+  const ids: number[] = [];
+  for (const page of pages) {
+    const positive = new Set<number>();
+    for (const row of page) {
+      for (const v of row) {
+        if (v > 0) {
+          positive.add(v);
+          if (positive.size > 1) return null;
+        }
+      }
+    }
+    if (positive.size !== 1) return null;
+    ids.push(positive.values().next().value as number);
+  }
+  if (new Set(ids).size !== ids.length) return null;
+  return ids;
+}
+
+/** True unless any page has >=2 distinct positive values (Python `_pages_could_be_class_stack`). */
+function pagesCouldBeClassStack(pages: number[][][]): boolean {
+  for (const page of pages) {
+    const positive = new Set<number>();
+    for (const row of page) {
+      for (const v of row) {
+        if (v > 0) {
+          positive.add(v);
+          if (positive.size >= 2) return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// --- builders ---------------------------------------------------------------
+
+function buildTimeStack(
+  pages: number[][][],
+  options: LoadLabelImagesOptions,
+  source: string
+): UserLabelImage[] {
+  return LabelImage.fromStack({
+    data: pages,
+    tracks: options.tracks ?? null,
+    categories: options.categories ?? null,
+    createTracks: options.createTracks ?? false,
+    source,
+  });
+}
+
+function buildClassStack(
+  pages: number[][][],
+  options: LoadLabelImagesOptions,
+  source: string
+): UserLabelImage {
+  const labelIds = inferLabelIdsFromPages(pages);
+  const masks = pages.map((page) => page.map((row) => row.map((v) => (v > 0 ? 1 : 0))));
+  const categories = coerceCategoriesToList(options.categories, pages.length);
+  return LabelImage.fromBinaryMasks(masks, {
+    labelIds: labelIds ?? undefined,
+    categories: categories ?? undefined,
+    source,
+  });
+}
+
+/** Coerce categories to a positional list of length `n`, or `null` if all empty. */
+function coerceCategoriesToList(
+  categories: Map<number, string> | string[] | null | undefined,
+  n: number
+): string[] | null {
+  if (categories == null) return null;
+  let list: string[];
+  if (Array.isArray(categories)) {
+    list = Array.from({ length: n }, (_, i) => categories[i] ?? "");
+  } else {
+    // Class-mode categories key by POSITIONAL post-composite IDs 1..N, NOT the
+    // preserved COCO label IDs (Python `_categories_as_list` parity).
+    list = Array.from({ length: n }, (_, i) => categories.get(i + 1) ?? "");
+  }
+  return list.some((c) => c !== "") ? list : null;
+}
+
+// --- helpers ----------------------------------------------------------------
+
+function normalizeFrames(
+  frames: number[] | null | undefined,
+  n: number
+): number[] {
+  if (frames == null) return Array.from({ length: n }, (_, i) => i);
+  return frames.filter((i) => i >= 0 && i < n);
+}
+
+/** Convert a decoded IFD's flat (uint8/uint16) sample array to a 2D `number[][]`. */
+function pageTo2D(ifd: TiffIfdLike): number[][] {
+  const { width, height, data } = ifd;
+  const out: number[][] = new Array(height);
+  for (let r = 0; r < height; r++) {
+    const row = new Array<number>(width);
+    for (let c = 0; c < width; c++) row[c] = data[r * width + c];
+    out[r] = row;
+  }
+  return out;
+}
+
+function warnAmbiguous(path: string, nPages: number, dtype: string): void {
+  const msg =
+    `Loaded ${nPages} frames from multi-page TIFF ${path} with no axis metadata ` +
+    `(dtype=${dtype}). Assuming pages are time. If pages represent classes for a ` +
+    `single frame, pass pagesAs: 'classes' to route through fromBinaryMasks with categories.`;
+  if (warnedMessages.has(msg)) return;
+  warnedMessages.add(msg);
+  console.warn(msg);
+}

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -8,6 +8,16 @@ import { createVideoBackend, VideoBackendType } from "../video/factory.js";
 import { OpenH5Options, SlpSource, isStreamingSupported } from "../codecs/slp/h5.js";
 import { readLabels as readAnalysisH5, writeLabels as writeAnalysisH5 } from "./analysis-h5.js";
 
+// TIFF label-image reader (browser-safe core; Node path reading is registered
+// via the side-effect import of ./label-images-node.js in the Node entry).
+export {
+  loadLabelImages,
+  setLabelImageFileReader,
+  type PagesAs,
+  type LoadLabelImagesOptions,
+  type LabelImageFileReader,
+} from "./label-images.js";
+
 function isNode(): boolean {
   return typeof process !== "undefined" && !!process.versions?.node;
 }

--- a/tests/io/label-images.test.ts
+++ b/tests/io/label-images.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect } from "../bun-test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadLabelImages, inferAxes, inferLabelIdsFromPages } from "../../src/io/label-images";
+import "../../src/io/label-images-node"; // register node:fs reader
+import { Track } from "../../src/model/instance";
+
+// ---------------------------------------------------------------------------
+// Minimal little-endian, uncompressed, strip-based TIFF writer (one strip per
+// page). Adapted from the design prototype's make_tiff.ts. The `tiff` package is
+// decode-only, so tests synthesize their own fixtures.
+// ---------------------------------------------------------------------------
+
+interface PageSpec {
+  width: number;
+  height: number;
+  bitsPerSample: 8 | 16 | 32;
+  pixels: number[]; // row-major, length width*height (short arrays zero-padded)
+  description?: string;
+  sampleFormat?: number; // 1=uint(default), 2=int, 3=float
+  samplesPerPixel?: number; // default 1
+}
+
+const TYPE_SHORT = 3;
+const TYPE_LONG = 4;
+const TYPE_ASCII = 2;
+
+function makeTiff(pages: PageSpec[]): Uint8Array {
+  const HEADER = 8;
+  const ifdByteSize = (p: PageSpec): number => {
+    let n = 9; // base tags
+    if (p.description !== undefined) n += 1;
+    if (p.sampleFormat !== undefined) n += 1;
+    return 2 + n * 12 + 4;
+  };
+
+  let cursor = HEADER;
+  const layout = pages.map((p) => {
+    const ifdOffset = cursor;
+    cursor += ifdByteSize(p);
+    let descOffset = 0;
+    let descBytes = 0;
+    if (p.description !== undefined) {
+      descBytes = new TextEncoder().encode(p.description).length + 1;
+      descOffset = cursor;
+      cursor += descBytes;
+      if (cursor % 2 !== 0) cursor += 1;
+    }
+    const bytesPerSample = p.bitsPerSample / 8;
+    const stripBytes = p.width * p.height * (p.samplesPerPixel ?? 1) * bytesPerSample;
+    const stripOffset = cursor;
+    cursor += stripBytes;
+    if (cursor % 2 !== 0) cursor += 1;
+    return { p, ifdOffset, descOffset, descBytes, stripOffset, stripBytes };
+  });
+
+  const buf = new Uint8Array(cursor);
+  const dv = new DataView(buf.buffer);
+  const LE = true;
+  buf[0] = 0x49;
+  buf[1] = 0x49;
+  dv.setUint16(2, 42, LE);
+  dv.setUint32(4, layout[0].ifdOffset, LE);
+
+  for (let i = 0; i < layout.length; i++) {
+    const L = layout[i];
+    const p = L.p;
+    const nextIFD = i + 1 < layout.length ? layout[i + 1].ifdOffset : 0;
+    const entries: { tag: number; type: number; count: number; value: number }[] = [];
+    entries.push({ tag: 256, type: TYPE_SHORT, count: 1, value: p.width });
+    entries.push({ tag: 257, type: TYPE_SHORT, count: 1, value: p.height });
+    entries.push({ tag: 258, type: TYPE_SHORT, count: 1, value: p.bitsPerSample });
+    entries.push({ tag: 259, type: TYPE_SHORT, count: 1, value: 1 }); // no compression
+    entries.push({ tag: 262, type: TYPE_SHORT, count: 1, value: 1 }); // BlackIsZero
+    if (p.description !== undefined) {
+      entries.push({ tag: 270, type: TYPE_ASCII, count: L.descBytes, value: L.descOffset });
+    }
+    entries.push({ tag: 273, type: TYPE_LONG, count: 1, value: L.stripOffset });
+    entries.push({ tag: 277, type: TYPE_SHORT, count: 1, value: p.samplesPerPixel ?? 1 });
+    entries.push({ tag: 278, type: TYPE_SHORT, count: 1, value: p.height });
+    entries.push({ tag: 279, type: TYPE_LONG, count: 1, value: L.stripBytes });
+    if (p.sampleFormat !== undefined) {
+      entries.push({ tag: 339, type: TYPE_SHORT, count: 1, value: p.sampleFormat });
+    }
+    entries.sort((a, b) => a.tag - b.tag);
+
+    let o = L.ifdOffset;
+    dv.setUint16(o, entries.length, LE);
+    o += 2;
+    for (const e of entries) {
+      dv.setUint16(o, e.tag, LE);
+      dv.setUint16(o + 2, e.type, LE);
+      dv.setUint32(o + 4, e.count, LE);
+      if (e.type === TYPE_SHORT && e.count === 1) {
+        dv.setUint16(o + 8, e.value, LE);
+        dv.setUint16(o + 10, 0, LE);
+      } else {
+        dv.setUint32(o + 8, e.value, LE);
+      }
+      o += 12;
+    }
+    dv.setUint32(o, nextIFD, LE);
+
+    if (p.description !== undefined) {
+      const enc = new TextEncoder().encode(p.description);
+      buf.set(enc, L.descOffset);
+      buf[L.descOffset + enc.length] = 0;
+    }
+    if (p.bitsPerSample === 8) {
+      for (let k = 0; k < p.pixels.length; k++) buf[L.stripOffset + k] = p.pixels[k] & 0xff;
+    } else if (p.bitsPerSample === 16) {
+      for (let k = 0; k < p.pixels.length; k++) dv.setUint16(L.stripOffset + k * 2, p.pixels[k] & 0xffff, LE);
+    } else {
+      for (let k = 0; k < p.pixels.length; k++) dv.setUint32(L.stripOffset + k * 4, p.pixels[k] >>> 0, LE);
+    }
+  }
+  return buf;
+}
+
+/** Build a page from a 2D number array. */
+function page(rows: number[][], opts?: Partial<PageSpec>): PageSpec {
+  const height = rows.length;
+  const width = rows[0].length;
+  const pixels: number[] = [];
+  for (const row of rows) pixels.push(...row);
+  return { width, height, bitsPerSample: 8, pixels, ...opts };
+}
+
+const blobOf = (bytes: Uint8Array): Blob => new Blob([bytes.buffer as ArrayBuffer]);
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("inferAxes", () => {
+  it("single page is YX", () => {
+    expect(inferAxes(undefined, 1)).toBe("YX");
+  });
+  it("plain multipage with no metadata is unknown", () => {
+    expect(inferAxes(undefined, 3)).toBe("unknown");
+  });
+  it("ImageJ multi-channel single-frame is CYX", () => {
+    expect(inferAxes("ImageJ=1.53\nimages=3\nchannels=3\nslices=1\nframes=1\n", 3)).toBe("CYX");
+  });
+  it("ImageJ z/time stack is TYX", () => {
+    expect(inferAxes("ImageJ=1.53\nimages=3\nslices=3\n", 3)).toBe("TYX");
+    expect(inferAxes("ImageJ=1.53\nimages=4\nframes=4\n", 4)).toBe("TYX");
+  });
+  it("ImageJ channels+frames is TCYX", () => {
+    expect(inferAxes("ImageJ=1.53\nimages=4\nchannels=2\nframes=2\n", 4)).toBe("TCYX");
+  });
+  it("OME SizeC>1 single timepoint is CYX", () => {
+    const ome = '<?xml version="1.0"?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"><Image><Pixels SizeC="3" SizeT="1" SizeZ="1" SizeX="4" SizeY="4" DimensionOrder="XYCZT"/></Image></OME>';
+    expect(inferAxes(ome, 3)).toBe("CYX");
+  });
+});
+
+describe("inferLabelIdsFromPages", () => {
+  it("preserves distinct single-class page IDs", () => {
+    expect(inferLabelIdsFromPages([[[5, 0]], [[0, 17]], [[99, 0]]])).toEqual([5, 17, 99]);
+  });
+  it("returns null for colliding IDs (purely binary)", () => {
+    expect(inferLabelIdsFromPages([[[1, 0]], [[0, 1]]])).toBeNull();
+  });
+  it("returns null when a page has multiple positive values", () => {
+    expect(inferLabelIdsFromPages([[[1, 2]], [[0, 3]]])).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadLabelImages — time mode
+// ---------------------------------------------------------------------------
+
+describe("loadLabelImages — time mode", () => {
+  it("reads a single page as one label image", async () => {
+    const tiff = makeTiff([page([[0, 1], [2, 0]])]);
+    const lis = await loadLabelImages(blobOf(tiff));
+    expect(lis).toHaveLength(1);
+    expect(lis[0].height).toBe(2);
+    expect(lis[0].width).toBe(2);
+    expect(lis[0].labelIds).toEqual([1, 2]);
+  });
+
+  it("preserves per-page integer values across a multi-page time stack", async () => {
+    // Each page has 2+ distinct labels -> not a class stack -> time, no warning.
+    const tiff = makeTiff([
+      page([[0, 1], [2, 0]]),
+      page([[3, 0], [0, 4]]),
+      page([[5, 6], [0, 0]]),
+    ]);
+    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time" });
+    expect(lis).toHaveLength(3);
+    expect(lis[0].labelIds).toEqual([1, 2]);
+    expect(lis[1].labelIds).toEqual([3, 4]);
+    expect(lis[2].labelIds).toEqual([5, 6]);
+  });
+
+  it("uint16 values survive intact", async () => {
+    const tiff = makeTiff([page([[0, 60000], [300, 0]], { bitsPerSample: 16 })]);
+    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time" });
+    expect(lis[0].labelIds).toEqual([300, 60000]);
+  });
+
+  it("createTracks:false yields no tracks; true auto-creates shared tracks", async () => {
+    const tiff = makeTiff([page([[0, 1], [2, 0]]), page([[1, 0], [0, 2]])]);
+    const trackless = await loadLabelImages(blobOf(tiff), { pagesAs: "time" });
+    expect(trackless[0].tracks).toEqual([]);
+
+    const tracked = await loadLabelImages(blobOf(tiff), { pagesAs: "time", createTracks: true });
+    expect(tracked[0].tracks).toHaveLength(2);
+    // Shared Track objects across frames (same label IDs).
+    expect(tracked[0].objects.get(1)!.track).toBe(tracked[1].objects.get(1)!.track);
+  });
+
+  it("applies categories by label ID (Map) in time mode", async () => {
+    const tiff = makeTiff([page([[0, 1], [2, 0]])]);
+    const lis = await loadLabelImages(blobOf(tiff), {
+      pagesAs: "time",
+      categories: new Map([[1, "cell"], [2, "nucleus"]]),
+    });
+    expect(lis[0].objects.get(1)!.category).toBe("cell");
+    expect(lis[0].objects.get(2)!.category).toBe("nucleus");
+  });
+
+  it("honors explicit tracks (positional)", async () => {
+    const tiff = makeTiff([page([[0, 1], [2, 0]])]);
+    const a = new Track("A");
+    const b = new Track("B");
+    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time", tracks: [a, b] });
+    expect(lis[0].objects.get(1)!.track).toBe(a);
+    expect(lis[0].objects.get(2)!.track).toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadLabelImages — classes mode
+// ---------------------------------------------------------------------------
+
+describe("loadLabelImages — classes mode", () => {
+  it("composites single-class pages and preserves distinct COCO IDs", async () => {
+    const tiff = makeTiff([
+      page([[5, 0], [0, 0]]),
+      page([[0, 17], [0, 0]]),
+      page([[0, 0], [99, 0]]),
+    ]);
+    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "classes" });
+    expect(lis).toHaveLength(1);
+    expect(lis[0].labelIds).toEqual([5, 17, 99]);
+  });
+
+  it("renumbers positionally 1..N for purely-binary pages", async () => {
+    const tiff = makeTiff([
+      page([[1, 0], [0, 0]]),
+      page([[0, 1], [0, 0]]),
+      page([[0, 0], [1, 0]]),
+    ]);
+    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "classes" });
+    expect(lis[0].labelIds).toEqual([1, 2, 3]);
+  });
+
+  it("assigns positional categories per class", async () => {
+    const tiff = makeTiff([page([[1, 0]]), page([[0, 1]])]);
+    const lis = await loadLabelImages(blobOf(tiff), {
+      pagesAs: "classes",
+      categories: ["cell", "debris"],
+    });
+    expect(lis[0].objects.get(1)!.category).toBe("cell");
+    expect(lis[0].objects.get(2)!.category).toBe("debris");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// auto-detection
+// ---------------------------------------------------------------------------
+
+describe("loadLabelImages — auto detection", () => {
+  it("ImageJ CYX metadata routes to classes (1 image)", async () => {
+    const desc = "ImageJ=1.53\nimages=3\nchannels=3\nslices=1\nframes=1\nhyperstack=true\n";
+    // Distinct pixel positions per class so composited IDs don't overlap.
+    const tiff = makeTiff([
+      page([[5, 0, 0]], { description: desc }),
+      page([[0, 17, 0]]),
+      page([[0, 0, 99]]),
+    ]);
+    const lis = await loadLabelImages(blobOf(tiff)); // auto
+    expect(lis).toHaveLength(1);
+    expect(lis[0].labelIds).toEqual([5, 17, 99]);
+  });
+
+  it("ImageJ time metadata routes to time (N images)", async () => {
+    const desc = "ImageJ=1.53\nimages=3\nslices=3\n";
+    const tiff = makeTiff([
+      page([[1, 2]], { description: desc }),
+      page([[3, 0]]),
+      page([[0, 4]]),
+    ]);
+    const lis = await loadLabelImages(blobOf(tiff)); // auto
+    expect(lis).toHaveLength(3);
+  });
+
+  it("OME CYX metadata routes to classes", async () => {
+    const ome = '<?xml version="1.0"?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"><Image><Pixels SizeC="2" SizeT="1" SizeZ="1"/></Image></OME>';
+    const tiff = makeTiff([page([[7, 0]], { description: ome }), page([[0, 8]])]);
+    const lis = await loadLabelImages(blobOf(tiff));
+    expect(lis).toHaveLength(1);
+    expect(lis[0].labelIds).toEqual([7, 8]);
+  });
+
+  it("TCYX metadata throws a clear deferred error", async () => {
+    const desc = "ImageJ=1.53\nimages=4\nchannels=2\nframes=2\n";
+    const tiff = makeTiff([
+      page([[1, 0]], { description: desc }),
+      page([[0, 1]]),
+      page([[1, 0]]),
+      page([[0, 1]]),
+    ]);
+    await expect(loadLabelImages(blobOf(tiff))).rejects.toThrow("TCYX");
+  });
+
+  it("warns and routes to time for an ambiguous plain class-like stack", async () => {
+    const tiff = makeTiff([page([[1, 0]]), page([[0, 1]]), page([[1, 0]])]);
+    const warnings: string[] = [];
+    const orig = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(String(args[0]));
+    try {
+      const lis = await loadLabelImages(blobOf(tiff), { source: "ambiguous-uniq.tif" });
+      expect(lis).toHaveLength(3); // routed to time
+    } finally {
+      console.warn = orig;
+    }
+    expect(warnings.some((w) => /multi-page TIFF/.test(w) && /pagesAs: 'classes'/.test(w))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// frames subset, errors, node path / directory
+// ---------------------------------------------------------------------------
+
+describe("loadLabelImages — frames, errors, paths", () => {
+  it("selects a subset of pages with frames", async () => {
+    const tiff = makeTiff([
+      page([[1, 2]]),
+      page([[3, 4]]),
+      page([[5, 6]]),
+      page([[7, 8]]),
+    ]);
+    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time", frames: [0, 2] });
+    expect(lis).toHaveLength(2);
+    expect(lis[0].labelIds).toEqual([1, 2]);
+    expect(lis[1].labelIds).toEqual([5, 6]);
+  });
+
+  it("throws a clear error for 32-bit integer TIFFs", async () => {
+    const tiff = makeTiff([page([[1, 2], [3, 4]], { bitsPerSample: 32, sampleFormat: 1 })]);
+    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "time" })).rejects.toThrow(
+      /8- and 16-bit unsigned/
+    );
+  });
+
+  it("rejects floating-point TIFFs (not silently truncated)", async () => {
+    const tiff = makeTiff([page([[1, 2], [3, 4]], { bitsPerSample: 32, sampleFormat: 3 })]);
+    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "time" })).rejects.toThrow(
+      /Floating-point/
+    );
+  });
+
+  it("rejects multi-channel (RGB) TIFFs", async () => {
+    const tiff = makeTiff([
+      { width: 2, height: 1, bitsPerSample: 8, samplesPerPixel: 3, pixels: [] },
+    ]);
+    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "time" })).rejects.toThrow(
+      /single-channel/
+    );
+  });
+
+  it("assigns class-mode categories from a Map (positional 1..N keys)", async () => {
+    const tiff = makeTiff([page([[7, 0]]), page([[0, 8]])]);
+    const lis = await loadLabelImages(blobOf(tiff), {
+      pagesAs: "classes",
+      categories: new Map([[1, "cell"], [2, "debris"]]),
+    });
+    // Categories key by positional post-composite IDs 1..N, even though the
+    // preserved label IDs are 7 and 8.
+    expect(lis[0].objects.get(7)!.category).toBe("cell");
+    expect(lis[0].objects.get(8)!.category).toBe("debris");
+  });
+
+  it("ignores out-of-range frame indices", async () => {
+    const tiff = makeTiff([page([[1, 2]]), page([[3, 4]]), page([[5, 6]])]);
+    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time", frames: [0, 5, 2] });
+    expect(lis).toHaveLength(2); // 5 is out of range -> dropped
+    expect(lis[0].labelIds).toEqual([1, 2]);
+    expect(lis[1].labelIds).toEqual([5, 6]);
+  });
+
+  it("selects a subset of files from a directory with frames", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "li-dirf-"));
+    fs.writeFileSync(path.join(dir, "00.tif"), makeTiff([page([[1, 0]])]));
+    fs.writeFileSync(path.join(dir, "01.tif"), makeTiff([page([[0, 2]])]));
+    fs.writeFileSync(path.join(dir, "02.tif"), makeTiff([page([[3, 0]])]));
+    try {
+      const lis = await loadLabelImages(dir, { pagesAs: "time", frames: [0, 2] });
+      expect(lis).toHaveLength(2);
+      expect(lis[0].labelIds).toEqual([1]);
+      expect(lis[1].labelIds).toEqual([3]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns [] for an empty directory", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "li-empty-"));
+    try {
+      expect(await loadLabelImages(dir)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws on an invalid pagesAs value", async () => {
+    const tiff = makeTiff([page([[1, 0]])]);
+    // @ts-expect-error testing runtime validation
+    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "bogus" })).rejects.toThrow(
+      "pagesAs must be"
+    );
+  });
+
+  it("reads a .tif from a path (node:fs reader)", async () => {
+    const tiff = makeTiff([page([[10, 0], [0, 20]]), page([[0, 30], [40, 0]])]);
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "li-test-"));
+    const file = path.join(dir, "labels.tif");
+    fs.writeFileSync(file, tiff);
+    try {
+      const lis = await loadLabelImages(file, { pagesAs: "time" });
+      expect(lis).toHaveLength(2);
+      expect(lis[0].labelIds).toEqual([10, 20]);
+      expect(lis[1].labelIds).toEqual([30, 40]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads a directory of single-frame TIFFs (alphanumeric order)", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "li-dir-"));
+    fs.writeFileSync(path.join(dir, "00.tif"), makeTiff([page([[1, 0]])]));
+    fs.writeFileSync(path.join(dir, "01.tif"), makeTiff([page([[0, 2]])]));
+    fs.writeFileSync(path.join(dir, "02.tiff"), makeTiff([page([[3, 0]])]));
+    try {
+      const lis = await loadLabelImages(dir, { pagesAs: "time" });
+      expect(lis).toHaveLength(3);
+      expect(lis[0].labelIds).toEqual([1]);
+      expect(lis[1].labelIds).toEqual([2]);
+      expect(lis[2].labelIds).toEqual([3]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a TIFF **label-image reader** — `loadLabelImages()` — porting the read path of Python sleap-io's `read_label_images` (`sleap_io/io/tiff.py`, [PR #421](https://github.com/talmolab/sleap-io/pull/421)). This closes the **last v0.4.0 parity gap** (#110); implements #140.

TIFF label images are dense integer rasters (one label ID per pixel) produced by segmentation tools (Cellpose, StarDist, ImageJ, ilastik). They read into the existing `LabelImage` model — **no model changes**.

Backed by a design investigation (research + three Bun-tested decoder prototypes) and an adversarial multi-agent review; artifacts live in `scratch/2026-05-29-tiff-loadlabelimages/` (gitignored).

## API

```ts
export type PagesAs = "auto" | "time" | "classes";
export interface LoadLabelImagesOptions {
  pagesAs?: PagesAs;                              // default "auto"
  createTracks?: boolean;                         // default false (#387 parity)
  tracks?: Map<number, Track> | Track[] | null;
  categories?: Map<number, string> | string[] | null;
  frames?: number[] | null;                       // page subset (0-based)
  source?: string;
}
// Node: a path (file or directory). Browser: a File/Blob.
export async function loadLabelImages(
  source: string | File | Blob,
  options?: LoadLabelImagesOptions,
): Promise<UserLabelImage[]>;
```

## Behavior

- **Decoder:** the [`tiff`](https://www.npmjs.com/package/tiff) (image-js) package — pure-JS ESM, native typed arrays (label IDs preserved), named `ImageDescription` (tag 270) access.
- **`pagesAs` auto-detection:** explicit `pagesAs` → tag-270 metadata → fallback `time`. Parses ImageJ (`channels/slices/frames`) and OME (`<Pixels SizeC/SizeT/SizeZ>`) to route a single-timepoint multi-channel **CYX** stack → classes, else → **time** (z-stacks map to time). 4D **TCYX** throws a clear "not yet supported" error (deferred).
- **Time mode:** one `UserLabelImage` per page, per-page integer values preserved as label IDs, shared track/category map.
- **Classes mode:** composited via `fromBinaryMasks` with COCO-style label-ID preservation (distinct single-value pages), else positional `1..N`. Categories key by label ID (time) / positional `1..N` (classes).
- **`createTracks`** defaults `false` (`LabelImage.fromArray`/#387 parity); ignored in classes mode (Python parity). **`frames`** page subset. One-shot ambiguous-multipage warning (deduped).
- **Inputs:** Node path (file or directory, alphanumeric glob) via an injected `node:fs` reader; browser `File`/`Blob`. `node:fs` stays out of the browser graph (issue #70 pattern, like `.seq`).
- **Dtype guard:** only unsigned 8/16-bit single-channel pages; **float / signed / 32-bit / multi-channel are rejected with clear, actionable errors** (no silent truncation).

## Dependency

`tiff` is an **`optionalDependency`**, lazy-imported and **tsup-externalized** (skia-canvas pattern, #140 decision 3): it stays a runtime `import("tiff")` resolving from the consumer's install — never bundled into our dist — and a missing package surfaces an actionable "install `tiff`" error. Verified: zero `tiff`/`node:fs` content in the browser bundle; `loadLabelImages` exported from both entry points.

## Testing

`tests/io/label-images.test.ts` — **34 tests** with a synthetic TIFF encoder: pure helpers (`inferAxes`, `inferLabelIdsFromPages`); time mode (single/multi-page, uint16, createTracks, tracks, Map categories); classes mode (COCO-ID preservation, positional renumber, list + Map categories); ImageJ/OME auto-detect (CYX→classes, TYX→time, TCYX→error); ambiguous warning; `frames` subset (+ out-of-range, + directory); node path + directory (+ empty); float/signed/32-bit/multi-channel rejection; `pagesAs` validation.

Full suite: **1286 pass, 1 skip, 0 fail**; `tsc` lint clean; build green.

## Deferred (follow-ups)

4D TCYX auto-detect (needs manual series reshaping); the writer `saveLabelImages` + v3 `.meta.json` sidecar; int32/uint32; PackBits / JPEG-in-TIFF / BigTIFF.

Part of #110 (v0.4.0 parity). Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
