### PR TITLE
fix(video): stop routing .avi/.mpeg to MediaBunny; throw clean UnsupportedVideoFormatError (#165)

### DIFF
--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -30,7 +30,11 @@ export {
   BlobByteSource,
   type ByteSource,
 } from "./video/seq-video.js";
-export { createVideoBackend, type VideoBackendType } from "./video/factory.js";
+export {
+  createVideoBackend,
+  UnsupportedVideoFormatError,
+  type VideoBackendType,
+} from "./video/factory.js";
 // CropRect is re-exported transitively via ./transform/index.js (single source).
 export {
   CropVideoBackend,

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,11 @@ export {
   BlobByteSource,
   type ByteSource,
 } from "./video/seq-video.js";
-export { createVideoBackend, type VideoBackendType } from "./video/factory.js";
+export {
+  createVideoBackend,
+  UnsupportedVideoFormatError,
+  type VideoBackendType,
+} from "./video/factory.js";
 // CropRect is re-exported transitively via ./transform/index.js (single source).
 export {
   CropVideoBackend,

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -9,8 +9,47 @@ import { openH5File } from "../codecs/slp/h5.js";
 /** Supported video backend identifiers for user selection. */
 export type VideoBackendType = "mp4box" | "mediabunny" | "media";
 
-/** File extensions that MediaBunny handles (non-MP4 formats). */
-const MEDIABUNNY_EXTENSIONS = ["webm", "mkv", "ogg", "mov", "mpeg", "avi"];
+/**
+ * File extensions that MediaBunny handles (non-MP4 formats). `ts` is MPEG-TS,
+ * which MediaBunny demuxes (its typical H.264/H.265 payload is WebCodecs-decodable);
+ * `.mpeg`/`.mpg` (MPEG program streams) and `.avi` are NOT here — MediaBunny has no
+ * demuxer for them (see {@link UnsupportedVideoFormatError} and UNSUPPORTED_EXTENSIONS).
+ */
+const MEDIABUNNY_EXTENSIONS = ["webm", "mkv", "ogg", "mov", "ts"];
+
+/**
+ * File extensions no web video backend can decode. AVI has no demuxer in
+ * MediaBunny, and AVI/MPEG payloads (MJPEG, Xvid/DivX, MPEG-1/2) are not
+ * WebCodecs-decodable; routing them anywhere produces an opaque mid-decode
+ * failure, so we reject them up front instead. Real support would need an
+ * ffmpeg-class path (ffmpeg.wasm in the browser, or a native ffmpeg sidecar on
+ * desktop) — tracked separately. Transcode to MP4 (H.264) as a workaround.
+ */
+const UNSUPPORTED_EXTENSIONS = ["avi", "mpeg", "mpg"];
+
+/**
+ * Thrown when a video file's container/codec cannot be decoded by any available
+ * web backend (e.g. `.avi`, `.mpeg`, `.mpg`). This is a clean, catchable signal
+ * so callers can show an actionable "unsupported format" message instead of
+ * letting a backend fail opaquely mid-decode. Transcode to MP4 (H.264) first.
+ */
+export class UnsupportedVideoFormatError extends Error {
+  /** The offending file extension (without the leading dot), e.g. `"avi"`. */
+  readonly extension: string;
+
+  constructor(extension: string) {
+    super(
+      `Unsupported video format ".${extension}". AVI and MPEG program streams ` +
+        `cannot be decoded in the browser or desktop app. Transcode to MP4 (H.264) ` +
+        `first, e.g. \`ffmpeg -i input.${extension} -c:v libx264 output.mp4\`.`
+    );
+    this.name = "UnsupportedVideoFormatError";
+    this.extension = extension;
+    // Restore the prototype chain so `instanceof` holds even under older
+    // transpile targets (matches MergeError/SkeletonMismatchError convention).
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
 
 export async function createVideoBackend(
   source: string | File | Blob,
@@ -67,6 +106,13 @@ export async function createVideoBackend(
   if (options?.backend === "media") {
     if (isBlob) return new MediaVideoBackend(URL.createObjectURL(source as Blob));
     return new MediaVideoBackend(filename);
+  }
+
+  // Formats no web backend can decode: fail loudly with a clean, catchable
+  // error rather than silently routing them to a backend that chokes mid-decode.
+  // (Explicit `backend` overrides above are honored as an escape hatch.)
+  if (UNSUPPORTED_EXTENSIONS.includes(ext)) {
+    throw new UnsupportedVideoFormatError(ext);
   }
 
   // Auto-select by format

--- a/tests/video/factory.test.ts
+++ b/tests/video/factory.test.ts
@@ -70,4 +70,50 @@ describe("createVideoBackend", () => {
       createVideoBackend(file, { backend: "mediabunny" })
     ).rejects.toThrow(/MediaBunny/);
   });
+
+  it("selects MediaBunny for .ts (MPEG-TS) files", async () => {
+    const { createVideoBackend } = await import("../../src/video/factory.js");
+    // .ts replaced .mpeg in the MediaBunny list: it is the real MPEG-TS case,
+    // which MediaBunny can demux (typical H.264/H.265 payload).
+    await expect(createVideoBackend("stream.ts")).rejects.toThrow(/MediaBunny/);
+  });
+
+  // .avi and MPEG program streams (.mpeg/.mpg) have no web decode path: reject
+  // them with a clean, catchable error instead of silently routing to MediaBunny
+  // (which has no AVI/MPEG-PS demuxer and would fail opaquely mid-decode).
+  for (const ext of ["avi", "mpeg", "mpg"]) {
+    it(`rejects .${ext} with a catchable UnsupportedVideoFormatError`, async () => {
+      const { createVideoBackend, UnsupportedVideoFormatError } = await import(
+        "../../src/video/factory.js"
+      );
+      let caught: unknown;
+      try {
+        await createVideoBackend(`clip.${ext}`);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(UnsupportedVideoFormatError);
+      expect((caught as InstanceType<typeof UnsupportedVideoFormatError>).extension).toBe(ext);
+      // Traceable, not an opaque MediaBunny mid-decode failure; points at MP4.
+      expect((caught as Error).message).not.toMatch(/MediaBunny/);
+      expect((caught as Error).message).toMatch(/MP4/);
+    });
+  }
+
+  it("rejects a Blob/File with an .avi filename", async () => {
+    const { createVideoBackend, UnsupportedVideoFormatError } = await import(
+      "../../src/video/factory.js"
+    );
+    const file = new File([new Blob(["fake"])], "clip.avi");
+    await expect(createVideoBackend(file)).rejects.toThrow(UnsupportedVideoFormatError);
+  });
+
+  it("honors an explicit backend override for unsupported extensions (escape hatch)", async () => {
+    const { createVideoBackend } = await import("../../src/video/factory.js");
+    // Forcing a backend bypasses the unsupported-format guard, so this attempts
+    // MediaBunny (mock throws /MediaBunny/) rather than UnsupportedVideoFormatError.
+    await expect(
+      createVideoBackend("clip.avi", { backend: "mediabunny" })
+    ).rejects.toThrow(/MediaBunny/);
+  });
 });


### PR DESCRIPTION
Closes #165.

## Problem

`createVideoBackend` listed `"mpeg"` and `"avi"` in `MEDIABUNNY_EXTENSIONS` (`src/video/factory.ts`), but the bundled MediaBunny has **no AVI demuxer** and **no MPEG program-stream demuxer** (only MPEG-TS). So `.avi`/`.mpeg` files were handed to a backend that can't read them and **failed opaquely mid-decode** ("No video track found") instead of erroring cleanly as "unsupported format." The backend's own docstring already listed only "WebM, Matroska, Ogg, MOV, MPEG-TS" (no AVI) — the factory list was the inaccurate one. The `.avi`/`.mpeg` routing was never covered by tests, so the mismatch went unnoticed. Discovered downstream in talmolab/sleap-app#157 / #156.

## Change ("honest cleanup")

- **Drop `"avi"`/`"mpeg"`** from `MEDIABUNNY_EXTENSIONS`, and **add `"ts"`** — the *real* MPEG-TS case, which MediaBunny can demux (typical H.264/H.265 payload is WebCodecs-decodable). The factory list now matches the backend's docstring.
- **Add `UnsupportedVideoFormatError`** (exported from both `index.ts` and `index.browser.ts`) and throw it up front for `.avi`/`.mpeg`/`.mpg`, so callers get a **clean, catchable** signal (with an actionable "transcode to MP4 (H.264)" message + the `ffmpeg` command) instead of a silent failure. The error carries `.extension`. Prototype chain is restored (`Object.setPrototypeOf`) to match the existing `MergeError`/`SkeletonMismatchError` convention.
- Explicit `backend` overrides are honored as an **escape hatch** (the guard sits after the override branches), so a determined caller can still force a backend.

## Not in scope

Real `.avi`/`.mpeg` decode requires an **ffmpeg-class path** (ffmpeg.wasm in the browser, or a native ffmpeg sidecar on desktop) — the whole web+desktop stack decodes through one shared WebCodecs path with no ffmpeg anywhere, and legacy AVI/MPEG codecs (MJPEG, Xvid/DivX, MPEG-1/2) are not WebCodecs-decodable. That is a separate, larger effort (best approach: transcode-on-import, reusing the Mp4Box backend). The MediaBunny AVI demuxer PR (Vanilagy/mediabunny#155) is unmerged and would only add demux, not legacy-codec decode.

## Tests

`tests/video/factory.test.ts` (all 11 pass):
- `.ts` (MPEG-TS) routes to MediaBunny.
- `.avi` / `.mpeg` / `.mpg` reject with a catchable `UnsupportedVideoFormatError` carrying `.extension`; message is traceable (not an opaque MediaBunny failure) and points at MP4.
- Blob/File with an `.avi` name rejects.
- Explicit `backend: "mediabunny"` override on `.avi` still reaches MediaBunny (escape hatch).

Typecheck (`bun run lint`) and build (`bun run build`) both clean. Full suite: 1500 pass, 1 skip, 1 pre-existing/environmental fail (a Python `sleap-io` cross-compat test that shells out to `uv run --with sleap-io`; fails identically on the base commit, unrelated to this change).

## Downstream consumer

sleap-app already rejects `.avi`/`.mpeg` at its own allowlist (`resolveVideos.ts` `BACKEND_BY_EXT`), so no user-facing regression. Once released, sleap-app can additionally `catch (e instanceof UnsupportedVideoFormatError)` for the SLP-embedded-path and surface the actionable message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)