### PR TITLE
feat(codecs): add writeSkeletonJson (jsonpickle encoder) (#167)

### DIFF
--- a/src/codecs/skeleton-json.ts
+++ b/src/codecs/skeleton-json.ts
@@ -179,3 +179,113 @@ export function readSkeletonJson(
 
   return new Skeleton({ nodes, edges, symmetries, name: data.graph?.name });
 }
+
+/** Encode a node as a fresh jsonpickle py/object (name, weight=1.0). */
+function encodeNode(name: string): JsonPickleNode {
+  return {
+    "py/object": "sleap.skeleton.Node",
+    "py/state": { "py/tuple": [name, 1.0] },
+  };
+}
+
+function encodeSkeleton(skeleton: Skeleton): JsonPickleSkeletonData {
+  const links: JsonPickleLink[] = [];
+
+  // Edge types: first occurrence of a type emits py/reduce, later occurrences a
+  // py/id back-reference. Counting py/reduce occurrences in order matches both
+  // the Python encoder and the duplicate-object branch of readSkeletonJson.
+  const edgeTypePyId = new Map<number, number>();
+  let nextEdgeTypePyId = 1;
+  function encodeEdgeType(typeVal: number): JsonPickleEdgeType {
+    const existing = edgeTypePyId.get(typeVal);
+    if (existing !== undefined) return { "py/id": existing };
+    edgeTypePyId.set(typeVal, nextEdgeTypePyId++);
+    return {
+      "py/reduce": [
+        { "py/type": "sleap.skeleton.EdgeType" },
+        { "py/tuple": [typeVal] },
+      ],
+    };
+  }
+
+  // py/ids for the trailing nodes array, assigned in first-appearance order
+  // across edges, then symmetries, then any remaining nodes (Python order).
+  const nodePyId = new Map<string, number>();
+  let nextNodePyId = 1;
+  const ensureNodePyId = (name: string) => {
+    if (!nodePyId.has(name)) nodePyId.set(name, nextNodePyId++);
+  };
+  // Nodes that appear in at least one link — readSkeletonJson recovers these
+  // from the links; isolated nodes are emitted as py/object below instead.
+  const linkedNodes = new Set<string>();
+
+  // Edges first (type 1), so the type-1 py/reduce/py/id back-refs resolve before
+  // any symmetry (type 2) appears — mirrors Python's edges-then-symmetries order.
+  let edgeInsertIdx = 0;
+  for (const edge of skeleton.edges) {
+    const src = edge.source.name;
+    const dst = edge.destination.name;
+    links.push({
+      edge_insert_idx: edgeInsertIdx++,
+      key: 0,
+      source: encodeNode(src),
+      target: encodeNode(dst),
+      type: encodeEdgeType(1),
+    });
+    ensureNodePyId(src);
+    ensureNodePyId(dst);
+    linkedNodes.add(src).add(dst);
+  }
+
+  for (const [left, right] of skeleton.symmetryNames) {
+    links.push({
+      key: 0,
+      source: encodeNode(left),
+      target: encodeNode(right),
+      type: encodeEdgeType(2),
+    });
+    ensureNodePyId(left);
+    ensureNodePyId(right);
+    linkedNodes.add(left).add(right);
+  }
+
+  for (const node of skeleton.nodes) ensureNodePyId(node.name);
+
+  // nodes array, in skeleton-node order. Connected nodes use a py/id ref (the
+  // Python format); nodes in no link are emitted as a full py/object so a
+  // duplicate-object read still recovers them (Python emits py/id here, which
+  // readSkeletonJson cannot resolve for an isolated node).
+  const nodes = skeleton.nodes.map((node) =>
+    linkedNodes.has(node.name)
+      ? { id: { "py/id": nodePyId.get(node.name)! } }
+      : { id: encodeNode(node.name) }
+  );
+
+  return {
+    directed: true,
+    graph: {
+      name: skeleton.name ?? "",
+      num_edges_inserted: skeleton.edges.length,
+    },
+    links,
+    multigraph: true,
+    nodes,
+  };
+}
+
+/**
+ * Serialize skeleton(s) to the jsonpickle graph format consumed by
+ * {@link readSkeletonJson} and by PyQt SLEAP / Python `sleap_io`'s
+ * `SkeletonDecoder`. Port of Python `sleap_io.io.skeleton.SkeletonEncoder`.
+ *
+ * Emits the "duplicate-object" variant: every link source/target is a fresh
+ * py/object Node; the first occurrence of each edge type uses py/reduce, later
+ * occurrences a py/id back-reference. A single Skeleton serializes to a bare
+ * object; a list to a JSON array (matching the two standalone-file shapes).
+ */
+export function writeSkeletonJson(skeletons: Skeleton | Skeleton[]): string {
+  const data = Array.isArray(skeletons)
+    ? skeletons.map(encodeSkeleton)
+    : encodeSkeleton(skeletons);
+  return JSON.stringify(data);
+}

--- a/tests/skeleton-json.test.ts
+++ b/tests/skeleton-json.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "./bun-test";
-import { readSkeletonJson } from "../src/codecs/skeleton-json.js";
+import { readSkeletonJson, writeSkeletonJson } from "../src/codecs/skeleton-json.js";
+import { Skeleton, Node, Edge, Symmetry } from "../src/model/skeleton.js";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import fs from "node:fs";
@@ -9,6 +10,14 @@ const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 function loadFixtureJson(filename: string): string {
   return fs.readFileSync(path.join(fixtureRoot, "slp", filename), "utf-8");
 }
+
+// Content comparison helpers (order-independent; the jsonpickle format does not
+// preserve node order, mirroring Python — assert membership, not ordering).
+const nameKeys = (s: Skeleton) => [...s.nodeNames].sort();
+const edgeKeys = (s: Skeleton) =>
+  s.edges.map((e) => `${e.source.name} ${e.destination.name}`).sort();
+const symKeys = (s: Skeleton) =>
+  s.symmetryNames.map(([a, b]) => [a, b].slice().sort().join(" ")).sort();
 
 describe("Skeleton JSON codec", () => {
   it("reads flies13.skeleton.json", () => {
@@ -76,5 +85,110 @@ describe("Skeleton JSON codec", () => {
     const json = loadFixtureJson("flies13.skeleton.json");
     const skeleton = readSkeletonJson(json);
     expect(skeleton.nodes.length).toBe(13);
+  });
+});
+
+describe("writeSkeletonJson", () => {
+  // Read a fixture, write it back out, read again, and assert content survives.
+  function roundTripFixture(original: Skeleton): Skeleton {
+    const json = writeSkeletonJson(original);
+    expect(typeof json).toBe("string");
+    return readSkeletonJson(json);
+  }
+
+  it("round-trips flies13 (edges + symmetries)", () => {
+    const original = readSkeletonJson(loadFixtureJson("flies13.skeleton.json"));
+    const reparsed = roundTripFixture(original);
+    expect(reparsed.nodes.length).toBe(original.nodes.length);
+    expect(nameKeys(reparsed)).toEqual(nameKeys(original));
+    expect(edgeKeys(reparsed)).toEqual(edgeKeys(original));
+    expect(symKeys(reparsed)).toEqual(symKeys(original));
+    expect(reparsed.symmetryNames.length).toBeGreaterThan(0);
+    expect(reparsed.name).toBe(original.name);
+  });
+
+  it("round-trips fly32 (32 nodes, 25 edges, no symmetries)", () => {
+    const arr = JSON.parse(loadFixtureJson("fly32.skeleton.json")) as unknown[];
+    const original = readSkeletonJson(arr[0] as Record<string, unknown>);
+    const reparsed = roundTripFixture(original);
+    expect(reparsed.nodes.length).toBe(32);
+    expect(nameKeys(reparsed)).toEqual(nameKeys(original));
+    expect(edgeKeys(reparsed)).toEqual(edgeKeys(original));
+    expect(reparsed.symmetryNames.length).toBe(0);
+  });
+
+  it("round-trips mice_hc", () => {
+    const parsed = JSON.parse(loadFixtureJson("mice_hc.json")) as Record<string, unknown>;
+    const original = readSkeletonJson(parsed.nx_graph as Record<string, unknown>);
+    const reparsed = roundTripFixture(original);
+    expect(reparsed.nodes.length).toBe(5);
+    expect(nameKeys(reparsed)).toEqual(nameKeys(original));
+    expect(edgeKeys(reparsed)).toEqual(edgeKeys(original));
+    expect(reparsed.name).toBe("Skeleton-0");
+  });
+
+  it("emits jsonpickle duplicate-object structure (py/object nodes, py/reduce then py/id edge types)", () => {
+    const original = readSkeletonJson(loadFixtureJson("flies13.skeleton.json"));
+    const data = JSON.parse(writeSkeletonJson(original)) as Record<string, unknown>;
+    expect(data.directed).toBe(true);
+    expect(data.multigraph).toBe(true);
+    const links = data.links as Array<Record<string, any>>;
+    // Every link source/target is a fresh py/object Node (duplicate-object mode).
+    expect(links[0].source["py/object"]).toBe("sleap.skeleton.Node");
+    expect(links[0].source["py/state"]["py/tuple"][1]).toBe(1.0);
+    // First edge type is a py/reduce; a later edge reuses it via py/id.
+    expect(links[0].type["py/reduce"][0]["py/type"]).toBe("sleap.skeleton.EdgeType");
+    expect(links[0].type["py/reduce"][1]["py/tuple"][0]).toBe(1);
+    expect(links[1].type["py/id"]).toBe(1);
+    // num_edges_inserted matches the edge count.
+    expect((data.graph as any).num_edges_inserted).toBe(original.edges.length);
+  });
+
+  it("returns a bare object for one skeleton and an array for a list", () => {
+    const sk = readSkeletonJson(loadFixtureJson("flies13.skeleton.json"));
+    expect(Array.isArray(JSON.parse(writeSkeletonJson(sk)))).toBe(false);
+    const arr = JSON.parse(writeSkeletonJson([sk])) as unknown[];
+    expect(Array.isArray(arr)).toBe(true);
+    expect(arr.length).toBe(1);
+    // Each element round-trips independently.
+    expect(readSkeletonJson(arr[0] as Record<string, unknown>).nodes.length).toBe(13);
+  });
+
+  it("preserves an isolated node (no edges/symmetries) through round-trip", () => {
+    const [a, b, c] = [new Node("a"), new Node("b"), new Node("c")];
+    const original = new Skeleton({
+      nodes: [a, b, c],
+      edges: [new Edge(a, b)],
+      name: "Iso",
+    });
+    const reparsed = roundTripFixture(original);
+    expect(reparsed.nodes.length).toBe(3);
+    expect(nameKeys(reparsed)).toEqual(["a", "b", "c"]);
+    expect(edgeKeys(reparsed)).toEqual(["a b"]);
+  });
+
+  it("preserves a nodes-only skeleton (no links at all)", () => {
+    const original = new Skeleton({
+      nodes: [new Node("x"), new Node("y")],
+      name: "NodesOnly",
+    });
+    const reparsed = roundTripFixture(original);
+    expect(reparsed.nodes.length).toBe(2);
+    expect(nameKeys(reparsed)).toEqual(["x", "y"]);
+    expect(reparsed.edges.length).toBe(0);
+  });
+
+  it("round-trips a symmetry-bearing skeleton built from scratch", () => {
+    const [l, r, m] = [new Node("L"), new Node("R"), new Node("mid")];
+    const original = new Skeleton({
+      nodes: [l, r, m],
+      edges: [new Edge(m, l), new Edge(m, r)],
+      symmetries: [new Symmetry([l, r])],
+      name: "Sym",
+    });
+    const reparsed = roundTripFixture(original);
+    expect(nameKeys(reparsed)).toEqual(["L", "R", "mid"]);
+    expect(edgeKeys(reparsed)).toEqual(["mid L", "mid R"]);
+    expect(symKeys(reparsed)).toEqual(["L R"]);
   });
 });


### PR DESCRIPTION
Closes #167 (Part 1 — the primary ask; Part 2 `.h5` skeleton I/O deferred, see below).

## Problem

The skeleton JSON codec was read-only: `readSkeletonJson` parsed the jsonpickle graph format but had **no encoder counterpart** (the YAML codec already had both `decodeYamlSkeleton`/`encodeYamlSkeleton`). This is the last data-layer gap for full skeleton Save-As parity in sleap-app (talmolab/sleap-app#163 / PR #171 ships YAML export today; `.json` export was waiting on this).

## Change

Adds `writeSkeletonJson(skeletons: Skeleton | Skeleton[]): string` — a port of Python `sleap_io.io.skeleton.SkeletonEncoder` — to `src/codecs/skeleton-json.ts`. It produces the **duplicate-object** jsonpickle variant:

- A fresh `py/object` Node for every link source/target.
- First occurrence of each edge type emits `py/reduce`; later occurrences a `py/id` back-reference. **Edges (type 1) precede symmetries (type 2)**, so the back-refs resolve in both Python and `readSkeletonJson`'s duplicate-mode edge-type counter.
- A single `Skeleton` serializes to a bare object; a list to a JSON array (the two standalone-file shapes).

### Isolated-node robustness (one deliberate deviation from Python)

Python emits **every** node in the trailing `nodes` array as `{"id": {"py/id": N}}`. `readSkeletonJson` recovers nodes from the *links*, so a node that appears in **no** link (an isolated node, or a nodes-only skeleton) would be **lost on a JS round-trip**. This encoder instead emits **unlinked** nodes as a full `py/object` in the `nodes` array (connected nodes keep Python's `py/id`, so connected skeletons stay byte-faithful). Verified this still reopens in Python — so nodes-only and isolated-node skeletons now round-trip both ways, where the pure Python format loses them on JS read.

## Verification

- **JS round-trip** (`tests/skeleton-json.test.ts`, 8 new tests, all green): `write → read` for flies13 / fly32 / mice_hc (node set, directed edge pairs, deduped symmetry pairs, name); jsonpickle structural assertions; single-vs-array; **isolated-node** and **nodes-only** preservation; a from-scratch symmetry skeleton.
- **Python interop oracle** (the harder bar): JS-written output decoded via `sleap_io.io.skeleton.decode_skeleton` — `flies13` (13 nodes / 12 edges / 5 sym), `fly32` (32 / 25 / 0), `iso` (3 nodes incl. the isolated one), `nodes-only` (2 nodes), `sym` (3 / 2 / 1) — **all preserved**.
- Typecheck (`bun run lint`) and build (`bun run build`) clean.
- Full suite: **1502 pass / 1 skip / 1 fail**, the 1 fail being the pre-existing environmental `skeleton-edgeless-nodes` Python cross-compat test (`numpy.float32` `skeleton_id` bug in the locally-installed Python `sleap-io`), which fails identically on the base commit and is unrelated to this change.

Auto-exported via the existing `export * from "./codecs/skeleton-json.js"` in `index.ts` and `index.browser.ts` (no index edit needed).

## Not in scope

**Part 2 — standalone-skeleton `.h5` read/write** — is deferred per the issue: PyQt's own `.h5` skeleton *write* is a commented-out TODO, so there is no interop target to validate against yet.

## Downstream

Unblocks sleap-app `src/lib/skeletonIO.ts` to offer `.json` in its skeleton **Save As…** path (today it exports `.yaml` only; the import picker already accepts `.json`/`.yaml`/`.slp`). Pairs with talmolab/sleap-app#163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)