### PR TITLE
fix(video): resolve embedded pkg.slp frame count without a decode probe (fixes Windows Frames=0)

### DIFF
--- a/src/codecs/slp/frame-count.ts
+++ b/src/codecs/slp/frame-count.ts
@@ -1,0 +1,41 @@
+/**
+ * Resolve the source frame count (the seekbar / navigation extent) for an
+ * embedded SLP video, synchronously, from metadata that is cheap to read.
+ *
+ * Priority:
+ *  1. The `frames` HDF5 attribute — the source video's true total frame count
+ *     (written by recent sleap-io / sleap_io). Authoritative when present.
+ *  2. The frame count carried in videos_json `backend.shape[0]`.
+ *  3. `max(frame_numbers) + 1` — a lower bound derived from the stored frames'
+ *     source indices. Used for pkg.slp files written WITHOUT a `frames` attr
+ *     (e.g. older PyQt SLEAP), so the seekbar still spans the labeled-frame
+ *     range. This is intentionally computed here rather than via an async
+ *     per-video image-decode probe (which raced the UI and produced 0 / "?" /
+ *     wrong counts on multi-video packages).
+ *
+ * Note: this is the SOURCE extent (what the seekbar spans), NOT the number of
+ * embedded images — that is `frame_numbers.length`, surfaced separately.
+ *
+ * Returns undefined when none of the inputs yield a positive count.
+ */
+export function resolveSourceFrameCount(opts: {
+  /** Value of the dataset's `frames` HDF5 attribute, if present. */
+  framesAttr?: number;
+  /** Frame count from videos_json `backend.shape[0]`, if present. */
+  jsonFrameCount?: number;
+  /** Source frame indices of the stored (embedded) images. */
+  frameNumbers?: number[];
+}): number | undefined {
+  const { framesAttr, jsonFrameCount, frameNumbers } = opts;
+  if (framesAttr !== undefined && framesAttr > 0) return framesAttr;
+  if (jsonFrameCount !== undefined && jsonFrameCount > 0) return jsonFrameCount;
+  if (frameNumbers && frameNumbers.length > 0) {
+    // Loop (not Math.max(...spread)) to stay safe for large frame_numbers.
+    let max = 0;
+    for (const n of frameNumbers) {
+      if (n > max) max = n;
+    }
+    return max + 1;
+  }
+  return undefined;
+}

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -20,6 +20,7 @@ import { Camera, CameraGroup, FrameGroup, InstanceGroup, RecordingSession } from
 import { Identity } from "../../model/identity.js";
 import { StreamingHdf5VideoBackend } from "../../video/streaming-hdf5-video.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
+import { resolveSourceFrameCount } from "./frame-count.js";
 import type { CropRect } from "../../transform/points.js";
 import type { Fill } from "../../transform/frame.js";
 
@@ -320,7 +321,27 @@ async function readVideosStreaming(
         }
       }
 
-      const frameCount = frameCountFromAttrs ?? meta.frameCount;
+      // For embedded videos we read frame_numbers up front so the source frame
+      // count (the seekbar extent) can be resolved synchronously — see below.
+      // frame_sizes lets the 1D-concatenated layout (JS writer) byte-range
+      // slice exactly, mirroring the sync reader (read.ts) — see issue #135.
+      let frameNumbers: number[] = [];
+      let frameSizes: number[] | undefined;
+      if (openVideos && meta.embedded && datasetPath) {
+        frameNumbers = await readFrameNumbersStreaming(file, datasetPath);
+        frameSizes = await readFrameSizesStreaming(file, datasetPath);
+      }
+
+      // Source frame count: prefer the `frames` attr, then the videos_json
+      // count, then max(frame_numbers)+1. The last fallback keeps multi-video
+      // pkg.slp files (written without a `frames` attr, e.g. older PyQt SLEAP)
+      // resolving a shape at read time instead of relying on an async per-video
+      // image-decode probe that races the UI (reporting 0 / "?" / wrong counts).
+      const frameCount = resolveSourceFrameCount({
+        framesAttr: frameCountFromAttrs,
+        jsonFrameCount: meta.frameCount,
+        frameNumbers,
+      });
       const shape: [number, number, number, number] | undefined =
         (meta.height && meta.width && meta.channels)
           ? [frameCount ?? 0, meta.height, meta.width, meta.channels]
@@ -335,12 +356,6 @@ async function readVideosStreaming(
       // Create streaming backend for embedded videos when openVideos is true
       let backend = null;
       if (openVideos && meta.embedded && datasetPath) {
-        // Read frame_numbers (and frame_sizes when present) for this video.
-        // frame_sizes lets the 1D-concatenated layout (JS writer) byte-range
-        // slice exactly, mirroring the sync reader (read.ts) — see issue #135.
-        const frameNumbers = await readFrameNumbersStreaming(file, datasetPath);
-        const frameSizes = await readFrameSizesStreaming(file, datasetPath);
-
         backend = new StreamingHdf5VideoBackend({
           filename: meta.filename,
           h5file: file,
@@ -353,6 +368,10 @@ async function readVideosStreaming(
           fps: meta.fps,
         });
 
+        // Only probe (decode one image) when height/width are still unknown —
+        // i.e. neither the dataset attrs nor videos_json provided them. With a
+        // resolved shape this is skipped, so the common pkg.slp path no longer
+        // pays a per-video network decode.
         if (!shape || shape[0] === 0) {
           await backend.probeShape(frameCount ?? undefined);
         }

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -8,6 +8,7 @@ import { SuggestionFrame } from "../../model/suggestions.js";
 import { Video } from "../../model/video.js";
 import { createVideoBackend } from "../../video/factory.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
+import { resolveSourceFrameCount } from "./frame-count.js";
 import type { CropRect } from "../../transform/points.js";
 import type { Fill } from "../../transform/frame.js";
 import { Camera, CameraGroup, FrameGroup, InstanceGroup, RecordingSession } from "../../model/camera.js";
@@ -467,6 +468,9 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
     let format = backendMeta.format as string | undefined;
     let channelOrderFromAttrs: string | undefined;
     let frameCountFromAttrs: number | undefined;
+    let heightFromAttrs: number | undefined;
+    let widthFromAttrs: number | undefined;
+    let channelsFromAttrs: number | undefined;
     if (datasetPath) {
       const videoDs = file.get(datasetPath);
       if (videoDs) {
@@ -479,15 +483,41 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
         if (framesNum !== undefined && framesNum > 0) {
           frameCountFromAttrs = framesNum;
         }
+        // Height/width/channels from dataset attrs, used when JSON metadata is
+        // missing (common for pkg.slp). Mirrors read-streaming.ts.
+        const h = attrToNumber(attrs.height);
+        if (h !== undefined && h > 0) heightFromAttrs = h;
+        const w = attrToNumber(attrs.width);
+        if (w !== undefined && w > 0) widthFromAttrs = w;
+        const c = attrToNumber(attrs.channels);
+        if (c !== undefined && c > 0) channelsFromAttrs = c;
       }
     }
 
-    // Compose shape: prefer frames attribute for [0] (source video total),
-    // keep height/width/channels from JSON shape when present.
+    // Read frame_numbers up front so the source frame count can be resolved
+    // synchronously (the dataset itself only holds a subset; see below). Reused
+    // by the backend below so it is not read twice.
+    const frameNumbers = datasetPath ? readFrameNumbers(file, datasetPath) : [];
+
+    // Compose shape. Dimensions prefer the videos_json shape, falling back to
+    // the dataset attrs (pkg.slp files often carry height/width/channels as
+    // attrs with no JSON shape). The source frame count (seekbar extent) comes
+    // from the `frames` attr, then videos_json, then max(frame_numbers)+1 — the
+    // last keeps multi-video pkg.slp files written without a `frames` attr
+    // (older PyQt SLEAP) resolving an extent instead of reporting none. Mirrors
+    // read-streaming.ts so the eager and streaming readers stay in parity.
     const jsonShape = backendMeta.shape as number[] | undefined;
+    const height = jsonShape?.[1] ?? heightFromAttrs;
+    const width = jsonShape?.[2] ?? widthFromAttrs;
+    const channels = jsonShape?.[3] ?? channelsFromAttrs;
+    const frameCount = resolveSourceFrameCount({
+      framesAttr: frameCountFromAttrs,
+      jsonFrameCount: jsonShape?.[0],
+      frameNumbers,
+    });
     const shape: [number, number, number, number] | undefined =
-      jsonShape && jsonShape.length === 4
-        ? [frameCountFromAttrs ?? jsonShape[0], jsonShape[1], jsonShape[2], jsonShape[3]]
+      height && width && channels
+        ? [frameCount ?? 0, height, width, channels]
         : undefined;
 
     // Determine channel order with priority:
@@ -501,7 +531,7 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
       backend = await createVideoBackend(filename, {
         dataset: datasetPath ?? undefined,
         embedded,
-        frameNumbers: readFrameNumbers(file, datasetPath),
+        frameNumbers,
         frameSizes: readFrameSizes(file, datasetPath),
         format,
         channelOrder,

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -111,7 +111,11 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
             }
             fc = maxIdx + 1;
           }
-          this.shape = [fc, decoded.height, decoded.width, 4];
+          // Prefer the real channel count (from the dataset attrs, carried on
+          // the seed shape) over the decoded bitmap's channels, which is always
+          // 4 (RGBA) regardless of the stored grayscale/RGB image.
+          const channels = this.shape?.[3] ?? 4;
+          this.shape = [fc, decoded.height, decoded.width, channels];
         }
       }
     } catch { /* probe failed, shape stays undefined */ }

--- a/tests/codecs/embedded-shape-no-frames-attr.test.ts
+++ b/tests/codecs/embedded-shape-no-frames-attr.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Integration test: an embedded pkg.slp written WITHOUT a `frames` HDF5 attr
+ * and without a videos_json shape (e.g. older PyQt SLEAP) must still resolve a
+ * full video shape — [max(frame_numbers)+1, H, W, C] — from the dataset attrs
+ * and frame_numbers, on BOTH readers.
+ *
+ * Regression: previously the eager reader returned shape === null for such a
+ * file (it gated shape on a 4-length JSON shape and had no max(frame_numbers)+1
+ * fallback), while the streaming reader was being fixed to resolve it. This
+ * keeps the two readers in parity. The streaming (Worker) path can't run under
+ * Node, so the eager path is the runnable end-to-end check of the shared
+ * resolveSourceFrameCount logic.
+ */
+
+import { describe, it, expect } from "../bun-test";
+import { readSlp } from "../../src/codecs/slp/read.js";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const FIXTURE = path.join(
+  fileURLToPath(new URL("../data", import.meta.url)),
+  "slp",
+  "minimal_instance.pkg.slp",
+);
+
+describe("eager reader: embedded pkg.slp without a `frames` attr", () => {
+  it("resolves [max(frame_numbers)+1, H, W, C] from dataset attrs + frame_numbers", async () => {
+    const labels = await readSlp(FIXTURE, { openVideos: true });
+    const video = labels.videos[0];
+    // Fixture: no `frames` attr; dataset attrs height=384 width=384 channels=1;
+    // frame_numbers = [0] -> source extent 0 + 1 = 1.
+    expect(video.shape).toEqual([1, 384, 384, 1]);
+  });
+});

--- a/tests/codecs/frame-count.test.ts
+++ b/tests/codecs/frame-count.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for resolveSourceFrameCount — the synchronous source-frame-count
+ * resolution used by the SLP readers for embedded videos.
+ *
+ * Regression context: multi-video pkg.slp files written without a `frames`
+ * HDF5 attribute (e.g. older PyQt SLEAP) used to fall into an async per-video
+ * image-decode probe whose result raced the UI and reported 0 / "?" / wrong
+ * frame counts. The count must instead be derivable synchronously from
+ * frame_numbers (max + 1) so every embedded video resolves a shape at read
+ * time.
+ */
+
+import { describe, it, expect } from "../bun-test";
+import { resolveSourceFrameCount } from "../../src/codecs/slp/frame-count.js";
+
+describe("resolveSourceFrameCount", () => {
+  it("prefers the `frames` attr (the true source frame count)", () => {
+    expect(
+      resolveSourceFrameCount({
+        framesAttr: 180000,
+        jsonFrameCount: 23,
+        frameNumbers: [5, 100],
+      }),
+    ).toBe(180000);
+  });
+
+  it("falls back to the videos_json frame count when no `frames` attr", () => {
+    expect(
+      resolveSourceFrameCount({ jsonFrameCount: 1200, frameNumbers: [5] }),
+    ).toBe(1200);
+  });
+
+  it("derives max(frame_numbers)+1 when neither attr nor json count exists (PyQt pkg.slp)", () => {
+    // mice_hc video0: frame_numbers up to 12167 -> seekbar extent 12168.
+    expect(
+      resolveSourceFrameCount({ frameNumbers: [214, 705, 12167] }),
+    ).toBe(12168);
+  });
+
+  it("returns undefined when nothing is available", () => {
+    expect(resolveSourceFrameCount({})).toBeUndefined();
+    expect(resolveSourceFrameCount({ frameNumbers: [] })).toBeUndefined();
+  });
+
+  it("ignores non-positive attr / json counts and still uses frame_numbers", () => {
+    expect(
+      resolveSourceFrameCount({
+        framesAttr: 0,
+        jsonFrameCount: 0,
+        frameNumbers: [3, 9],
+      }),
+    ).toBe(10);
+  });
+});


### PR DESCRIPTION
## Problem

In the Windows desktop build, many embedded videos of a `pkg.slp` show **`0`** in the Videos-panel Frames column, while the **macOS** build (same app version) shows each video's count. Same file, same code — only the WebView differs.

## Root cause

For a `pkg.slp` written without a `frames` HDF5 attribute and without a `shape` in `videos_json` (i.e. anything written by PyQt SLEAP), the streaming reader builds `shape = [0, H, W, C]` and then defers the frame count to **`probeShape()`**, which reads embedded frame 0 from a variable-length (vlen) dataset and **decodes it with `createImageBitmap`** before it can set `shape[0] = max(frame_numbers)+1`.

That decode step is a fragile, platform-dependent gate:
- The vlen single-element read in the h5wasm worker is memory-unsafe across heap growth, and behaves differently on WebView2 (Windows) vs WKWebView (macOS).
- When it fails for a video, `probeShape` hits its `catch`, `shape[0]` stays `0`, and the Frames column shows `0`.

**The frame count never actually needed an image decode — `max(frame_numbers)+1` is derivable from metadata that is already read, and H/W/C are already available from dataset attrs.**

## Fix

- **`src/codecs/slp/frame-count.ts`** (new) — `resolveSourceFrameCount({framesAttr, jsonFrameCount, frameNumbers})`: `frames` attr → `videos_json` count → `max(frame_numbers)+1` (safe loop, not a spread).
- **`read-streaming.ts`** — read `frame_numbers` up front and resolve the count via the helper **before** composing `shape`, so the count is decode-independent. `probeShape` now only runs as a true last resort (height/width genuinely unknown).
- **`read.ts`** — mirror the same resolution so the eager and streaming readers stay in parity.
- **`streaming-hdf5-video.ts`** — when `probeShape` does run, use the real channel count instead of hardcoded RGBA-4.

This recovers the previously-orphaned commit `4e34320` (its branch was deleted on the mistaken belief main covered it via `probeShape`; main does not — `probeShape` is exactly the fragile path).

## Verification

- New unit tests (`frame-count.test.ts`, `embedded-shape-no-frames-attr.test.ts`) — 6/6 pass.
- `tsc --noEmit` clean; build OK; full suite 1523 pass / 1 skip / 1 fail (the failing `skeleton-edgeless-nodes` Python cross-compat test is **pre-existing**, fails identically on `main` — unrelated to this change).
- **Real-file check**: loaded a 30-embedded-video `pkg.slp` (no `frames` attr) in Node — where `createImageBitmap` is absent, i.e. the same condition as the Windows decode failure — and **all 30 videos resolved to the correct shapes** (`[233221,1024,1024,1]`, `27512`, …, `0` for empty videos), channels correctly `1`. With the old code those would all be `0`.

## Scope

This fixes the **frame count / `shape[0]`** (Videos panel column *and* the seekbar/navigation extent). It does **not** address the separate, deeper memory-unsafe vlen single-element read that can also cause **black frames** when rendering those videos on Windows — that's a follow-up (read-whole-and-cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
