### PR TITLE
fix(video): read whole vlen dataset for embedded frames (legacy pkg.slp)

### DIFF
--- a/src/video/embedded-frame.ts
+++ b/src/video/embedded-frame.ts
@@ -228,11 +228,26 @@ export async function readEmbeddedFrameBytes(
     return encoded ? trimPaddedRow(row, reader.frameSizes?.[index]) : row;
   }
 
-  // vlen: h5wasm slices a single element -> an array holding one blob.
+  // vlen: read the WHOLE dataset once and index into the cached blob array.
+  //
+  // h5wasm's hyperslab *sub-selection* of a variable-length dataset is
+  // memory-unsafe: requesting a single element (`[[index, index+1]]`) selects a
+  // subset of the global-heap-backed blobs and intermittently throws "memory
+  // access out of bounds" (browser Web Worker) or aborts the WASM runtime
+  // (Node), depending on heap state. Reading the whole dataset (`dataset.value`,
+  // all elements) goes through a different, reliable code path. This costs one
+  // video's worth of embedded images in memory (cached on `reader.legacy.whole`,
+  // freed on backend `close()`) — the per-frame slice optimization from #135
+  // simply does not apply to vlen, where slicing is broken. Legacy pkg.slp files
+  // (older PyQt SLEAP) use this layout; without this, getFrame returns null and
+  // the frame renders black.
   if (layout === "vlen") {
-    const { value } = await reader.readSlice([[index, index + 1]]);
-    const entry = Array.isArray(value) ? value[0] : value;
-    return asUint8Array(entry);
+    if (!reader.legacy.whole) {
+      const { value } = await reader.readSlice();
+      reader.legacy.whole = Array.isArray(value) ? value : [];
+    }
+    const whole = reader.legacy.whole;
+    return Array.isArray(whole) ? asUint8Array(whole[index]) : null;
   }
 
   // 1D concatenated with known sizes: exact byte-range slice.

--- a/tests/video/embedded-frame.test.ts
+++ b/tests/video/embedded-frame.test.ts
@@ -145,19 +145,27 @@ describe("readEmbeddedFrameBytes", () => {
     expect(calls.length).toBe(1);
   });
 
-  it("vlen: slices a single element and unwraps the blob", async () => {
+  it("vlen: reads the whole dataset once and caches it (h5wasm vlen hyperslab is unsafe)", async () => {
+    // h5wasm's single-element hyperslab slice of a variable-length dataset is
+    // memory-unsafe: selecting a SUBSET of the global-heap-backed elements
+    // throws "memory access out of bounds" (browser worker) / aborts (Node),
+    // intermittently, depending on heap state. Reading the WHOLE dataset (all
+    // elements) is reliable. So vlen must read whole + cache, never sub-slice.
+    const blobs = [int8([0x89, 0x50, 0x01]), int8([0x89, 0x50, 0x02]), int8([0x89, 0x50, 0x03])];
     const { reader, calls } = fakeReader({
-      shape: [2],
-      frameCount: 2, // == 2 -> vlen
+      shape: [3],
+      frameCount: 3, // == length -> vlen
       format: "png",
       onSlice: (slice) => {
-        expect(slice).toEqual([[1, 2]]);
-        return [int8([0x89, 0x50, 0xff])]; // array holding one blob
+        // A sub-range hyperslab is exactly what crashes h5wasm — never attempt it.
+        if (slice !== undefined) throw new Error("memory access out of bounds");
+        return blobs; // whole read returns every blob, reliably
       },
     });
-    const out = await readEmbeddedFrameBytes(reader, 1);
-    expect(Array.from(out!)).toEqual([0x89, 0x50, 0xff]);
-    expect(calls.length).toBe(1);
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual([0x89, 0x50, 0x01]);
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 2))!)).toEqual([0x89, 0x50, 0x03]);
+    // Whole dataset read exactly once (cached across frames); no sub-slice.
+    expect(calls).toEqual([undefined]);
   });
 
   it("legacy fallback: 1D concat without frame_sizes scans once and caches", async () => {
@@ -367,8 +375,8 @@ describe("Hdf5VideoBackend single-frame slicing (2D padded)", () => {
   });
 });
 
-describe("Hdf5VideoBackend single-frame slicing (real vlen pkg.slp)", () => {
-  it("slices a single vlen element without reading the whole dataset", async () => {
+describe("Hdf5VideoBackend frame reads (real vlen pkg.slp)", () => {
+  it("reads the whole vlen dataset once and caches it (h5wasm vlen hyperslab is unsafe)", async () => {
     const bytes = fs.readFileSync(path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"));
     const { file: rawFile, close } = await openH5File(new Uint8Array(bytes));
     const { file, spy } = wrapWithSpy(rawFile, close);
@@ -386,10 +394,15 @@ describe("Hdf5VideoBackend single-frame slicing (real vlen pkg.slp)", () => {
     const out = (await backend.getFrame(frameNumbers[0])) as Uint8Array;
     expect(out).toBeInstanceOf(Uint8Array);
     expect(out.length).toBeGreaterThan(0);
-    // It is a real PNG blob, sliced — and the whole vlen array was never read.
+    // A real PNG blob, read via the whole-dataset path — a per-element vlen
+    // hyperslab slice is memory-unsafe in h5wasm, so it is never attempted.
     expect(Array.from(out.subarray(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
-    expect(spy.value).toBe(0);
-    expect(spy.slice).toBeGreaterThan(0);
+    expect(spy.slice).toBe(0);
+    expect(spy.value).toBeGreaterThan(0);
+
+    // A second read is served from cache — the whole dataset is read only once.
+    await backend.getFrame(frameNumbers[0]);
+    expect(spy.value).toBe(1);
 
     file._close();
   });


### PR DESCRIPTION
## Problem

Legacy `pkg.slp` files (older PyQt SLEAP) embed images as **variable-length (vlen)** HDF5 datasets. Reading one embedded frame did a single-element hyperslab slice (`readSlice([[index, index + 1]])`). h5wasm's hyperslab **sub-selection of a vlen dataset is memory-unsafe** — it intermittently throws `"memory access out of bounds"` (browser Web Worker) or aborts the WASM runtime (Node), depending on heap state and element position. `getFrame` catches the throw and returns `null`, so affected frames render **black** even though the image is embedded.

Found while opening a 40-video legacy mice_hc `pkg.slp`: navigating to a labeled frame showed the instances but a black background (`getFrame(6395) returned null`), despite the frame being embedded in that video. A faithful synthetic vlen fixture reproduces it (2D-padded files do **not** — they slice fine); `minimal_instance.pkg.slp` doesn't trigger it only because a 1-element dataset's `[[0,1]]` selects everything, i.e. no real sub-selection.

## Fix

The `vlen` branch of `readEmbeddedFrameBytes` now reads the **whole dataset once** and caches the blob array on `reader.legacy.whole` (the same cache the `concat`/`ambiguous1d` fallbacks already use), then indexes per frame. The whole-dataset read goes through a different, reliable h5wasm code path. Covers both `StreamingHdf5VideoBackend` (browser worker) and `Hdf5VideoBackend` (Node) — they share this function and both clear the cache in `close()`.

## ⚠️ Pre-#135 behavior for legacy embedded images

This intentionally **reverts vlen embedded reads to the pre-#135 behavior**: one video's full embedded image set is held in memory (tens–hundreds of MB for large videos), freed on backend `close()`.

- **Modern pkg.slp (2D-padded / concat)** → unchanged; the #135 per-frame slice optimization is fully retained (low memory).
- **Legacy pkg.slp (vlen)** → whole-dataset cache. This is the only h5wasm-safe option, since per-element vlen hyperslab slicing is the broken operation. It restores exactly the memory profile that shipped before #135 for these files.

Consumer note: a backend whose `close()` is never called (e.g. an app that doesn't close on video switch) will accumulate one cache per *visited* vlen video; bounding that with close-on-switch is a possible follow-up on the consumer side, out of scope here.

## Tests

- Replaced the unit test that asserted single-element vlen slicing with one that simulates the real failure mode — a sub-range slice **throws** `"memory access out of bounds"`, the whole read succeeds — and asserts correct bytes via a single whole read.
- Updated the real-vlen-fixture integration test (`minimal_instance.pkg.slp`) from "slices without whole read" to "whole read, cached once" (`spy.slice === 0`, `spy.value > 0`, second call served from cache).
- Full suite green; `tsc --noEmit` clean. (The one unrelated `edge-less skeletons` Python-interop failure is pre-existing/environmental on `main`.)

Verified end-to-end on the real 40-video mice_hc `pkg.slp` via the streaming path: all embedded frames now render (previously intermittently black).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
