### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps the package version from 0.3.1 to 0.4.0 ahead of the 0.4.0 release.

This release bundles 12 commits since v0.3.1, including new I/O backends (JABS, Ultralytics YOLO, SLEAP Analysis-HDF5, Norpix .seq, TIFF label images), the `Labels.merge/match/clean` matching subsystem, the migration from npm to Bun, and rendering/video fixes. Full release notes will accompany the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)