### PR TITLE
feat(video): expose embedded frame numbers via Video.embeddedFrameIndices

### DIFF
--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -158,6 +158,19 @@ export class Video {
     return this._embedded;
   }
 
+  /**
+   * Sorted, de-duplicated source frame numbers that have an available image, or
+   * `null` when every frame is available (continuous video) or the set is
+   * unknown / the backend is closed. For an embedded-image video (`pkg.slp`)
+   * the backend exposes the stored `frame_numbers`; callers should treat `null`
+   * as "no restriction" (all frames imaged).
+   */
+  get embeddedFrameIndices(): number[] | null {
+    const nums = this.backend?.frameNumbers;
+    if (!nums || nums.length === 0) return null;
+    return [...new Set(nums)].sort((a, b) => a - b);
+  }
+
   get originalVideo(): Video | null {
     if (!this.sourceVideo) return null;
     let current = this.sourceVideo;

--- a/src/video/backend.ts
+++ b/src/video/backend.ts
@@ -5,6 +5,12 @@ export interface VideoBackend {
   shape?: [number, number, number, number];
   fps?: number;
   dataset?: string | null;
+  /**
+   * Embedded-image (HDF5 / `pkg.slp`) backends: the source frame numbers that
+   * have a stored image, in storage order. Left unset by continuous-video
+   * backends (mp4 / seq / image-sequence), where every frame is decodable.
+   */
+  frameNumbers?: number[];
   getFrame(frameIndex: number): Promise<VideoFrame | null>;
   getFrameTimes?(): Promise<number[] | null>;
   close(): void;

--- a/src/video/crop-backend.ts
+++ b/src/video/crop-backend.ts
@@ -299,6 +299,15 @@ export class CropVideoBackend implements VideoBackend {
   }
 
   /**
+   * Inner backend's embedded frame numbers (delegated). A crop is spatial and
+   * frame-preserving, so the embedded set is exactly the inner's. Without this,
+   * a cropped `pkg.slp` would report no embedded set (see {@link VideoBackend.frameNumbers}).
+   */
+  get frameNumbers(): number[] | undefined {
+    return this.inner.frameNumbers;
+  }
+
+  /**
    * Cropped frame shape `[F, h, w, c]`.
    *
    * Frame count and channel count come from the inner (a crop is spatial and

--- a/src/video/hdf5-video.ts
+++ b/src/video/hdf5-video.ts
@@ -23,6 +23,8 @@ export class Hdf5VideoBackend implements VideoBackend {
   dataset?: string | null;
   shape?: [number, number, number, number];
   fps?: number;
+  /** Source frame numbers with a stored image (storage order). */
+  frameNumbers: number[];
   private file: any;
   private datasetPath: string;
   private frameNumberToIndex: Map<number, number>;
@@ -48,6 +50,7 @@ export class Hdf5VideoBackend implements VideoBackend {
     this.dataset = options.datasetPath;
     // Build O(1) lookup map from frame numbers
     const frameNumbers = options.frameNumbers ?? [];
+    this.frameNumbers = frameNumbers;
     this.frameNumberToIndex = new Map(frameNumbers.map((num, idx) => [num, idx]));
     this.format = options.format ?? "png";
     this.channelOrder = options.channelOrder ?? "RGB";

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -28,6 +28,8 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
   dataset?: string | null;
   shape?: [number, number, number, number];
   fps?: number;
+  /** Source frame numbers with a stored image (storage order). */
+  frameNumbers: number[];
   private h5file: StreamingH5File;
   private datasetPath: string;
   private frameNumberToIndex: Map<number, number>;
@@ -54,6 +56,7 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     this.dataset = options.datasetPath;
     // Build O(1) lookup map from frame numbers
     const frameNumbers = options.frameNumbers ?? [];
+    this.frameNumbers = frameNumbers;
     this.frameNumberToIndex = new Map(frameNumbers.map((num, idx) => [num, idx]));
     this.format = options.format ?? "png";
     this.channelOrder = options.channelOrder ?? "RGB";

--- a/tests/model/video-embedded-frame-indices.test.ts
+++ b/tests/model/video-embedded-frame-indices.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for `Video.embeddedFrameIndices` — the public accessor that surfaces
+ * the source frame numbers with a stored image for embedded-image (`pkg.slp`)
+ * videos. Consumed by sleap-app's "navigate imaged frames only" mode
+ * (sleap-app issue #137): for a continuous video every frame is decodable, so
+ * the getter returns `null` ("no restriction"); for a `pkg.slp` it returns the
+ * sparse embedded set so navigation can be confined to frames you can see.
+ */
+import { describe, it, expect } from "../bun-test";
+import { Video } from "../../src/model/video.js";
+import type { VideoBackend, VideoFrame } from "../../src/video/backend.js";
+import { readSlp } from "../../src/codecs/slp/read.js";
+import { CropVideoBackend } from "../../src/video/crop-backend.js";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+
+/** Minimal backend stub holding only the fields the getter reads. */
+function backendWith(frameNumbers?: number[]): VideoBackend {
+  return {
+    filename: "stub",
+    frameNumbers,
+    getFrame: async (): Promise<VideoFrame | null> => null,
+    close: () => {},
+  } as VideoBackend;
+}
+
+describe("Video.embeddedFrameIndices", () => {
+  it("returns sorted, de-duplicated frame numbers from an embedded backend", () => {
+    const video = new Video({ filename: "x", backend: backendWith([20, 10, 10, 30]) });
+    expect(video.embeddedFrameIndices).toEqual([10, 20, 30]);
+  });
+
+  it("returns null for a continuous-video backend with no frame numbers", () => {
+    const video = new Video({ filename: "x", backend: backendWith(undefined) });
+    expect(video.embeddedFrameIndices).toBeNull();
+  });
+
+  it("returns null for an embedded backend with an empty set", () => {
+    const video = new Video({ filename: "x", backend: backendWith([]) });
+    expect(video.embeddedFrameIndices).toBeNull();
+  });
+
+  it("returns null when there is no backend", () => {
+    const video = new Video({ filename: "x", backend: null });
+    expect(video.embeddedFrameIndices).toBeNull();
+  });
+
+  it("surfaces the embedded set of a real pkg.slp loaded with openVideos", async () => {
+    const labels = await readSlp(
+      path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"),
+      { openVideos: true },
+    );
+    const video = labels.videos[0];
+    expect(video.hasEmbeddedImages).toBe(true);
+
+    const indices = video.embeddedFrameIndices;
+    expect(indices).not.toBeNull();
+    expect(indices!.length).toBeGreaterThan(0);
+    // Sorted ascending and de-duplicated.
+    expect(indices).toEqual([...new Set(indices!)].sort((a, b) => a - b));
+    // Every reported index must actually decode to a frame.
+    expect(await video.getFrame(indices![0])).not.toBeNull();
+  });
+
+  it("surfaces the embedded set through a CropVideoBackend (cropped pkg.slp)", async () => {
+    const labels = await readSlp(
+      path.join(fixtureRoot, "slp", "cropped_format_2_3.pkg.slp"),
+      { openVideos: true },
+    );
+    const video = labels.videos[0];
+    // A cropped pkg.slp wraps the embedded backend in a CropVideoBackend; the
+    // accessor must see through the wrapper or imaged-frame navigation no-ops.
+    expect(video.backend instanceof CropVideoBackend).toBe(true);
+
+    const indices = video.embeddedFrameIndices;
+    expect(indices).not.toBeNull();
+    expect(indices!.length).toBeGreaterThan(0);
+    expect(indices).toEqual([...new Set(indices!)].sort((a, b) => a - b));
+    expect(await video.getFrame(indices![0])).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Re-expose the embedded `frame_numbers` that the HDF5 readers already parse but keep private, behind a typed public API: **`Video.embeddedFrameIndices`**. This lets a consumer ask *which frames of an embedded (`pkg.slp`) video actually have a stored image* — the data sleap-app's "navigate imaged frames only" mode needs (talmolab/sleap-app#137).

Purely additive: one new optional interface field + new getters. **No change to SLP writing or serialization** — it only surfaces a list that was already parsed and stranded behind a `private`.

## Changes (+34 lines, 5 files)
- **`src/video/backend.ts`** — add optional `frameNumbers?: number[]` to the `VideoBackend` interface (embedded HDF5 backends set it; continuous backends leave it unset).
- **`src/video/hdf5-video.ts`**, **`src/video/streaming-hdf5-video.ts`** — both HDF5 backends already receive `frameNumbers` in their constructor (used to build a private lookup map); now also keep it on a public `frameNumbers` field, covering the Node (sync) and browser/Tauri (streaming) paths.
- **`src/video/crop-backend.ts`** — `CropVideoBackend.frameNumbers` getter delegating to `this.inner.frameNumbers`, so a cropped `pkg.slp` (SLP 2.3) surfaces its embedded set through the wrapper instead of reporting none.
- **`src/model/video.ts`** — `Video.embeddedFrameIndices` getter: the backend's `frameNumbers` sorted + de-duplicated, or `null` for a continuous / closed / empty video (callers treat `null` as "no restriction — all frames imaged").

## Tests
New `tests/model/video-embedded-frame-indices.test.ts` (6 tests): getter behavior (sort/dedup; `null` for continuous / no-backend / empty), the real `minimal_instance.pkg.slp`, and the cropped `cropped_format_2_3.pkg.slp` through the `CropVideoBackend` wrapper.

- `bun run lint` (`tsc --noEmit`) ✓
- `bun run build` ✓
- `bun run test` → 1453 pass / 1 skip / **1 fail**. The single failure (`edge-less skeletons: Python ↔ JS SLP cross-compat`) is a **pre-existing** local-Python-interop test that fails identically on `main` (verified via `git stash`); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
