### PR TITLE
feat(video): ImageVideoBackend (image-sequence decode) + resilient SLP video loading

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -8,7 +8,7 @@
 # source for reading .seq video files. The suite runs with `bun test --parallel`
 # (each file in its own worker process, implying `--isolate`); these preloads run
 # per worker, so the registrations are present in every test file.
-preload = ["./src/codecs/slp/h5-node.ts", "./src/model/node-fs-resolver.ts", "./src/video/seq-node.ts", "./src/io/label-images-node.ts"]
+preload = ["./src/codecs/slp/h5-node.ts", "./src/model/node-fs-resolver.ts", "./src/video/seq-node.ts", "./src/io/label-images-node.ts", "./src/video/node-image-reader.ts"]
 
 # Coverage (emitted only when `--coverage` is passed, e.g. `bun test --coverage`).
 # Write an lcov report into `coverage/` so CI can upload it as an artifact, and

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -5,8 +5,12 @@ import { LabeledFrame } from "../../model/labeled-frame.js";
 import { Instance, PredictedInstance, Track, pointsFromArray, predictedPointsFromArray } from "../../model/instance.js";
 import { Skeleton } from "../../model/skeleton.js";
 import { SuggestionFrame } from "../../model/suggestions.js";
-import { Video } from "../../model/video.js";
-import { createVideoBackend } from "../../video/factory.js";
+import { Video, type VideoBackendError } from "../../model/video.js";
+import {
+  createVideoBackend,
+  UnsupportedVideoFormatError,
+  isImageSource,
+} from "../../video/factory.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
 import { resolveSourceFrameCount } from "./frame-count.js";
 import type { CropRect } from "../../transform/points.js";
@@ -527,17 +531,35 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
     const channelOrder = (backendMeta.channel_order as string | undefined) ?? channelOrderFromAttrs ?? (formatId < 1.4 ? "BGR" : "RGB");
 
     let backend = null;
+    let backendError: VideoBackendError | null = null;
     if (openVideos) {
-      backend = await createVideoBackend(filename, {
-        dataset: datasetPath ?? undefined,
-        embedded,
-        frameNumbers,
-        frameSizes: readFrameSizes(file, datasetPath),
-        format,
-        channelOrder,
-        shape,
-        fps: backendMeta.fps,
-      });
+      try {
+        backend = await createVideoBackend(filename, {
+          dataset: datasetPath ?? undefined,
+          embedded,
+          frameNumbers,
+          frameSizes: readFrameSizes(file, datasetPath),
+          format,
+          channelOrder,
+          shape,
+          fps: backendMeta.fps,
+        });
+      } catch (err) {
+        // Resilient load: a single video whose backend can't be built — an
+        // image-sequence with missing files, an unsupported `.avi`/`.mpeg`, or
+        // a decode failure — must NOT abort the whole project load. Leave the
+        // backend null and record the reason so the consumer can show an
+        // actionable message / resolver instead of the load throwing.
+        backend = null;
+        backendError = {
+          kind: err instanceof UnsupportedVideoFormatError
+            ? "unsupported-format"
+            : isImageSource(filename)
+              ? "image-sequence"
+              : "decode",
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
     }
 
     const sourceVideo = parsed.source_video ? new Video({ filename: parsed.source_video.filename ?? "" }) : null;
@@ -574,6 +596,7 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
       new Video({
         filename,
         backend,
+        backendError,
         backendMetadata,
         sourceVideo,
         openBackend: openVideos,

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -23,6 +23,12 @@ export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
 export * from "./video/streaming-hdf5-video.js";
+export * from "./video/image-video.js";
+export {
+  setImageBytesReader,
+  getImageBytesReader,
+  type ImageBytesReader,
+} from "./video/image-source.js";
 export {
   SeqVideoBackend,
   SeqHeader,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,9 @@ import "./model/node-fs-resolver.js";
 import "./video/seq-node.js";
 // Register the Node `fs`-backed TIFF reader for loadLabelImages() path inputs.
 import "./io/label-images-node.js";
+// Register the Node `fs`-backed default image-bytes reader for ImageVideoBackend
+// (image-sequence videos: a list of image paths, one per frame).
+import "./video/node-image-reader.js";
 
 export * from "./model/labels.js";
 export * from "./model/labeled-frame.js";
@@ -30,6 +33,12 @@ export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
 export * from "./video/streaming-hdf5-video.js";
+export * from "./video/image-video.js";
+export {
+  setImageBytesReader,
+  getImageBytesReader,
+  type ImageBytesReader,
+} from "./video/image-source.js";
 export {
   SeqVideoBackend,
   SeqHeader,

--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -128,9 +128,26 @@ export function resolveCropRect(
   return [x1, y1, x2, y2];
 }
 
+/**
+ * Why a video's backend could not be opened during load (the backend is then
+ * left `null`). Drives the consumer's message/action — e.g. "locate image
+ * folder" for an image-sequence, "unsupported format" for `.avi`/`.mpeg`.
+ */
+export type VideoBackendErrorKind =
+  | "image-sequence"
+  | "unsupported-format"
+  | "decode";
+
+export interface VideoBackendError {
+  kind: VideoBackendErrorKind;
+  message: string;
+}
+
 export class Video {
   filename: string | string[];
   backend: VideoBackend | null;
+  /** Set when the backend failed to open during load (then `backend` is null). */
+  backendError: VideoBackendError | null;
   backendMetadata: Record<string, unknown>;
   sourceVideo: Video | null;
   openBackend: boolean;
@@ -141,6 +158,7 @@ export class Video {
   constructor(options: {
     filename: string | string[];
     backend?: VideoBackend | null;
+    backendError?: VideoBackendError | null;
     backendMetadata?: Record<string, unknown>;
     sourceVideo?: Video | null;
     openBackend?: boolean;
@@ -148,6 +166,7 @@ export class Video {
   }) {
     this.filename = options.filename;
     this.backend = options.backend ?? null;
+    this.backendError = options.backendError ?? null;
     this.backendMetadata = options.backendMetadata ?? {};
     this.sourceVideo = options.sourceVideo ?? null;
     this.openBackend = options.openBackend ?? true;

--- a/src/video/crop-backend.ts
+++ b/src/video/crop-backend.ts
@@ -23,6 +23,7 @@ import {
   type FlatPoints,
   type PointPairs,
 } from "../transform/points.js";
+import { decodeEncoded, rasterizeBitmap } from "./image-decode.js";
 
 export type { CropRect };
 
@@ -105,86 +106,6 @@ function isEncodedBytes(bytes: Uint8Array): boolean {
     bytes[2] === 0x4e &&
     bytes[3] === 0x47;
   return jpeg || png;
-}
-
-/** Rasterize an opaque `ImageBitmap` to RGBA `ImageData` (OffscreenCanvas / skia). */
-async function rasterizeBitmap(bitmap: ImageBitmap): Promise<ImageData> {
-  // Browser: OffscreenCanvas.
-  if (typeof OffscreenCanvas !== "undefined") {
-    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      throw new Error("Failed to get 2D context to rasterize a cropped frame");
-    }
-    ctx.drawImage(bitmap as unknown as CanvasImageSource, 0, 0);
-    return ctx.getImageData(0, 0, bitmap.width, bitmap.height);
-  }
-  // Node: skia-canvas (lazy dynamic import; never statically bundled).
-  try {
-    const sc = await import("skia-canvas");
-    const Canvas = (
-      sc as unknown as { Canvas: new (w: number, h: number) => unknown }
-    ).Canvas;
-    const canvas = new Canvas(bitmap.width, bitmap.height) as {
-      getContext: (t: string) => {
-        drawImage: (i: unknown, x: number, y: number) => void;
-        getImageData: (x: number, y: number, w: number, h: number) => ImageData;
-      };
-    };
-    const ctx = canvas.getContext("2d");
-    ctx.drawImage(bitmap, 0, 0);
-    return ctx.getImageData(0, 0, bitmap.width, bitmap.height);
-  } catch (err) {
-    throw new Error(
-      "Cropping a frame returned as an ImageBitmap requires an image " +
-        "rasterizer (a browser with OffscreenCanvas, or the optional " +
-        "`skia-canvas` package on Node). " +
-        `Original error: ${(err as Error).message}`
-    );
-  }
-}
-
-/** Decode encoded (PNG/JPEG) frame bytes to RGBA `ImageData` (browser / skia). */
-async function decodeEncoded(bytes: Uint8Array): Promise<ImageData> {
-  // Browser: createImageBitmap + OffscreenCanvas.
-  if (
-    typeof createImageBitmap !== "undefined" &&
-    typeof OffscreenCanvas !== "undefined"
-  ) {
-    const safe = new Uint8Array(bytes);
-    const bitmap = await createImageBitmap(new Blob([safe.buffer]));
-    return rasterizeBitmap(bitmap);
-  }
-  // Node: skia-canvas loadImage. Wrap bytes in a Buffer so skia does not misread
-  // a bare Uint8Array as a path.
-  try {
-    const sc = await import("skia-canvas");
-    const src =
-      typeof Buffer !== "undefined" ? Buffer.from(bytes) : (bytes as unknown);
-    const img = await (
-      sc as unknown as {
-        loadImage: (b: unknown) => Promise<{ width: number; height: number }>;
-      }
-    ).loadImage(src);
-    const Canvas = (
-      sc as unknown as { Canvas: new (w: number, h: number) => unknown }
-    ).Canvas;
-    const canvas = new Canvas(img.width, img.height) as {
-      getContext: (t: string) => {
-        drawImage: (i: unknown, x: number, y: number) => void;
-        getImageData: (x: number, y: number, w: number, h: number) => ImageData;
-      };
-    };
-    const ctx = canvas.getContext("2d");
-    ctx.drawImage(img, 0, 0);
-    return ctx.getImageData(0, 0, img.width, img.height);
-  } catch (err) {
-    throw new Error(
-      "Cropping a frame returned as undecoded JPEG/PNG bytes requires an image " +
-        "decoder (a browser, or the optional `skia-canvas` package on Node). " +
-        `Original error: ${(err as Error).message}`
-    );
-  }
 }
 
 /**

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -4,6 +4,7 @@ import { MediaVideoBackend } from "./media-video.js";
 import { Mp4BoxVideoBackend } from "./mp4box-video.js";
 import { MediaBunnyVideoBackend } from "./mediabunny-video.js";
 import { SeqVideoBackend } from "./seq-video.js";
+import { ImageVideoBackend } from "./image-video.js";
 import { openH5File } from "../codecs/slp/h5.js";
 
 /** Supported video backend identifiers for user selection. */
@@ -26,6 +27,26 @@ const MEDIABUNNY_EXTENSIONS = ["webm", "mkv", "ogg", "mov", "ts"];
  * desktop) — tracked separately. Transcode to MP4 (H.264) as a workaround.
  */
 const UNSUPPORTED_EXTENSIONS = ["avi", "mpeg", "mpg"];
+
+/**
+ * Image-sequence frame extensions (parity with Python `ImageVideo.EXTS`): one
+ * image per frame. PNG/JPEG/BMP decode in both a browser (`createImageBitmap`)
+ * and Node (`skia-canvas`); TIFF has no web decoder yet, so a `.tif`/`.tiff`
+ * source routes here but fails gracefully at decode (the SLP load guard records
+ * it) until a wasm TIFF decoder is added.
+ */
+export const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "tif", "tiff", "bmp"];
+
+/**
+ * True if `source` denotes an image-sequence (ImageVideo): a LIST of image
+ * paths, or a single image-extension filename. Used by the SLP loader to
+ * classify a backend-creation failure.
+ */
+export function isImageSource(source: string | string[]): boolean {
+  if (Array.isArray(source)) return true;
+  const ext = source.split("?")[0]?.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_EXTENSIONS.includes(ext);
+}
 
 /**
  * Thrown when a video file's container/codec cannot be decoded by any available
@@ -52,7 +73,7 @@ export class UnsupportedVideoFormatError extends Error {
 }
 
 export async function createVideoBackend(
-  source: string | File | Blob,
+  source: string | string[] | File | Blob,
   options?: {
     dataset?: string;
     embedded?: boolean;
@@ -65,6 +86,15 @@ export async function createVideoBackend(
     backend?: VideoBackendType;
   }
 ): Promise<VideoBackend> {
+  // Image-sequence video (Python `ImageVideo`): `source` is a LIST of image
+  // paths, one image per frame. Route to ImageVideoBackend before the single-
+  // filename logic below, which assumes a string and would crash on `.split`.
+  if (Array.isArray(source)) {
+    return ImageVideoBackend.create({
+      filename: source,
+      shape: options?.shape,
+    });
+  }
   const isBlob = typeof Blob !== "undefined" && source instanceof Blob;
   const filename = isBlob
     ? (source as File).name ?? ""
@@ -93,6 +123,14 @@ export async function createVideoBackend(
   // other backend can read the format).
   if (ext === "seq") {
     return SeqVideoBackend.create(source);
+  }
+
+  // Single image file (Python `ImageVideo` single-frame / from_filename): route
+  // to ImageVideoBackend with a one-element list. Multi-image lists are handled
+  // at the top of this function via Array.isArray. This must come before the
+  // MediaVideo fallback, which would otherwise try (and fail) to play a .jpg.
+  if (IMAGE_EXTENSIONS.includes(ext)) {
+    return ImageVideoBackend.create({ filename: [filename], shape: options?.shape });
   }
 
   // User-specified backend override

--- a/src/video/image-decode.ts
+++ b/src/video/image-decode.ts
@@ -1,0 +1,90 @@
+// src/video/image-decode.ts
+//
+// Shared image decode/rasterize helpers, used by both `CropVideoBackend` (to
+// rasterize/decode inner frames before cropping) and `ImageVideoBackend` (to
+// decode each image-sequence frame).
+//
+// Browser-safe: this module never statically imports a Node-only decoder.
+// Decoding/rasterizing uses `createImageBitmap` + `OffscreenCanvas` when
+// available (browser) else a lazy dynamic `import("skia-canvas")` (Node),
+// exactly like `seq-video.ts`. Bundlers must keep `skia-canvas` external.
+
+/** Rasterize an opaque `ImageBitmap` to RGBA `ImageData` (OffscreenCanvas / skia). */
+export async function rasterizeBitmap(bitmap: ImageBitmap): Promise<ImageData> {
+  // Browser: OffscreenCanvas.
+  if (typeof OffscreenCanvas !== "undefined") {
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      throw new Error("Failed to get 2D context to rasterize a frame");
+    }
+    ctx.drawImage(bitmap as unknown as CanvasImageSource, 0, 0);
+    return ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+  }
+  // Node: skia-canvas (lazy dynamic import; never statically bundled).
+  try {
+    const sc = await import("skia-canvas");
+    const Canvas = (
+      sc as unknown as { Canvas: new (w: number, h: number) => unknown }
+    ).Canvas;
+    const canvas = new Canvas(bitmap.width, bitmap.height) as {
+      getContext: (t: string) => {
+        drawImage: (i: unknown, x: number, y: number) => void;
+        getImageData: (x: number, y: number, w: number, h: number) => ImageData;
+      };
+    };
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(bitmap, 0, 0);
+    return ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+  } catch (err) {
+    throw new Error(
+      "Rasterizing a frame returned as an ImageBitmap requires an image " +
+        "rasterizer (a browser with OffscreenCanvas, or the optional " +
+        "`skia-canvas` package on Node). " +
+        `Original error: ${(err as Error).message}`
+    );
+  }
+}
+
+/** Decode encoded (PNG/JPEG/…) image bytes to RGBA `ImageData` (browser / skia). */
+export async function decodeEncoded(bytes: Uint8Array): Promise<ImageData> {
+  // Browser: createImageBitmap + OffscreenCanvas.
+  if (
+    typeof createImageBitmap !== "undefined" &&
+    typeof OffscreenCanvas !== "undefined"
+  ) {
+    const safe = new Uint8Array(bytes);
+    const bitmap = await createImageBitmap(new Blob([safe.buffer]));
+    return rasterizeBitmap(bitmap);
+  }
+  // Node: skia-canvas loadImage. Wrap bytes in a Buffer so skia does not misread
+  // a bare Uint8Array as a path.
+  try {
+    const sc = await import("skia-canvas");
+    const src =
+      typeof Buffer !== "undefined" ? Buffer.from(bytes) : (bytes as unknown);
+    const img = await (
+      sc as unknown as {
+        loadImage: (b: unknown) => Promise<{ width: number; height: number }>;
+      }
+    ).loadImage(src);
+    const Canvas = (
+      sc as unknown as { Canvas: new (w: number, h: number) => unknown }
+    ).Canvas;
+    const canvas = new Canvas(img.width, img.height) as {
+      getContext: (t: string) => {
+        drawImage: (i: unknown, x: number, y: number) => void;
+        getImageData: (x: number, y: number, w: number, h: number) => ImageData;
+      };
+    };
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+    return ctx.getImageData(0, 0, img.width, img.height);
+  } catch (err) {
+    throw new Error(
+      "Decoding undecoded JPEG/PNG image bytes requires an image decoder " +
+        "(a browser, or the optional `skia-canvas` package on Node). " +
+        `Original error: ${(err as Error).message}`
+    );
+  }
+}

--- a/src/video/image-source.ts
+++ b/src/video/image-source.ts
@@ -1,0 +1,30 @@
+// src/video/image-source.ts
+//
+// Pluggable "read image-file bytes by path" hook for `ImageVideoBackend`.
+//
+// Mirrors the FsResolver pattern (`src/model/matching.ts`): a settable override
+// plus a registered default. The Node default lives in `node-image-reader.ts`,
+// imported only by the Node entry point + the bun test preload — never by the
+// browser entry — so `node:fs` stays out of the browser module graph (issue
+// #70). In the browser, a consumer injects a reader (e.g. mapping basenames to
+// user-picked `File` bytes); on desktop (Tauri) a `plugin-fs.readFile` reader.
+
+export type ImageBytesReader = (path: string) => Promise<Uint8Array>;
+
+let _reader: ImageBytesReader | null = null;
+let _default: ImageBytesReader | null = null;
+
+/** Override the image-bytes reader. Pass `null` to fall back to the default. */
+export function setImageBytesReader(reader: ImageBytesReader | null): void {
+  _reader = reader;
+}
+
+/** Register the DEFAULT reader (called by the Node-only `node-image-reader`). */
+export function setDefaultImageBytesReader(reader: ImageBytesReader | null): void {
+  _default = reader;
+}
+
+/** The effective reader: explicit override if set, else the registered default. */
+export function getImageBytesReader(): ImageBytesReader | null {
+  return _reader ?? _default;
+}

--- a/src/video/image-video.ts
+++ b/src/video/image-video.ts
@@ -1,0 +1,127 @@
+// src/video/image-video.ts
+//
+// `ImageVideoBackend` — decoder for image-sequence videos, where `filename` is a
+// LIST of image paths (one image per frame). Port of Python sleap-io's
+// `ImageVideo` (`sleap_io/io/video_reading.py`).
+//
+// Bytes for each frame are obtained through an injected `ImageBytesReader`
+// (`image-source.ts`) — the browser sandbox can't read disk paths, and even on
+// desktop the reader is environment-specific (Tauri `plugin-fs`, Node `fs`).
+// Decoding reuses the shared `decodeEncoded` (`image-decode.ts`), which works in
+// both a browser (`createImageBitmap`) and Node (`skia-canvas`). PNG/JPEG/BMP/…
+// are supported; TIFF is NOT (no web decoder) — a TIFF source throws at decode.
+
+import { VideoBackend, VideoFrame } from "./backend.js";
+import { decodeEncoded } from "./image-decode.js";
+import { getImageBytesReader, type ImageBytesReader } from "./image-source.js";
+
+export interface ImageVideoOptions {
+  /** Image paths, one per frame. */
+  filename: string[];
+  /** Byte reader; defaults to the globally-injected reader (`image-source`). */
+  reader?: ImageBytesReader;
+  /**
+   * Optional `[frames, H, W, C]` from `.slp` metadata. When given, H/W/C are
+   * trusted (frame count is always `filename.length`) and the first frame is
+   * not decoded up front.
+   */
+  shape?: [number, number, number, number];
+}
+
+/** Default max decoded frames held in the bounded (FIFO-evicted) cache. */
+const DEFAULT_CACHE_SIZE = 32;
+
+export class ImageVideoBackend implements VideoBackend {
+  filename: string[];
+  shape: [number, number, number, number];
+  private reader: ImageBytesReader;
+  private cache = new Map<number, VideoFrame>();
+  private maxCache = DEFAULT_CACHE_SIZE;
+
+  private constructor(
+    filename: string[],
+    reader: ImageBytesReader,
+    shape: [number, number, number, number]
+  ) {
+    this.filename = filename;
+    this.reader = reader;
+    this.shape = shape;
+  }
+
+  /**
+   * Build a backend, inferring `shape` by decoding `filename[0]` once (cached)
+   * when no `shape` is supplied — parity with Python `VideoBackend.img_shape`
+   * (`read_test_frame` -> `_read_frame(0)`; index 0, not "first available").
+   */
+  static async create(opts: ImageVideoOptions): Promise<ImageVideoBackend> {
+    const reader = opts.reader ?? getImageBytesReader();
+    if (!reader) {
+      throw new Error(
+        "ImageVideoBackend requires an image-bytes reader, but none is " +
+          "injected. On desktop/Node a default is registered; in the browser " +
+          "supply one via setImageBytesReader()."
+      );
+    }
+    const frames = opts.filename.length;
+    let height = 0;
+    let width = 0;
+    let channels = 0;
+    const seed = new Map<number, VideoFrame>();
+
+    if (opts.shape) {
+      [, height, width, channels] = opts.shape;
+    } else if (frames > 0) {
+      const first = await decodeEncoded(await reader(opts.filename[0]));
+      seed.set(0, first);
+      height = first.height;
+      width = first.width;
+      channels = isGrayscale(first) ? 1 : 3;
+    }
+
+    const be = new ImageVideoBackend(opts.filename, reader, [
+      frames,
+      height,
+      width,
+      channels,
+    ]);
+    for (const [k, v] of seed) be.cache.set(k, v);
+    return be;
+  }
+
+  async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+    if (frameIndex < 0 || frameIndex >= this.filename.length) return null;
+    const cached = this.cache.get(frameIndex);
+    if (cached) return cached;
+    const frame = await decodeEncoded(await this.reader(this.filename[frameIndex]));
+    this.put(frameIndex, frame);
+    return frame;
+  }
+
+  private put(index: number, frame: VideoFrame): void {
+    // Bounded cache with FIFO eviction (Map preserves insertion order): evict
+    // the oldest-inserted frame once at capacity. Cheap and adequate for the
+    // mostly-sequential scrubbing/playback access pattern.
+    if (this.cache.size >= this.maxCache) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+    }
+    this.cache.set(index, frame);
+  }
+
+  close(): void {
+    this.cache.clear();
+  }
+}
+
+/**
+ * Grayscale iff the first and last colour channels (R vs B in RGBA) are equal
+ * for every pixel — parity with Python `VideoBackend.detect_grayscale`, which
+ * compares `test_img[..., 0]` against `test_img[..., -1]`.
+ */
+function isGrayscale(img: ImageData): boolean {
+  const d = img.data;
+  for (let i = 0; i < d.length; i += 4) {
+    if (d[i] !== d[i + 2]) return false;
+  }
+  return true;
+}

--- a/src/video/node-image-reader.ts
+++ b/src/video/node-image-reader.ts
@@ -1,0 +1,21 @@
+// src/video/node-image-reader.ts
+//
+// Node-only registration of a `node:fs`-backed default reader for
+// `ImageVideoBackend` (image-sequence videos).
+//
+// Imported by the Node entry point (`src/index.ts`) and the bun test preload
+// (`bunfig.toml`), but NEVER by the browser entry — keeping `node:fs` out of the
+// browser module graph (issue #70), exactly like `node-fs-resolver.ts`,
+// `seq-node.ts`, and `label-images-node.ts`.
+
+import * as fs from "node:fs";
+import { setDefaultImageBytesReader } from "./image-source.js";
+
+/** Read an image file path to its raw bytes. */
+async function nodeImageReader(path: string): Promise<Uint8Array> {
+  return new Uint8Array(await fs.promises.readFile(path));
+}
+
+setDefaultImageBytesReader(nodeImageReader);
+
+export { nodeImageReader };

--- a/tests/codecs/imagevideo-load.test.ts
+++ b/tests/codecs/imagevideo-load.test.ts
@@ -1,0 +1,53 @@
+/**
+ * End-to-end SLP loading of image-sequence (ImageVideo) videos, plus the
+ * per-video crash-guard.
+ *
+ * `imgvideo.slp` references a single image path (`tests/data/videos/imgs/
+ * img.00.jpg`). Before this work, `loadSlp(..., { openVideos: true })` routed
+ * that to `MediaVideoBackend` and threw ("requires a browser environment"),
+ * aborting the WHOLE load. Now:
+ *  - a single image-extension filename routes to `ImageVideoBackend` (parity
+ *    with Python `ImageVideo.from_filename`), and
+ *  - any per-video backend-creation failure is caught: the video loads with
+ *    `backend === null` and a `backendError`, instead of aborting the project.
+ */
+import { describe, it, expect } from "../bun-test";
+import { loadSlp } from "../../src/io/main.js";
+import { ImageVideoBackend } from "../../src/video/image-video.js";
+import { setImageBytesReader } from "../../src/video/image-source.js";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+const imgvideo = path.join(fixtureRoot, "slp", "imgvideo.slp");
+
+describe("ImageVideo SLP loading", () => {
+  it("loads a single-image ImageVideo and decodes its frame (Node default reader)", async () => {
+    const labels = await loadSlp(imgvideo, { openVideos: true });
+    const video = labels.videos[0];
+    expect(video.backend).toBeInstanceOf(ImageVideoBackend);
+    // The relative path resolves from the repo-root cwd via the Node reader.
+    const frame = (await video.getFrame(0)) as ImageData;
+    expect(frame).not.toBeNull();
+    expect(frame.width).toBeGreaterThan(0);
+    expect(frame.height).toBeGreaterThan(0);
+    // shape = [frames, H, W, C]
+    expect(video.shape?.[1]).toBe(frame.height);
+    expect(video.shape?.[2]).toBe(frame.width);
+  });
+
+  it("crash-guard: a failing backend leaves the video backend null instead of aborting", async () => {
+    setImageBytesReader(async () => {
+      throw new Error("simulated missing image file");
+    });
+    try {
+      const labels = await loadSlp(imgvideo, { openVideos: true });
+      const video = labels.videos[0];
+      expect(video.backend).toBeNull();
+      expect(video.backendError?.kind).toBe("image-sequence");
+      expect(video.backendError?.message).toContain("simulated missing image");
+    } finally {
+      setImageBytesReader(null);
+    }
+  });
+});

--- a/tests/video/factory-imagevideo.test.ts
+++ b/tests/video/factory-imagevideo.test.ts
@@ -1,0 +1,40 @@
+/**
+ * `createVideoBackend()` must route a LIST-valued source (image-sequence /
+ * ImageVideo) to `ImageVideoBackend`, instead of treating it as a single
+ * filename string (which crashed with `filename.split is not a function`).
+ */
+import { describe, it, expect } from "../bun-test";
+import { createVideoBackend } from "../../src/video/factory.js";
+import { ImageVideoBackend } from "../../src/video/image-video.js";
+import { setImageBytesReader } from "../../src/video/image-source.js";
+
+async function makePng(
+  w: number,
+  h: number,
+  rgb: [number, number, number]
+): Promise<Uint8Array> {
+  const sc = await import("skia-canvas");
+  const canvas = new sc.Canvas(w, h);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  ctx.fillRect(0, 0, w, h);
+  return new Uint8Array(await canvas.toBuffer("png"));
+}
+
+describe("createVideoBackend (image-sequence)", () => {
+  it("routes a list source to ImageVideoBackend", async () => {
+    const red = await makePng(2, 2, [255, 0, 0]);
+    setImageBytesReader(async () => red);
+    try {
+      const be = await createVideoBackend([
+        "a.png",
+        "b.png",
+        "c.png",
+      ] as unknown as string);
+      expect(be).toBeInstanceOf(ImageVideoBackend);
+      expect(be.shape).toEqual([3, 2, 2, 3]);
+    } finally {
+      setImageBytesReader(null);
+    }
+  });
+});

--- a/tests/video/image-decode.test.ts
+++ b/tests/video/image-decode.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for the shared image decoder (`src/video/image-decode.ts`).
+ *
+ * `decodeEncoded` turns PNG/JPEG bytes into RGBA `ImageData` in either a browser
+ * (`createImageBitmap` + `OffscreenCanvas`) or Node (`skia-canvas`). It is the
+ * single decode path reused by `CropVideoBackend` and the `ImageVideoBackend`.
+ * Under `bun test` there is no `createImageBitmap`, so these exercise the Node
+ * (skia-canvas) branch.
+ */
+import { describe, it, expect } from "../bun-test";
+import { decodeEncoded } from "../../src/video/image-decode.js";
+
+/** Encode a solid-color WxH image to PNG bytes via skia-canvas. */
+async function makePng(
+  w: number,
+  h: number,
+  rgb: [number, number, number]
+): Promise<Uint8Array> {
+  const sc = await import("skia-canvas");
+  const canvas = new sc.Canvas(w, h);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  ctx.fillRect(0, 0, w, h);
+  return new Uint8Array(await canvas.toBuffer("png"));
+}
+
+describe("decodeEncoded", () => {
+  it("decodes PNG bytes to RGBA ImageData with the right dimensions", async () => {
+    const png = await makePng(4, 3, [10, 20, 30]);
+    const img = await decodeEncoded(png);
+    expect(img.width).toBe(4);
+    expect(img.height).toBe(3);
+    expect(img.data.length).toBe(4 * 3 * 4); // RGBA
+  });
+
+  it("preserves pixel color (RGB order, opaque alpha)", async () => {
+    const png = await makePng(2, 2, [200, 100, 50]);
+    const img = await decodeEncoded(png);
+    // First pixel = RGBA.
+    expect(img.data[0]).toBe(200);
+    expect(img.data[1]).toBe(100);
+    expect(img.data[2]).toBe(50);
+    expect(img.data[3]).toBe(255);
+  });
+});

--- a/tests/video/image-video.test.ts
+++ b/tests/video/image-video.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for `ImageVideoBackend` (`src/video/image-video.ts`) — the decoder
+ * for image-sequence videos (Python `ImageVideo`: `filename` is a list of image
+ * paths, one image per frame). Bytes are obtained through an injected reader, so
+ * these tests run fully in Node with no filesystem.
+ *
+ * Parity with Python `ImageVideo` / `VideoBackend`:
+ *  - num_frames = filename.length (no decode),
+ *  - shape inferred by decoding filename[0] once,
+ *  - channels from a grayscale check on that first frame (1 if gray, else 3).
+ */
+import { describe, it, expect } from "../bun-test";
+import { ImageVideoBackend } from "../../src/video/image-video.js";
+
+/** Encode a solid-color WxH image to PNG bytes via skia-canvas. */
+async function makePng(
+  w: number,
+  h: number,
+  rgb: [number, number, number]
+): Promise<Uint8Array> {
+  const sc = await import("skia-canvas");
+  const canvas = new sc.Canvas(w, h);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  ctx.fillRect(0, 0, w, h);
+  return new Uint8Array(await canvas.toBuffer("png"));
+}
+
+/** A stub reader backed by an in-memory path -> bytes map; counts reads. */
+function stubReader(map: Record<string, Uint8Array>) {
+  const reads: string[] = [];
+  const fn = async (path: string): Promise<Uint8Array> => {
+    reads.push(path);
+    const bytes = map[path];
+    if (!bytes) throw new Error(`no bytes for ${path}`);
+    return bytes;
+  };
+  return { fn, reads };
+}
+
+describe("ImageVideoBackend", () => {
+  it("infers shape [frames, H, W, C] by decoding filename[0]", async () => {
+    const red = await makePng(4, 3, [200, 10, 10]);
+    const { fn } = stubReader({ "a.png": red, "b.png": red, "c.png": red });
+    const be = await ImageVideoBackend.create({
+      filename: ["a.png", "b.png", "c.png"],
+      reader: fn,
+    });
+    // frames = list length; H=3, W=4 from the decoded image; C=3 (color).
+    expect(be.shape).toEqual([3, 3, 4, 3]);
+    expect(be.filename).toEqual(["a.png", "b.png", "c.png"]);
+  });
+
+  it("reports C=1 for a grayscale first frame (Python detect_grayscale parity)", async () => {
+    const gray = await makePng(2, 2, [128, 128, 128]);
+    const { fn } = stubReader({ "g.png": gray });
+    const be = await ImageVideoBackend.create({ filename: ["g.png"], reader: fn });
+    expect(be.shape).toEqual([1, 2, 2, 1]);
+  });
+
+  it("getFrame(i) decodes the i-th image", async () => {
+    const red = await makePng(2, 2, [255, 0, 0]);
+    const blue = await makePng(2, 2, [0, 0, 255]);
+    const { fn } = stubReader({ "0.png": red, "1.png": blue });
+    const be = await ImageVideoBackend.create({
+      filename: ["0.png", "1.png"],
+      reader: fn,
+    });
+    const f0 = (await be.getFrame(0)) as ImageData;
+    const f1 = (await be.getFrame(1)) as ImageData;
+    expect([f0.data[0], f0.data[1], f0.data[2]]).toEqual([255, 0, 0]);
+    expect([f1.data[0], f1.data[1], f1.data[2]]).toEqual([0, 0, 255]);
+  });
+
+  it("returns null for an out-of-range frame index", async () => {
+    const red = await makePng(2, 2, [255, 0, 0]);
+    const { fn } = stubReader({ "0.png": red });
+    const be = await ImageVideoBackend.create({ filename: ["0.png"], reader: fn });
+    expect(await be.getFrame(1)).toBeNull();
+    expect(await be.getFrame(-1)).toBeNull();
+  });
+
+  it("caches decoded frames (reader hit once per index)", async () => {
+    const red = await makePng(2, 2, [255, 0, 0]);
+    const { fn, reads } = stubReader({ "0.png": red });
+    const be = await ImageVideoBackend.create({ filename: ["0.png"], reader: fn });
+    await be.getFrame(0);
+    await be.getFrame(0);
+    // One read for the shape probe + at most one for the frame; never re-read.
+    const hitsFor0 = reads.filter((p) => p === "0.png").length;
+    expect(hitsFor0).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/video/node-image-reader.test.ts
+++ b/tests/video/node-image-reader.test.ts
@@ -1,0 +1,25 @@
+/**
+ * The Node-only default image-bytes reader (`src/video/node-image-reader.ts`)
+ * registers a `node:fs`-backed reader as the default for `getImageBytesReader()`,
+ * mirroring `node-fs-resolver.ts` / `seq-node.ts`. Importing the module is what
+ * performs the registration.
+ */
+import { describe, it, expect } from "../bun-test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import "../../src/video/node-image-reader.js"; // side-effect: registers default
+import { getImageBytesReader } from "../../src/video/image-source.js";
+
+describe("node default image-bytes reader", () => {
+  it("reads a file path to its raw bytes", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "imgvid-"));
+    const p = path.join(dir, "x.bin");
+    fs.writeFileSync(p, new Uint8Array([1, 2, 3, 4, 5]));
+    const reader = getImageBytesReader();
+    expect(reader).not.toBeNull();
+    const got = await reader!(p);
+    expect(Array.from(got)).toEqual([1, 2, 3, 4, 5]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Problem

A `.slp` whose video is an **image sequence** (its `filename` is a *list* of
image paths, or a single image path) currently **aborts the entire project
load**: `createVideoBackend` assumed a string and either crashed on
`filename.split` (list) or routed a `.jpg` to `MediaVideoBackend` (which throws
*"requires a browser environment"* in Node). Python (`sleap_io`) has an
`ImageVideo` backend; the JS port simply lacked that one sibling.

## What's in this PR

**`ImageVideoBackend`** (`src/video/image-video.ts`) — implements the
`VideoBackend` contract over a list of image paths:
- `getFrame(i)` obtains bytes via an injected reader, decodes with the shared
  decoder, and caches (bounded, FIFO). `num_frames = filename.length`.
- Shape inferred by decoding `filename[0]` once (parity with Python
  `VideoBackend.img_shape → read_test_frame → _read_frame(0)`); channels via a
  first-vs-last-channel grayscale check (parity with `detect_grayscale`).
- Bytes come from a pluggable **`ImageBytesReader`** (`image-source.ts`),
  mirroring the existing `FsResolver` pattern: a settable override + a Node `fs`
  default (`node-image-reader.ts`, registered only in the Node entry + test
  preload so `node:fs` stays out of the browser graph, issue #70). Browser
  consumers inject their own (e.g. Tauri plugin-fs, or a folder picker — see the
  sleap-app follow-up).

**Factory routing** (`factory.ts`) — a list source, or a single
image-extension filename (`png/jpg/jpeg/tif/tiff/bmp`, Python `ImageVideo.EXTS`),
routes to `ImageVideoBackend`. TIFF has no web decoder yet (fails gracefully at
decode).

**Crash-guard** (`codecs/slp/read.ts`) — the per-video `createVideoBackend`
call is now wrapped; on any failure the video loads with `backend = null` and a
typed **`Video.backendError`** (`{ kind: "image-sequence" | "unsupported-format"
| "decode" }`) instead of aborting the load. This also makes `.avi`/`.mpeg`
(`UnsupportedVideoFormatError`) degrade gracefully.

**Refactor** — extracted the dual-env (`createImageBitmap` / skia-canvas)
`decodeEncoded` + `rasterizeBitmap` out of `crop-backend.ts` into shared
`image-decode.ts`, reused by both backends.

## Testing

- **11 new tests** (all green): decode helper, `ImageVideoBackend`
  (shape/grayscale/decode/bounds/cache), Node default reader, factory
  list-routing, and an end-to-end load of the real `imgvideo.slp` fixture + the
  crash-guard.
- Full suite: **1528 pass**. (The 1 failing test — `edge-less skeletons …
  JS→Python SLP cross-compat` — is pre-existing, unrelated to this PR, and
  depends on a working `uv`/`sleap-io` Python env.)
- `tsc --noEmit` clean; `build` (tsup ESM + DTS) succeeds; browser-bundle purity
  intact (`node:fs` only in the Node entry).
- Downstream desktop E2E (sleap-app): a real image-sequence `.slp` loads, and a
  relocated sequence re-resolves via an injected reader and renders.

## Follow-ups (separate)

- sleap-app: Tauri image-bytes reader + "Locate image folder…" UX (PR2).
- Browser folder-picker resolver; wasm TIFF decoder; `.avi`/`.mpeg`
  transcode-on-import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
