### PR TITLE
feat(render): auto-draw SegmentationMask overlays + color overlays by track (Python #462, #470)

### DIFF
--- a/src/rendering/overlays.ts
+++ b/src/rendering/overlays.ts
@@ -700,7 +700,10 @@ function isROI(value: unknown): value is ROI {
  * @param image - RGBA ImageData, mutated in place.
  * @param overlay - A LabelImage, or a list of SegmentationMask / ROI / BoundingBox.
  * @param opts - `alpha` (0.3), `palette` ("distinct"), `outline` (false),
- *   `outlineWidth` (1), `outlineColor` (null).
+ *   `outlineWidth` (1), `outlineColor` (null), and an optional `colors` override.
+ *   When `colors` is supplied, those per-item colors win over the positional
+ *   palette (mirrors Python `_apply_overlay`'s `colors` param, PR #470); it is
+ *   ignored for label-image overlays.
  * @returns The same ImageData.
  */
 export function applyOverlay(
@@ -717,6 +720,7 @@ export function applyOverlay(
     outline?: boolean;
     outlineWidth?: number;
     outlineColor?: RGB | null;
+    colors?: RGB[] | null;
   },
 ): ImageData {
   const alpha = clampAlpha(opts?.alpha ?? 0.3);
@@ -724,6 +728,7 @@ export function applyOverlay(
   const outline = opts?.outline ?? false;
   const outlineWidth = opts?.outlineWidth ?? 1;
   const outlineColor = opts?.outlineColor ?? null;
+  const colorsOverride = opts?.colors ?? null;
 
   // Single LabelImage (or raw Int32Array-backed) overlay.
   if (!Array.isArray(overlay)) {
@@ -753,7 +758,10 @@ export function applyOverlay(
     );
   }
 
-  const colors = getPalette(palette, overlay.length);
+  // Per-item colors: honor a caller-supplied override (e.g. track-keyed colors
+  // from render.ts, PR #470), else fall back to the positional palette so the
+  // default behavior is unchanged.
+  const colors = colorsOverride ?? getPalette(palette, overlay.length);
 
   if (isSegmentationMask(first)) {
     drawMasks(image, overlay as SegmentationMask[], { colors, alpha });

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -4,7 +4,13 @@ import type { Labels } from "../model/labels.js";
 import type { LabeledFrame } from "../model/labeled-frame.js";
 import type { Instance, PredictedInstance, Track } from "../model/instance.js";
 import type { Skeleton } from "../model/skeleton.js";
-import type { RenderOptions, RGB, ColorScheme, PaletteName } from "./types.js";
+import type {
+  RenderOptions,
+  RGB,
+  ColorScheme,
+  PaletteName,
+  Overlay,
+} from "./types.js";
 import {
   getPalette,
   resolveColor,
@@ -79,6 +85,11 @@ interface SourceData {
   frameIdx: number;
   tracks: Track[];
   trackIndexMap: Map<Track, number>;
+  /**
+   * The resolved LabeledFrame being rendered (null for an instance-list source
+   * or an empty Labels). Used to auto-resolve a masks overlay (PR #462).
+   */
+  lf: LabeledFrame | null;
 }
 
 /**
@@ -96,8 +107,18 @@ export async function renderImage(
   const opts = { ...DEFAULT_OPTIONS, ...options };
 
   // Extract instances and metadata from source
-  const { instances, skeleton, frameSize, frameIdx, tracks, trackIndexMap } =
+  const { instances, skeleton, frameSize, frameIdx, tracks, trackIndexMap, lf } =
     extractSourceData(source, opts);
+
+  // PR #462: auto-resolve a masks overlay. When no overlay is explicitly given
+  // and the rendered LabeledFrame carries masks, use them as the overlay. An
+  // explicit overlay always wins, and ONLY masks are auto-resolved (not label
+  // images) — mirroring Python render_image (core.py: `overlay = list(lf.masks)`
+  // when `overlay is None and lf is not None and lf.masks`). Array sources have
+  // no lf, so they never auto-resolve.
+  if ((opts.overlay === undefined || opts.overlay === null) && lf && lf.masks.length > 0) {
+    opts.overlay = [...lf.masks];
+  }
 
   // Motion trails can contribute frames even when the current frame is empty
   // (past frames supply the trail), so they relax the "nothing to render" guard
@@ -155,6 +176,15 @@ export async function renderImage(
     ctx.fillRect(0, 0, scaledWidth, scaledHeight);
   }
 
+  // Determine color scheme. Hoisted ABOVE the overlay block (PR #470) so the
+  // overlay and the poses share the SAME resolved scheme: when it resolves to
+  // "track", the overlay annotations are colored by their track identity to
+  // match their pose colors. hasTracks is derived from INSTANCES only (mirrors
+  // Python), so an annotation-only frame under colorBy:"auto" stays "instance"
+  // and overlays keep positional coloring.
+  const hasTracks = instances.some((inst) => inst.track != null);
+  const colorScheme = determineColorScheme(opts.colorBy, hasTracks, true);
+
   // Apply the annotation overlay AFTER the background and BEFORE trails/poses,
   // mirroring Python render_image (core.py L1159-1180: overlay applied on the
   // base frame, before trails/centroids/poses).
@@ -167,12 +197,28 @@ export async function renderImage(
   // overlay in source space, then scale-composite back onto the (possibly
   // scaled) canvas. When `scale === 1` this is an in-place read/blend/write.
   if (opts.overlay !== undefined && opts.overlay !== null) {
+    // PR #470: color the overlay by track identity when the resolved scheme is
+    // "track" and the overlay is a non-empty list of track-carrying elements
+    // (masks / rois / bboxes — NOT label images). Each element's track maps
+    // through the SAME trackIndexMap AND the SAME pose `palette` the poses use
+    // (NOT overlayPalette), so an animal's mask is the exact color of its pose.
+    // Untracked elements fall back to the first palette color. Otherwise colors
+    // stays undefined and applyOverlay keeps its positional overlayPalette
+    // default (unchanged behavior). Mirrors Python `get_palette(palette, ...)`.
+    const overlayColors = resolveOverlayTrackColors(
+      colorScheme,
+      opts.overlay,
+      opts.palette,
+      tracks,
+      trackIndexMap
+    );
     const overlayOpts = {
       alpha: opts.overlayAlpha,
       palette: opts.overlayPalette,
       outline: opts.overlayOutline,
       outlineWidth: opts.overlayOutlineWidth,
       outlineColor: opts.overlayOutlineColor,
+      colors: overlayColors,
     };
     if (opts.scale === 1) {
       // Fast path: blend directly on the scaled canvas (== source resolution).
@@ -210,10 +256,6 @@ export async function renderImage(
   // Get skeleton info
   const edgeInds = skeleton?.edgeIndices ?? [];
   const nodeNames = skeleton?.nodeNames ?? [];
-
-  // Determine color scheme
-  const hasTracks = instances.some((inst) => inst.track != null);
-  const colorScheme = determineColorScheme(opts.colorBy, hasTracks, true);
 
   // Build color map
   const colors = buildColorMap(
@@ -511,6 +553,7 @@ function extractSourceData(
       frameIdx: 0,
       tracks,
       trackIndexMap,
+      lf: null,
     };
   }
 
@@ -549,6 +592,7 @@ function extractSourceData(
       frameIdx: frame.frameIdx,
       tracks,
       trackIndexMap,
+      lf: frame,
     };
   }
 
@@ -565,6 +609,7 @@ function extractSourceData(
       frameIdx: 0,
       tracks,
       trackIndexMap,
+      lf: null,
     };
   }
 
@@ -599,6 +644,7 @@ function extractSourceData(
     frameIdx: firstFrame.frameIdx,
     tracks,
     trackIndexMap,
+    lf: firstFrame,
   };
 }
 
@@ -664,6 +710,56 @@ function buildColorMap(
         ),
       };
   }
+}
+
+/**
+ * Build per-element overlay colors keyed by track identity (PR #470).
+ *
+ * Returns `null` (leaving applyOverlay's positional-palette default in place)
+ * unless ALL of the following hold:
+ *  - the resolved color scheme is "track",
+ *  - the overlay is a non-empty array (a single LabelImage is excluded), and
+ *  - its elements carry tracks (masks / rois / bboxes — label-image lists, whose
+ *    elements are Int32Array-backed, are excluded so they keep their own LUT).
+ *
+ * Each element's `.track` is mapped through the SAME `trackIndexMap` AND the
+ * SAME pose `palette` the poses use (a palette of `max(tracks.length, 1)`
+ * colors); untracked elements fall back to the first color. The caller passes
+ * the pose `palette` (NOT `overlayPalette`) here, mirroring Python
+ * `get_palette(palette, ...)`, so an annotation is the exact color of its pose.
+ */
+function resolveOverlayTrackColors(
+  scheme: ColorScheme,
+  overlay: Overlay,
+  paletteName: string,
+  tracks: Track[],
+  trackIndexMap: Map<Track, number>
+): RGB[] | null {
+  if (scheme !== "track") return null;
+  // No tracks → keep positional coloring (mirrors Python's `has_tracks` gate),
+  // so a forced colorBy:"track" on track-less data doesn't collapse every
+  // overlay element onto the first palette color.
+  if (tracks.length === 0) return null;
+  if (!Array.isArray(overlay) || overlay.length === 0) return null;
+  // Label-image lists are Int32Array-backed; skip them (Python ignores colors
+  // for label-image overlays).
+  const first = overlay[0] as { data?: unknown };
+  if (first?.data instanceof Int32Array) return null;
+
+  const nTracks = Math.max(1, tracks.length);
+  const palette = getPalette(paletteName as PaletteName, nTracks);
+
+  return (overlay as Array<{ track?: Track | null }>).map((el) => {
+    const track = el.track;
+    if (track) {
+      const trackIdx = trackIndexMap.get(track);
+      if (trackIdx !== undefined) {
+        return palette[trackIdx % palette.length];
+      }
+    }
+    // Untracked elements fall back to the first palette color.
+    return palette[0];
+  });
 }
 
 // Export utilities

--- a/src/rendering/video.ts
+++ b/src/rendering/video.ts
@@ -84,6 +84,22 @@ export async function renderVideo(
       videoOverlay = videoLabelImages;
     }
   }
+  // PR #462: auto-resolve masks per frame when no explicit overlay and no label
+  // images were resolved (label images take precedence — resolved first, above).
+  // Mirrors Python render_video (`overlay = lambda fidx:
+  // labels.get_masks(video=target_video, frame_idx=fidx)`), only wired up when
+  // the target video actually has masks. The callable is keyed by SOURCE frame
+  // index (makeOverlayResolver passes `frame.frameIdx`), so per-frame masks line
+  // up regardless of render position. Track-color (PR #470) is then applied
+  // inside renderImage on the resolved per-frame masks.
+  if (videoOverlay === undefined && !Array.isArray(source)) {
+    const targetVideo = selectedFrames[0].video;
+    const labels = source;
+    if (labels.getMasks({ video: targetVideo }).length > 0) {
+      videoOverlay = (frameIdx: number): Overlay =>
+        labels.getMasks({ video: targetVideo, frameIdx });
+    }
+  }
   const overlayForFrame = makeOverlayResolver(videoOverlay);
 
   // Build per-video temporal context for motion trails once (keyed by frame

--- a/tests/rendering/overlays.test.ts
+++ b/tests/rendering/overlays.test.ts
@@ -18,12 +18,14 @@ import {
 } from "../../src/model/bbox";
 import { UserROI } from "../../src/model/roi";
 import { Skeleton } from "../../src/model/skeleton";
-import { Instance } from "../../src/model/instance";
+import { Instance, Track } from "../../src/model/instance";
 import { LabeledFrame } from "../../src/model/labeled-frame";
+import { Labels } from "../../src/model/labels";
 import { Video } from "../../src/model/video";
-import { PALETTES } from "../../src/rendering/colors";
+import { PALETTES, getPalette } from "../../src/rendering/colors";
 
 const DISTINCT = PALETTES.distinct;
+const STANDARD = PALETTES.standard;
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -1038,6 +1040,38 @@ describe("applyOverlay", () => {
     applyOverlay(img, [] as SegmentationMask[]);
     expect(Array.from(img.data)).toEqual(before);
   });
+
+  it("uses an explicit colors override over the positional palette (PR #470)", async () => {
+    const img = await makeImage(12, 12, [255, 255, 255]);
+    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 4, 4), 12, 12);
+    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 6, 6, 10, 10), 12, 12);
+
+    // Override colors: element 0 -> blue, element 1 -> red (NOT the distinct
+    // palette order). This proves the override wins over getPalette positional.
+    applyOverlay(img, [m0, m1], {
+      alpha: 0.5,
+      palette: "distinct",
+      colors: [
+        [0, 0, 255],
+        [255, 0, 0],
+      ],
+    });
+
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [0, 0, 255], 0.5));
+    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+  });
+
+  it("falls back to the positional palette when colors is omitted/null (PR #470)", async () => {
+    const img = await makeImage(12, 12, [255, 255, 255]);
+    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 4, 4), 12, 12);
+    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 6, 6, 10, 10), 12, 12);
+
+    applyOverlay(img, [m0, m1], { alpha: 0.4, palette: "distinct", colors: null });
+
+    // Same as the default-palette dispatch above: [0] then [1].
+    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], DISTINCT[0], 0.4));
+    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], DISTINCT[1], 0.4));
+  });
 });
 
 // ===========================================================================
@@ -1204,6 +1238,437 @@ describe("renderImage with overlay", () => {
       4,
     );
   });
+
+  // -------------------------------------------------------------------------
+  // PR #462: auto-draw lf.masks when no overlay is passed
+  // -------------------------------------------------------------------------
+
+  it("auto-draws lf.masks when no overlay option is given (PR #462)", async () => {
+    const video = createVideo();
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 10, 10, 25, 25),
+      40,
+      40,
+    );
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [],
+      masks: [mask],
+    });
+
+    // NOTE: no `overlay` option — masks must be auto-resolved from lf.masks.
+    const img = await renderImage(frame, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      overlayAlpha: 0.5,
+      overlayPalette: "distinct",
+    });
+
+    // Masked region blended toward distinct[0]; background untouched.
+    expectRGBNear(
+      pixel(img, 15, 15),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
+    expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
+  });
+
+  it("auto-draws lf.masks for a Labels source via the first frame (PR #462)", async () => {
+    const video = createVideo();
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 12, 12, 20, 20),
+      40,
+      40,
+    );
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [],
+      masks: [mask],
+    });
+    const labels = new Labels({ labeledFrames: [frame] });
+
+    const img = await renderImage(labels, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      overlayAlpha: 0.5,
+      overlayPalette: "distinct",
+    });
+
+    expectRGBNear(
+      pixel(img, 15, 15),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
+  });
+
+  it("explicit overlay still wins over lf.masks (PR #462)", async () => {
+    const video = createVideo();
+    // lf carries maskA (region rows/cols 2-8), but the explicit overlay draws
+    // maskB (region 12-18). Only the explicit one should be drawn.
+    const maskA = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 2, 2, 8, 8),
+      20,
+      20,
+    );
+    const maskB = UserSegmentationMask.fromArray(
+      squareMask(20, 20, 12, 12, 18, 18),
+      20,
+      20,
+    );
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [],
+      masks: [maskA],
+    });
+
+    const img = await renderImage(frame, {
+      width: 20,
+      height: 20,
+      background: [255, 255, 255],
+      overlay: [maskB],
+      overlayAlpha: 0.5,
+    });
+
+    // Explicit maskB region is blended; the lf.masks (maskA) region is NOT.
+    expectRGBNear(
+      pixel(img, 15, 15),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
+    expectRGBNear(pixel(img, 4, 4), [255, 255, 255]);
+  });
+
+  it("does not auto-draw when the frame has no masks (PR #462)", async () => {
+    const video = createVideo();
+    const skeleton = createTestSkeleton();
+    const instance = new Instance({
+      points: { head: [5, 5], tail: [15, 15] },
+      skeleton,
+    });
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instance],
+      masks: [],
+    });
+
+    const img = await renderImage(frame, {
+      width: 20,
+      height: 20,
+      background: [255, 255, 255],
+      showNodes: false,
+      showEdges: false,
+    });
+
+    // No masks -> nothing to auto-draw; the whole background stays white.
+    expectRGBNear(pixel(img, 10, 10), [255, 255, 255]);
+    expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
+  });
+
+  // -------------------------------------------------------------------------
+  // PR #470: color overlay annotations by track identity
+  // -------------------------------------------------------------------------
+
+  it("colors masks by track identity under colorBy:'track' (PR #470)", async () => {
+    const video = createVideo();
+    const skeleton = createTestSkeleton();
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+
+    // Two tracked instances so the track index order is [trackA, trackB].
+    const instA = new Instance({
+      points: { head: [3, 3], tail: [5, 5] },
+      skeleton,
+      track: trackA,
+    });
+    const instB = new Instance({
+      points: { head: [30, 30], tail: [32, 32] },
+      skeleton,
+      track: trackB,
+    });
+
+    // maskA -> trackB, maskB -> trackA: deliberately reverse the LIST order vs
+    // the track order to prove coloring follows .track, not list position.
+    const maskA = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 10, 10, 16, 16),
+      40,
+      40,
+    );
+    maskA.track = trackB;
+    const maskB = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 22, 22, 28, 28),
+      40,
+      40,
+    );
+    maskB.track = trackA;
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA, instB],
+      masks: [maskA, maskB],
+    });
+
+    const img = await renderImage(frame, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      colorBy: "track",
+      overlayAlpha: 0.5,
+      // Pose palette ("standard") differs from overlayPalette ("distinct"): the
+      // track-colored masks must use the POSE palette so they match the poses,
+      // NOT the positional overlayPalette (PR #470). Asserting against
+      // "standard" here would fail under the old overlayPalette-based coloring.
+      palette: "standard",
+      overlayPalette: "distinct",
+      showNodes: false,
+      showEdges: false,
+    });
+
+    // Track index map: trackA=0, trackB=1 (instance discovery order).
+    const posePalette = getPalette("standard", 2);
+    const overlayPalette = getPalette("distinct", 2);
+    // maskA carries trackB (index 1); maskB carries trackA (index 0).
+    expectRGBNear(
+      pixel(img, 12, 12),
+      blendRGB([255, 255, 255], posePalette[1], 0.5),
+      4,
+    );
+    expectRGBNear(
+      pixel(img, 24, 24),
+      blendRGB([255, 255, 255], posePalette[0], 0.5),
+      4,
+    );
+    // Guard: the mask is NOT colored from the positional overlayPalette (would
+    // be the old buggy behavior). standard[1] and distinct[1] are distinct sets.
+    const buggy = blendRGB([255, 255, 255], overlayPalette[1], 0.5);
+    const actual = pixel(img, 12, 12);
+    const dist =
+      Math.abs(actual[0] - buggy[0]) +
+      Math.abs(actual[1] - buggy[1]) +
+      Math.abs(actual[2] - buggy[2]);
+    expect(dist).toBeGreaterThan(10);
+  });
+
+  it("aligns a mask track color slot with its pose track color slot (PR #470)", async () => {
+    const video = createVideo();
+    const skeleton = createTestSkeleton();
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+
+    // Pose for trackB drawn at a node we can sample; trackA at another node.
+    const instA = new Instance({
+      points: { head: [3, 3], tail: [4, 4] },
+      skeleton,
+      track: trackA,
+    });
+    const instB = new Instance({
+      points: { head: [35, 35], tail: [36, 36] },
+      skeleton,
+      track: trackB,
+    });
+    const maskB = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 20, 20, 26, 26),
+      40,
+      40,
+    );
+    maskB.track = trackB;
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA, instB],
+      masks: [maskB],
+    });
+
+    const img = await renderImage(frame, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      colorBy: "track",
+      overlayAlpha: 0.5,
+      overlayPalette: "distinct",
+      palette: "standard",
+      showNodes: true,
+      showEdges: false,
+      markerSize: 3,
+    });
+
+    // trackB is index 1. PR #470: the mask uses the POSE palette ("standard"),
+    // NOT overlayPalette ("distinct"), so its fill is the blend of STANDARD[1]
+    // — the exact track color the pose node uses (sampled below). The mask fill
+    // (alpha 0.5) blends STANDARD[1] over the white background.
+    expectRGBNear(
+      pixel(img, 22, 22),
+      blendRGB([255, 255, 255], STANDARD[1], 0.5),
+      4,
+    );
+    // Pose node for trackB near (35,35) is opaque STANDARD[1] (alpha default 1).
+    let poseColored = false;
+    for (let y = 33; y < 38 && !poseColored; y++) {
+      for (let x = 33; x < 38; x++) {
+        const [r, g, b] = pixel(img, x, y);
+        if (
+          Math.abs(r - STANDARD[1][0]) <= 4 &&
+          Math.abs(g - STANDARD[1][1]) <= 4 &&
+          Math.abs(b - STANDARD[1][2]) <= 4
+        ) {
+          poseColored = true;
+          break;
+        }
+      }
+    }
+    expect(poseColored).toBe(true);
+  });
+
+  it("untracked mask falls back to the first track color under colorBy:'track' (PR #470)", async () => {
+    const video = createVideo();
+    const skeleton = createTestSkeleton();
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const instA = new Instance({
+      points: { head: [3, 3], tail: [4, 4] },
+      skeleton,
+      track: trackA,
+    });
+    const instB = new Instance({
+      points: { head: [35, 35], tail: [36, 36] },
+      skeleton,
+      track: trackB,
+    });
+    // Mask with NO track -> should fall back to palette[0].
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 18, 18, 24, 24),
+      40,
+      40,
+    );
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA, instB],
+      masks: [mask],
+    });
+
+    const img = await renderImage(frame, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      colorBy: "track",
+      overlayAlpha: 0.5,
+      palette: "standard",
+      overlayPalette: "distinct",
+      showNodes: false,
+      showEdges: false,
+    });
+
+    // Untracked -> first POSE-palette color (PR #470 colors overlays from the
+    // pose palette, not overlayPalette).
+    const posePalette = getPalette("standard", 2);
+    expectRGBNear(
+      pixel(img, 20, 20),
+      blendRGB([255, 255, 255], posePalette[0], 0.5),
+      4,
+    );
+  });
+
+  it("keeps positional overlay coloring when scheme != track (PR #470)", async () => {
+    const video = createVideo();
+    const skeleton = createTestSkeleton();
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    // Tracked instances exist, but colorBy:'instance' forces non-track scheme.
+    const instA = new Instance({
+      points: { head: [3, 3], tail: [4, 4] },
+      skeleton,
+      track: trackA,
+    });
+    // maskA carries trackB, maskB carries trackA: if track-coloring leaked in,
+    // their colors would swap. Positional coloring must keep [0] then [1].
+    const maskA = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 10, 10, 16, 16),
+      40,
+      40,
+    );
+    maskA.track = trackB;
+    const maskB = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 22, 22, 28, 28),
+      40,
+      40,
+    );
+    maskB.track = trackA;
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA],
+      masks: [maskA, maskB],
+    });
+
+    const img = await renderImage(frame, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      colorBy: "instance",
+      overlayAlpha: 0.5,
+      overlayPalette: "distinct",
+      showNodes: false,
+      showEdges: false,
+    });
+
+    // Positional palette: list element 0 (maskA) -> [0], element 1 (maskB) -> [1].
+    expectRGBNear(
+      pixel(img, 12, 12),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
+    expectRGBNear(
+      pixel(img, 24, 24),
+      blendRGB([255, 255, 255], DISTINCT[1], 0.5),
+      4,
+    );
+  });
+
+  it("forced colorBy:'track' with no tracks stays positional (PR #470 guard)", async () => {
+    const video = createVideo();
+    const skeleton = createTestSkeleton();
+    // Instances and masks, but NO tracks anywhere. Forcing colorBy:'track'
+    // must NOT collapse every mask onto the first color — it falls back to
+    // positional overlayPalette coloring (mirrors Python's has_tracks gate).
+    const inst = new Instance({ points: { head: [3, 3], tail: [4, 4] }, skeleton });
+    const maskA = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 10, 10, 16, 16),
+      40,
+      40,
+    );
+    const maskB = UserSegmentationMask.fromArray(
+      squareMask(40, 40, 22, 22, 28, 28),
+      40,
+      40,
+    );
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      masks: [maskA, maskB],
+    });
+
+    const img = await renderImage(frame, {
+      width: 40,
+      height: 40,
+      background: [255, 255, 255],
+      colorBy: "track",
+      overlayAlpha: 0.5,
+      overlayPalette: "distinct",
+      showNodes: false,
+      showEdges: false,
+    });
+
+    // Positional overlayPalette: maskA -> [0], maskB -> [1] (NOT both [0]).
+    expectRGBNear(pixel(img, 12, 12), blendRGB([255, 255, 255], DISTINCT[0], 0.5), 4);
+    expectRGBNear(pixel(img, 24, 24), blendRGB([255, 255, 255], DISTINCT[1], 0.5), 4);
+  });
 });
 
 // ===========================================================================
@@ -1337,5 +1802,31 @@ describe("renderVideo per-frame overlay", () => {
     expectRGBNear(pixel(imgB, 3, 3), [255, 255, 255]);
     expectRGBNear(pixel(imgB, 15, 15), blendRGB([255, 255, 255], DISTINCT[0], 0.5), 4);
     expectRGBNear(pixel(imgA, 15, 15), [255, 255, 255]);
+  });
+
+  it("auto-detects masks for a Labels source when no overlay is passed (PR #462)", async () => {
+    const { checkFfmpeg } = await import("../../src/rendering/video");
+    if (!(await checkFfmpeg())) return; // skip when ffmpeg unavailable
+
+    const video = new Video({ filename: "v.mp4" });
+    const f0 = frameWithMask(video, 0, [2, 2, 8, 8]);
+    const f1 = frameWithMask(video, 1, [10, 10, 18, 18]);
+    const labels = new Labels({ labeledFrames: [f0, f1] });
+
+    // No `overlay` option: renderVideo must auto-resolve masks per frame via
+    // Labels.getMasks({ video, frameIdx }).
+    const tmp = `/tmp/overlay-auto-masks-${Date.now()}.mp4`;
+    await expect(
+      renderVideo(labels, tmp, {
+        width: 20,
+        height: 20,
+        background: [255, 255, 255],
+        overlayAlpha: 0.5,
+      }),
+    ).resolves.toBeUndefined();
+
+    const fs = await import("node:fs");
+    expect(fs.existsSync(tmp)).toBe(true);
+    fs.unlinkSync(tmp);
   });
 });


### PR DESCRIPTION
## Summary

Ports two rendering PRs from `talmolab/sleap-io`:

- [#462](https://github.com/talmolab/sleap-io/pull/462) — **auto-draw `SegmentationMask` overlays** so a segmentation-only frame/video actually renders its masks (previously masks were silently undrawn unless an explicit overlay was passed).
- [#470](https://github.com/talmolab/sleap-io/pull/470) — **color mask/ROI/bbox overlays by track identity** so a tracked animal's mask matches its pose color and doesn't change color when its list index shifts.

## Key Changes

### #462 — auto-draw masks
- `renderImage` auto-uses the rendered `LabeledFrame`'s `masks` as the overlay when no explicit overlay is given (explicit overlay always wins; only masks, not label images).
- `renderVideo` resolves masks per-frame for the target video via a callable, mirroring the existing label-image auto-detect (label images take precedence).
- The Python grayscale `(H,W,1)` crash fix is **N/A** — JS overlays operate on RGBA `ImageData`.

### #470 — track-colored overlays
- `applyOverlay` gains a `colors?` override; when null it falls back to the positional `getPalette` (unchanged default).
- `renderImage` builds per-element overlay colors by mapping each element's `.track` through the **same `trackIndexMap` and the same pose `palette`** the poses use — so an annotation is the *exact* color of its pose. Mirrors Python `get_palette(palette, ...)`.

## Notable correctness fix during review

The first implementation colored overlays from `overlayPalette` instead of the **pose `palette`** — which would have meant masks *didn't* match pose colors (defeating #470). Caught by the adversarial review and fixed: track-keyed overlay colors now use `opts.palette`, with `palette`≠`overlayPalette` tests that would fail under the old behavior. Also added a `hasTracks` guard so a forced `colorBy:"track"` on track-less data stays positional (Python parity).

## Tests

13 rendering tests (`tests/rendering/overlays.test.ts`): auto-draw via LabeledFrame and Labels source; explicit overlay still wins; no masks → no overlay; `applyOverlay` colors override vs positional fallback; track coloring follows `.track` not list order; **mask color == pose color** (pose palette, not overlayPalette); untracked → first pose color; no-tracks guard stays positional; non-track scheme unchanged.

- `tests/rendering` → **175 pass / 0 fail**; `tsc` clean. Full suite unchanged except the pre-existing WebCodecs (`Mp4BoxVideoBackend`) failures.

## Scoped-out follow-ups
- **`include_unlabeled`**: Python flips it when masks auto-resolve; JS `renderVideo` has no unlabeled-frame expansion path, so it's not ported (masks still render on every iterated labeled frame).
- **#162**: `renderVideo` colors poses+overlays by *per-frame* track index (not the global `labels.tracks`), so absolute cross-frame color stability is a separate follow-up. This PR delivers the within-frame overlay↔pose color match, which is #470's core mechanism.

## Process
Built with a multi-agent workflow (parallel recon → implement → verify → 3-lens review). The review caught the palette bug and the test-strength gaps, which are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)