### PR TITLE
feat(model): add Labels.removeVideo / removeVideos (#166)

### DIFF
--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -1018,6 +1018,40 @@ export class Labels {
   }
 
   /**
+   * Remove one or more videos and every reference to them — the "drop" analog
+   * of {@link replaceVideos}. Labeled frames and suggestions belonging to a
+   * removed video are dropped (a frame's ROIs go with it), as are static ROIs
+   * that reference it. Videos not present are ignored (a no-op, matching
+   * {@link addVideo}'s lenient convention).
+   *
+   * Tracks and skeletons are intentionally left untouched — cleaning those up
+   * is a separate concern (see {@link clean}).
+   */
+  removeVideos(videos: Video[]): void {
+    if (videos.length === 0) return;
+    if (this._lazyFrameList) this.materialize();
+
+    const toRemove = new Set(videos);
+
+    this.labeledFrames = this.labeledFrames.filter(
+      (lf) => !toRemove.has(lf.video)
+    );
+    this.suggestions = this.suggestions.filter((s) => !toRemove.has(s.video));
+    this._staticRois = this._staticRois.filter(
+      (roi) => !roi.video || !toRemove.has(roi.video)
+    );
+    this.videos = this.videos.filter((v) => !toRemove.has(v));
+
+    // Frame/track indices are keyed by video identity, so must be rebuilt.
+    this._invalidateIndices();
+  }
+
+  /** Remove a single video and all references to it (see {@link removeVideos}). */
+  removeVideo(video: Video): void {
+    this.removeVideos([video]);
+  }
+
+  /**
    * Create a deep copy of this Labels object.
    *
    * @param options.openVideos - Controls video backend behavior in the copy:

--- a/tests/model/labels-remove-video.test.ts
+++ b/tests/model/labels-remove-video.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "../bun-test";
+import { Labels } from "../../src/model/labels.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { Video } from "../../src/model/video.js";
+import { SuggestionFrame } from "../../src/model/suggestions.js";
+import { UserROI } from "../../src/model/roi.js";
+import { Skeleton, Node } from "../../src/model/skeleton.js";
+
+describe("Labels.removeVideo / removeVideos", () => {
+  const mkRoi = (video: Video | null) =>
+    new UserROI({
+      geometry: { type: "Point", coordinates: [0, 0] },
+      video,
+      frameIdx: 0,
+    });
+
+  it("removes the video from labels.videos", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const b = new Video({ filename: "b.mp4" });
+    const labels = new Labels({ videos: [a, b] });
+    labels.removeVideo(a);
+    expect(labels.videos).toEqual([b]);
+  });
+
+  it("drops labeled frames for the removed video and keeps the rest", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const b = new Video({ filename: "b.mp4" });
+    const fa = new LabeledFrame({ video: a, frameIdx: 0 });
+    const fb = new LabeledFrame({ video: b, frameIdx: 0 });
+    const labels = new Labels({ labeledFrames: [fa, fb], videos: [a, b] });
+    labels.removeVideo(a);
+    expect(labels.labeledFrames).toEqual([fb]);
+    expect(labels.videos).toEqual([b]);
+  });
+
+  it("drops suggestions for the removed video and keeps the rest", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const b = new Video({ filename: "b.mp4" });
+    const sa = new SuggestionFrame({ video: a, frameIdx: 0 });
+    const sb = new SuggestionFrame({ video: b, frameIdx: 1 });
+    const labels = new Labels({ videos: [a, b], suggestions: [sa, sb] });
+    labels.removeVideo(a);
+    expect(labels.suggestions).toEqual([sb]);
+  });
+
+  it("drops static ROIs for the removed video, keeping null-video and other-video ROIs", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const b = new Video({ filename: "b.mp4" });
+    const roiA = mkRoi(a);
+    const roiB = mkRoi(b);
+    const roiNull = mkRoi(null);
+    const labels = new Labels({ videos: [a, b], rois: [roiA, roiB, roiNull] });
+    labels.removeVideo(a);
+    expect(labels._staticRois).toEqual([roiB, roiNull]);
+  });
+
+  it("rebuilds the frame index after removal", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const b = new Video({ filename: "b.mp4" });
+    const fa = new LabeledFrame({ video: a, frameIdx: 3 });
+    const fb = new LabeledFrame({ video: b, frameIdx: 3 });
+    const labels = new Labels({ labeledFrames: [fa, fb], videos: [a, b] });
+    // Prime the index so removal must invalidate it.
+    expect(labels.getFrame(a, 3)).toBe(fa);
+    labels.removeVideo(a);
+    expect(labels.getFrame(a, 3)).toBeNull();
+    expect(labels.getFrame(b, 3)).toBe(fb);
+  });
+
+  it("is a no-op for a video not present in the labels", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const other = new Video({ filename: "other.mp4" });
+    const fa = new LabeledFrame({ video: a, frameIdx: 0 });
+    const labels = new Labels({ labeledFrames: [fa], videos: [a] });
+    labels.removeVideo(other);
+    expect(labels.videos).toEqual([a]);
+    expect(labels.labeledFrames).toEqual([fa]);
+  });
+
+  it("removeVideos removes several videos at once", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const b = new Video({ filename: "b.mp4" });
+    const c = new Video({ filename: "c.mp4" });
+    const fa = new LabeledFrame({ video: a, frameIdx: 0 });
+    const fb = new LabeledFrame({ video: b, frameIdx: 0 });
+    const fc = new LabeledFrame({ video: c, frameIdx: 0 });
+    const labels = new Labels({ labeledFrames: [fa, fb, fc], videos: [a, b, c] });
+    labels.removeVideos([a, c]);
+    expect(labels.videos).toEqual([b]);
+    expect(labels.labeledFrames).toEqual([fb]);
+  });
+
+  it("removeVideos is a no-op for an empty list", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const fa = new LabeledFrame({ video: a, frameIdx: 0 });
+    const labels = new Labels({ labeledFrames: [fa], videos: [a] });
+    labels.removeVideos([]);
+    expect(labels.videos).toEqual([a]);
+    expect(labels.labeledFrames).toEqual([fa]);
+  });
+
+  it("leaves skeletons untouched (no track/skeleton GC)", () => {
+    const a = new Video({ filename: "a.mp4" });
+    const skeleton = new Skeleton({ nodes: [new Node("x")], name: "S" });
+    const labels = new Labels({ videos: [a], skeletons: [skeleton] });
+    labels.removeVideo(a);
+    expect(labels.skeletons).toEqual([skeleton]);
+  });
+});


### PR DESCRIPTION
Closes #166.

## Summary

Adds `Labels.removeVideo(video)` and `Labels.removeVideos(videos)` — the **"drop" analog of `replaceVideos`**. Removing a video correctly is a data-model operation because a video is referenced in several places inside `Labels`, some of them private and not safely reachable from a GUI (notably `_staticRois`). A GUI-side `filter` of the public arrays would leave dangling references and risk an inconsistent `Labels` on save/reload.

## Behavior

Mirrors the exact reference surface that `replaceVideos` already handles (`src/model/labels.ts`), using **filter** instead of re-point:

- Drops the video(s) from `this.videos`.
- Drops `labeledFrames` whose `video` is removed (a frame's per-frame `rois` go with it).
- Drops `suggestions` whose `video` is removed.
- Drops `_staticRois` referencing a removed video (with a null-guard, since `ROI.video` is nullable).
- Rebuilds the frame/track indices via `_invalidateIndices()` (they're keyed by video identity).
- Materializes a lazy frame list first, like `replaceVideos`.

Edge cases: videos **not present are ignored** (a no-op, matching `addVideo`'s lenient convention); an **empty list is a no-op**. **Tracks and skeletons are intentionally left untouched** — cleaning those up is a separate concern (see `clean()`). `removeVideo` delegates to `removeVideos`.

> Note: Python `sleap-io` has no direct `Labels.remove_video`; this is derived from `replace_videos` (re-point → filter) and the videos-removal branch of `clean()`.

## Tests

`tests/model/labels-remove-video.test.ts` (9 tests, all green; mirrors `labels-replace-videos.test.ts`): removal + isolation across videos / labeled frames / suggestions / static ROIs; null-video static ROI preserved; frame-index rebuild after removal; unknown-video no-op; empty-list no-op; batch removal; skeletons untouched.

Typecheck (`bun run lint`) and build (`bun run build`) clean. Full suite: **1503 pass / 1 skip / 1 fail**, the 1 fail being the pre-existing environmental `skeleton-edgeless-nodes` Python cross-compat test (unrelated; fails identically on the base commit).

## Consumer

Unblocks sleap-app's Videos-panel **"Remove Video"** control (currently a `toast.info("Remove Video is not yet implemented")` stub). Once released, the app wires a confirm dialog + store update around `removeVideo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)