### PR TITLE
feat(rendering): segmentation overlay rendering (Python PR #374)

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -329,6 +329,259 @@ const imageData = await renderImage(lf, {
 
 ---
 
+## Overlay Rendering
+
+Overlays draw segmentation annotations behind the poses. They come in two flavors:
+
+- **Raster overlays** — segmentation masks (`SegmentationMask[]`) and integer
+  label images (`LabelImage`) are alpha-blended directly onto the frame pixels.
+- **Vector overlays** — bounding boxes (`BoundingBox[]`) and ROI geometries
+  (`ROI[]`) are stroked (and optionally filled) on top of the frame.
+
+Overlays are applied **after the background and before the trails and poses**, so
+segmentation appears behind the skeleton graphics. Set the `overlay` option on
+`renderImage`/`renderVideo`, or call the standalone draw functions
+(`drawMasks`, `drawLabelImage`, `drawBboxes`, `drawRois`) on an `ImageData`.
+
+!!! note "Node-only"
+    Overlay drawing depends on `skia-canvas` and is part of the **Node** render
+    path only. The browser entry (`index.browser.ts`) does not export these
+    functions. Browser `OffscreenCanvas` compositing and mask contour tracing
+    are tracked as follow-ups (see [issue #96](https://github.com/talmolab/sleap-io.js/issues/96)).
+
+### Overlay options
+
+These options on `renderImage` (and `renderVideo`) control overlay appearance:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `overlay` | `LabelImage \| SegmentationMask[] \| ROI[] \| BoundingBox[]` | _(none)_ | The annotation(s) to draw |
+| `overlayAlpha` | `number` | `0.3` | Fill / blend opacity (0-1) |
+| `overlayPalette` | `PaletteName \| string` | `"distinct"` | Per-item color palette |
+| `overlayOutline` | `boolean` | `false` | Draw region outlines (label images only) |
+| `overlayOutlineWidth` | `number` | `1` | Outline width in pixels (label images only) |
+| `overlayOutlineColor` | `RGB \| null` | `null` | Uniform outline color, or `null` for a darkened per-label color |
+
+For a list overlay (`SegmentationMask[]`, `ROI[]`, `BoundingBox[]`) each item is
+colored by cycling `overlayPalette` across the list. A single `LabelImage` is
+colored per-label-id from the palette. `overlayAlpha` maps to the fill opacity in
+every case (the mask blend amount, or the bbox/ROI fill).
+
+### Label image overlay
+
+A `LabelImage` stores per-pixel integer label IDs (0 = background). Render it with
+optional outlines:
+
+```ts
+import {
+  renderImage,
+  saveImage,
+  LabeledFrame,
+  Video,
+  UserLabelImage,
+} from "@talmolab/sleap-io.js";
+
+// Build a 64x64 label image: a 20x20 square of label 1, a 16x16 square of label 2.
+const H = 64;
+const W = 64;
+const data = new Int32Array(H * W);
+for (let y = 8; y < 28; y++) {
+  for (let x = 8; x < 28; x++) data[y * W + x] = 1;
+}
+for (let y = 36; y < 52; y++) {
+  for (let x = 40; x < 56; x++) data[y * W + x] = 2;
+}
+const labelImage = UserLabelImage.fromArray(data, H, W);
+
+const video = new Video({ filename: "clip.mp4" });
+const lf = new LabeledFrame({ video, frameIdx: 0, instances: [] });
+
+const img = await renderImage(lf, {
+  width: W,
+  height: H,
+  background: "black",
+  overlay: labelImage,
+  overlayAlpha: 0.4,
+  overlayOutline: true,
+  overlayOutlineWidth: 2,
+});
+await saveImage(img, "label-image-overlay.png");
+```
+
+Each label ID gets a distinct color from `overlayPalette`. With
+`overlayOutline: true`, region boundaries are painted using the outline color (or
+a darkened version of each region's color when `overlayOutlineColor` is `null`).
+
+When a `LabeledFrame` already carries label images, pass the first one directly:
+
+```ts
+const img = await renderImage(lf, {
+  width: 640,
+  height: 480,
+  overlay: lf.labelImages[0],
+  overlayAlpha: 0.5,
+  overlayPalette: "distinct",
+});
+```
+
+### Segmentation mask overlay
+
+Pass a list of `SegmentationMask` to blend each mask in its own palette color:
+
+```ts
+import { renderImage, saveImage, UserSegmentationMask } from "@talmolab/sleap-io.js";
+
+// Two binary masks (Uint8Array of 0/1), each H*W row-major.
+const H = 64;
+const W = 64;
+const a = new Uint8Array(H * W);
+const b = new Uint8Array(H * W);
+for (let y = 10; y < 30; y++) for (let x = 10; x < 30; x++) a[y * W + x] = 1;
+for (let y = 34; y < 54; y++) for (let x = 34; x < 54; x++) b[y * W + x] = 1;
+
+const masks = [
+  UserSegmentationMask.fromArray(a, H, W),
+  UserSegmentationMask.fromArray(b, H, W),
+];
+
+const img = await renderImage(lf, {
+  width: W,
+  height: H,
+  background: "black",
+  overlay: masks,
+  overlayAlpha: 0.5,
+  overlayPalette: "distinct",
+});
+await saveImage(img, "mask-overlay.png");
+```
+
+If your `LabeledFrame` already has masks, use `overlay: lf.masks`.
+
+### Bounding box overlay
+
+Bounding boxes are stroked (rotation-aware) with an optional translucent fill.
+`PredictedBoundingBox` also draws its score near the top-left corner:
+
+```ts
+import {
+  renderImage,
+  saveImage,
+  UserBoundingBox,
+  PredictedBoundingBox,
+} from "@talmolab/sleap-io.js";
+
+const bboxes = [
+  UserBoundingBox.fromXyxy(10, 10, 120, 90),
+  new PredictedBoundingBox({ x1: 150, y1: 40, x2: 260, y2: 150, score: 0.87 }),
+];
+
+const img = await renderImage(lf, {
+  width: 320,
+  height: 240,
+  background: "black",
+  overlay: bboxes,
+  overlayAlpha: 0.2, // translucent fill; outline is always drawn
+  overlayPalette: "distinct",
+});
+await saveImage(img, "bbox-overlay.png");
+```
+
+### ROI overlay
+
+ROIs draw GeoJSON geometries — polygons (with even-odd holes), points/multipoints
+(filled circles), and line strings:
+
+```ts
+import { renderImage, saveImage, UserROI } from "@talmolab/sleap-io.js";
+
+const rois = [
+  UserROI.fromPolygon([
+    [20, 20],
+    [120, 30],
+    [100, 120],
+    [30, 100],
+  ]),
+];
+
+const img = await renderImage(lf, {
+  width: 200,
+  height: 160,
+  background: "black",
+  overlay: rois,
+  overlayAlpha: 0.25, // polygon fill opacity (outline always stroked)
+  overlayPalette: "distinct",
+});
+await saveImage(img, "roi-overlay.png");
+```
+
+### Standalone draw functions
+
+Each overlay type also has a standalone function that mutates an `ImageData` in
+place and returns it. This is handy when you already have an `ImageData` (for
+example from a previous `renderImage` call) and want to add an overlay without a
+full re-render:
+
+```ts
+import { renderImage, drawMasks, drawBboxes, saveImage } from "@talmolab/sleap-io.js";
+
+const img = await renderImage(lf, { width: 640, height: 480, background: "black" });
+
+// Blend masks, then stroke boxes on the same ImageData.
+drawMasks(img, lf.masks, { alpha: 0.4 });
+drawBboxes(img, lf.bboxes, { lineWidth: 2, fillAlpha: 0.2 });
+
+await saveImage(img, "manual-overlay.png");
+```
+
+`applyOverlay(image, overlay, opts)` is the dispatcher used internally by
+`renderImage`: it inspects the overlay type and routes to the right draw function
+with palette colors derived from `opts.palette`.
+
+```ts
+import { applyOverlay } from "@talmolab/sleap-io.js";
+
+applyOverlay(img, lf.labelImages[0], {
+  alpha: 0.4,
+  palette: "distinct",
+  outline: true,
+});
+```
+
+### Overlays in video
+
+`renderVideo` accepts the same `overlay`/`overlayAlpha`/... options. The `overlay`
+value can be resolved per frame in several forms:
+
+- A **static** overlay (single `LabelImage`, or a list of masks/ROIs/boxes)
+  applied to every frame.
+- A `LabelImage[]` indexed by the frame's position in the render sequence (one
+  label image per rendered frame).
+- A `Map<number, Overlay>` keyed by the source `frameIdx`.
+- A callable `(frameIdx: number) => Overlay | undefined` invoked per frame.
+
+```ts
+import { loadSlp, renderVideo } from "@talmolab/sleap-io.js";
+
+const labels = await loadSlp("predictions.slp");
+
+// Per-frame label images keyed by source frame index.
+const overlayByFrame = new Map(
+  labels.labeledFrames.map((lf) => [lf.frameIdx, lf.labelImages[0]]),
+);
+
+await renderVideo(labels, "segmented.mp4", {
+  overlay: overlayByFrame,
+  overlayAlpha: 0.4,
+  overlayPalette: "distinct",
+});
+```
+
+When `overlay` is omitted and the source `Labels` contains label images for the
+target video, `renderVideo` auto-detects and uses them (parity with Python
+`render_video`). `renderImage` does **not** auto-detect.
+
+---
+
 ## Video Rendering
 
 Video rendering requires [ffmpeg](https://ffmpeg.org/download.html) to be installed and in your PATH.
@@ -517,6 +770,12 @@ Render poses from a `Labels`, `LabeledFrame`, or array of `Instance`/`PredictedI
 - `options.trailAlphaFade`: Fade oldest → newest (default: `true`)
 - `options.trailAlpha`: Global trail opacity 0-1 (default: `1`)
 - `options.trailColor`: Uniform trail color spec, or `null` to match poses (default: `null`)
+- `options.overlay`: Annotation overlay drawn before poses: a `LabelImage`, or a list of `SegmentationMask` / `ROI` / `BoundingBox` (default: none). Node-only.
+- `options.overlayAlpha`: Overlay fill/blend opacity 0-1 (default: `0.3`)
+- `options.overlayPalette`: Overlay palette name (default: `"distinct"`)
+- `options.overlayOutline`: Draw region outlines, label images only (default: `false`)
+- `options.overlayOutlineWidth`: Outline width in pixels, label images only (default: `1`)
+- `options.overlayOutlineColor`: Uniform outline color `RGB`, or `null` for a darkened per-label color (default: `null`)
 - `options.background`: `"transparent"` or color spec
 - `options.image`: Background `ImageData`
 - `options.preRenderCallback`: `(ctx: RenderContext) => void`
@@ -541,8 +800,72 @@ Render video with pose overlays. Requires ffmpeg.
   - `options.crf`: Quality factor (default: `25`)
   - `options.preset`: Encoding preset (default: `"superfast"`)
   - `options.onProgress`: `(current: number, total: number) => void`
+  - `options.overlay`: A static `Overlay`, a `LabelImage[]` indexed by render position, a `Map<number, Overlay>` keyed by source `frameIdx`, or a `(frameIdx) => Overlay | undefined` callable. Auto-detected from the source's label images when omitted.
 
 **Returns:** `Promise<void>`
+
+### Overlay drawing functions
+
+Node-only helpers that draw segmentation annotations onto an `ImageData`, mutating
+`image.data` in place and returning the same `ImageData`. Used internally by
+`renderImage` and also exported for direct use.
+
+#### `drawMasks(image, masks, opts?)`
+
+Blend segmentation masks as colored regions.
+
+- `image`: `ImageData`
+- `masks`: `SegmentationMask[]`
+- `opts.color`: Single `RGB` (default: `[255, 0, 0]`)
+- `opts.colors`: Per-mask `RGB[]` (overrides `color`)
+- `opts.alpha`: Blend opacity 0-1 (default: `0.3`)
+
+#### `drawLabelImage(image, labels, opts?)`
+
+Blend an integer label image, coloring each label ID from the palette.
+
+- `image`: `ImageData`
+- `labels`: `LabelImage` or `RawLabelImage` (`{ data: Int32Array, width, height, scale?, offset? }`)
+- `opts.alpha`: Blend opacity 0-1 (default: `0.3`)
+- `opts.palette`: Palette name (default: `"distinct"`)
+- `opts.outline`: Draw region outlines (default: `false`)
+- `opts.outlineWidth`: Outline width in pixels (default: `1`)
+- `opts.outlineColor`: Uniform outline `RGB`, or `null` for a darkened per-label color (default: `null`)
+- `opts.scale`/`opts.offset`: Spatial-transform overrides for raw arrays
+
+#### `drawBboxes(image, bboxes, opts?)`
+
+Stroke bounding boxes (rotation-aware) with an optional fill; predicted boxes draw their score.
+
+- `image`: `ImageData`
+- `bboxes`: `BoundingBox[]`
+- `opts.color`: Single `RGB` (default: `[0, 255, 0]`)
+- `opts.colors`: Per-box `RGB[]` (overrides `color`)
+- `opts.lineWidth`: Stroke width (default: `2`)
+- `opts.fillAlpha`: Fill opacity 0-1 (default: `0`)
+
+#### `drawRois(image, rois, opts?)`
+
+Draw ROI GeoJSON geometries (polygons with even-odd holes, points, line strings).
+
+- `image`: `ImageData`
+- `rois`: `ROI[]`
+- `opts.color`: Single `RGB` (default: `[0, 255, 0]`)
+- `opts.colors`: Per-ROI `RGB[]` (overrides `color`)
+- `opts.lineWidth`: Stroke width (default: `2`)
+- `opts.fillAlpha`: Fill opacity 0-1 (default: `0`)
+
+#### `applyOverlay(image, overlay, opts?)`
+
+Dispatcher that routes an overlay to the right draw function with palette colors.
+
+- `image`: `ImageData`
+- `overlay`: `LabelImage | RawLabelImage | SegmentationMask[] | ROI[] | BoundingBox[]`
+- `opts.alpha`: Fill/blend opacity 0-1 (default: `0.3`)
+- `opts.palette`: Palette name (default: `"distinct"`)
+- `opts.outline` / `opts.outlineWidth` / `opts.outlineColor`: Outline controls (label images only)
+
+**Returns:** `ImageData` (the same object, mutated in place)
 
 ### `RenderContext`
 

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -10,6 +10,8 @@ export type {
   MarkerShape,
   RenderOptions,
   VideoOptions,
+  Overlay,
+  VideoOverlay,
 } from "./types.js";
 
 // Color utilities
@@ -58,3 +60,14 @@ export {
 
 // Video rendering
 export { renderVideo, checkFfmpeg } from "./video.js";
+
+// Overlay drawing (Node-only raster/vector overlays for segmentation masks,
+// label images, bounding boxes, and ROIs). Not exported from the browser entry.
+export {
+  drawMasks,
+  drawLabelImage,
+  drawBboxes,
+  drawRois,
+  applyOverlay,
+} from "./overlays.js";
+export type { RawLabelImage } from "./overlays.js";

--- a/src/rendering/overlays.ts
+++ b/src/rendering/overlays.ts
@@ -1,0 +1,774 @@
+// src/rendering/overlays.ts
+//
+// Node-only raster/vector overlay drawing for segmentation masks, integer
+// label images, bounding boxes, and ROI geometries. This is a faithful port of
+// Python sleap-io's `sleap_io/rendering/overlays.py` (PR #374) plus the
+// `_apply_overlay` dispatcher from `core.py`.
+//
+// All functions operate on an `ImageData` (RGBA, row-major), mutate
+// `image.data` in place, and return the same `ImageData` for chaining. The
+// alpha channel is always left at 255. Raster overlays (masks, label images)
+// blend pixels directly on the `Uint8ClampedArray`; vector overlays (bboxes,
+// ROIs) draw through an internal skia-canvas `Canvas` (putImageData -> path
+// ops -> getImageData -> copy back).
+//
+// Browser / OffscreenCanvas compositing is intentionally out of scope: these
+// functions are exported from `index.ts` (Node) only, never `index.browser.ts`.
+
+import type { SegmentationMask } from "../model/mask.js";
+import { resizeNearest } from "../model/mask.js";
+import type { LabelImage } from "../model/label-image.js";
+import type { BoundingBox } from "../model/bbox.js";
+import type { ROI, Geometry } from "../model/roi.js";
+import type { RGB, PaletteName } from "./types.js";
+import { getPalette, rgbToCSS } from "./colors.js";
+import { createRequire } from "node:module";
+
+// Synchronous, ESM-safe handle to the Node-only skia-canvas module. Created
+// lazily on first vector draw so importing this module never eagerly loads
+// skia-canvas (it remains an external/optional dependency, browser-excluded).
+const requireCjs = createRequire(import.meta.url);
+let _skiaCanvas: typeof import("skia-canvas") | null = null;
+function getSkiaCanvas(): typeof import("skia-canvas") {
+  if (_skiaCanvas === null) {
+    _skiaCanvas = requireCjs("skia-canvas") as typeof import("skia-canvas");
+  }
+  return _skiaCanvas;
+}
+
+/** A minimal raw label-image overlay (no spatial-transform object wrapper). */
+export interface RawLabelImage {
+  data: Int32Array;
+  width: number;
+  height: number;
+  scale?: [number, number];
+  offset?: [number, number];
+}
+
+/** Blend a single uint8 channel value: dst*(1-a) + src*a, floored to uint8. */
+function blendChannel(dst: number, src: number, alpha: number): number {
+  return Math.trunc(dst * (1 - alpha) + src * alpha);
+}
+
+/** Clamp a blend opacity to [0, 1]; non-finite inputs fall back to 0. */
+function clampAlpha(alpha: number): number {
+  if (!Number.isFinite(alpha)) return 0;
+  return alpha < 0 ? 0 : alpha > 1 ? 1 : alpha;
+}
+
+/**
+ * Pick the per-item color for index `i`. When an explicit `colors` array is
+ * shorter than the item list it cycles (`colors[i % colors.length]`) rather
+ * than indexing out of bounds; an empty array falls back to `fallback`.
+ */
+function pickColor(colors: RGB[] | null, i: number, fallback: RGB): RGB {
+  if (colors === null || colors.length === 0) return fallback;
+  return colors[i % colors.length];
+}
+
+/**
+ * Draw segmentation masks as colored overlays on an image.
+ *
+ * For each mask, the masked pixels are alpha-blended toward the mask color.
+ * Spatial transforms (scale/offset) are honored: the binary mask is resized
+ * (nearest-neighbor) to its image extent, placed at its offset, and clipped to
+ * the image bounds. Port of `draw_masks` (overlays.py L115-176).
+ *
+ * @param image - RGBA ImageData, mutated in place.
+ * @param masks - Segmentation masks to draw.
+ * @param opts - `color` (default [255,0,0]), per-mask `colors`, `alpha` (0.3).
+ * @returns The same ImageData.
+ */
+export function drawMasks(
+  image: ImageData,
+  masks: SegmentationMask[],
+  opts?: { color?: RGB; colors?: RGB[]; alpha?: number },
+): ImageData {
+  const color = opts?.color ?? [255, 0, 0];
+  const colors = opts?.colors ?? null;
+  const alpha = clampAlpha(opts?.alpha ?? 0.3);
+
+  const imgW = image.width;
+  const imgH = image.height;
+  const pixels = image.data;
+
+  for (let i = 0; i < masks.length; i++) {
+    const mask = masks[i];
+    const maskColor = pickColor(colors, i, color);
+    const maskData = mask.data; // binary 0/1, row-major (mask.height x mask.width)
+
+    let region: Uint8Array; // binary mask aligned to a placement window
+    let x0: number;
+    let y0: number;
+    let drawW: number;
+    let drawH: number;
+
+    if (mask.hasSpatialTransform) {
+      // Resize the binary mask to its image-space extent then place at offset.
+      const ext = mask.imageExtent;
+      const targetH = ext.height;
+      const targetW = ext.width;
+      const resized = resizeNearest(
+        maskData,
+        mask.height,
+        mask.width,
+        targetH,
+        targetW,
+      );
+
+      const ox = Math.trunc(mask.offset[0]);
+      const oy = Math.trunc(mask.offset[1]);
+      y0 = Math.max(0, oy);
+      x0 = Math.max(0, ox);
+      const y1 = Math.min(imgH, oy + targetH);
+      const x1 = Math.min(imgW, ox + targetW);
+
+      if (y1 <= y0 || x1 <= x0) continue;
+
+      drawH = y1 - y0;
+      drawW = x1 - x0;
+
+      // Crop the resized mask to the visible window (handles negative offset).
+      const my0 = y0 - oy;
+      const mx0 = x0 - ox;
+      region = new Uint8Array(drawH * drawW);
+      for (let r = 0; r < drawH; r++) {
+        const srcRow = (my0 + r) * targetW + mx0;
+        region.set(resized.subarray(srcRow, srcRow + drawW), r * drawW);
+      }
+    } else {
+      drawH = Math.min(mask.height, imgH);
+      drawW = Math.min(mask.width, imgW);
+      x0 = 0;
+      y0 = 0;
+      // Crop top-left window of the mask into a tight buffer.
+      region = new Uint8Array(drawH * drawW);
+      for (let r = 0; r < drawH; r++) {
+        const srcRow = r * mask.width;
+        region.set(maskData.subarray(srcRow, srcRow + drawW), r * drawW);
+      }
+    }
+
+    const [cr, cg, cb] = maskColor;
+    for (let r = 0; r < drawH; r++) {
+      for (let c = 0; c < drawW; c++) {
+        if (region[r * drawW + c] === 0) continue;
+        const px = ((y0 + r) * imgW + (x0 + c)) * 4;
+        pixels[px] = blendChannel(pixels[px], cr, alpha);
+        pixels[px + 1] = blendChannel(pixels[px + 1], cg, alpha);
+        pixels[px + 2] = blendChannel(pixels[px + 2], cb, alpha);
+      }
+    }
+  }
+
+  return image;
+}
+
+/**
+ * Draw an integer label image as a colored overlay on an image.
+ *
+ * Builds a per-label color LUT (label_id -> palette[label_id % len]), blends
+ * foreground pixels (label > 0) toward their color, and optionally draws region
+ * outlines. Spatial transforms (scale/offset) are honored via nearest-neighbor
+ * resize + offset placement + clip. Port of `draw_label_image` (overlays.py
+ * L179-293).
+ *
+ * @param image - RGBA ImageData, mutated in place.
+ * @param labels - A `LabelImage` or a raw `{ data, width, height, scale?, offset? }`.
+ * @param opts - `alpha` (0.3), `palette` ("distinct"), `outline` (false),
+ *   `outlineWidth` (1), `outlineColor` (null), plus optional `scale`/`offset`
+ *   overrides for raw arrays.
+ * @returns The same ImageData.
+ */
+export function drawLabelImage(
+  image: ImageData,
+  labels: LabelImage | RawLabelImage,
+  opts?: {
+    alpha?: number;
+    palette?: PaletteName | string;
+    outline?: boolean;
+    outlineWidth?: number;
+    outlineColor?: RGB | null;
+    scale?: [number, number];
+    offset?: [number, number];
+  },
+): ImageData {
+  const alpha = clampAlpha(opts?.alpha ?? 0.3);
+  const palette = opts?.palette ?? "distinct";
+  const outline = opts?.outline ?? false;
+  const outlineWidth = opts?.outlineWidth ?? 1;
+  const outlineColor = opts?.outlineColor ?? null;
+
+  const labData = labels.data;
+  const labH = labels.height;
+  const labW = labels.width;
+  // Prefer explicit opts, then the object's own transform, else identity.
+  const scale: [number, number] =
+    opts?.scale ?? (labels as LabelImage).scale ?? [1, 1];
+  const offset: [number, number] =
+    opts?.offset ?? (labels as LabelImage).offset ?? [0, 0];
+
+  // Unique non-background labels and max id.
+  let maxId = 0;
+  let hasFg = false;
+  for (let i = 0; i < labData.length; i++) {
+    const v = labData[i];
+    if (v > 0) {
+      hasFg = true;
+      if (v > maxId) maxId = v;
+    }
+  }
+  if (!hasFg) return image;
+
+  // Build LUT: shape (maxId + 1) x 3 as Float32 (matches Python lut float32).
+  const paletteColors = getPalette(palette, maxId + 1);
+  const lut = new Float32Array((maxId + 1) * 3);
+  for (let id = 1; id <= maxId; id++) {
+    const col = paletteColors[id % paletteColors.length];
+    lut[id * 3] = col[0];
+    lut[id * 3 + 1] = col[1];
+    lut[id * 3 + 2] = col[2];
+  }
+
+  const imgW = image.width;
+  const imgH = image.height;
+  const pixels = image.data;
+
+  const hasTransform =
+    scale[0] !== 1 || scale[1] !== 1 || offset[0] !== 0 || offset[1] !== 0;
+
+  // The label window that will be blended/outlined: a tight buffer placed at
+  // (x0, y0) of the target image, with dimensions drawW x drawH.
+  let region: Int32Array;
+  let x0: number;
+  let y0: number;
+  let drawW: number;
+  let drawH: number;
+
+  if (hasTransform) {
+    const sx = scale[0];
+    const sy = scale[1];
+    const targetH = Math.trunc(labH / sy);
+    const targetW = Math.trunc(labW / sx);
+    const resized = resizeNearest(labData, labH, labW, targetH, targetW);
+
+    const ox = Math.trunc(offset[0]);
+    const oy = Math.trunc(offset[1]);
+    y0 = Math.max(0, oy);
+    x0 = Math.max(0, ox);
+    const y1 = Math.min(imgH, oy + targetH);
+    const x1 = Math.min(imgW, ox + targetW);
+
+    if (y1 <= y0 || x1 <= x0) return image;
+
+    drawH = y1 - y0;
+    drawW = x1 - x0;
+
+    const my0 = y0 - oy;
+    const mx0 = x0 - ox;
+    region = new Int32Array(drawH * drawW);
+    for (let r = 0; r < drawH; r++) {
+      const srcRow = (my0 + r) * targetW + mx0;
+      region.set(resized.subarray(srcRow, srcRow + drawW), r * drawW);
+    }
+  } else {
+    drawH = Math.min(labH, imgH);
+    drawW = Math.min(labW, imgW);
+    x0 = 0;
+    y0 = 0;
+    region = new Int32Array(drawH * drawW);
+    for (let r = 0; r < drawH; r++) {
+      const srcRow = r * labW;
+      region.set(labData.subarray(srcRow, srcRow + drawW), r * drawW);
+    }
+  }
+
+  // Vectorized blend: apply colored overlay where label > 0.
+  for (let r = 0; r < drawH; r++) {
+    for (let c = 0; c < drawW; c++) {
+      const lab = region[r * drawW + c];
+      if (lab <= 0) continue;
+      const safe = lab > maxId ? maxId : lab;
+      const li = safe * 3;
+      const px = ((y0 + r) * imgW + (x0 + c)) * 4;
+      pixels[px] = Math.trunc(pixels[px] * (1 - alpha) + lut[li] * alpha);
+      pixels[px + 1] = Math.trunc(
+        pixels[px + 1] * (1 - alpha) + lut[li + 1] * alpha,
+      );
+      pixels[px + 2] = Math.trunc(
+        pixels[px + 2] * (1 - alpha) + lut[li + 2] * alpha,
+      );
+    }
+  }
+
+  if (outline) {
+    drawLabelOutlines(
+      image,
+      region,
+      x0,
+      y0,
+      drawH,
+      drawW,
+      outlineWidth,
+      outlineColor,
+      lut,
+      maxId,
+    );
+  }
+
+  return image;
+}
+
+/**
+ * Paint outlines around labeled regions via edge detection.
+ *
+ * Detects boundary pixels (where a foreground label differs from a 4-neighbor),
+ * optionally dilates the edge mask with a square structuring element, and
+ * paints either a uniform `outlineColor` or a darkened per-label color
+ * (`lut * 0.6`). Port of `_draw_label_outlines` (overlays.py L296-360).
+ *
+ * Operates on the same tight `region` buffer (drawH x drawW) placed at
+ * (x0, y0) in the target image.
+ */
+function drawLabelOutlines(
+  image: ImageData,
+  region: Int32Array,
+  x0: number,
+  y0: number,
+  drawH: number,
+  drawW: number,
+  outlineWidth: number,
+  outlineColor: RGB | null,
+  lut: Float32Array,
+  maxId: number,
+): void {
+  const imgW = image.width;
+  const pixels = image.data;
+
+  // Edge mask: boundary where label differs from a neighbor, restricted to fg.
+  const edges = new Uint8Array(drawH * drawW);
+  const at = (r: number, c: number): number => region[r * drawW + c];
+  for (let r = 0; r < drawH; r++) {
+    for (let c = 0; c < drawW; c++) {
+      const v = at(r, c);
+      let edge = false;
+      if (c + 1 < drawW && v !== at(r, c + 1)) edge = true;
+      if (!edge && c - 1 >= 0 && v !== at(r, c - 1)) edge = true;
+      if (!edge && r + 1 < drawH && v !== at(r + 1, c)) edge = true;
+      if (!edge && r - 1 >= 0 && v !== at(r - 1, c)) edge = true;
+      // Python ORs all 4 shifted comparisons into a symmetric edge map and then
+      // ANDs with (label > 0). A pixel is an edge if any neighbor (existing) in
+      // either direction differs and the pixel itself is foreground.
+      if (edge && v > 0) edges[r * drawW + c] = 1;
+    }
+  }
+
+  // Dilate for thicker outlines (square element, pad = width // 2).
+  let finalEdges = edges;
+  if (outlineWidth > 1) {
+    const pad = Math.trunc(outlineWidth / 2);
+    const dilated = new Uint8Array(drawH * drawW);
+    for (let dy = -pad; dy <= pad; dy++) {
+      for (let dx = -pad; dx <= pad; dx++) {
+        const sy = Math.max(0, dy);
+        const ey = drawH + Math.min(0, dy);
+        const sx = Math.max(0, dx);
+        const ex = drawW + Math.min(0, dx);
+        const oy = Math.max(0, -dy);
+        const ox = Math.max(0, -dx);
+        for (let r = sy; r < ey; r++) {
+          for (let c = sx; c < ex; c++) {
+            if (edges[(oy + (r - sy)) * drawW + (ox + (c - sx))]) {
+              dilated[r * drawW + c] = 1;
+            }
+          }
+        }
+      }
+    }
+    // Re-restrict dilated edges to foreground (matches Python `& labels > 0`).
+    for (let i = 0; i < dilated.length; i++) {
+      if (dilated[i] && region[i] > 0) dilated[i] = 1;
+      else dilated[i] = 0;
+    }
+    finalEdges = dilated;
+  }
+
+  for (let r = 0; r < drawH; r++) {
+    for (let c = 0; c < drawW; c++) {
+      if (!finalEdges[r * drawW + c]) continue;
+      const px = ((y0 + r) * imgW + (x0 + c)) * 4;
+      if (outlineColor !== null) {
+        pixels[px] = outlineColor[0];
+        pixels[px + 1] = outlineColor[1];
+        pixels[px + 2] = outlineColor[2];
+      } else {
+        const lab = region[r * drawW + c];
+        const safe = lab > maxId ? maxId : lab;
+        const li = safe * 3;
+        // dark = (lut * 0.6) cast to uint8.
+        pixels[px] = Math.trunc(lut[li] * 0.6);
+        pixels[px + 1] = Math.trunc(lut[li + 1] * 0.6);
+        pixels[px + 2] = Math.trunc(lut[li + 2] * 0.6);
+      }
+    }
+  }
+}
+
+/** Stroke style used by vector overlays (square caps, no anti-alias). */
+function configureStroke(
+  ctx: CanvasRenderingContext2D,
+  rgb: RGB,
+  lineWidth: number,
+): void {
+  ctx.strokeStyle = rgbToCSS(rgb);
+  ctx.lineWidth = lineWidth;
+  ctx.lineCap = "square";
+}
+
+/**
+ * Draw bounding boxes on an image.
+ *
+ * Each box is drawn as a closed path through its (rotation-aware) corners, with
+ * an optional translucent fill, and—for `PredictedBoundingBox`—a "score" label
+ * near the top-left corner. Rendered through an internal skia-canvas `Canvas`.
+ * Port of `draw_bboxes` (overlays.py L363-510).
+ *
+ * @param image - RGBA ImageData, mutated in place.
+ * @param bboxes - Bounding boxes to draw.
+ * @param opts - `color` (default [0,255,0]), per-bbox `colors`, `lineWidth`
+ *   (2), `fillAlpha` (0).
+ * @returns The same ImageData.
+ */
+export function drawBboxes(
+  image: ImageData,
+  bboxes: BoundingBox[],
+  opts?: { color?: RGB; colors?: RGB[]; lineWidth?: number; fillAlpha?: number },
+): ImageData {
+  if (bboxes.length === 0) return image;
+
+  const color = opts?.color ?? [0, 255, 0];
+  const colors = opts?.colors ?? null;
+  const lineWidth = opts?.lineWidth ?? 2;
+  const fillAlpha = clampAlpha(opts?.fillAlpha ?? 0);
+
+  return withVectorCanvas(image, (ctx) => {
+    for (let i = 0; i < bboxes.length; i++) {
+      const bbox = bboxes[i];
+      const c = pickColor(colors, i, color);
+      const corners = bbox.corners;
+      if (corners.length === 0) continue;
+
+      ctx.beginPath();
+      ctx.moveTo(corners[0][0], corners[0][1]);
+      for (let j = 1; j < corners.length; j++) {
+        ctx.lineTo(corners[j][0], corners[j][1]);
+      }
+      ctx.closePath();
+
+      if (fillAlpha > 0) {
+        ctx.fillStyle = rgbToCSS(c, fillAlpha);
+        ctx.fill();
+      }
+      configureStroke(ctx, c, lineWidth);
+      ctx.stroke();
+
+      // Score text for predicted bboxes (drawn near the top-left corner).
+      if (bbox.isPredicted) {
+        const score = (bbox as BoundingBox & { score: number }).score;
+        ctx.font = "12px sans-serif";
+        ctx.fillStyle = rgbToCSS(c);
+        ctx.fillText(score.toFixed(2), corners[0][0], corners[0][1] - 5);
+      }
+    }
+  });
+}
+
+/**
+ * Draw ROI geometries on an image.
+ *
+ * Renders each ROI's GeoJSON geometry: polygons (with even-odd holes), points
+ * and multipoints (filled circles, radius = max(lineWidth, 2)), and line
+ * strings. Rendered through an internal skia-canvas `Canvas`. Port of
+ * `draw_rois` + `_draw_geometry` (overlays.py L22-112, L513-640).
+ *
+ * @param image - RGBA ImageData, mutated in place.
+ * @param rois - ROIs to draw.
+ * @param opts - `color` (default [0,255,0]), per-ROI `colors`, `lineWidth` (2),
+ *   `fillAlpha` (0).
+ * @returns The same ImageData.
+ */
+export function drawRois(
+  image: ImageData,
+  rois: ROI[],
+  opts?: { color?: RGB; colors?: RGB[]; lineWidth?: number; fillAlpha?: number },
+): ImageData {
+  if (rois.length === 0) return image;
+
+  const color = opts?.color ?? [0, 255, 0];
+  const colors = opts?.colors ?? null;
+  const lineWidth = opts?.lineWidth ?? 2;
+  const fillAlpha = clampAlpha(opts?.fillAlpha ?? 0);
+
+  return withVectorCanvas(image, (ctx) => {
+    for (let i = 0; i < rois.length; i++) {
+      const c = pickColor(colors, i, color);
+      drawGeometry(ctx, rois[i].geometry, c, lineWidth, fillAlpha);
+    }
+  });
+}
+
+/**
+ * Recursively draw a GeoJSON geometry on a canvas context.
+ *
+ * Port of `_draw_geometry` (overlays.py L513-580). Polygon holes use the
+ * even-odd fill rule; points/multipoints draw filled circles of radius
+ * `max(lineWidth, 2)`.
+ */
+function drawGeometry(
+  ctx: CanvasRenderingContext2D,
+  geometry: Geometry,
+  rgb: RGB,
+  lineWidth: number,
+  fillAlpha: number,
+): void {
+  switch (geometry.type) {
+    case "Polygon": {
+      polygonToPath(ctx, geometry.coordinates);
+      if (fillAlpha > 0) {
+        ctx.fillStyle = rgbToCSS(rgb, fillAlpha);
+        ctx.fill("evenodd");
+      }
+      configureStroke(ctx, rgb, lineWidth);
+      ctx.stroke();
+      break;
+    }
+    case "MultiPolygon": {
+      for (const polygon of geometry.coordinates) {
+        polygonToPath(ctx, polygon);
+        if (fillAlpha > 0) {
+          ctx.fillStyle = rgbToCSS(rgb, fillAlpha);
+          ctx.fill("evenodd");
+        }
+        configureStroke(ctx, rgb, lineWidth);
+        ctx.stroke();
+      }
+      break;
+    }
+    case "Point": {
+      const radius = Math.max(lineWidth, 2);
+      ctx.beginPath();
+      ctx.arc(geometry.coordinates[0], geometry.coordinates[1], radius, 0, Math.PI * 2);
+      ctx.fillStyle = rgbToCSS(rgb);
+      ctx.fill();
+      break;
+    }
+    case "MultiPoint": {
+      const radius = Math.max(lineWidth, 2);
+      ctx.fillStyle = rgbToCSS(rgb);
+      for (const pt of geometry.coordinates) {
+        ctx.beginPath();
+        ctx.arc(pt[0], pt[1], radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      break;
+    }
+    case "LineString": {
+      const coords = geometry.coordinates;
+      if (coords.length > 0) {
+        ctx.beginPath();
+        ctx.moveTo(coords[0][0], coords[0][1]);
+        for (let i = 1; i < coords.length; i++) {
+          ctx.lineTo(coords[i][0], coords[i][1]);
+        }
+        configureStroke(ctx, rgb, lineWidth);
+        ctx.stroke();
+      }
+      break;
+    }
+    case "GeometryCollection": {
+      for (const sub of geometry.geometries) {
+        drawGeometry(ctx, sub, rgb, lineWidth, fillAlpha);
+      }
+      break;
+    }
+  }
+}
+
+/**
+ * Build a polygon path (exterior + interior holes) on the context.
+ *
+ * Each ring is a closed sub-path. With the even-odd fill rule, interior rings
+ * cut holes out of the exterior. Port of `_polygon_to_path` (overlays.py
+ * L583-620).
+ */
+function polygonToPath(ctx: CanvasRenderingContext2D, rings: number[][][]): void {
+  ctx.beginPath();
+  for (const ring of rings) {
+    if (ring.length === 0) continue;
+    ctx.moveTo(ring[0][0], ring[0][1]);
+    for (let i = 1; i < ring.length; i++) {
+      ctx.lineTo(ring[i][0], ring[i][1]);
+    }
+    ctx.closePath();
+  }
+}
+
+/**
+ * Run a vector-drawing callback against the image through an internal
+ * skia-canvas `Canvas`, copying the result back into `image.data` in place.
+ *
+ * Mirrors the Python pattern of padding to RGBA, drawing on a skia surface, and
+ * copying RGB channels back. Here we keep the alpha channel at 255.
+ */
+function withVectorCanvas(
+  image: ImageData,
+  draw: (ctx: CanvasRenderingContext2D) => void,
+): ImageData {
+  const { Canvas } = getSkiaCanvas();
+  const canvas = new Canvas(image.width, image.height);
+  const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ctx.putImageData(image as any, 0, 0);
+
+  draw(ctx);
+
+  const result = ctx.getImageData(0, 0, image.width, image.height);
+  // Copy RGB channels back; keep alpha at 255 to match the raster path.
+  const src = result.data;
+  const dst = image.data;
+  for (let i = 0; i < dst.length; i += 4) {
+    dst[i] = src[i];
+    dst[i + 1] = src[i + 1];
+    dst[i + 2] = src[i + 2];
+    dst[i + 3] = 255;
+  }
+  return image;
+}
+
+/** Runtime guard for a LabelImage-like object (has Int32Array `data`). */
+function isLabelImageLike(value: unknown): value is LabelImage | RawLabelImage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    (value as { data: unknown }).data instanceof Int32Array &&
+    "width" in value &&
+    "height" in value
+  );
+}
+
+/** Runtime guard for a SegmentationMask (has `rleCounts` / `data` Uint8Array). */
+function isSegmentationMask(value: unknown): value is SegmentationMask {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "rleCounts" in value &&
+    "hasSpatialTransform" in value
+  );
+}
+
+/** Runtime guard for a BoundingBox (has `corners` and `x1`/`x2`). */
+function isBoundingBox(value: unknown): value is BoundingBox {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "corners" in value &&
+    "x1" in value &&
+    "x2" in value
+  );
+}
+
+/** Runtime guard for an ROI (has GeoJSON `geometry`). */
+function isROI(value: unknown): value is ROI {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "geometry" in value &&
+    typeof (value as { geometry: unknown }).geometry === "object"
+  );
+}
+
+/**
+ * Apply an annotation overlay to an image, dispatching by type.
+ *
+ * Mirrors Python `_apply_overlay` (core.py L473-566): a `LabelImage` (or raw
+ * Int32Array-backed object) routes to {@link drawLabelImage}; a non-empty list
+ * routes to {@link drawMasks} / {@link drawRois} / {@link drawBboxes} with
+ * per-item palette colors. A `list[LabelImage]` raises (per-frame dispatch must
+ * happen at the renderVideo level), and unknown element types raise.
+ *
+ * @param image - RGBA ImageData, mutated in place.
+ * @param overlay - A LabelImage, or a list of SegmentationMask / ROI / BoundingBox.
+ * @param opts - `alpha` (0.3), `palette` ("distinct"), `outline` (false),
+ *   `outlineWidth` (1), `outlineColor` (null).
+ * @returns The same ImageData.
+ */
+export function applyOverlay(
+  image: ImageData,
+  overlay:
+    | LabelImage
+    | RawLabelImage
+    | SegmentationMask[]
+    | ROI[]
+    | BoundingBox[],
+  opts?: {
+    alpha?: number;
+    palette?: PaletteName | string;
+    outline?: boolean;
+    outlineWidth?: number;
+    outlineColor?: RGB | null;
+  },
+): ImageData {
+  const alpha = clampAlpha(opts?.alpha ?? 0.3);
+  const palette = opts?.palette ?? "distinct";
+  const outline = opts?.outline ?? false;
+  const outlineWidth = opts?.outlineWidth ?? 1;
+  const outlineColor = opts?.outlineColor ?? null;
+
+  // Single LabelImage (or raw Int32Array-backed) overlay.
+  if (!Array.isArray(overlay)) {
+    if (isLabelImageLike(overlay)) {
+      drawLabelImage(image, overlay, {
+        alpha,
+        palette,
+        outline,
+        outlineWidth,
+        outlineColor,
+      });
+    }
+    return image;
+  }
+
+  // Empty list is a no-op.
+  if (overlay.length === 0) return image;
+
+  const first = overlay[0];
+
+  // list[LabelImage] is not allowed here; per-frame dispatch belongs to video.
+  if (isLabelImageLike(first)) {
+    throw new TypeError(
+      "Pass individual LabelImage objects to applyOverlay, not a list. " +
+        "Per-frame dispatch from a list[LabelImage] should happen at the " +
+        "renderVideo level.",
+    );
+  }
+
+  const colors = getPalette(palette, overlay.length);
+
+  if (isSegmentationMask(first)) {
+    drawMasks(image, overlay as SegmentationMask[], { colors, alpha });
+  } else if (isROI(first)) {
+    drawRois(image, overlay as ROI[], { colors, fillAlpha: alpha });
+  } else if (isBoundingBox(first)) {
+    drawBboxes(image, overlay as BoundingBox[], { colors, fillAlpha: alpha });
+  } else {
+    throw new TypeError(
+      `Unsupported overlay element type: ${
+        (first as { constructor?: { name?: string } })?.constructor?.name ??
+        typeof first
+      }. Expected SegmentationMask, ROI, or BoundingBox.`,
+    );
+  }
+
+  return image;
+}

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -21,6 +21,7 @@ import {
   collectTracks,
 } from "./trails.js";
 import { RenderContext, InstanceContext } from "./context.js";
+import { applyOverlay } from "./overlays.js";
 
 // Default options
 const DEFAULT_OPTIONS: Required<
@@ -35,6 +36,9 @@ const DEFAULT_OPTIONS: Required<
     | "trailFrames"
     | "trailTracks"
     | "trailPtsCache"
+    // `overlay` is absence-checked (undefined = no overlay), so it has no
+    // default value; `overlayOutlineColor` is null by default below.
+    | "overlay"
   >
 > = {
   colorBy: "auto",
@@ -55,6 +59,13 @@ const DEFAULT_OPTIONS: Required<
   trailAlphaFade: true,
   trailAlpha: 1,
   trailColor: null,
+  // Segmentation / annotation overlay (off by default). Mirrors Python
+  // render_image overlay params (overlay=None, overlay_alpha=0.3, etc.).
+  overlayAlpha: 0.3,
+  overlayPalette: "distinct",
+  overlayOutline: false,
+  overlayOutlineWidth: 1,
+  overlayOutlineColor: null,
 };
 
 /** Default fallback color */
@@ -142,6 +153,58 @@ export async function renderImage(
     const bgColor = resolveColor(opts.background);
     ctx.fillStyle = rgbToCSS(bgColor);
     ctx.fillRect(0, 0, scaledWidth, scaledHeight);
+  }
+
+  // Apply the annotation overlay AFTER the background and BEFORE trails/poses,
+  // mirroring Python render_image (core.py L1159-1180: overlay applied on the
+  // base frame, before trails/centroids/poses).
+  //
+  // Scale handling: overlay annotation coordinates (mask/label-image pixels,
+  // bbox corners, ROI geometry) are in SOURCE pixels. Python applies the
+  // overlay to the un-scaled base frame and then scales the whole result, so
+  // poses (drawn here at `x * scale`) stay aligned with the overlay. We
+  // replicate that equivalent: read the canvas at source resolution, blend the
+  // overlay in source space, then scale-composite back onto the (possibly
+  // scaled) canvas. When `scale === 1` this is an in-place read/blend/write.
+  if (opts.overlay !== undefined && opts.overlay !== null) {
+    const overlayOpts = {
+      alpha: opts.overlayAlpha,
+      palette: opts.overlayPalette,
+      outline: opts.overlayOutline,
+      outlineWidth: opts.overlayOutlineWidth,
+      outlineColor: opts.overlayOutlineColor,
+    };
+    if (opts.scale === 1) {
+      // Fast path: blend directly on the scaled canvas (== source resolution).
+      const imageData = ctx.getImageData(0, 0, scaledWidth, scaledHeight);
+      applyOverlay(
+        imageData as unknown as ImageData,
+        opts.overlay,
+        overlayOpts,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ctx.putImageData(imageData as any, 0, 0);
+    } else {
+      // Scaled path: render the current background at source resolution onto a
+      // temporary canvas, blend the overlay there (source-pixel coords), then
+      // draw it scaled onto the main canvas so it lines up with the poses.
+      const srcCanvas = new Canvas(width, height);
+      const srcCtx = srcCanvas.getContext("2d");
+      // Downscale the already-drawn (scaled) background into source space.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      srcCtx.drawImage(canvas as any, 0, 0, width, height);
+      const imageData = srcCtx.getImageData(0, 0, width, height);
+      applyOverlay(
+        imageData as unknown as ImageData,
+        opts.overlay,
+        overlayOpts,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      srcCtx.putImageData(imageData as any, 0, 0);
+      ctx.clearRect(0, 0, scaledWidth, scaledHeight);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ctx.drawImage(srcCanvas as any, 0, 0, scaledWidth, scaledHeight);
+    }
   }
 
   // Get skeleton info

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -4,6 +4,26 @@ import type { RenderContext } from "./context.js";
 import type { InstanceContext } from "./context.js";
 import type { LabeledFrame } from "../model/labeled-frame.js";
 import type { Instance, PredictedInstance, Track } from "../model/instance.js";
+import type { SegmentationMask } from "../model/mask.js";
+import type { LabelImage } from "../model/label-image.js";
+import type { BoundingBox } from "../model/bbox.js";
+import type { ROI } from "../model/roi.js";
+import type { RawLabelImage } from "./overlays.js";
+
+/**
+ * A single-frame annotation overlay applied before poses are drawn.
+ *
+ * Mirrors Python `_apply_overlay` dispatch (core.py L473-566): a `LabelImage`
+ * (or a raw `Int32Array`-backed object) routes to the label-image raster path;
+ * a list of `SegmentationMask` / `ROI` / `BoundingBox` routes to the
+ * corresponding draw function with per-item palette colors.
+ */
+export type Overlay =
+  | LabelImage
+  | RawLabelImage
+  | SegmentationMask[]
+  | ROI[]
+  | BoundingBox[];
 
 /** RGB color as [r, g, b] with values 0-255 */
 export type RGB = [number, number, number];
@@ -90,6 +110,23 @@ export interface RenderOptions {
   background?: "transparent" | ColorSpec;
   image?: ImageData | null;
 
+  // Segmentation / annotation overlay (applied AFTER the background and BEFORE
+  // trails and poses, mirroring Python render_image L1159-1180). Node-only:
+  // overlay drawing lives in the raster render path and is not part of the
+  // browser entry. See `applyOverlay` in overlays.ts.
+  /**
+   * Annotation overlay drawn behind the poses: a single `LabelImage` (or a raw
+   * `Int32Array`-backed object), or a list of `SegmentationMask` / `ROI` /
+   * `BoundingBox`. Overlay coordinates are in source pixels and are scaled to
+   * match the poses (see `scale`). Default: undefined (no overlay).
+   */
+  overlay?: Overlay;
+  overlayAlpha?: number; // Default: 0.3 (fill opacity, 0-1)
+  overlayPalette?: PaletteName | string; // Default: "distinct"
+  overlayOutline?: boolean; // Default: false (label images only)
+  overlayOutlineWidth?: number; // Default: 1 (pixels, label images only)
+  overlayOutlineColor?: RGB | null; // Default: null (darkened per-label color)
+
   // Frame size (required if no image provided)
   width?: number;
   height?: number;
@@ -100,8 +137,35 @@ export interface RenderOptions {
   perInstanceCallback?: (ctx: InstanceContext) => void;
 }
 
+/**
+ * Per-frame overlay resolved for each rendered frame of a video.
+ *
+ * Mirrors Python render_video overlay dispatch (core.py L1719-1754):
+ * - A static {@link Overlay} (single `LabelImage` or a list of masks/rois/bboxes)
+ *   is applied to every frame.
+ * - `LabelImage[]` is indexed by the position of the frame in the render
+ *   sequence (one label image per frame); out-of-range frames get no overlay.
+ * - A `Map<number, Overlay>` is keyed by the source frame index
+ *   (`LabeledFrame.frameIdx`); missing keys get no overlay.
+ * - A callable `(frameIdx) => Overlay | undefined` is invoked per frame with the
+ *   source frame index, returning that frame's overlay (or `undefined`).
+ */
+export type VideoOverlay =
+  | Overlay
+  | LabelImage[]
+  | Map<number, Overlay>
+  | ((frameIdx: number) => Overlay | undefined);
+
 /** Video rendering options (extends RenderOptions) */
-export interface VideoOptions extends RenderOptions {
+export interface VideoOptions extends Omit<RenderOptions, "overlay"> {
+  /**
+   * Per-frame annotation overlay. See {@link VideoOverlay}. A single static
+   * overlay applies to every frame; a `LabelImage[]` is indexed by render
+   * position; a `Map` is keyed by source frame index; a callable is invoked per
+   * frame. Mirrors Python render_video (core.py L1719-1754).
+   */
+  overlay?: VideoOverlay;
+
   // Frame selection
   frameInds?: number[];
   start?: number;

--- a/src/rendering/video.ts
+++ b/src/rendering/video.ts
@@ -5,7 +5,13 @@ import type { Labels } from "../model/labels.js";
 import type { LabeledFrame } from "../model/labeled-frame.js";
 import type { Video } from "../model/video.js";
 import type { Instance, PredictedInstance } from "../model/instance.js";
-import type { VideoOptions } from "./types.js";
+import type { LabelImage } from "../model/label-image.js";
+import type {
+  Overlay,
+  RenderOptions,
+  VideoOptions,
+  VideoOverlay,
+} from "./types.js";
 import { renderImage } from "./render.js";
 
 /**
@@ -61,6 +67,25 @@ export async function renderVideo(
     throw new Error("No frames to render");
   }
 
+  // Resolve the per-frame overlay parameter (mirrors Python render_video,
+  // core.py L1719-1754). Auto-detect: when no explicit overlay is given and a
+  // Labels source has label images for the rendered video, use them as a
+  // per-frame LabelImage[] (indexed by render position). Mirrors core.py
+  // L1549-1556.
+  let videoOverlay: VideoOverlay | undefined = options.overlay;
+  if (
+    videoOverlay === undefined &&
+    !Array.isArray(source) &&
+    source.labelImages.length > 0
+  ) {
+    const targetVideo = selectedFrames[0].video;
+    const videoLabelImages = source.getLabelImages({ video: targetVideo });
+    if (videoLabelImages.length > 0) {
+      videoOverlay = videoLabelImages;
+    }
+  }
+  const overlayForFrame = makeOverlayResolver(videoOverlay);
+
   // Build per-video temporal context for motion trails once (keyed by frame
   // index), using ALL source frames so a trail can reach back before the
   // selected range. Each rendered frame then gets its video's frame map.
@@ -82,18 +107,29 @@ export async function renderVideo(
       videoFrames.set(lf.frameIdx, lf);
     }
   }
-  const optsForFrame = (frame: LabeledFrame): VideoOptions =>
-    options.showTrails
+  // Build the per-frame render options. Overlay is resolved per frame (static
+  // value, position-indexed list, frame-index-keyed Map, or callable) and
+  // passed through as the single-frame `overlay` that renderImage understands.
+  const optsForFrame = (frame: LabeledFrame, position: number): RenderOptions => {
+    // Strip the video-level (per-frame) `overlay` so the spread does not leak a
+    // `VideoOverlay` into the single-frame `RenderOptions`; it is replaced by
+    // the resolved single-frame overlay below.
+    const { overlay: _ignored, ...rest } = options;
+    void _ignored;
+    const base: RenderOptions = options.showTrails
       ? {
-          ...options,
+          ...rest,
           trailFrames: framesByVideo.get(frame.video),
           trailTracks: options.trailTracks ?? canonicalTracks,
           trailPtsCache,
         }
-      : options;
+      : { ...rest };
+    base.overlay = overlayForFrame(frame, position);
+    return base;
+  };
 
   // Get frame dimensions from first frame
-  const firstImage = await renderImage(selectedFrames[0], optsForFrame(selectedFrames[0]));
+  const firstImage = await renderImage(selectedFrames[0], optsForFrame(selectedFrames[0], 0));
   const width = firstImage.width;
   const height = firstImage.height;
 
@@ -154,7 +190,7 @@ export async function renderVideo(
     }
 
     const frame = selectedFrames[i];
-    const imageData = await renderImage(frame, optsForFrame(frame));
+    const imageData = await renderImage(frame, optsForFrame(frame, i));
 
     // Write raw RGBA data to ffmpeg stdin
     const buffer = Buffer.from(imageData.data.buffer);
@@ -192,4 +228,60 @@ export async function renderVideo(
 
     ffmpeg.on("error", reject);
   });
+}
+
+/** Whether a value is a `LabelImage`-like object (Int32Array-backed `data`). */
+function isLabelImageLike(value: unknown): value is LabelImage {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    (value as { data: unknown }).data instanceof Int32Array
+  );
+}
+
+/** Whether a value is a non-empty `LabelImage[]` (per-frame, position-indexed). */
+function isLabelImageList(value: unknown): value is LabelImage[] {
+  return Array.isArray(value) && value.length > 0 && isLabelImageLike(value[0]);
+}
+
+/**
+ * Build a per-frame overlay resolver from the (already auto-detected) video
+ * overlay parameter. Mirrors Python `_get_frame_overlay` (core.py L1732-1754):
+ *
+ * - `undefined` -> no overlay on any frame.
+ * - callable `(frameIdx) => Overlay | undefined` -> invoked with the source
+ *   frame index for each frame.
+ * - `Map<number, Overlay>` -> keyed by the source frame index
+ *   (`LabeledFrame.frameIdx`); missing keys yield no overlay.
+ * - `LabelImage[]` -> indexed by the frame's render position; out-of-range
+ *   positions yield no overlay.
+ * - any other static {@link Overlay} (single `LabelImage`, or a list of
+ *   `SegmentationMask` / `ROI` / `BoundingBox`) -> applied to every frame.
+ *
+ * The resolver returns the single-frame `Overlay` consumed by renderImage.
+ */
+function makeOverlayResolver(
+  overlay: VideoOverlay | undefined,
+): (frame: LabeledFrame, position: number) => Overlay | undefined {
+  if (overlay === undefined) {
+    return () => undefined;
+  }
+  if (typeof overlay === "function") {
+    const fn = overlay as (frameIdx: number) => Overlay | undefined;
+    return (frame) => fn(frame.frameIdx);
+  }
+  if (overlay instanceof Map) {
+    const map = overlay as Map<number, Overlay>;
+    return (frame) => map.get(frame.frameIdx);
+  }
+  if (isLabelImageList(overlay)) {
+    const list = overlay;
+    return (_frame, position) =>
+      position < list.length ? list[position] : undefined;
+  }
+  // Static overlay (single LabelImage or a list of masks/rois/bboxes) applied
+  // to every frame.
+  const staticOverlay = overlay as Overlay;
+  return () => staticOverlay;
 }

--- a/tests/rendering/overlays.test.ts
+++ b/tests/rendering/overlays.test.ts
@@ -1,0 +1,1341 @@
+import { describe, it, expect } from "../bun-test";
+import {
+  drawMasks,
+  drawLabelImage,
+  drawBboxes,
+  drawRois,
+  applyOverlay,
+} from "../../src/rendering/overlays";
+import type { RawLabelImage } from "../../src/rendering/overlays";
+import { renderImage } from "../../src/rendering/render";
+import { renderVideo } from "../../src/rendering/video";
+import { UserSegmentationMask, SegmentationMask } from "../../src/model/mask";
+import { UserLabelImage } from "../../src/model/label-image";
+import {
+  UserBoundingBox,
+  PredictedBoundingBox,
+  BoundingBox,
+} from "../../src/model/bbox";
+import { UserROI } from "../../src/model/roi";
+import { Skeleton } from "../../src/model/skeleton";
+import { Instance } from "../../src/model/instance";
+import { LabeledFrame } from "../../src/model/labeled-frame";
+import { Video } from "../../src/model/video";
+import { PALETTES } from "../../src/rendering/colors";
+
+const DISTINCT = PALETTES.distinct;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a solid-color RGBA ImageData of the given size using skia-canvas, so
+ * that the same object round-trips through `putImageData`/`getImageData` in the
+ * vector-overlay path (drawBboxes/drawRois).
+ */
+async function makeImage(
+  width: number,
+  height: number,
+  fill: [number, number, number] = [255, 255, 255],
+): Promise<ImageData> {
+  const { Canvas } = await import("skia-canvas");
+  const canvas = new Canvas(width, height);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${fill[0]}, ${fill[1]}, ${fill[2]})`;
+  ctx.fillRect(0, 0, width, height);
+  return ctx.getImageData(0, 0, width, height) as unknown as ImageData;
+}
+
+/** Read the RGB triple at pixel (x, y) of an ImageData. */
+function pixel(img: ImageData, x: number, y: number): [number, number, number] {
+  const idx = (y * img.width + x) * 4;
+  return [img.data[idx], img.data[idx + 1], img.data[idx + 2]];
+}
+
+/** Assert an RGB triple matches an expected triple within +/- tolerance. */
+function expectRGBNear(
+  actual: [number, number, number],
+  expected: [number, number, number],
+  tol = 2,
+): void {
+  for (let i = 0; i < 3; i++) {
+    expect(Math.abs(actual[i] - expected[i])).toBeLessThanOrEqual(tol);
+  }
+}
+
+/** Truncating blend used by the raster overlays: trunc(dst*(1-a) + src*a). */
+function blend(dst: number, src: number, alpha: number): number {
+  return Math.trunc(dst * (1 - alpha) + src * alpha);
+}
+
+function blendRGB(
+  dst: [number, number, number],
+  src: [number, number, number],
+  alpha: number,
+): [number, number, number] {
+  return [
+    blend(dst[0], src[0], alpha),
+    blend(dst[1], src[1], alpha),
+    blend(dst[2], src[2], alpha),
+  ];
+}
+
+/**
+ * A solid square binary mask of size H x W with a foreground block from
+ * (r0, c0) inclusive to (r1, c1) exclusive.
+ */
+function squareMask(
+  height: number,
+  width: number,
+  r0: number,
+  c0: number,
+  r1: number,
+  c1: number,
+): Uint8Array {
+  const m = new Uint8Array(height * width);
+  for (let r = r0; r < r1; r++) {
+    for (let c = c0; c < c1; c++) {
+      m[r * width + c] = 1;
+    }
+  }
+  return m;
+}
+
+function createTestSkeleton(): Skeleton {
+  return new Skeleton({
+    nodes: ["head", "tail"],
+    edges: [["head", "tail"]],
+  });
+}
+
+// ===========================================================================
+// drawMasks
+// ===========================================================================
+
+describe("drawMasks", () => {
+  it("blends a single mask color with the default alpha (0.3)", async () => {
+    const img = await makeImage(10, 10, [255, 255, 255]);
+    // Foreground block rows 2-5, cols 2-5.
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(10, 10, 2, 2, 6, 6),
+      10,
+      10,
+    );
+
+    drawMasks(img, [mask]); // default color [255,0,0], alpha 0.3
+
+    // Inside the block: white blended toward red at alpha 0.3.
+    expectRGBNear(pixel(img, 3, 3), blendRGB([255, 255, 255], [255, 0, 0], 0.3));
+    // Outside the block: untouched.
+    expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
+    expectRGBNear(pixel(img, 9, 9), [255, 255, 255]);
+  });
+
+  it("honors an explicit color and alpha and the blend math at a known pixel", async () => {
+    const img = await makeImage(8, 8, [0, 0, 0]);
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(8, 8, 0, 0, 4, 4),
+      8,
+      8,
+    );
+
+    drawMasks(img, [mask], { color: [100, 200, 50], alpha: 0.5 });
+
+    // black blended toward [100,200,50] at 0.5 = [50, 100, 25].
+    expectRGBNear(pixel(img, 1, 1), [
+      blend(0, 100, 0.5),
+      blend(0, 200, 0.5),
+      blend(0, 50, 0.5),
+    ]);
+  });
+
+  it("uses per-mask colors when provided", async () => {
+    const img = await makeImage(12, 12, [255, 255, 255]);
+    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 4, 4), 12, 12);
+    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 6, 6, 10, 10), 12, 12);
+
+    drawMasks(img, [m0, m1], {
+      colors: [
+        [255, 0, 0],
+        [0, 0, 255],
+      ],
+      alpha: 0.4,
+    });
+
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.4));
+    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], [0, 0, 255], 0.4));
+  });
+
+  it("is a no-op for an empty mask list", async () => {
+    const img = await makeImage(6, 6, [10, 20, 30]);
+    const before = Array.from(img.data);
+    drawMasks(img, []);
+    expect(Array.from(img.data)).toEqual(before);
+  });
+
+  it("places a mask with a spatial transform (scale) at its image extent", async () => {
+    // 4x4 mask data, scale 2 -> image extent 2x2. Fill the whole 4x4 mask so
+    // the entire downscaled 2x2 extent is foreground at image (0,0)-(1,1).
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    const data = squareMask(4, 4, 0, 0, 4, 4); // fully foreground in mask space
+    const mask = new UserSegmentationMask({
+      rleCounts: (await import("../../src/model/mask")).encodeRle(data, 4, 4),
+      height: 4,
+      width: 4,
+      scale: [2, 2],
+    });
+    expect(mask.hasSpatialTransform).toBe(true);
+    expect(mask.imageExtent).toEqual({ height: 2, width: 2 });
+
+    drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 });
+
+    // After nearest-neighbor downscale to 2x2, the whole 2x2 extent is fg.
+    expectRGBNear(pixel(img, 0, 0), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    // Beyond the 2x2 extent: untouched.
+    expectRGBNear(pixel(img, 5, 5), [255, 255, 255]);
+  });
+
+  it("places a mask at a positive offset", async () => {
+    const img = await makeImage(10, 10, [255, 255, 255]);
+    const data = squareMask(3, 3, 0, 0, 3, 3); // fully fg 3x3
+    const mask = new UserSegmentationMask({
+      rleCounts: (await import("../../src/model/mask")).encodeRle(data, 3, 3),
+      height: 3,
+      width: 3,
+      offset: [4, 5],
+    });
+
+    drawMasks(img, [mask], { color: [0, 255, 0], alpha: 0.5 });
+
+    // Offset (ox=4, oy=5): fg lands at image rows 5-7, cols 4-6.
+    expectRGBNear(pixel(img, 4, 5), blendRGB([255, 255, 255], [0, 255, 0], 0.5));
+    expectRGBNear(pixel(img, 6, 7), blendRGB([255, 255, 255], [0, 255, 0], 0.5));
+    // Origin untouched (offset moved the mask away).
+    expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
+  });
+
+  it("clips an out-of-bounds offset to the image bounds without throwing", async () => {
+    const img = await makeImage(6, 6, [255, 255, 255]);
+    const data = squareMask(4, 4, 0, 0, 4, 4);
+    const mask = new UserSegmentationMask({
+      rleCounts: (await import("../../src/model/mask")).encodeRle(data, 4, 4),
+      height: 4,
+      width: 4,
+      offset: [4, 4], // 4..8 but image is only 6 wide/tall -> clipped to 4..6
+    });
+
+    expect(() => drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 })).not.toThrow();
+
+    // Inside the visible clipped window.
+    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(pixel(img, 4, 4), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    // Outside the placement window untouched.
+    expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
+  });
+
+  it("fully skips a mask whose offset is entirely off-image", async () => {
+    const img = await makeImage(6, 6, [255, 255, 255]);
+    const before = Array.from(img.data);
+    const data = squareMask(3, 3, 0, 0, 3, 3);
+    const mask = new UserSegmentationMask({
+      rleCounts: (await import("../../src/model/mask")).encodeRle(data, 3, 3),
+      height: 3,
+      width: 3,
+      offset: [100, 100],
+    });
+    drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 });
+    expect(Array.from(img.data)).toEqual(before);
+  });
+
+  it("clips a mask with a negative offset on the top/left boundary", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    const data = squareMask(4, 4, 0, 0, 4, 4); // fully fg 4x4
+    const mask = new UserSegmentationMask({
+      rleCounts: (await import("../../src/model/mask")).encodeRle(data, 4, 4),
+      height: 4,
+      width: 4,
+      offset: [-2, -2], // top-left 2x2 of the mask falls off the image
+    });
+
+    expect(() =>
+      drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 }),
+    ).not.toThrow();
+
+    // Visible window is image (0,0)-(1,1); it shows the blended mask fg.
+    expectRGBNear(pixel(img, 0, 0), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    // Beyond the placed 4x4 (which now ends at image (1,1)): untouched.
+    expectRGBNear(pixel(img, 3, 3), [255, 255, 255]);
+  });
+
+  it("applies a scale and offset transform together", async () => {
+    const img = await makeImage(12, 12, [255, 255, 255]);
+    const data = squareMask(4, 4, 0, 0, 4, 4); // fully fg 4x4
+    const mask = new UserSegmentationMask({
+      rleCounts: (await import("../../src/model/mask")).encodeRle(data, 4, 4),
+      height: 4,
+      width: 4,
+      scale: [2, 2], // downscale extent to 2x2
+      offset: [3, 3], // place at image (3,3)
+    });
+    expect(mask.hasSpatialTransform).toBe(true);
+    expect(mask.imageExtent).toEqual({ height: 2, width: 2 });
+
+    drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 });
+
+    // 2x2 extent placed at (3,3) covers image (3,3)-(4,4).
+    expectRGBNear(pixel(img, 3, 3), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(pixel(img, 4, 4), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    // Before the offset and beyond the extent: untouched.
+    expectRGBNear(pixel(img, 2, 2), [255, 255, 255]);
+    expectRGBNear(pixel(img, 5, 5), [255, 255, 255]);
+  });
+
+  it("blends overlapping masks sequentially", async () => {
+    const img = await makeImage(10, 10, [255, 255, 255]);
+    const m0 = UserSegmentationMask.fromArray(squareMask(10, 10, 2, 2, 6, 6), 10, 10);
+    const m1 = UserSegmentationMask.fromArray(squareMask(10, 10, 4, 4, 8, 8), 10, 10);
+
+    drawMasks(img, [m0, m1], {
+      colors: [
+        [255, 0, 0],
+        [0, 0, 255],
+      ],
+      alpha: 0.5,
+    });
+
+    // Non-overlap of m0 (rows/cols 2-3): just red blended once.
+    expectRGBNear(pixel(img, 2, 2), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    // Non-overlap of m1 (rows/cols 6-7): just blue blended once.
+    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], [0, 0, 255], 0.5));
+    // Overlap (rows/cols 4-5): red first, then blue on top of that result.
+    const afterRed = blendRGB([255, 255, 255], [255, 0, 0], 0.5);
+    const afterBlue = blendRGB(afterRed, [0, 0, 255], 0.5);
+    expectRGBNear(pixel(img, 4, 4), afterBlue);
+    expect(pixel(img, 4, 4)[2]).toBeGreaterThan(pixel(img, 4, 4)[0]); // blue dominates
+  });
+
+  it("clips a mask larger than the image from all edges", async () => {
+    const img = await makeImage(6, 6, [255, 255, 255]);
+    const largeMask = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 0, 0, 20, 20),
+      20,
+      20,
+    );
+
+    expect(() =>
+      drawMasks(img, [largeMask], { color: [255, 0, 0], alpha: 0.5 }),
+    ).not.toThrow();
+
+    // Only the top-left 6x6 of the 20x20 mask is visible; the whole image is fg.
+    expectRGBNear(pixel(img, 0, 0), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+  });
+
+  it("cycles a short per-mask colors array via modulo", async () => {
+    const img = await makeImage(12, 12, [255, 255, 255]);
+    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 3, 3), 12, 12);
+    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 4, 4, 7, 7), 12, 12);
+    const m2 = UserSegmentationMask.fromArray(squareMask(12, 12, 8, 8, 11, 11), 12, 12);
+
+    // Two colors for three masks: index 2 must reuse colors[0] (modulo cycling),
+    // not index out of bounds with `undefined`.
+    expect(() =>
+      drawMasks(img, [m0, m1, m2], {
+        colors: [
+          [255, 0, 0],
+          [0, 0, 255],
+        ],
+        alpha: 0.5,
+      }),
+    ).not.toThrow();
+
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], [0, 0, 255], 0.5));
+    // m2 wraps back to colors[0] = red.
+    expectRGBNear(pixel(img, 9, 9), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+  });
+
+  it("clamps an out-of-range alpha into [0, 1]", async () => {
+    const high = await makeImage(8, 8, [255, 255, 255]);
+    const opaque = await makeImage(8, 8, [255, 255, 255]);
+    const mask = UserSegmentationMask.fromArray(squareMask(8, 8, 0, 0, 4, 4), 8, 8);
+
+    // alpha = 2.0 must clamp to 1.0 (fully replace with the color), never
+    // produce out-of-range/negative blends.
+    drawMasks(high, [mask], { color: [10, 20, 30], alpha: 2.0 });
+    drawMasks(opaque, [mask], { color: [10, 20, 30], alpha: 1.0 });
+    expectRGBNear(pixel(high, 1, 1), [10, 20, 30]);
+    expect(Array.from(high.data)).toEqual(Array.from(opaque.data));
+
+    // alpha = -1.0 must clamp to 0.0 (no change).
+    const negative = await makeImage(8, 8, [255, 255, 255]);
+    drawMasks(negative, [mask], { color: [10, 20, 30], alpha: -1.0 });
+    expectRGBNear(pixel(negative, 1, 1), [255, 255, 255]);
+  });
+});
+
+// ===========================================================================
+// drawLabelImage
+// ===========================================================================
+
+describe("drawLabelImage", () => {
+  it("colors 2+ label ids from the distinct LUT and blends correctly", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    // Label 1 occupies rows 0-3 cols 0-3; label 2 occupies rows 4-7 cols 4-7.
+    const data = new Int32Array(8 * 8);
+    for (let r = 0; r < 4; r++) for (let c = 0; c < 4; c++) data[r * 8 + c] = 1;
+    for (let r = 4; r < 8; r++) for (let c = 4; c < 8; c++) data[r * 8 + c] = 2;
+    const li = UserLabelImage.fromArray(data, 8, 8);
+
+    drawLabelImage(img, li, { alpha: 0.3, palette: "distinct" });
+
+    // LUT: id1 -> distinct[1], id2 -> distinct[2].
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], DISTINCT[1], 0.3));
+    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], DISTINCT[2], 0.3));
+    // Background (label 0) untouched.
+    expectRGBNear(pixel(img, 7, 0), [255, 255, 255]);
+  });
+
+  it("leaves background (label 0) untouched", async () => {
+    const img = await makeImage(6, 6, [12, 34, 56]);
+    const data = new Int32Array(6 * 6);
+    data[0] = 1; // single fg pixel
+    const li = UserLabelImage.fromArray(data, 6, 6);
+
+    drawLabelImage(img, li, { alpha: 0.5 });
+
+    // Pixel 0 changed; all others remain the original background.
+    expectRGBNear(pixel(img, 1, 0), [12, 34, 56]);
+    expectRGBNear(pixel(img, 5, 5), [12, 34, 56]);
+  });
+
+  it("does not change pixels when outline=false", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    const data = new Int32Array(8 * 8);
+    for (let r = 2; r < 6; r++) for (let c = 2; c < 6; c++) data[r * 8 + c] = 1;
+    const li = UserLabelImage.fromArray(data, 8, 8);
+
+    drawLabelImage(img, li, { alpha: 0.3, outline: false });
+
+    // Interior and boundary pixels are both the plain fill (no darkened edge).
+    const fill = blendRGB([255, 255, 255], DISTINCT[1], 0.3);
+    expectRGBNear(pixel(img, 4, 4), fill); // interior
+    expectRGBNear(pixel(img, 2, 2), fill); // boundary, but no outline applied
+  });
+
+  it("paints a darkened per-label outline when outline=true", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    const data = new Int32Array(8 * 8);
+    for (let r = 2; r < 6; r++) for (let c = 2; c < 6; c++) data[r * 8 + c] = 1;
+    const li = UserLabelImage.fromArray(data, 8, 8);
+
+    drawLabelImage(img, li, { alpha: 0.3, outline: true });
+
+    // The boundary pixel is the darkened LUT color (lut * 0.6), not the fill.
+    const dark: [number, number, number] = [
+      Math.trunc(DISTINCT[1][0] * 0.6),
+      Math.trunc(DISTINCT[1][1] * 0.6),
+      Math.trunc(DISTINCT[1][2] * 0.6),
+    ];
+    expectRGBNear(pixel(img, 2, 2), dark);
+    // The deep interior pixel (no neighbor differs) keeps the plain fill.
+    const fill = blendRGB([255, 255, 255], DISTINCT[1], 0.3);
+    expectRGBNear(pixel(img, 4, 4), fill);
+  });
+
+  it("uses a uniform outlineColor when provided", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    const data = new Int32Array(8 * 8);
+    for (let r = 2; r < 6; r++) for (let c = 2; c < 6; c++) data[r * 8 + c] = 1;
+    const li = UserLabelImage.fromArray(data, 8, 8);
+
+    drawLabelImage(img, li, {
+      alpha: 0.3,
+      outline: true,
+      outlineColor: [0, 0, 0],
+    });
+
+    // Boundary pixel painted solid black (the uniform outline color).
+    expectRGBNear(pixel(img, 2, 2), [0, 0, 0]);
+  });
+
+  it("makes a thicker outline when outlineWidth > 1 (dilation)", async () => {
+    const buildOutlined = async (
+      width: number,
+    ): Promise<ImageData> => {
+      const img = await makeImage(12, 12, [255, 255, 255]);
+      const data = new Int32Array(12 * 12);
+      for (let r = 3; r < 9; r++) for (let c = 3; c < 9; c++) data[r * 12 + c] = 1;
+      const li = UserLabelImage.fromArray(data, 12, 12);
+      drawLabelImage(img, li, {
+        alpha: 0.3,
+        outline: true,
+        outlineColor: [0, 0, 0],
+        outlineWidth: width,
+      });
+      return img;
+    };
+
+    const thin = await buildOutlined(1);
+    const thick = await buildOutlined(3);
+
+    const countBlack = (img: ImageData): number => {
+      let n = 0;
+      for (let i = 0; i < img.data.length; i += 4) {
+        if (img.data[i] === 0 && img.data[i + 1] === 0 && img.data[i + 2] === 0) {
+          n++;
+        }
+      }
+      return n;
+    };
+
+    // A wider outline dilates the edge mask, painting strictly more black pixels.
+    expect(countBlack(thick)).toBeGreaterThan(countBlack(thin));
+  });
+
+  it("honors a scale spatial transform for placement", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    // 4x4 label data, scale 2 -> image extent 2x2. Fill all of it with label 1.
+    const data = new Int32Array(4 * 4).fill(1);
+    const li = new UserLabelImage({ data, height: 4, width: 4, scale: [2, 2] });
+    expect(li.imageExtent).toEqual({ height: 2, width: 2 });
+
+    drawLabelImage(img, li, { alpha: 0.5, palette: "distinct" });
+
+    const fill = blendRGB([255, 255, 255], DISTINCT[1], 0.5);
+    expectRGBNear(pixel(img, 0, 0), fill);
+    expectRGBNear(pixel(img, 1, 1), fill);
+    // Outside the 2x2 image extent: untouched.
+    expectRGBNear(pixel(img, 5, 5), [255, 255, 255]);
+  });
+
+  it("honors an offset spatial transform for placement", async () => {
+    const img = await makeImage(10, 10, [255, 255, 255]);
+    const data = new Int32Array(3 * 3).fill(1);
+    const li = new UserLabelImage({ data, height: 3, width: 3, offset: [4, 5] });
+
+    drawLabelImage(img, li, { alpha: 0.5, palette: "distinct" });
+
+    const fill = blendRGB([255, 255, 255], DISTINCT[1], 0.5);
+    // Offset (ox=4, oy=5) -> rows 5-7, cols 4-6.
+    expectRGBNear(pixel(img, 4, 5), fill);
+    expectRGBNear(pixel(img, 6, 7), fill);
+    expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
+  });
+
+  it("accepts a RawLabelImage with explicit scale/offset overrides", async () => {
+    const img = await makeImage(10, 10, [255, 255, 255]);
+    const raw: RawLabelImage = {
+      data: new Int32Array(3 * 3).fill(1),
+      height: 3,
+      width: 3,
+    };
+    drawLabelImage(img, raw, {
+      alpha: 0.5,
+      palette: "distinct",
+      offset: [2, 2],
+    });
+    const fill = blendRGB([255, 255, 255], DISTINCT[1], 0.5);
+    expectRGBNear(pixel(img, 2, 2), fill);
+    expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
+  });
+
+  it("is a no-op when there is no foreground", async () => {
+    const img = await makeImage(6, 6, [9, 9, 9]);
+    const before = Array.from(img.data);
+    const li = UserLabelImage.fromArray(new Int32Array(36), 6, 6);
+    drawLabelImage(img, li, { alpha: 0.5 });
+    expect(Array.from(img.data)).toEqual(before);
+  });
+
+  it("wraps label IDs beyond the palette size using modulo", async () => {
+    const n = DISTINCT.length; // 20 for "distinct"
+    const img = await makeImage(10, 10, [255, 255, 255]);
+    const data = new Int32Array(10 * 10);
+    data[0 * 10 + 1] = 1; // label 1 -> distinct[1]
+    data[5 * 10 + 0] = n + 1; // label (n+1) wraps to distinct[(n+1) % n] = distinct[1]
+    const li = UserLabelImage.fromArray(data, 10, 10);
+
+    drawLabelImage(img, li, { alpha: 0.5, palette: "distinct" });
+
+    // Both pixels map to distinct[1], so they must blend to the same color.
+    const c1 = pixel(img, 1, 0);
+    const cWrap = pixel(img, 0, 5);
+    expectRGBNear(c1, blendRGB([255, 255, 255], DISTINCT[1], 0.5));
+    expectRGBNear(cWrap, c1);
+  });
+
+  it("honors a negative offset (clips on the top/left boundary)", async () => {
+    const img = await makeImage(10, 10, [255, 255, 255]);
+    const data = new Int32Array(4 * 4).fill(1);
+    const li = new UserLabelImage({
+      data,
+      height: 4,
+      width: 4,
+      offset: [-2, -2],
+    });
+
+    drawLabelImage(img, li, { alpha: 0.5, palette: "distinct" });
+
+    const fill = blendRGB([255, 255, 255], DISTINCT[1], 0.5);
+    // The bottom-right 2x2 of the label lands at image (0,0)-(1,1).
+    expectRGBNear(pixel(img, 0, 0), fill);
+    expectRGBNear(pixel(img, 1, 1), fill);
+    // Beyond the placed window (label ends at image (1,1)): untouched.
+    expectRGBNear(pixel(img, 3, 3), [255, 255, 255]);
+  });
+});
+
+// ===========================================================================
+// drawBboxes
+// ===========================================================================
+
+describe("drawBboxes", () => {
+  it("draws an axis-aligned box outline (edge pixels colored)", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const bbox = UserBoundingBox.fromXyxy(10, 10, 30, 30);
+
+    drawBboxes(img, [bbox], { color: [255, 0, 0], lineWidth: 2 });
+
+    // Some pixel on the top edge (y ~ 10) is colored (not white).
+    let edgeColored = false;
+    for (let x = 11; x < 29; x++) {
+      const [r, g, b] = pixel(img, x, 10);
+      if (r !== 255 || g !== 255 || b !== 255) {
+        edgeColored = true;
+        break;
+      }
+    }
+    expect(edgeColored).toBe(true);
+
+    // Box interior center stays white (no fill by default).
+    expectRGBNear(pixel(img, 20, 20), [255, 255, 255]);
+  });
+
+  it("fills the interior when fillAlpha > 0", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const bbox = UserBoundingBox.fromXyxy(10, 10, 30, 30);
+
+    drawBboxes(img, [bbox], { color: [255, 0, 0], fillAlpha: 0.5 });
+
+    // Center pixel is now tinted toward red (fill applied).
+    const [r, g, b] = pixel(img, 20, 20);
+    expect(r).toBeGreaterThan(200); // red-ish
+    expect(g).toBeLessThan(230); // greens/blues pulled down
+    expect(b).toBeLessThan(230);
+  });
+
+  it("draws a rotated box (corners differ from axis-aligned)", async () => {
+    const img = await makeImage(60, 60, [255, 255, 255]);
+    const bbox = new UserBoundingBox({
+      x1: 20,
+      y1: 20,
+      x2: 40,
+      y2: 40,
+      angle: Math.PI / 4, // 45 degrees
+    });
+
+    expect(() => drawBboxes(img, [bbox], { color: [0, 0, 255] })).not.toThrow();
+
+    // A rotated square reaches a corner directly above its center (~30, 16)
+    // where an axis-aligned box would have nothing. Just confirm something is
+    // drawn somewhere off the axis-aligned edges.
+    let anyColored = false;
+    for (let y = 10; y < 50 && !anyColored; y++) {
+      for (let x = 10; x < 50; x++) {
+        const [r, g, b] = pixel(img, x, y);
+        if (b > r && b > g) {
+          anyColored = true;
+          break;
+        }
+      }
+    }
+    expect(anyColored).toBe(true);
+  });
+
+  it("draws score text near the corner for a PredictedBoundingBox", async () => {
+    const plain = await makeImage(60, 40, [255, 255, 255]);
+    const predicted = await makeImage(60, 40, [255, 255, 255]);
+
+    const userBox = UserBoundingBox.fromXyxy(15, 20, 45, 35);
+    const predBox = new PredictedBoundingBox({
+      x1: 15,
+      y1: 20,
+      x2: 45,
+      y2: 35,
+      score: 0.91,
+    });
+
+    drawBboxes(plain, [userBox], { color: [0, 128, 0] });
+    drawBboxes(predicted, [predBox], { color: [0, 128, 0] });
+
+    // The score text is drawn above the top-left corner (~y=20-5=15). Count
+    // non-white pixels in the band above the box top; the predicted box must
+    // have strictly more (the rendered "0.91" glyphs).
+    const countAbove = (img: ImageData): number => {
+      let n = 0;
+      for (let y = 5; y < 19; y++) {
+        for (let x = 12; x < 50; x++) {
+          const [r, g, b] = pixel(img, x, y);
+          if (r !== 255 || g !== 255 || b !== 255) n++;
+        }
+      }
+      return n;
+    };
+
+    expect(countAbove(predicted)).toBeGreaterThan(countAbove(plain));
+  });
+
+  it("uses per-bbox colors when provided", async () => {
+    const img = await makeImage(80, 40, [255, 255, 255]);
+    const b0 = UserBoundingBox.fromXyxy(5, 5, 25, 35);
+    const b1 = UserBoundingBox.fromXyxy(50, 5, 70, 35);
+
+    drawBboxes(img, [b0, b1], {
+      colors: [
+        [255, 0, 0],
+        [0, 0, 255],
+      ],
+      lineWidth: 3,
+    });
+
+    // Find a red-dominant pixel near the first box and a blue-dominant pixel
+    // near the second.
+    const hasColor = (
+      x0: number,
+      x1: number,
+      pred: (r: number, g: number, b: number) => boolean,
+    ): boolean => {
+      for (let y = 5; y < 36; y++) {
+        for (let x = x0; x < x1; x++) {
+          const [r, g, b] = pixel(img, x, y);
+          if (pred(r, g, b)) return true;
+        }
+      }
+      return false;
+    };
+
+    expect(hasColor(4, 27, (r, g, b) => r > 150 && g < 100 && b < 100)).toBe(true);
+    expect(hasColor(48, 72, (r, g, b) => b > 150 && r < 100 && g < 100)).toBe(true);
+  });
+
+  it("is a no-op for an empty bbox list", async () => {
+    const img = await makeImage(10, 10, [3, 4, 5]);
+    const before = Array.from(img.data);
+    drawBboxes(img, []);
+    expect(Array.from(img.data)).toEqual(before);
+  });
+});
+
+// ===========================================================================
+// drawRois
+// ===========================================================================
+
+describe("drawRois", () => {
+  it("draws a polygon outline", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const roi = UserROI.fromPolygon([
+      [10, 10],
+      [30, 10],
+      [30, 30],
+      [10, 30],
+    ]);
+
+    drawRois(img, [roi], { color: [255, 0, 0], lineWidth: 2 });
+
+    // An edge pixel along the top is colored.
+    let edgeColored = false;
+    for (let x = 11; x < 29; x++) {
+      const [r, g, b] = pixel(img, x, 10);
+      if (r !== 255 || g !== 255 || b !== 255) {
+        edgeColored = true;
+        break;
+      }
+    }
+    expect(edgeColored).toBe(true);
+  });
+
+  it("cuts a hole using the even-odd fill rule", async () => {
+    const img = await makeImage(50, 50, [255, 255, 255]);
+    // Outer ring + inner hole ring.
+    const roi = new UserROI({
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [5, 5],
+            [45, 5],
+            [45, 45],
+            [5, 45],
+            [5, 5],
+          ],
+          [
+            [18, 18],
+            [32, 18],
+            [32, 32],
+            [18, 32],
+            [18, 18],
+          ],
+        ],
+      },
+    });
+
+    drawRois(img, [roi], { color: [255, 0, 0], fillAlpha: 0.6 });
+
+    // Between outer and inner ring: filled (red-ish, not white).
+    const [or, og, ob] = pixel(img, 10, 25);
+    expect(or > og || or > ob).toBe(true);
+    expect(or !== 255 || og !== 255 || ob !== 255).toBe(true);
+
+    // Inside the hole: NOT filled -> still white.
+    expectRGBNear(pixel(img, 25, 25), [255, 255, 255]);
+  });
+
+  it("draws a filled dot for a Point geometry", async () => {
+    const img = await makeImage(30, 30, [255, 255, 255]);
+    const roi = new UserROI({ geometry: { type: "Point", coordinates: [15, 15] } });
+
+    drawRois(img, [roi], { color: [0, 0, 255], lineWidth: 4 });
+
+    // Center of the point is colored blue.
+    const [r, g, b] = pixel(img, 15, 15);
+    expect(b).toBeGreaterThan(150);
+    expect(r).toBeLessThan(100);
+  });
+
+  it("draws a line for a LineString geometry", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const roi = new UserROI({
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [5, 20],
+          [35, 20],
+        ],
+      },
+    });
+
+    drawRois(img, [roi], { color: [255, 0, 0], lineWidth: 2 });
+
+    // Midpoint of the horizontal line is colored.
+    const [r, g, b] = pixel(img, 20, 20);
+    expect(r !== 255 || g !== 255 || b !== 255).toBe(true);
+  });
+
+  it("draws each polygon of a MultiPolygon", async () => {
+    const img = await makeImage(60, 40, [255, 255, 255]);
+    const roi = new UserROI({
+      geometry: {
+        type: "MultiPolygon",
+        coordinates: [
+          [
+            [
+              [5, 5],
+              [20, 5],
+              [20, 20],
+              [5, 20],
+              [5, 5],
+            ],
+          ],
+          [
+            [
+              [35, 15],
+              [55, 15],
+              [55, 35],
+              [35, 35],
+              [35, 15],
+            ],
+          ],
+        ],
+      },
+    });
+
+    drawRois(img, [roi], { color: [0, 128, 0], fillAlpha: 0.5 });
+
+    // Both polygon interiors are filled (greenish, not white).
+    const a = pixel(img, 12, 12);
+    const b = pixel(img, 45, 25);
+    expect(a[0] !== 255 || a[1] !== 255 || a[2] !== 255).toBe(true);
+    expect(b[0] !== 255 || b[1] !== 255 || b[2] !== 255).toBe(true);
+  });
+
+  it("fills a polygon interior when fillAlpha > 0", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const filled = UserROI.fromPolygon([
+      [10, 10],
+      [30, 10],
+      [30, 30],
+      [10, 30],
+    ]);
+
+    drawRois(img, [filled], { color: [255, 0, 0], fillAlpha: 0.5 });
+
+    // Interior is now tinted (not white).
+    const [r, g, b] = pixel(img, 20, 20);
+    expect(r !== 255 || g !== 255 || b !== 255).toBe(true);
+  });
+
+  it("draws each point of a MultiPoint geometry", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const roi = new UserROI({
+      geometry: {
+        type: "MultiPoint",
+        coordinates: [
+          [10, 10],
+          [30, 30],
+        ],
+      },
+    });
+
+    drawRois(img, [roi], { color: [0, 0, 255], lineWidth: 4 });
+
+    // Both point centers are filled blue.
+    for (const [x, y] of [
+      [10, 10],
+      [30, 30],
+    ]) {
+      const [r, g, b] = pixel(img, x, y);
+      expect(b).toBeGreaterThan(150);
+      expect(r).toBeLessThan(100);
+    }
+  });
+
+  it("draws each member of a GeometryCollection (Point + LineString)", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const roi = new UserROI({
+      geometry: {
+        type: "GeometryCollection",
+        geometries: [
+          { type: "Point", coordinates: [10, 10] },
+          {
+            type: "LineString",
+            coordinates: [
+              [5, 30],
+              [35, 30],
+            ],
+          },
+        ],
+      },
+    });
+
+    drawRois(img, [roi], { color: [255, 0, 0], lineWidth: 3 });
+
+    // The point center is drawn.
+    {
+      const [r, g, b] = pixel(img, 10, 10);
+      expect(r !== 255 || g !== 255 || b !== 255).toBe(true);
+    }
+    // The line midpoint is drawn.
+    {
+      const [r, g, b] = pixel(img, 20, 30);
+      expect(r !== 255 || g !== 255 || b !== 255).toBe(true);
+    }
+  });
+
+  it("is a no-op for an empty roi list", async () => {
+    const img = await makeImage(10, 10, [7, 8, 9]);
+    const before = Array.from(img.data);
+    drawRois(img, []);
+    expect(Array.from(img.data)).toEqual(before);
+  });
+});
+
+// ===========================================================================
+// applyOverlay dispatcher
+// ===========================================================================
+
+describe("applyOverlay", () => {
+  it("dispatches a single LabelImage to the label-image raster path", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    const data = new Int32Array(8 * 8);
+    for (let r = 0; r < 4; r++) for (let c = 0; c < 4; c++) data[r * 8 + c] = 1;
+    const li = UserLabelImage.fromArray(data, 8, 8);
+
+    applyOverlay(img, li, { alpha: 0.3, palette: "distinct" });
+
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], DISTINCT[1], 0.3));
+    expectRGBNear(pixel(img, 7, 7), [255, 255, 255]);
+  });
+
+  it("dispatches a SegmentationMask[] with per-item palette colors", async () => {
+    const img = await makeImage(12, 12, [255, 255, 255]);
+    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 4, 4), 12, 12);
+    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 6, 6, 10, 10), 12, 12);
+
+    applyOverlay(img, [m0, m1], { alpha: 0.4, palette: "distinct" });
+
+    // Per-item colors from getPalette("distinct", 2): [0] and [1].
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], DISTINCT[0], 0.4));
+    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], DISTINCT[1], 0.4));
+  });
+
+  it("dispatches an ROI[] to the vector path", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const roi = UserROI.fromPolygon([
+      [10, 10],
+      [30, 10],
+      [30, 30],
+      [10, 30],
+    ]);
+
+    applyOverlay(img, [roi], { alpha: 0.5, palette: "distinct" });
+
+    // Polygon edge colored somewhere on the top edge.
+    let edgeColored = false;
+    for (let x = 11; x < 29; x++) {
+      const [r, g, b] = pixel(img, x, 10);
+      if (r !== 255 || g !== 255 || b !== 255) {
+        edgeColored = true;
+        break;
+      }
+    }
+    expect(edgeColored).toBe(true);
+  });
+
+  it("dispatches a BoundingBox[] to the vector path", async () => {
+    const img = await makeImage(40, 40, [255, 255, 255]);
+    const bbox = UserBoundingBox.fromXyxy(10, 10, 30, 30);
+
+    applyOverlay(img, [bbox], { alpha: 0.5, palette: "distinct" });
+
+    let edgeColored = false;
+    for (let x = 11; x < 29; x++) {
+      const [r, g, b] = pixel(img, x, 10);
+      if (r !== 255 || g !== 255 || b !== 255) {
+        edgeColored = true;
+        break;
+      }
+    }
+    expect(edgeColored).toBe(true);
+  });
+
+  it("throws a TypeError for a list[LabelImage]", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    const li = UserLabelImage.fromArray(new Int32Array(64).fill(1), 8, 8);
+    // Cast through unknown: the public type forbids LabelImage[], but the
+    // runtime guard must still reject it (per-frame dispatch belongs to video).
+    expect(() =>
+      applyOverlay(img, [li] as unknown as Parameters<typeof applyOverlay>[1]),
+    ).toThrow(TypeError);
+  });
+
+  it("throws a TypeError for an unknown element type", async () => {
+    const img = await makeImage(8, 8, [255, 255, 255]);
+    expect(() =>
+      applyOverlay(
+        img,
+        [{ foo: "bar" }] as unknown as Parameters<typeof applyOverlay>[1],
+      ),
+    ).toThrow(TypeError);
+  });
+
+  it("is a no-op for an empty overlay list", async () => {
+    const img = await makeImage(6, 6, [1, 2, 3]);
+    const before = Array.from(img.data);
+    applyOverlay(img, [] as SegmentationMask[]);
+    expect(Array.from(img.data)).toEqual(before);
+  });
+});
+
+// ===========================================================================
+// renderImage integration
+// ===========================================================================
+
+describe("renderImage with overlay", () => {
+  function createVideo(): Video {
+    return new Video({ filename: "overlay-test.mp4" });
+  }
+
+  it("applies a mask overlay beneath the poses", async () => {
+    const skeleton = createTestSkeleton();
+    // Pose node at (5, 5) so its marker pixel keeps the pose color on top.
+    const instance = new Instance({
+      points: { head: [5, 5], tail: [25, 25] },
+      skeleton,
+    });
+
+    // Mask covering a different region (rows/cols 12-20) that the pose does not
+    // touch, so we can assert the blended overlay color there.
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 12, 12, 20, 20),
+      40,
+      40,
+    );
+
+    const img = await renderImage([instance], {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      overlay: [mask],
+      overlayAlpha: 0.5,
+      overlayPalette: "distinct",
+      showEdges: false,
+      showNodes: true,
+      markerSize: 3,
+    });
+
+    // Mask-only region: white blended toward distinct[0] at 0.5.
+    expectRGBNear(
+      pixel(img, 15, 15),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
+
+    // Pose marker region near (5,5): NOT white and NOT the mask color (a pose
+    // node was drawn on top). Just confirm the pixel was painted by the pose.
+    let poseColored = false;
+    for (let y = 3; y < 8 && !poseColored; y++) {
+      for (let x = 3; x < 8; x++) {
+        const [r, g, b] = pixel(img, x, y);
+        if (r !== 255 || g !== 255 || b !== 255) {
+          poseColored = true;
+          break;
+        }
+      }
+    }
+    expect(poseColored).toBe(true);
+  });
+
+  it("respects overlayAlpha", async () => {
+    const skeleton = createTestSkeleton();
+    const instance = new Instance({
+      points: { head: [2, 2], tail: [4, 4] },
+      skeleton,
+    });
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(30, 30, 15, 15, 25, 25),
+      30,
+      30,
+    );
+
+    const lowAlpha = await renderImage([instance], {
+      width: 30,
+      height: 30,
+      background: [255, 255, 255],
+      overlay: [mask],
+      overlayAlpha: 0.2,
+      overlayPalette: "distinct",
+      showNodes: false,
+      showEdges: false,
+    });
+    const highAlpha = await renderImage([instance], {
+      width: 30,
+      height: 30,
+      background: [255, 255, 255],
+      overlay: [mask],
+      overlayAlpha: 0.8,
+      overlayPalette: "distinct",
+      showNodes: false,
+      showEdges: false,
+    });
+
+    expectRGBNear(
+      pixel(lowAlpha, 20, 20),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.2),
+      4,
+    );
+    expectRGBNear(
+      pixel(highAlpha, 20, 20),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.8),
+      4,
+    );
+    // Higher alpha pulls the green channel further from white.
+    expect(pixel(highAlpha, 20, 20)[1]).toBeLessThan(pixel(lowAlpha, 20, 20)[1]);
+  });
+
+  it("renders a segmentation-only LabeledFrame (no instances) without throwing", async () => {
+    const video = createVideo();
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 10, 10, 25, 25),
+      40,
+      40,
+    );
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [],
+      masks: [mask],
+    });
+
+    const img = await renderImage(frame, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      overlay: [mask],
+      overlayAlpha: 0.5,
+      overlayPalette: "distinct",
+    });
+
+    expect(img.width).toBe(40);
+    expectRGBNear(
+      pixel(img, 15, 15),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
+  });
+
+  it("applies a LabelImage overlay passed directly", async () => {
+    const video = createVideo();
+    const data = new Int32Array(30 * 30);
+    for (let r = 5; r < 20; r++) for (let c = 5; c < 20; c++) data[r * 30 + c] = 1;
+    const li = UserLabelImage.fromArray(data, 30, 30);
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [],
+      labelImages: [li],
+    });
+
+    const img = await renderImage(frame, {
+      width: 30,
+      height: 30,
+      background: [255, 255, 255],
+      overlay: li,
+      overlayAlpha: 0.4,
+      overlayPalette: "distinct",
+    });
+
+    expectRGBNear(
+      pixel(img, 10, 10),
+      blendRGB([255, 255, 255], DISTINCT[1], 0.4),
+      4,
+    );
+  });
+});
+
+// ===========================================================================
+// renderVideo per-frame overlay (smoke-level; ffmpeg-gated)
+// ===========================================================================
+
+describe("renderVideo per-frame overlay", () => {
+  function frameWithMask(
+    video: Video,
+    frameIdx: number,
+    block: [number, number, number, number],
+  ): LabeledFrame {
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(20, 20, block[0], block[1], block[2], block[3]),
+      20,
+      20,
+    );
+    return new LabeledFrame({ video, frameIdx, instances: [], masks: [mask] });
+  }
+
+  it("renders frames with a static overlay applied to every frame", async () => {
+    const { checkFfmpeg } = await import("../../src/rendering/video");
+    if (!(await checkFfmpeg())) return; // skip when ffmpeg unavailable
+
+    const video = new Video({ filename: "v.mp4" });
+    const f0 = frameWithMask(video, 0, [2, 2, 8, 8]);
+    const f1 = frameWithMask(video, 1, [2, 2, 8, 8]);
+    const staticMask = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 10, 10, 18, 18),
+      20,
+      20,
+    );
+
+    const tmp = `/tmp/overlay-static-${Date.now()}.mp4`;
+    await expect(
+      renderVideo([f0, f1], tmp, {
+        width: 20,
+        height: 20,
+        background: [255, 255, 255],
+        overlay: [staticMask],
+        overlayAlpha: 0.5,
+      }),
+    ).resolves.toBeUndefined();
+
+    const fs = await import("node:fs");
+    expect(fs.existsSync(tmp)).toBe(true);
+    fs.unlinkSync(tmp);
+  });
+
+  it("renders frames with a callable overlay differing per frame", async () => {
+    const { checkFfmpeg } = await import("../../src/rendering/video");
+    if (!(await checkFfmpeg())) return; // skip when ffmpeg unavailable
+
+    const video = new Video({ filename: "v.mp4" });
+    const maskA = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 1, 1, 6, 6),
+      20,
+      20,
+    );
+    const maskB = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 12, 12, 18, 18),
+      20,
+      20,
+    );
+    // Attach the per-frame masks to each frame so renderImage has something to
+    // render (the empty-frame guard is annotation-aware). The callable overlay
+    // independently selects which mask to draw per frame index.
+    const f0 = new LabeledFrame({ video, frameIdx: 0, instances: [], masks: [maskA] });
+    const f1 = new LabeledFrame({ video, frameIdx: 1, instances: [], masks: [maskB] });
+    const overlayFn = (frameIdx: number): SegmentationMask[] =>
+      frameIdx === 0 ? [maskA] : [maskB];
+
+    const tmp = `/tmp/overlay-callable-${Date.now()}.mp4`;
+    await expect(
+      renderVideo([f0, f1], tmp, {
+        width: 20,
+        height: 20,
+        background: [255, 255, 255],
+        overlay: overlayFn,
+        overlayAlpha: 0.5,
+      }),
+    ).resolves.toBeUndefined();
+
+    const fs = await import("node:fs");
+    expect(fs.existsSync(tmp)).toBe(true);
+    fs.unlinkSync(tmp);
+  });
+
+  it("renders single-frame outputs that differ between two distinct overlays", async () => {
+    // ffmpeg-independent: compare the underlying renderImage output the video
+    // path uses per frame, so the assertion of "differs per frame" holds even
+    // without ffmpeg installed.
+    const video = new Video({ filename: "v.mp4" });
+    const maskA = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 1, 1, 6, 6),
+      20,
+      20,
+    );
+    const maskB = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 12, 12, 18, 18),
+      20,
+      20,
+    );
+    // Carry an annotation so the empty-frame guard passes; the explicit overlay
+    // option is what actually drives the blended pixels below.
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [],
+      masks: [maskA, maskB],
+    });
+
+    const imgA = await renderImage(frame, {
+      width: 20,
+      height: 20,
+      background: [255, 255, 255],
+      overlay: [maskA],
+      overlayAlpha: 0.5,
+    });
+    const imgB = await renderImage(frame, {
+      width: 20,
+      height: 20,
+      background: [255, 255, 255],
+      overlay: [maskB],
+      overlayAlpha: 0.5,
+    });
+
+    expect(Array.from(imgA.data)).not.toEqual(Array.from(imgB.data));
+    // maskA region tinted in A, white in B; vice versa for maskB region.
+    expectRGBNear(pixel(imgA, 3, 3), blendRGB([255, 255, 255], DISTINCT[0], 0.5), 4);
+    expectRGBNear(pixel(imgB, 3, 3), [255, 255, 255]);
+    expectRGBNear(pixel(imgB, 15, 15), blendRGB([255, 255, 255], DISTINCT[0], 0.5), 4);
+    expectRGBNear(pixel(imgA, 15, 15), [255, 255, 255]);
+  });
+});


### PR DESCRIPTION
## Summary

Ports Python sleap-io [PR #374](https://github.com/talmolab/sleap-io/pull/374) (segmentation overlay rendering) to the JS Node raster path, closing the implementation portion of #96.

A new Node-only module `src/rendering/overlays.ts` faithfully ports `overlays.py` plus the `_apply_overlay` dispatcher from `core.py`, and the overlay is wired into both `renderImage` and `renderVideo`.

## What's new

**Standalone draw functions** (exported from `index.ts`, mutate an `ImageData` in place):

| Function | Behavior |
|---|---|
| `drawMasks` | Alpha-blend `SegmentationMask[]` onto pixels; honors scale/offset spatial transforms (nearest-neighbor resize + offset placement + clip) |
| `drawLabelImage` | LUT-colored integer label overlay; optional region outlines (4-neighbor edge detection + square-element dilation; uniform or darkened per-label color) |
| `drawBboxes` | Closed-path corners (rotation-aware), optional translucent fill, `score` text for `PredictedBoundingBox` |
| `drawRois` | GeoJSON geometry — Polygon (even-odd holes), MultiPolygon, Point/MultiPoint (filled circles), LineString, GeometryCollection |
| `applyOverlay` | Type dispatcher matching Python: per-item palette colors; `TypeError` on `list[LabelImage]` and unknown element types |

**Render wiring:**
- `renderImage` gains `overlay`, `overlayAlpha` (0.3), `overlayPalette` (`"distinct"`), `overlayOutline` (false), `overlayOutlineWidth` (1), `overlayOutlineColor` (null). The overlay is applied **after the background and before trails/poses**, in source-pixel space so it stays aligned with poses under non-unit `scale`.
- `renderVideo` gains a per-frame `VideoOverlay`: a static overlay, a `LabelImage[]` indexed by render position, a `Map<number, Overlay>` keyed by `frameIdx`, or a `(frameIdx) => Overlay` callable — with auto-detection from `Labels.labelImages`, mirroring Python `render_video`.

## Correctness / parity notes
- Raster blend (`dst*(1-a) + src*a`) uses `Math.trunc`, which matches numpy `.astype(uint8)` truncation exactly.
- Edge detection, square-element dilation (`pad = width//2`), darkened outline (`lut*0.6`), LUT cycling (`palette[id % len]`), and the dispatcher branches/`TypeError`s all mirror the Python source line-for-line.
- `resizeNearest` is reused from `model/mask.ts` rather than duplicated.

## Scope (matches PR #374 + #96 framing)
- **In scope:** the Node raster path (skia-canvas) — bakes overlays into `ImageData`/files.
- **Out of scope (separate follow-ups):** browser-side OffscreenCanvas compositing and mask contour tracing (marching-squares). Overlays are exported from `index.ts` only — **never** `index.browser.ts`; the browser bundle stays render-free (verified: 0 overlay/skia references in `dist/index.browser.js`).

## Tests
60 tests in `tests/rendering/overlays.test.ts` with **real pixel assertions** (blended RGB at known coordinates, edge colors, even-odd hole cutouts, score text, per-frame video overlays) covering every draw function, all dispatcher branches, and both `renderImage`/`renderVideo` overlay paths — including spatial transforms, negative/out-of-bounds offsets, overlapping masks, palette wrapping, color-array cycling, and alpha clamping.

## Verification (local)
- `bun run lint` → exit 0
- `bun run build` → success; browser bundle confirmed free of overlay/skia code
- `bun test` → overlay suite **60/60 pass**; full suite **1330 pass / 1 skip / 11 fail**

> The 11 failures are all pre-existing `Mp4BoxVideoBackend` "requires WebCodecs support" cases — a documented `mock.module` cross-file leak under `bun test --parallel` (see `tests/bun-test.ts`), reproducing identically on `main`. They pass in isolation (11/11) and are unrelated to rendering. Local bun is 1.3.5 vs CI's pinned 1.3.14, which differ in WebCodecs availability.

## Docs
New **Overlay Rendering** section in `docs/rendering.md`: options table, runnable per-type examples (label image / mask / bbox / ROI), standalone-function reference, and a video-overlay guide. `mkdocs build --strict` passes.

## Review
Implementation went through a 4-lens adversarial review (Python parity, correctness/edge-cases, types/build/browser-safety, test adequacy). Two genuine bugs were fixed (out-of-bounds per-item `colors` indexing → modulo cycling; unclamped `alpha`/`fillAlpha` → clamp to `[0,1]`) and 10 tests added. False positives were deferred with rationale — notably `MultiLineString`, which is not representable in the JS `Geometry` union (no parser/WKB support), so its draw case is moot.

Closes #96 (Node raster path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
