### PR TITLE
fix(matching): resolve effective shape through sourceVideo chain (Python #476)

### DIFF
--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -685,6 +685,11 @@ async function readVideos(
       }
     }
 
+    // NOTE: source_video is reconstructed filename-only, so the source's shape
+    // is dropped on reload. This leaves _getEffectiveShape() with no source
+    // shape for a reloaded embedded subset, keeping the embedded-subset ->
+    // restore-original matching workflow broken across save/load. Tracked in
+    // #160 (a follow-up to the in-memory #476 source-chain fix).
     const sourceVideo = parsed.source_video
       ? new Video({ filename: parsed.source_video.filename ?? "" })
       : null;

--- a/src/model/matching.ts
+++ b/src/model/matching.ts
@@ -542,11 +542,20 @@ function hasKey(obj: Record<string, unknown>, key: string): boolean {
 }
 
 /**
- * Get the effective shape for comparison purposes (matching.py:531-555).
+ * Get the effective shape for comparison purposes (matching.py:531-559).
  *
- * Recurses into `originalVideo` FIRST (returns its effective shape if non-null);
- * else uses a KEY-PRESENCE check on `backendMetadata["shape"]` (returns the
- * stored value AS-IS, even if `null`); else falls back to `video.shape`.
+ * Walks the `sourceVideo` chain NEAREST-FIRST and returns the first known shape
+ * along it. An embedded subset's frame count is a view of its source video (e.g.
+ * a 27-frame embedded subset of an 80-frame restored original), so the nearest
+ * source's full shape is the right identity for shape comparison — even when the
+ * deeper chain root has an unknown shape. Recursion bottoms out at the root
+ * (`sourceVideo == null`). If no source shape is found, uses a KEY-PRESENCE
+ * check on `backendMetadata["shape"]` (returns the stored value AS-IS, even if
+ * `null`); else falls back to `video.shape`.
+ *
+ * This reads only in-memory metadata (no file I/O); the heavier `isSameFile`
+ * identity check is reserved for the actual match so that shape stays a
+ * permissive pre-filter.
  *
  * PARITY: uses real key-presence (`hasOwnProperty`), NOT truthiness, and does
  * NOT rely on the JS `shape` getter's `??` ordering.
@@ -554,11 +563,12 @@ function hasKey(obj: Record<string, unknown>, key: string): boolean {
 export function _getEffectiveShape(
   video: Video,
 ): [number, number, number, number] | null {
-  // For embedded videos, prefer original_video's shape.
-  if (video.originalVideo != null) {
-    const originalShape = _getEffectiveShape(video.originalVideo);
-    if (originalShape != null) {
-      return originalShape;
+  // Prefer the nearest source's shape (subset frame counts are a view of it).
+  const source = video.sourceVideo;
+  if (source != null) {
+    const sourceShape = _getEffectiveShape(source);
+    if (sourceShape != null) {
+      return sourceShape;
     }
   }
 

--- a/tests/model/video-matching-helpers.test.ts
+++ b/tests/model/video-matching-helpers.test.ts
@@ -26,6 +26,10 @@ import { mkdtemp, rm } from "node:fs/promises";
 
 import { Video } from "../../src/model/video.js";
 import type { VideoBackend, VideoFrame } from "../../src/video/backend.js";
+import { Labels } from "../../src/model/labels.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { Instance, PredictedInstance } from "../../src/model/instance.js";
+import { Skeleton } from "../../src/model/skeleton.js";
 import {
   VideoMatcher,
   VideoMatchMethod,
@@ -35,6 +39,7 @@ import {
   _getRootVideo,
   _fileExists,
   originalVideosConflict,
+  shapesCompatible,
   sanitizeFilename,
   setFsResolver,
 } from "../../src/model/matching.js";
@@ -194,11 +199,11 @@ describe("VideoMatcher coverage gaps (GROUP 12)", () => {
   });
 
   // PY test_get_effective_shape_with_original_video (1090-1113)
-  it("_getEffectiveShape follows originalVideo chain", () => {
+  it("_getEffectiveShape follows sourceVideo chain", () => {
     const original = makeVideo("/data/original.mp4", [100, 480, 640, 3]);
     const embedded = makeVideo("embedded.pkg.slp", undefined, original);
 
-    // original_video is computed from source_video chain.
+    // Single-level chain: nearest source IS the root.
     expect(embedded.originalVideo).toBe(original);
 
     const shape = _getEffectiveShape(embedded);
@@ -583,5 +588,250 @@ describe("Video.hasOverlappingImages (image_dedup semantics)", () => {
     const single = makeVideo("/a/video.mp4");
     expect(video1.hasOverlappingImages(single)).toBe(false);
     expect(single.hasOverlappingImages(video1)).toBe(false);
+  });
+});
+
+// =============================================================================
+// Embedded subset shape matching (#476)
+// =============================================================================
+//
+// Port of Python `TestEmbeddedSubsetShapeMatching` (tests/model/test_matching.py,
+// added by PR #476 "resolve effective shape through source chain so embedded
+// subsets match", upstream issue #473).
+//
+// THE WORKFLOW: embed a SUBSET of user-labeled frames (e.g. 27 of 80) into a
+// `.pkg.slp`, run prediction against the RESTORED original source (80 frames),
+// then match GT vs predictions. Before the fix, `_getEffectiveShape` jumped to
+// the chain ROOT (`originalVideo`); when the root shape was unknown it fell back
+// to the video's OWN subset frame count, so the 27-frame subset and 80-frame
+// restored original reported different frame counts and were REJECTED on the
+// permissive `shapesCompatible` pre-filter BEFORE the definitive `isSameFile`
+// identity check ever ran. The fix walks `sourceVideo` nearest-first so the
+// subset borrows its source's full (80,...) shape.
+//
+// Tests 1-8 and 10 are pure in-memory and port directly via `makeVideo`; 11-12
+// are end-to-end via in-memory `Labels.match`/`Labels.merge`. Python tests 9
+// (`test_distinct_crops_not_collapsed`) and 13
+// (`test_embed_subset_restore_original_match_pipeline`) require a real video
+// fixture + full `.pkg.slp` embed/restore round-trip I/O and are NOT ported here
+// (fixture-dependent); the in-memory cases fully cover the fix's logic.
+
+describe("Embedded subset shape matching (#476)", () => {
+  // Mirrors Python `_subset_chain()`: root has an UNKNOWN shape, the restored
+  // original knows (80,...), and the embedded subset knows (27,...).
+  function subsetChain(): { root: Video; restored: Video; embedded: Video } {
+    const root = makeVideo("labeling/original.pkg.slp"); // unknown shape
+    const restored = makeVideo(
+      "restored_source.pkg.slp",
+      [80, 1024, 1024, 1],
+      root,
+    );
+    const embedded = makeVideo(
+      "embedded_subset.pkg.slp",
+      [27, 1024, 1024, 1],
+      restored,
+    );
+    return { root, restored, embedded };
+  }
+
+  // PY test_effective_shape_uses_nearest_known_source (THE core fix test)
+  it("effective shape uses the nearest known source, not own subset count", () => {
+    const { restored, embedded } = subsetChain();
+    // Subset resolves to the nearest source's 80-frame shape, NOT its own 27.
+    expect(_getEffectiveShape(embedded)).toEqual([80, 1024, 1024, 1]);
+    expect(_getEffectiveShape(restored)).toEqual([80, 1024, 1024, 1]);
+  });
+
+  // PY test_shapes_compatible_subset_vs_source
+  it("subset and source are shape-compatible and same file", async () => {
+    const { restored, embedded } = subsetChain();
+    expect(shapesCompatible(embedded, restored)).toBe(true);
+    expect(await isSameFile(embedded, restored)).toBe(true);
+  });
+
+  // PY test_find_match_restored_finds_embedded_subset
+  it("AUTO find_match: restored original finds embedded subset", async () => {
+    const { restored, embedded } = subsetChain();
+    const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
+    expect(await matcher.findMatch(restored, [embedded])).toBe(embedded);
+  });
+
+  // PY test_find_match_embedded_subset_finds_restored
+  it("AUTO find_match: embedded subset finds restored original", async () => {
+    const { restored, embedded } = subsetChain();
+    const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
+    expect(await matcher.findMatch(embedded, [restored])).toBe(restored);
+  });
+
+  // PY test_pairwise_match_subset_restored_both_directions
+  it("AUTO pairwise match: subset <-> restored both directions", async () => {
+    const { restored, embedded } = subsetChain();
+    const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
+    expect(await matcher.match(embedded, restored)).toBe(true);
+    expect(await matcher.match(restored, embedded)).toBe(true);
+  });
+
+  // PY test_different_files_incompatible_shape_still_rejected (GUARD)
+  it("unrelated files with incompatible shapes are still rejected", async () => {
+    const a = makeVideo("/data/a.mp4", [100, 480, 640, 3]);
+    const b = makeVideo("/data/b.mp4", [50, 480, 640, 3]); // no source chain
+    const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
+    expect(await matcher.findMatch(a, [b])).toBeNull();
+    expect(await matcher.match(a, b)).toBe(false);
+  });
+
+  // PY test_same_file_siblings_no_source_chain_still_rejected_on_shape (GUARD)
+  // Genuine same-file siblings with NO source relationship keep their OWN shapes
+  // and stay shape-rejected — only a video WITH a sourceVideo borrows its
+  // source's shape. The dataset fields are incidental; the shapes drive the
+  // rejection (shapesCompatible / find_match / match do not consult dataset).
+  it("same-file siblings without a source chain stay shape-rejected", async () => {
+    const v0 = makeVideo("project.pkg.slp", [4, 384, 384, 1]);
+    v0.backendMetadata.dataset = "video0/video";
+    const v1 = makeVideo("project.pkg.slp", [1, 320, 560, 3]);
+    v1.backendMetadata.dataset = "video1/video";
+
+    expect(shapesCompatible(v0, v1)).toBe(false);
+    const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
+    expect(await matcher.findMatch(v1, [v0])).toBeNull();
+    expect(await matcher.match(v0, v1)).toBe(false);
+  });
+
+  // PY test_provenance_conflict_still_rejected (GUARD)
+  // Same shape, but distinct provenance roots -> not a match. In JS,
+  // originalVideosConflict is FS-gated (the /data/*.mp4 roots do not exist), so
+  // rejection lands on leaf-path uniqueness: the roots have DIFFERENT basenames
+  // (v1.mp4 vs v2.mp4) so neither the embedded nor root basenames collide ->
+  // null / false either way.
+  it("distinct provenance roots with same shape are rejected", async () => {
+    const root1 = makeVideo("/data/v1.mp4");
+    const e1 = makeVideo("e1.pkg.slp", [100, 480, 640, 3], root1);
+    const root2 = makeVideo("/data/v2.mp4");
+    const e2 = makeVideo("e2.pkg.slp", [100, 480, 640, 3], root2);
+
+    const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
+    expect(await matcher.findMatch(e1, [e2])).toBeNull();
+    expect(await matcher.match(e1, e2)).toBe(false);
+  });
+
+  // PY test_find_match_imagevideo_same_file_subset
+  it("ImageVideo same-file subset matches its source (list filenames)", async () => {
+    const images = ["f0.png", "f1.png", "f2.png", "f3.png"];
+    const root = makeVideo([...images]); // distinct array copies
+    const restored = makeVideo([...images], [4, 128, 128, 1], root);
+    const embedded = makeVideo([...images], [2, 128, 128, 1], restored);
+
+    expect(shapesCompatible(embedded, restored)).toBe(true);
+    expect(await isSameFile(embedded, restored)).toBe(true);
+
+    const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
+    expect(await matcher.findMatch(restored, [embedded])).toBe(embedded);
+    expect(await matcher.match(embedded, restored)).toBe(true);
+  });
+
+  // PY test_labels_match_embedded_subset_to_restored_original (end-to-end)
+  it("Labels.match: embedded-subset GT matches restored-original predictions", async () => {
+    const skeleton = new Skeleton(["a", "b"]);
+    const { restored, embedded } = subsetChain();
+
+    const gt = new Labels({
+      videos: [embedded],
+      skeletons: [skeleton],
+      labeledFrames: [0, 5, 10].map(
+        (frameIdx) =>
+          new LabeledFrame({
+            video: embedded,
+            frameIdx,
+            instances: [
+              Instance.fromNumpy({
+                pointsData: [
+                  [1, 1],
+                  [2, 2],
+                ],
+                skeleton,
+              }),
+            ],
+          }),
+      ),
+    });
+
+    const pr = new Labels({
+      videos: [restored],
+      skeletons: [skeleton],
+      labeledFrames: [0, 5, 10].map(
+        (frameIdx) =>
+          new LabeledFrame({
+            video: restored,
+            frameIdx,
+            instances: [
+              PredictedInstance.fromNumpy({
+                pointsData: [
+                  [1, 1],
+                  [2, 2],
+                ],
+                score: 1,
+                skeleton,
+              }),
+            ],
+          }),
+      ),
+    });
+
+    const result = await gt.match(pr);
+    // Map is keyed by OTHER (pr) -> SELF (gt): restored -> embedded.
+    expect(result.videoMap.get(restored)).toBe(embedded);
+    expect(result.allVideosMatched).toBe(true);
+  });
+
+  // PY test_labels_merge_restored_preds_into_subset_gt_dedups_video (end-to-end)
+  it("Labels.merge: restored predictions merge into subset GT without dup video", async () => {
+    const skeleton = new Skeleton(["a", "b"]);
+    const { restored, embedded } = subsetChain();
+
+    const gt = new Labels({
+      videos: [embedded],
+      skeletons: [skeleton],
+      labeledFrames: [
+        new LabeledFrame({
+          video: embedded,
+          frameIdx: 0,
+          instances: [
+            Instance.fromNumpy({
+              pointsData: [
+                [1, 1],
+                [2, 2],
+              ],
+              skeleton,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const pr = new Labels({
+      videos: [restored],
+      skeletons: [skeleton],
+      labeledFrames: [
+        new LabeledFrame({
+          video: restored,
+          frameIdx: 1,
+          instances: [
+            PredictedInstance.fromNumpy({
+              pointsData: [
+                [3, 3],
+                [4, 4],
+              ],
+              score: 1,
+              skeleton,
+            }),
+          ],
+        }),
+      ],
+    });
+
+    await gt.merge(pr);
+    // Same file is not duplicated on merge.
+    expect(gt.videos.length).toBe(1);
+    expect(gt.labeledFrames.length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Ports [talmolab/sleap-io#476](https://github.com/talmolab/sleap-io/pull/476). `_getEffectiveShape()` (`src/model/matching.ts`) now walks the `sourceVideo` chain **nearest-first**, returning the first known shape, instead of jumping to the `originalVideo` **root**.

### The bug

The AUTO video-match cascade runs the heuristic `shapesCompatible()` **rejection before** the definitive `isSameFile()` check. Because `_getEffectiveShape` jumped to the chain root and fell back to a video's *own* frame count when the root shape was unknown, an embedded subset (e.g. 27 frames) and its restored original source (80 frames) reported different frame counts and were rejected on shape — breaking the embed-subset → predict → restore-original GT/prediction matching workflow.

### The fix

Walk `sourceVideo` nearest-first so a derived video inherits its nearest known source's full shape, even when the deeper root shape is unknown. In-memory metadata only — no file I/O. Cascade order is unchanged and shape stays a permissive pre-filter; identity is still gated by `isSameFile`, so the change is **strictly more permissive at the shape rung** and cannot wrongly match unrelated files (covered by negative-guard tests).

## Tests

10 regression tests ported from Python `TestEmbeddedSubsetShapeMatching` (in `tests/model/video-matching-helpers.test.ts`): nearest-known-source resolution with an **unknown root**, subset↔source shape-compat + same-file, AUTO `findMatch`/`match` both directions, end-to-end `Labels.match`/`merge`, and negative guards (unrelated incompatible shapes; same-file siblings with no source chain; distinct provenance roots).

- Targeted: `video-matching-helpers` + `matching` + `instance-matching` → **100 pass / 0 fail**; `tsc` clean.
- No matching/merge regressions in the broader suite.

## Known follow-up (out of scope for this PR) — #160

The full embed-subset → restore-original workflow also requires the **source video's shape to survive a SLP save/load**. JS currently serializes `source_video` **filename-only** (`src/codecs/slp/{write,read}.ts`), so a reloaded subset's source has no shape and `_getEffectiveShape` falls back to the subset's own frame count. This in-memory `_getEffectiveShape` fix is the prerequisite; persisting the source shape is tracked in **#160** (Python already round-trips it, which is why this PR faithfully matches #476 — that PR is purely the `_getEffectiveShape` change). Documented inline at `read.ts` and the two fixture-dependent end-to-end Python tests were intentionally not ported (they need the #160 round-trip to pass).

## Process
Built with a multi-agent workflow (recon → implement → verify → 2-lens review). The review surfaced the #160 serialization gap, which is filed as a follow-up rather than silently expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)