### PR TITLE
feat(model,slp): mask human-in-the-loop — toUser() + persisted fromPredicted + link-first merge

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -303,6 +303,8 @@ Merge annotations from one `LabeledFrame` into another with strategy-aware handl
 
 The `auto` and `update_tracks` strategies compare centroid distances against `threshold` (default `5.0` px). Empty masks and ROIs whose centroid is `null` are skipped by the matcher.
 
+Under `"auto"`, mask merging honors the `fromPredicted` provenance link *before* spatial matching: if a user mask in either frame links to a predicted mask in the other (by object identity), that pair is matched regardless of distance, and only falls back to centroid proximity when no link exists. Other annotation modalities have no `fromPredicted` link, so they are unaffected.
+
 The strategy argument is typed as `MergeStrategy`, re-exported from the package root for type-safe call sites:
 
 ```ts
@@ -453,16 +455,28 @@ mirrors `Instance.fromPredicted`: it returns a new `UserSegmentationMask` that
 copies the RLE raster and carries over metadata (`name`, `category`, `source`,
 `track`, `trackingScore`, `instance`, `scale`, `offset`) while dropping
 prediction-only fields (`score`, `scoreMap`). It sets `fromPredicted` on the
-returned mask as an in-memory provenance link.
+returned mask as a provenance link.
 
 ```ts
 const userMask = pred.toUser();      // userMask.fromPredicted === pred
 const detached = pred.toUser(false); // detached.fromPredicted === null
 ```
 
-> **Note:** unlike `Instance.fromPredicted` (which IS persisted), the mask's
-> `fromPredicted` link is in-memory only and is intentionally NOT written to the
-> SLP format — it becomes `null` after a save/load round-trip.
+> **Note:** like `Instance.fromPredicted`, the mask's `fromPredicted` link IS
+> persisted to the SLP format. It is stored as an index into the saved mask list
+> and re-linked on read, so it survives a save/load round-trip as long as the
+> source prediction is also saved (in the same or another frame). If the source
+> prediction is not saved, the link loads as `null`. Recording at least one link
+> bumps the SLP `format_id` to 2.4; the column is always written and reads are
+> presence-gated, so files written before this column existed load the link as
+> `null`.
+
+`LabeledFrame.unusedPredictedMasks` returns the predicted masks in a frame that
+no user mask has adopted — the mask analogue of `LabeledFrame.unusedPredictions`.
+A prediction is adopted when a user mask in the same frame links to it via
+`fromPredicted` (checked first, by identity) or, lacking a link, spatially
+overlaps it (bbox-centroid within 5 px). The remaining unclaimed predictions are
+returned, e.g. for surfacing unreviewed detections in a proofreading UI.
 
 ### `BoundingBox`
 Axis-aligned or rotated bounding box for detection/tracking workflows. `BoundingBox` is abstract; use `UserBoundingBox` or `PredictedBoundingBox` for direct construction.
@@ -671,6 +685,7 @@ The SLP format version (`format_id`) is set automatically based on content:
 | 2.1 | Spatial metadata (scale/offset) |
 | 2.2 | Chunked label image storage |
 | 2.3 | Virtual video crops present |
+| 2.4 | Persisted mask `fromPredicted` provenance link |
 
 ##### Virtual Crops (Format 2.3+)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -448,6 +448,22 @@ const roi = mask.toPolygon();
 const bb = mask.toBbox();
 ```
 
+**Adopting predictions (human-in-the-loop).** `PredictedSegmentationMask.toUser()`
+mirrors `Instance.fromPredicted`: it returns a new `UserSegmentationMask` that
+copies the RLE raster and carries over metadata (`name`, `category`, `source`,
+`track`, `trackingScore`, `instance`, `scale`, `offset`) while dropping
+prediction-only fields (`score`, `scoreMap`). It sets `fromPredicted` on the
+returned mask as an in-memory provenance link.
+
+```ts
+const userMask = pred.toUser();      // userMask.fromPredicted === pred
+const detached = pred.toUser(false); // detached.fromPredicted === null
+```
+
+> **Note:** unlike `Instance.fromPredicted` (which IS persisted), the mask's
+> `fromPredicted` link is in-memory only and is intentionally NOT written to the
+> SLP format — it becomes `null` after a save/load round-trip.
+
 ### `BoundingBox`
 Axis-aligned or rotated bounding box for detection/tracking workflows. `BoundingBox` is abstract; use `UserBoundingBox` or `PredictedBoundingBox` for direct construction.
 

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -1121,6 +1121,9 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
   const scoreCol = masksData.score ?? [];
   const instanceCol = masksData.instance ?? [];
   const maskTrackingScoreCol = masksData.tracking_score ?? [];
+  // v2.4+: from_predicted provenance index into the flat mask list. Absent in
+  // pre-2.4 files (presence-gated by name) -> [] -> per-row fallback -1.
+  const fromPredictedCol = masksData.from_predicted ?? [];
 
   // v2.1+: spatial metadata columns (default to 1.0/0.0 for old files)
   const scaleXCol = masksData.scale_x ?? [];
@@ -1132,6 +1135,10 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
   const scoreMaps = readScoreMaps(file, "mask_score_map_index", "mask_score_maps");
 
   const masks: [SegmentationMask, number, number][] = [];
+  // Deferred from_predicted re-link: collect (userMaskIdx, srcIdx) pairs and
+  // resolve after ALL masks are built, since a source prediction can appear
+  // later in the flat list (mirrors instance from_predicted).
+  const fromPredictedPairs: Array<[number, number]> = [];
   for (let i = 0; i < heights.length; i++) {
     const rleStart = Number(rleStarts[i]);
     const rleEnd = Number(rleEnds[i]);
@@ -1187,6 +1194,9 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
       });
     } else {
       mask = new UserSegmentationMask(baseOptions);
+      // Collect from_predicted link for deferred re-link (user masks only).
+      const fpIdx = fromPredictedCol.length > i ? Number(fromPredictedCol[i]) : -1;
+      if (fpIdx >= 0) fromPredictedPairs.push([i, fpIdx]);
     }
 
     // Resolve instance reference
@@ -1197,6 +1207,16 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
 
     masks.push([mask, videoIdx, frameIdxVal]);
   }
+
+  // Deferred from_predicted re-link pass. Bounds-checked so out-of-range or -1
+  // indices leave fromPredicted at its constructor default (null).
+  for (const [i, fpIdx] of fromPredictedPairs) {
+    if (fpIdx >= 0 && fpIdx < masks.length) {
+      (masks[i][0] as UserSegmentationMask).fromPredicted =
+        masks[fpIdx][0] as PredictedSegmentationMask;
+    }
+  }
+
   return masks;
 }
 

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -9,7 +9,7 @@ import { Video } from "../../model/video.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
 import { getH5Module, getH5FileSystem, ensureH5StagingDir } from "./h5.js";
 import { ROI, PredictedROI, encodeWkb } from "../../model/roi.js";
-import { SegmentationMask, PredictedSegmentationMask } from "../../model/mask.js";
+import { SegmentationMask, UserSegmentationMask, PredictedSegmentationMask } from "../../model/mask.js";
 import { BoundingBox, PredictedBoundingBox } from "../../model/bbox.js";
 import { Centroid, PredictedCentroid } from "../../model/centroid.js";
 import { LabelImage, PredictedLabelImage } from "../../model/label-image.js";
@@ -590,6 +590,25 @@ function writeMetadata(file: any, labels: Labels): void {
   // uncropped videos_json safely. Port of Python write_metadata (slp.py:1891-1895).
   if (labels.videos.some((v) => v._cropTuple() !== null)) {
     formatId = Math.max(formatId, 2.3);
+  }
+
+  // v2.4: persisted mask from_predicted provenance link. Bumped ONLY when some
+  // user mask actually records a *resolvable* link — i.e. its source prediction
+  // is itself in the saved mask list (object identity), mirroring the persisted
+  // from_predicted index being >= 0. A dangling link (source omitted from the
+  // saved frames) writes -1 and must NOT bump the format. The from_predicted
+  // column is always written; reads are presence-gated so pre-2.4 files load the
+  // link as null.
+  const savedMasks = labels.masks;
+  const savedMaskSet = new Set<SegmentationMask>(savedMasks);
+  if (
+    savedMasks.some(
+      (m) =>
+        (m as UserSegmentationMask).fromPredicted != null &&
+        savedMaskSet.has((m as UserSegmentationMask).fromPredicted as SegmentationMask),
+    )
+  ) {
+    formatId = Math.max(formatId, 2.4);
   }
 
   file.create_group("metadata");
@@ -1368,6 +1387,13 @@ function writeMasks(
   const scoreMapChunks: Uint8Array[] = [];
   let smOffset = 0;
 
+  // Map each mask object to its position in the flat list so a user mask's
+  // `fromPredicted` link can be resolved to a global index (mirrors instance
+  // from_predicted). Keyed by the object itself (object identity) — the JS
+  // analog of Python's id(mask).
+  const maskIdToIdx = new Map<SegmentationMask, number>();
+  masks.forEach((m, i) => maskIdToIdx.set(m, i));
+
   for (let i = 0; i < masks.length; i++) {
     const mask = masks[i];
     // Convert Uint32Array RLE counts to bytes (little-endian)
@@ -1389,10 +1415,19 @@ function writeMasks(
     const instanceIdx = mask.instance ? instances.indexOf(mask.instance as Instance) : (mask._instanceIdx ?? -1);
     const maskTrackingScore = mask.trackingScore ?? Number.NaN;
 
+    // Resolve the from_predicted provenance link to a global index into the
+    // flat mask list. -1 sentinel when there is no link or the source
+    // prediction is absent from the saved list (Map miss). Only user masks
+    // carry fromPredicted; predicted masks always resolve to -1.
+    const fromPredictedSrc = (mask as UserSegmentationMask).fromPredicted ?? null;
+    const fromPredictedIdx =
+      fromPredictedSrc != null ? (maskIdToIdx.get(fromPredictedSrc) ?? -1) : -1;
+
     rows.push([
       mask.height, mask.width, 2, videoIdx, frameIdx, trackIdx,
       score, rleStart, rleEnd, isPredicted, instanceIdx, maskTrackingScore,
       mask.scale[0], mask.scale[1], mask.offset[0], mask.offset[1],
+      fromPredictedIdx,
     ]);
     categories.push(mask.category);
     names.push(mask.name);
@@ -1416,7 +1451,7 @@ function writeMasks(
   }
 
   createMatrixDataset(file, "masks", rows,
-    ["height", "width", "annotation_type", "video", "frame_idx", "track", "score", "rle_start", "rle_end", "is_predicted", "instance", "tracking_score", "scale_x", "scale_y", "offset_x", "offset_y"], "<f8");
+    ["height", "width", "annotation_type", "video", "frame_idx", "track", "score", "rle_start", "rle_end", "is_predicted", "instance", "tracking_score", "scale_x", "scale_y", "offset_x", "offset_y", "from_predicted"], "<f8");
 
   // Write string metadata as datasets at root level (v1.9+)
   writeStringDataset(file, "mask_categories", categories);

--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -2,7 +2,7 @@ import { Instance, PredictedInstance } from "./instance.js";
 import { Video } from "./video.js";
 import { Centroid } from "./centroid.js";
 import { BoundingBox } from "./bbox.js";
-import { SegmentationMask } from "./mask.js";
+import { SegmentationMask, PredictedSegmentationMask } from "./mask.js";
 import { LabelImage } from "./label-image.js";
 import { ROI } from "./roi.js";
 import { InstanceMatcher, InstanceMatchMethod } from "./matching.js";
@@ -104,6 +104,58 @@ export function _findAnnotationMatches(
 }
 
 /**
+ * Find provenance-link matches between two annotation lists.
+ *
+ * A user annotation in one list is "linked" to a prediction in the other list
+ * when its `fromPredicted` reference points (by object identity) at that
+ * prediction. Such matches are scored `Infinity` so the greedy 1:1 pass in
+ * {@link _resolveAnnotationAuto} prefers them and bypasses the spatial distance
+ * threshold entirely (an explicit link always beats spatial proximity).
+ *
+ * Generic over modality via `(ann as any).fromPredicted`: only segmentation
+ * masks carry a `fromPredicted` link today, so other annotation types produce
+ * zero link matches and behave exactly as before.
+ *
+ * @returns List of {selfIdx, otherIdx, score} with score = Infinity. Links are
+ *   detected in both directions (a user in self pointing into other, and a user
+ *   in other pointing into self).
+ */
+export function _findAnnotationLinkMatches(
+  selfList: Annotation[],
+  otherList: Annotation[],
+): Array<{ selfIdx: number; otherIdx: number; score: number }> {
+  const matches: Array<{ selfIdx: number; otherIdx: number; score: number }> =
+    [];
+  // Object-identity index maps (the JS analog of Python's id()).
+  const selfIdToIdx = new Map<Annotation, number>();
+  for (let i = 0; i < selfList.length; i++) selfIdToIdx.set(selfList[i], i);
+  const otherIdToIdx = new Map<Annotation, number>();
+  for (let j = 0; j < otherList.length; j++) otherIdToIdx.set(otherList[j], j);
+
+  // self -> other: a user annotation in self links to a prediction in other.
+  for (let i = 0; i < selfList.length; i++) {
+    const src = (selfList[i] as any).fromPredicted;
+    if (src == null) continue;
+    const j = otherIdToIdx.get(src);
+    if (j !== undefined) {
+      matches.push({ selfIdx: i, otherIdx: j, score: Infinity });
+    }
+  }
+
+  // other -> self: a user annotation in other links to a prediction in self.
+  for (let j = 0; j < otherList.length; j++) {
+    const src = (otherList[j] as any).fromPredicted;
+    if (src == null) continue;
+    const i = selfIdToIdx.get(src);
+    if (i !== undefined) {
+      matches.push({ selfIdx: i, otherIdx: j, score: Infinity });
+    }
+  }
+
+  return matches;
+}
+
+/**
  * Apply auto merge resolution to a list of annotations.
  *
  * Mirrors the instance auto-merge cascade: keep user from self, spatially
@@ -126,11 +178,18 @@ function _resolveAnnotationAuto(
     }
   }
 
-  // 2. Find spatial matches
-  const matches = _findAnnotationMatches(selfList, otherList, attr, threshold);
+  // 2. Find matches, link-first then spatial fallback. Provenance-link matches
+  // (score Infinity) are seeded first so the greedy 1:1 pass below prefers them
+  // and bypasses the distance threshold; spatial matches are appended as the
+  // fallback for annotations with no explicit fromPredicted link.
+  const matches = _findAnnotationLinkMatches(selfList, otherList);
+  matches.push(..._findAnnotationMatches(selfList, otherList, attr, threshold));
 
   // 3. Greedy one-to-one matching: sort by score descending, assign each
-  // self/other index at most once so no annotation is silently dropped.
+  // self/other index at most once so no annotation is silently dropped. An
+  // Infinity-scored link always sorts ahead of any finite spatial score; two
+  // link matches compare equal (their relative order is irrelevant since each
+  // resolves a distinct index pair).
   matches.sort((a, b) => b.score - a.score);
   const matchedSelf = new Set<number>();
   const matchedOther = new Set<number>();
@@ -324,6 +383,47 @@ export class LabeledFrame {
     }
 
     return this.predictedInstances.filter((inst) => !usedPredicted.has(inst));
+  }
+
+  /**
+   * Predicted masks in this frame that have not been adopted by a user mask.
+   *
+   * The mask analogue of {@link unusedPredictions}. A prediction is considered
+   * adopted (and therefore excluded) when a user mask in the same frame:
+   *   1. links to it via `fromPredicted` (checked FIRST, by object identity), or
+   *   2. lacking such a link, spatially overlaps it (bbox-centroid within 5 px,
+   *      the auto-merge default).
+   *
+   * Predictions that no user mask claims by either rule are returned, e.g. for
+   * surfacing them in a proofreading UI.
+   */
+  get unusedPredictedMasks(): PredictedSegmentationMask[] {
+    const predicted = this.masks.filter(
+      (m) => m instanceof PredictedSegmentationMask,
+    ) as PredictedSegmentationMask[];
+    if (!predicted.length) return [];
+
+    const userMasks = this.masks.filter((m) => !m.isPredicted);
+    const adopted = new Set<SegmentationMask>();
+
+    // 1. Link-first: any prediction explicitly referenced by a user mask's
+    // fromPredicted is adopted (by object identity).
+    for (const u of userMasks) {
+      const src = (u as any).fromPredicted;
+      if (src != null) adopted.add(src);
+    }
+
+    // 2. Spatial fallback: remaining (unlinked) predictions adopted by any user
+    // mask whose bbox centroid is within 5 px.
+    const remaining = predicted.filter((m) => !adopted.has(m));
+    if (remaining.length && userMasks.length) {
+      const matches = _findAnnotationMatches(remaining, userMasks, "masks", 5.0);
+      for (const { selfIdx } of matches) {
+        adopted.add(remaining[selfIdx]);
+      }
+    }
+
+    return predicted.filter((m) => !adopted.has(m));
   }
 
   removePredictions(): void {

--- a/src/model/mask.ts
+++ b/src/model/mask.ts
@@ -363,8 +363,28 @@ export class SegmentationMask {
   }
 }
 
+export interface UserSegmentationMaskOptions extends SegmentationMaskOptions {
+  /** In-memory provenance link to the predicted mask this was adopted from. */
+  fromPredicted?: PredictedSegmentationMask | null;
+}
+
 /** User-annotated segmentation mask (no prediction score). */
-export class UserSegmentationMask extends SegmentationMask {}
+export class UserSegmentationMask extends SegmentationMask {
+  /**
+   * In-memory provenance link to the `PredictedSegmentationMask` this user mask
+   * was adopted from, set by {@link PredictedSegmentationMask.toUser}.
+   *
+   * This mirrors `Instance.fromPredicted`, but unlike instances it is an
+   * in-memory-only link: it is intentionally NOT persisted to the SLP format,
+   * so it becomes `null` after a save/load round-trip.
+   */
+  fromPredicted: PredictedSegmentationMask | null;
+
+  constructor(options: UserSegmentationMaskOptions) {
+    super(options);
+    this.fromPredicted = options.fromPredicted ?? null;
+  }
+}
 
 /** Predicted segmentation mask with a confidence score and optional score map. */
 export class PredictedSegmentationMask extends SegmentationMask {
@@ -392,6 +412,46 @@ export class PredictedSegmentationMask extends SegmentationMask {
 
   get isPredicted(): boolean {
     return true;
+  }
+
+  /**
+   * Adopt this predicted mask as a user-annotated mask (human-in-the-loop).
+   *
+   * Returns a NEW {@link UserSegmentationMask} that carries an independent
+   * COPY of the RLE raster (via `rleCounts.slice()`) plus the metadata
+   * (`name`, `category`, `source`, `track`, `trackingScore`, `instance`,
+   * `scale`, `offset`). Prediction-only fields (`score`, `scoreMap`,
+   * `scoreMapScale`, `scoreMapOffset`) are dropped. The internal
+   * `_instanceIdx` is carried over.
+   *
+   * The `track` and `instance` references are SHARED (not deep-copied), while
+   * the RLE raster and the `scale`/`offset` tuples are copied so the user mask
+   * owns independent buffers.
+   *
+   * Mirrors `Instance.fromPredicted` semantics, but the resulting
+   * `fromPredicted` link is in-memory only: it is intentionally NOT persisted
+   * to the SLP format and will be `null` after a save/load round-trip.
+   *
+   * @param link - When `true` (default), set the returned mask's
+   *   `fromPredicted` to this predicted mask. When `false`, leave it `null`.
+   */
+  toUser(link = true): UserSegmentationMask {
+    const user = new UserSegmentationMask({
+      rleCounts: this.rleCounts.slice(),
+      height: this.height,
+      width: this.width,
+      name: this.name,
+      category: this.category,
+      source: this.source,
+      track: this.track,
+      trackingScore: this.trackingScore,
+      instance: this.instance,
+      scale: [this.scale[0], this.scale[1]],
+      offset: [this.offset[0], this.offset[1]],
+      fromPredicted: link ? this : null,
+    });
+    user._instanceIdx = this._instanceIdx;
+    return user;
   }
 }
 

--- a/src/model/mask.ts
+++ b/src/model/mask.ts
@@ -267,7 +267,10 @@ export class SegmentationMask {
       });
     }
 
-    return new UserSegmentationMask(baseOpts);
+    return new UserSegmentationMask({
+      ...baseOpts,
+      fromPredicted: this instanceof UserSegmentationMask ? this.fromPredicted : null,
+    });
   }
 
   get bbox(): { x: number; y: number; width: number; height: number } {
@@ -364,19 +367,24 @@ export class SegmentationMask {
 }
 
 export interface UserSegmentationMaskOptions extends SegmentationMaskOptions {
-  /** In-memory provenance link to the predicted mask this was adopted from. */
+  /**
+   * Provenance link to the predicted mask this was adopted from. Persisted to
+   * the SLP format as an index into the saved mask list (see
+   * {@link UserSegmentationMask.fromPredicted}).
+   */
   fromPredicted?: PredictedSegmentationMask | null;
 }
 
 /** User-annotated segmentation mask (no prediction score). */
 export class UserSegmentationMask extends SegmentationMask {
   /**
-   * In-memory provenance link to the `PredictedSegmentationMask` this user mask
-   * was adopted from, set by {@link PredictedSegmentationMask.toUser}.
+   * Provenance link to the `PredictedSegmentationMask` this user mask was
+   * adopted from, set by {@link PredictedSegmentationMask.toUser}.
    *
-   * This mirrors `Instance.fromPredicted`, but unlike instances it is an
-   * in-memory-only link: it is intentionally NOT persisted to the SLP format,
-   * so it becomes `null` after a save/load round-trip.
+   * Mirroring `Instance.fromPredicted`, this link is persisted to the SLP
+   * format as an index into the saved mask list. It survives a save/load
+   * round-trip as long as the source prediction is also saved (in the same or
+   * another frame). Files written before this column existed load it as `null`.
    */
   fromPredicted: PredictedSegmentationMask | null;
 
@@ -428,9 +436,10 @@ export class PredictedSegmentationMask extends SegmentationMask {
    * the RLE raster and the `scale`/`offset` tuples are copied so the user mask
    * owns independent buffers.
    *
-   * Mirrors `Instance.fromPredicted` semantics, but the resulting
-   * `fromPredicted` link is in-memory only: it is intentionally NOT persisted
-   * to the SLP format and will be `null` after a save/load round-trip.
+   * Mirrors `Instance.fromPredicted` semantics: the resulting `fromPredicted`
+   * link is persisted to the SLP format as an index into the saved mask list,
+   * and survives a save/load round-trip as long as the source prediction is
+   * also saved. Files written before this column existed load it as `null`.
    *
    * @param link - When `true` (default), set the returned mask's
    *   `fromPredicted` to this predicted mask. When `false`, leave it `null`.

--- a/tests/mask.test.ts
+++ b/tests/mask.test.ts
@@ -461,6 +461,28 @@ describe("Scale/offset spatial metadata", () => {
     expect(pm.scoreMap).not.toBeNull();
     expect(pm.scoreMap!.length).toBe(4); // 2*2
   });
+
+  it("resampled preserves fromPredicted on a linked user mask", () => {
+    const rle = encodeRle(makeMask2D(4, 4, () => true), 4, 4);
+    const pred = new PredictedSegmentationMask({
+      rleCounts: rle, height: 4, width: 4, score: 0.9,
+    });
+    const user = pred.toUser(); // links fromPredicted to pred
+    const resampled = user.resampled(2, 2);
+    expect(resampled).toBeInstanceOf(UserSegmentationMask);
+    // The provenance link is carried onto the resampled copy (mirrors
+    // track/instance preservation).
+    expect((resampled as UserSegmentationMask).fromPredicted).toBe(pred);
+  });
+
+  it("resampled leaves fromPredicted null on an unlinked user mask", () => {
+    const rle = encodeRle(makeMask2D(4, 4, () => true), 4, 4);
+    const user = new UserSegmentationMask({ rleCounts: rle, height: 4, width: 4 });
+    expect(user.fromPredicted).toBeNull();
+    const resampled = user.resampled(2, 2);
+    expect(resampled).toBeInstanceOf(UserSegmentationMask);
+    expect((resampled as UserSegmentationMask).fromPredicted).toBeNull();
+  });
 });
 
 describe("resizeNearest", () => {

--- a/tests/mask.test.ts
+++ b/tests/mask.test.ts
@@ -8,7 +8,8 @@ import {
   resizeNearest,
 } from "../src/model/mask.js";
 import { UserBoundingBox, PredictedBoundingBox } from "../src/model/bbox.js";
-import { Track } from "../src/model/instance.js";
+import { Track, Instance } from "../src/model/instance.js";
+import { Skeleton } from "../src/model/skeleton.js";
 import { Video } from "../src/model/video.js";
 
 function makeMask2D(height: number, width: number, fill?: (r: number, c: number) => boolean): Uint8Array {
@@ -225,6 +226,148 @@ describe("Abstract base and subclasses", () => {
     expect(mask.scoreMap).toBe(sm);
     expect(mask.scoreMapScale).toEqual([2, 2]);
     expect(mask.scoreMapOffset).toEqual([1, 1]);
+  });
+});
+
+describe("PredictedSegmentationMask.toUser", () => {
+  function makePred(
+    fill: (r: number, c: number) => boolean = () => true,
+    extra: Record<string, unknown> = {},
+  ): PredictedSegmentationMask {
+    const rle = encodeRle(makeMask2D(5, 5, fill), 5, 5);
+    return new PredictedSegmentationMask({
+      rleCounts: rle,
+      height: 5,
+      width: 5,
+      score: 0.85,
+      ...extra,
+    });
+  }
+
+  it("basic: returns a UserSegmentationMask with matching raster", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+    expect(user).toBeInstanceOf(UserSegmentationMask);
+    expect(user.isPredicted).toBe(false);
+    expect(user.height).toBe(pred.height);
+    expect(user.width).toBe(pred.width);
+    expect(user.data).toEqual(pred.data);
+  });
+
+  it("metadata: shares track, preserves trackingScore/category/name/source", () => {
+    const track = new Track("t1");
+    const pred = makePred(() => true, {
+      track,
+      trackingScore: 0.42,
+      category: "cell",
+      name: "obj1",
+      source: "model",
+    });
+    const user = pred.toUser();
+    expect(user.track).toBe(track);
+    expect(user.trackingScore).toBe(0.42);
+    expect(user.category).toBe("cell");
+    expect(user.name).toBe("obj1");
+    expect(user.source).toBe("model");
+  });
+
+  it("drops score and scoreMap", () => {
+    const scoreMap = new Float32Array(25).fill(0.5);
+    const pred = makePred(() => true, { scoreMap });
+    const user = pred.toUser();
+    expect((user as any).score).toBeUndefined();
+    expect((user as any).scoreMap).toBeUndefined();
+    expect(user.isPredicted).toBe(false);
+  });
+
+  it("sets fromPredicted to the source mask", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+    expect(user.fromPredicted).toBe(pred);
+  });
+
+  it("link=false leaves fromPredicted null", () => {
+    const pred = makePred();
+    const user = pred.toUser(false);
+    expect(user.fromPredicted).toBeNull();
+  });
+
+  it("preserves scale/offset verbatim without applying to raster", () => {
+    const pred = makePred(() => true, { scale: [0.5, 0.5], offset: [10, 20] });
+    const user = pred.toUser();
+    expect(user.scale).toEqual([0.5, 0.5]);
+    expect(user.offset).toEqual([10, 20]);
+    expect(user.data).toEqual(pred.data);
+    expect(user.area).toBe(pred.area);
+  });
+
+  it("copies scale/offset into independent tuples", () => {
+    const pred = makePred(() => true, { scale: [0.5, 0.5], offset: [10, 20] });
+    const user = pred.toUser();
+    // Fresh arrays, not shared references with the source prediction.
+    expect(user.scale).not.toBe(pred.scale);
+    expect(user.offset).not.toBe(pred.offset);
+    // Mutating the user copy must not leak back into the prediction.
+    user.scale[0] = 9;
+    user.offset[0] = 99;
+    expect(pred.scale).toEqual([0.5, 0.5]);
+    expect(pred.offset).toEqual([10, 20]);
+  });
+
+  it("preserves the instance reference", () => {
+    const skeleton = new Skeleton(["A", "B"]);
+    const instance = Instance.fromArray([[0, 0], [1, 1]], skeleton);
+    const pred = makePred(() => true, { instance });
+    const user = pred.toUser();
+    expect(user.instance).toBe(instance);
+  });
+
+  it("preserves _instanceIdx", () => {
+    const pred = makePred();
+    pred._instanceIdx = 3;
+    const user = pred.toUser();
+    expect(user._instanceIdx).toBe(3);
+  });
+
+  it("copies rleCounts into an independent buffer", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+    expect(user.rleCounts).not.toBe(pred.rleCounts);
+    expect(user.rleCounts).toEqual(pred.rleCounts);
+    const before = pred.rleCounts[0];
+    user.rleCounts[0] = user.rleCounts[0] + 7;
+    expect(pred.rleCounts[0]).toBe(before);
+  });
+
+  it("handles an empty mask", () => {
+    const pred = makePred(() => false);
+    const user = pred.toUser();
+    expect(user.area).toBe(0);
+    expect(user.fromPredicted).toBe(pred);
+  });
+
+  it("UserSegmentationMask has no toUser method", () => {
+    const user = SegmentationMask.fromArray(makeMask2D(5, 5), 5, 5);
+    expect((user as any).toUser).toBeUndefined();
+  });
+
+  it("fromPredicted defaults to null on a directly constructed user mask", () => {
+    const fromArray = SegmentationMask.fromArray(makeMask2D(5, 5), 5, 5);
+    expect(fromArray.fromPredicted).toBeNull();
+    const direct = new UserSegmentationMask({
+      rleCounts: encodeRle(makeMask2D(5, 5), 5, 5),
+      height: 5,
+      width: 5,
+    });
+    expect(direct.fromPredicted).toBeNull();
+  });
+
+  it("returns distinct masks sharing the same fromPredicted link", () => {
+    const pred = makePred();
+    const user1 = pred.toUser();
+    const user2 = pred.toUser();
+    expect(user1).not.toBe(user2);
+    expect(user1.fromPredicted).toBe(user2.fromPredicted);
   });
 });
 

--- a/tests/model/labeled-frame-merge.test.ts
+++ b/tests/model/labeled-frame-merge.test.ts
@@ -29,6 +29,11 @@ import {
   InstanceMatcher,
   InstanceMatchMethod,
 } from "../../src/model/matching.js";
+import {
+  UserSegmentationMask,
+  PredictedSegmentationMask,
+  encodeRle,
+} from "../../src/model/mask.js";
 
 describe("LabeledFrame.merge", () => {
   // A1 — test_merge_keep_original (test_merging_integration.py:19-39)
@@ -369,5 +374,197 @@ describe("_resolveMergedIsNegative", () => {
     expect(
       _resolveMergedIsNegative(true, true, [predInst(), userInst()]),
     ).toEqual([false, true]);
+  });
+});
+
+// Port of GROUND TRUTH talmolab/sleap-io PR #478 (mask unused_predictions +
+// link-first mask merge): in-memory model/merge logic only, no format change.
+describe("LabeledFrame.unusedPredictedMasks", () => {
+  const video = new Video({ filename: "test.mp4", openBackend: false });
+
+  // 5x5 raster with a 3x3 block at rows/cols 1..3 -> bbox centroid ~ (2.5, 2.5)
+  // before any offset; offset shifts the centroid directly.
+  function rle3x3(): Uint32Array {
+    const flat = new Uint8Array(25);
+    for (let r = 1; r < 4; r++) for (let c = 1; c < 4; c++) flat[r * 5 + c] = 1;
+    return encodeRle(flat, 5, 5);
+  }
+
+  function makePred(offset: [number, number] = [0, 0]): PredictedSegmentationMask {
+    return new PredictedSegmentationMask({
+      rleCounts: rle3x3(),
+      height: 5,
+      width: 5,
+      score: 0.9,
+      offset,
+    });
+  }
+
+  function makeUser(offset: [number, number] = [0, 0]): UserSegmentationMask {
+    return new UserSegmentationMask({
+      rleCounts: rle3x3(),
+      height: 5,
+      width: 5,
+      offset,
+    });
+  }
+
+  it("none_when_no_predictions: a frame with only a user mask -> []", () => {
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [makeUser()] });
+    expect(lf.unusedPredictedMasks).toEqual([]);
+  });
+
+  it("unadopted_reported: a lone predicted mask -> [pred]", () => {
+    const pred = makePred();
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [pred] });
+    expect(lf.unusedPredictedMasks).toEqual([pred]);
+  });
+
+  it("excludes_linked: pred + pred.toUser() (linked) -> []", () => {
+    const pred = makePred();
+    const user = pred.toUser(); // user.fromPredicted === pred
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [pred, user] });
+    expect(lf.unusedPredictedMasks).toEqual([]);
+  });
+
+  it("link_overrides_distance: linked user moved far away still adopts the pred -> []", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+    // Move the user mask far from the prediction; the link still adopts it.
+    user.offset = [500, 500];
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [pred, user] });
+    expect(lf.unusedPredictedMasks).toEqual([]);
+  });
+
+  it("spatial_fallback: an unlinked user mask overlapping within 5 px adopts the pred -> []", () => {
+    const pred = makePred();
+    // Independent (unlinked) user mask at ~2 px offset -> within the 5 px default.
+    const user = makeUser([2, 0]);
+    expect(user.fromPredicted).toBeNull();
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [pred, user] });
+    expect(lf.unusedPredictedMasks).toEqual([]);
+  });
+
+  it("mixed: adopted + user-only + far orphan -> [orphan]", () => {
+    const adopted = makePred();
+    const user = adopted.toUser(); // adopts `adopted` via the link
+    const orphan = makePred([500, 500]); // far from any user mask
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [adopted, user, orphan],
+    });
+    expect(lf.unusedPredictedMasks).toEqual([orphan]);
+  });
+});
+
+describe("LabeledFrame.mergeAnnotations link-first mask merge (auto)", () => {
+  const video = new Video({ filename: "test.mp4", openBackend: false });
+
+  function rle3x3(): Uint32Array {
+    const flat = new Uint8Array(25);
+    for (let r = 1; r < 4; r++) for (let c = 1; c < 4; c++) flat[r * 5 + c] = 1;
+    return encodeRle(flat, 5, 5);
+  }
+
+  function makePred(offset: [number, number] = [0, 0]): PredictedSegmentationMask {
+    return new PredictedSegmentationMask({
+      rleCounts: rle3x3(),
+      height: 5,
+      width: 5,
+      score: 0.9,
+      offset,
+    });
+  }
+
+  it("link_overrides_distance: self pred + other far-moved user adopted from it -> 1 user mask", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+    user.offset = [500, 500]; // far from the prediction spatially
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [pred] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [user] });
+
+    lf1.mergeAnnotations(lf2, "auto");
+
+    // The link matches pred<->user despite the distance: the prediction is
+    // replaced by the user mask, leaving exactly one (user) mask.
+    expect(lf1.masks.length).toBe(1);
+    expect(lf1.masks[0].isPredicted).toBe(false);
+  });
+
+  it("link_self_side: self holds the user correction linked to other's pred -> 1 user mask", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+    user.offset = [500, 500];
+    // Self holds the user mask, other holds the prediction (opposite sides).
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [user] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [pred] });
+
+    lf1.mergeAnnotations(lf2, "auto");
+
+    expect(lf1.masks.length).toBe(1);
+    expect(lf1.masks[0].isPredicted).toBe(false);
+    expect(lf1.masks[0]).toBe(user);
+  });
+
+  it("link_beats_spatial_decoy: user replaces its true source, decoy pred on top of user stays predicted", () => {
+    const trueSource = makePred([500, 500]); // far away true source
+    const user = trueSource.toUser(); // linked to trueSource, sits at [500,500]
+    const decoy = makePred([500, 500]); // unrelated pred spatially on top of user
+    const lf1 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [trueSource, decoy],
+    });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [user] });
+
+    lf1.mergeAnnotations(lf2, "auto");
+
+    // The link pairs user<->trueSource (greedy 1:1 with Infinity score), so the
+    // decoy is NOT matched to the user and survives as a prediction. trueSource
+    // is replaced by the user mask.
+    expect(lf1.masks.length).toBe(2);
+    const users = lf1.masks.filter((m) => !m.isPredicted);
+    const preds = lf1.masks.filter((m) => m.isPredicted);
+    expect(users.length).toBe(1);
+    expect(preds.length).toBe(1);
+    expect(preds[0]).toBe(decoy);
+  });
+
+  it("link_multiple_pairs: two independent cross-frame links both resolve -> 2 user masks", () => {
+    const predA = makePred([0, 0]);
+    const userA = predA.toUser();
+    userA.offset = [500, 500];
+    const predB = makePred([1000, 1000]);
+    const userB = predB.toUser();
+    userB.offset = [2000, 2000];
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [predA, predB] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [userA, userB] });
+
+    lf1.mergeAnnotations(lf2, "auto");
+
+    // Both predictions are replaced by their linked user corrections.
+    expect(lf1.masks.length).toBe(2);
+    expect(lf1.masks.every((m) => !m.isPredicted)).toBe(true);
+  });
+
+  it("link_source_absent: both users link to an external pred (in neither frame), far apart -> both kept", () => {
+    // External prediction belongs to neither frame's mask list.
+    const external = makePred();
+    const userA = external.toUser();
+    userA.offset = [0, 0];
+    const userB = external.toUser();
+    userB.offset = [500, 500]; // far from userA so no spatial match either
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [userA] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [userB] });
+
+    lf1.mergeAnnotations(lf2, "auto");
+
+    // Neither user links to a mask present in the OTHER frame, and they are far
+    // apart, so no match -> both user masks are kept.
+    expect(lf1.masks.length).toBe(2);
+    expect(lf1.masks.every((m) => !m.isPredicted)).toBe(true);
   });
 });

--- a/tests/slp-rois-masks.test.ts
+++ b/tests/slp-rois-masks.test.ts
@@ -128,6 +128,73 @@ describe("SLP ROI/Mask I/O", () => {
     }
   });
 
+  it("does not persist mask fromPredicted across SLP round-trip", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    // Build a 100x100 binary mask raster shared by both masks.
+    const maskData = new Uint8Array(100 * 100);
+    for (let r = 10; r < 30; r++) {
+      for (let c = 20; c < 50; c++) {
+        maskData[r * 100 + c] = 1;
+      }
+    }
+    const { encodeRle } = await import("../src/model/mask.js");
+    const rle = encodeRle(maskData, 100, 100);
+
+    // A predicted mask and the user mask adopted from it via toUser().
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: rle.slice(),
+      height: 100,
+      width: 100,
+      score: 0.9,
+      name: "mask1",
+      category: "cell",
+      source: "model",
+    });
+    const userMask = predMask.toUser(true);
+
+    // In-memory provenance link exists before save.
+    expect(userMask.fromPredicted).toBe(predMask);
+
+    const lfMask = new LabeledFrame({
+      video,
+      frameIdx: 3,
+      masks: [predMask, userMask],
+    });
+    const labels = new Labels({
+      labeledFrames: [frame, lfMask],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const loaded = await roundTrip(labels);
+    loaded.materialize();
+
+    // Both masks survive: exactly one predicted, one user.
+    expect(loaded.masks.length).toBe(2);
+    const loadedPred = loaded.masks.find(
+      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+    )!;
+    const loadedUser = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    )!;
+    expect(loadedPred).toBeDefined();
+    expect(loadedUser).toBeDefined();
+
+    // Predicted mask keeps its score and raster.
+    expect(loadedPred.score).toBeCloseTo(0.9);
+    expect(loadedPred.data).toEqual(maskData);
+
+    // User mask raster is intact.
+    expect(loadedUser.data).toEqual(maskData);
+
+    // The provenance link is intentionally not persisted -> null after load.
+    expect(loadedUser.fromPredicted).toBeNull();
+  });
+
   it("backward compat: reads file with no ROIs/masks as empty arrays", async () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });

--- a/tests/slp-rois-masks.test.ts
+++ b/tests/slp-rois-masks.test.ts
@@ -10,10 +10,42 @@ import { UserLabelImage, PredictedLabelImage } from "../src/model/label-image.js
 import { saveSlpToBytes } from "../src/codecs/slp/write.js";
 import { readSlp } from "../src/codecs/slp/read.js";
 import { LabeledFrame } from "../src/model/labeled-frame.js";
+import { ready, File as H5File } from "h5wasm/node";
 
 async function roundTrip(labels: Labels): Promise<Labels> {
   const bytes = await saveSlpToBytes(labels);
   return readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+}
+
+/** Read the metadata `format_id` attr from saved SLP bytes via h5wasm. */
+async function readFormatId(bytes: Uint8Array): Promise<number> {
+  const module = await ready;
+  const memPath = `/tmp/slp_fmt_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
+  module.FS.writeFile(memPath, bytes);
+  const file = new H5File(memPath, "r");
+  try {
+    const fmtAttr = (file.get("metadata") as { attrs: Record<string, { value?: number }> })
+      .attrs["format_id"];
+    return Number(fmtAttr?.value ?? fmtAttr);
+  } finally {
+    file.close();
+    module.FS.unlink(memPath);
+  }
+}
+
+/** Build a flat row-major binary mask raster. */
+function makeMaskRaster(
+  height: number,
+  width: number,
+  fill: (r: number, c: number) => boolean,
+): Uint8Array {
+  const flat = new Uint8Array(height * width);
+  for (let r = 0; r < height; r++) {
+    for (let c = 0; c < width; c++) {
+      flat[r * width + c] = fill(r, c) ? 1 : 0;
+    }
+  }
+  return flat;
 }
 
 describe("SLP ROI/Mask I/O", () => {
@@ -128,19 +160,14 @@ describe("SLP ROI/Mask I/O", () => {
     }
   });
 
-  it("does not persist mask fromPredicted across SLP round-trip", async () => {
+  it("persists mask fromPredicted across SLP round-trip", async () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     // Build a 100x100 binary mask raster shared by both masks.
-    const maskData = new Uint8Array(100 * 100);
-    for (let r = 10; r < 30; r++) {
-      for (let c = 20; c < 50; c++) {
-        maskData[r * 100 + c] = 1;
-      }
-    }
+    const maskData = makeMaskRaster(100, 100, (r, c) => r >= 10 && r < 30 && c >= 20 && c < 50);
     const { encodeRle } = await import("../src/model/mask.js");
     const rle = encodeRle(maskData, 100, 100);
 
@@ -170,7 +197,11 @@ describe("SLP ROI/Mask I/O", () => {
       skeletons: [skeleton],
     });
 
-    const loaded = await roundTrip(labels);
+    const bytes = await saveSlpToBytes(labels);
+    // Recording a link bumps the format to 2.4.
+    expect(await readFormatId(bytes)).toBeGreaterThanOrEqual(2.4);
+
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
     loaded.materialize();
 
     // Both masks survive: exactly one predicted, one user.
@@ -191,7 +222,412 @@ describe("SLP ROI/Mask I/O", () => {
     // User mask raster is intact.
     expect(loadedUser.data).toEqual(maskData);
 
-    // The provenance link is intentionally not persisted -> null after load.
+    // The provenance link is persisted as an index into the saved mask list and
+    // re-linked to the loaded predicted mask after read.
+    expect(loadedUser.fromPredicted).toBe(loadedPred);
+  });
+
+  it("leaves mask fromPredicted null when toUser(false) (no link, format stays < 2.4)", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const { encodeRle } = await import("../src/model/mask.js");
+    const rle = encodeRle(maskData, 40, 40);
+
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: rle.slice(),
+      height: 40,
+      width: 40,
+      score: 0.5,
+    });
+    // Adopt WITHOUT linking.
+    const userMask = predMask.toUser(false);
+    expect(userMask.fromPredicted).toBeNull();
+
+    const lfMask = new LabeledFrame({ video, frameIdx: 1, masks: [predMask, userMask] });
+    const labels = new Labels({
+      labeledFrames: [frame, lfMask],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const bytes = await saveSlpToBytes(labels);
+    // No mask records a link -> format must NOT be bumped to 2.4.
+    expect(await readFormatId(bytes)).toBeLessThan(2.4);
+
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    loaded.materialize();
+    const loadedUser = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    )!;
+    expect(loadedUser.fromPredicted).toBeNull();
+  });
+
+  it("re-links multiple user masks sharing one source prediction", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    const maskData = makeMaskRaster(50, 50, (r, c) => r >= 10 && r < 25 && c >= 10 && c < 25);
+    const { encodeRle } = await import("../src/model/mask.js");
+    const rle = encodeRle(maskData, 50, 50);
+
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: rle.slice(),
+      height: 50,
+      width: 50,
+      score: 0.8,
+    });
+    // Two user masks both adopt the same prediction.
+    const userA = predMask.toUser(true);
+    const userB = predMask.toUser(true);
+    expect(userA.fromPredicted).toBe(predMask);
+    expect(userB.fromPredicted).toBe(predMask);
+
+    const lfMask = new LabeledFrame({
+      video,
+      frameIdx: 2,
+      masks: [predMask, userA, userB],
+    });
+    const labels = new Labels({
+      labeledFrames: [frame, lfMask],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const loaded = await roundTrip(labels);
+    loaded.materialize();
+
+    const loadedPred = loaded.masks.find(
+      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+    )!;
+    const loadedUsers = loaded.masks.filter(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    );
+    expect(loadedUsers.length).toBe(2);
+    // Both user masks re-link to the SAME loaded prediction object.
+    for (const u of loadedUsers) {
+      expect(u.fromPredicted).toBe(loadedPred);
+    }
+  });
+
+  it("loads fromPredicted as null when the source prediction is not saved (dangling)", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const { encodeRle } = await import("../src/model/mask.js");
+    const rle = encodeRle(maskData, 40, 40);
+
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: rle.slice(),
+      height: 40,
+      width: 40,
+      score: 0.5,
+    });
+    const userMask = predMask.toUser(true);
+    expect(userMask.fromPredicted).toBe(predMask);
+
+    // Only the USER mask is saved; the source prediction is omitted from the
+    // frame, so write resolves the link to -1 (Map miss).
+    const lfMask = new LabeledFrame({ video, frameIdx: 1, masks: [userMask] });
+    const labels = new Labels({
+      labeledFrames: [frame, lfMask],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const bytes = await saveSlpToBytes(labels);
+    // Source absent -> no recorded link -> format not bumped.
+    expect(await readFormatId(bytes)).toBeLessThan(2.4);
+
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    loaded.materialize();
+    expect(loaded.masks.length).toBe(1);
+    const loadedUser = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    )!;
+    expect(loadedUser.fromPredicted).toBeNull();
+  });
+
+  it("disambiguates fromPredicted across frames (each user links to its own frame's prediction)", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const { encodeRle } = await import("../src/model/mask.js");
+
+    // Distinct rasters so the loaded masks are individually identifiable.
+    const rasterA = makeMaskRaster(30, 30, (r, c) => r >= 2 && r < 8 && c >= 2 && c < 8);
+    const rasterB = makeMaskRaster(30, 30, (r, c) => r >= 20 && r < 26 && c >= 20 && c < 26);
+
+    const predA = new PredictedSegmentationMask({
+      rleCounts: encodeRle(rasterA, 30, 30),
+      height: 30,
+      width: 30,
+      score: 0.7,
+      name: "A",
+    });
+    const predB = new PredictedSegmentationMask({
+      rleCounts: encodeRle(rasterB, 30, 30),
+      height: 30,
+      width: 30,
+      score: 0.6,
+      name: "B",
+    });
+    const userA = predA.toUser(true);
+    const userB = predB.toUser(true);
+
+    const lfA = new LabeledFrame({ video, frameIdx: 1, masks: [predA, userA] });
+    const lfB = new LabeledFrame({ video, frameIdx: 2, masks: [predB, userB] });
+    const labels = new Labels({
+      labeledFrames: [frame, lfA, lfB],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const loaded = await roundTrip(labels);
+    loaded.materialize();
+
+    const loadedUserA = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask && m.name === "A",
+    )!;
+    const loadedUserB = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask && m.name === "B",
+    )!;
+    expect(loadedUserA.fromPredicted).not.toBeNull();
+    expect(loadedUserB.fromPredicted).not.toBeNull();
+    // Each user mask links to the prediction with the matching raster, not the
+    // other frame's prediction.
+    expect(loadedUserA.fromPredicted!.data).toEqual(rasterA);
+    expect(loadedUserB.fromPredicted!.data).toEqual(rasterB);
+    expect(loadedUserA.fromPredicted).not.toBe(loadedUserB.fromPredicted);
+  });
+
+  it("preserves fromPredicted across a double round-trip", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    const maskData = makeMaskRaster(60, 60, (r, c) => r >= 10 && r < 30 && c >= 10 && c < 30);
+    const { encodeRle } = await import("../src/model/mask.js");
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: encodeRle(maskData, 60, 60),
+      height: 60,
+      width: 60,
+      score: 0.95,
+    });
+    const userMask = predMask.toUser(true);
+
+    const lfMask = new LabeledFrame({ video, frameIdx: 4, masks: [predMask, userMask] });
+    const labels = new Labels({
+      labeledFrames: [frame, lfMask],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const once = await roundTrip(labels);
+    once.materialize();
+    const twice = await roundTrip(once);
+    twice.materialize();
+
+    const loadedPred = twice.masks.find(
+      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+    )!;
+    const loadedUser = twice.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    )!;
+    expect(loadedUser.fromPredicted).toBe(loadedPred);
+  });
+
+  it("persists both instance and mask fromPredicted in the same file", async () => {
+    const { PredictedInstance } = await import("../src/model/instance.js");
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+
+    // Predicted instance + a user instance carrying the instance fromPredicted link.
+    const predInst = PredictedInstance.fromArray([[10, 20]], skeleton, 0.9);
+    const userInst = new Instance({
+      points: { A: [10, 20] },
+      skeleton,
+      fromPredicted: predInst,
+    });
+    expect(userInst.fromPredicted).toBe(predInst);
+
+    // Predicted mask adopted to a user mask (mask fromPredicted).
+    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const { encodeRle } = await import("../src/model/mask.js");
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: encodeRle(maskData, 40, 40),
+      height: 40,
+      width: 40,
+      score: 0.8,
+    });
+    const userMask = predMask.toUser(true);
+
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [predInst, userInst],
+      masks: [predMask, userMask],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const loaded = await roundTrip(labels);
+    loaded.materialize();
+
+    const loadedUserMask = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    )!;
+    const loadedPredMask = loaded.masks.find(
+      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+    )!;
+    expect(loadedUserMask.fromPredicted).toBe(loadedPredMask);
+
+    // Instance fromPredicted still round-trips alongside the mask link.
+    const loadedFrame = loaded.labeledFrames[0];
+    const loadedUserInst = loadedFrame.instances.find(
+      (i) => !(i instanceof PredictedInstance),
+    ) as Instance;
+    expect(loadedUserInst.fromPredicted).not.toBeNull();
+  });
+
+  it("loads fromPredicted as null from a legacy file without the from_predicted column", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const { encodeRle } = await import("../src/model/mask.js");
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: encodeRle(maskData, 40, 40),
+      height: 40,
+      width: 40,
+      score: 0.8,
+    });
+    const userMask = predMask.toUser(true);
+    const lfMask = new LabeledFrame({ video, frameIdx: 1, masks: [predMask, userMask] });
+    const labels = new Labels({
+      labeledFrames: [frame, lfMask],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    // Write normally (includes the from_predicted column), then surgically
+    // strip "from_predicted" from the masks dataset's field_names attr to
+    // simulate a pre-2.4 file. The reader is presence-gated by NAME, so the
+    // column becomes invisible and every user mask loads with null.
+    const bytes = await saveSlpToBytes(labels);
+    const module = await ready;
+    const memPath = `/tmp/slp_legacy_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
+    module.FS.writeFile(memPath, new Uint8Array(bytes));
+    {
+      const f = new H5File(memPath, "a");
+      const masksDs = f.get("masks") as {
+        attrs: Record<string, { value?: unknown }>;
+        create_attribute: (name: string, value: unknown, shape: unknown, dtype: string) => void;
+        delete_attribute: (name: string) => void;
+      };
+      const fieldNames: string[] = JSON.parse(
+        String((masksDs.attrs["field_names"] as { value?: unknown }).value),
+      );
+      const stripped = fieldNames.filter((n) => n !== "from_predicted");
+      const strippedJson = JSON.stringify(stripped);
+      // h5wasm's create_attribute cannot overwrite an existing attribute
+      // ("Object already exists"); delete the original field_names first so the
+      // pre-2.4 (column-stripped) attribute takes effect.
+      masksDs.delete_attribute("field_names");
+      masksDs.create_attribute(
+        "field_names",
+        strippedJson,
+        null,
+        `S${new TextEncoder().encode(strippedJson).length}`,
+      );
+      f.close();
+    }
+    const legacyBytes = module.FS.readFile(memPath) as Uint8Array;
+    module.FS.unlink(memPath);
+
+    const loaded = await readSlp(new Uint8Array(legacyBytes).buffer, { openVideos: false });
+    loaded.materialize();
+    const loadedUser = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    )!;
+    expect(loadedUser.fromPredicted).toBeNull();
+  });
+
+  it("loads fromPredicted as null when the persisted index is out of range", async () => {
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [10, 20] }, skeleton });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const { encodeRle } = await import("../src/model/mask.js");
+    const predMask = new PredictedSegmentationMask({
+      rleCounts: encodeRle(maskData, 40, 40),
+      height: 40,
+      width: 40,
+      score: 0.8,
+    });
+    const userMask = predMask.toUser(true);
+    const lfMask = new LabeledFrame({ video, frameIdx: 1, masks: [predMask, userMask] });
+    const labels = new Labels({
+      labeledFrames: [frame, lfMask],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    // Write, then overwrite every from_predicted cell with an out-of-range index
+    // (999) via write_slice to simulate a corrupt file. The bounds-checked
+    // re-link (fpIdx < masks.length) leaves fromPredicted null.
+    const bytes = await saveSlpToBytes(labels);
+    const module = await ready;
+    const memPath = `/tmp/slp_oor_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
+    module.FS.writeFile(memPath, new Uint8Array(bytes));
+    {
+      const f = new H5File(memPath, "a");
+      const masksDs = f.get("masks") as {
+        shape: number[];
+        attrs: Record<string, { value?: unknown }>;
+        write_slice: (ranges: Array<[number, number]>, data: Float64Array) => void;
+      };
+      const fieldNames: string[] = JSON.parse(
+        String((masksDs.attrs["field_names"] as { value?: unknown }).value),
+      );
+      const fpCol = fieldNames.indexOf("from_predicted");
+      expect(fpCol).toBeGreaterThanOrEqual(0);
+      const rowCount = masksDs.shape[0];
+      // Overwrite the from_predicted column (a [rowCount, 1] hyperslab) with 999.
+      masksDs.write_slice(
+        [
+          [0, rowCount],
+          [fpCol, fpCol + 1],
+        ],
+        Float64Array.from({ length: rowCount }, () => 999),
+      );
+      f.close();
+    }
+    const corruptBytes = module.FS.readFile(memPath) as Uint8Array;
+    module.FS.unlink(memPath);
+
+    const loaded = await readSlp(new Uint8Array(corruptBytes).buffer, { openVideos: false });
+    loaded.materialize();
+    const loadedUser = loaded.masks.find(
+      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
+    )!;
     expect(loadedUser.fromPredicted).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Ports the segmentation-mask human-in-the-loop (HITL) stack from Python `sleap-io` — three PRs that together give masks the same predicted → human-correct → retrain loop that poses already have via `Instance.fromPredicted`:

| Python PR | What it adds |
|-----------|--------------|
| [#472](https://github.com/talmolab/sleap-io/pull/472) | In-memory `PredictedSegmentationMask.toUser()` + `UserSegmentationMask.fromPredicted` provenance |
| [#475](https://github.com/talmolab/sleap-io/pull/475) | Persist `fromPredicted` to the SLP format (new `from_predicted` column, format **2.4**) |
| [#478](https://github.com/talmolab/sleap-io/pull/478) | `LabeledFrame.unusedPredictedMasks` + link-first auto-merge for masks |

## Key Changes

### #472 — adoption path (`src/model/mask.ts`)
- **`PredictedSegmentationMask.toUser(link = true)`** → a new `UserSegmentationMask` copying the RLE raster + metadata (`name`, `category`, `source`, `track`, `trackingScore`, `instance`, `scale`, `offset`) and `_instanceIdx`, dropping prediction-only fields (`score`, `scoreMap`, …). `track`/`instance` refs are shared; raster and scale/offset are copied. Sets `fromPredicted = link ? this : null`.
- **`UserSegmentationMask.fromPredicted`** (+ exported `UserSegmentationMaskOptions`), backward-compatible with all existing call sites.

### #475 — persistence (`src/codecs/slp/{write,read}.ts`, `mask.ts`)
- **Write**: an object-identity `{mask → global index}` map resolves each user mask's `fromPredicted` to an index in the flat mask list, written in a new `from_predicted` column (`-1` when absent or the source isn't saved). `format_id` bumps to **2.4** only when a *resolvable* link exists (a dangling link writes `-1` and does **not** bump). The column is always written.
- **Read**: the column is read **by name (presence-gated** — pre-2.4 files load `null`), then resolved in a **bounds-checked deferred re-link** pass after all masks are built (out-of-range/`-1` → `null`), mirroring instance `fromPredicted`.
- **`resampled()`** preserves the link on user masks.

### #478 — merge + discovery (`src/model/labeled-frame.ts`)
- **`_findAnnotationLinkMatches`** seeds the auto-merge cascade with `fromPredicted` links (score `Infinity`) before spatial matching, so an adopted correction resolves against its exact source prediction regardless of centroid distance. Generic via `(ann).fromPredicted`, so non-mask modalities produce zero link matches and behave **exactly as before**.
- **`LabeledFrame.unusedPredictedMasks`** — predicted masks not adopted by a user mask (link-first, then 5 px spatial fallback); the mask analogue of `unusedPredictions`.

## Example

```ts
// Adopt a prediction as a user correction (provenance recorded).
const userMask = pred.toUser();        // userMask.fromPredicted === pred

// Survives a save/load round-trip when the source prediction is also saved.
const loaded = await roundTrip(labels);
loadedUser.fromPredicted === loadedPred;   // true (format_id >= 2.4)

// "Retrain only what a human touched":
frame.unusedPredictedMasks;                // predictions with no adopting user mask

// Auto-merge: the link beats spatial proximity (even a far-moved correction).
base.mergeAnnotations(corrections, "auto");
```

## Notable porting decisions
- **JS uses name-keyed flat-matrix mask columns** (not Python's compound dtype), so `from_predicted` is appended by name and stays row/name aligned; the reader is naturally presence-gated by column name.
- **Format bump gated on a *resolvable* link** (source present in the saved set), not merely a non-null reference — caught during verification (a dangling link must not bump to 2.4).
- The merge cascade's greedy 1:1 sort tolerates `Infinity` link scores (a link always sorts ahead of any finite spatial score).

## Omitted
PR #472's codecov CI tweak is Python-CI-specific (no codecov here).

## Testing
- Targeted: `tests/mask.test.ts`, `tests/slp-rois-masks.test.ts`, `tests/model/labeled-frame-merge.test.ts` → **109 pass / 0 fail**; `tsc` clean.
- SLP coverage includes link round-trip, `link=false`/dangling → `null` (+ no format bump), shared-source, multi-frame disambiguation, double round-trip, instance + `fromPredicted` coexistence, and legacy-no-column + out-of-range-index → `null` (HDF5 surgery).
- CI: `test` passes on **ubuntu + windows** and the Deploy Preview builds.
- Local full `bun test` shows 11 pre-existing `Mp4BoxVideoBackend` failures — a test-isolation bug (they pass in isolation; CI is green), unrelated to this work and tracked in #159.

## Process
Built with multi-agent workflows (recon → implement → automated verify → multi-lens adversarial review). Verification caught the format-bump-on-dangling-link source bug; review confirmed no regression to instance/non-mask merge paths and column alignment in the codec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
