### PR TITLE
fix(video): read the full image list for image-sequence videos

### DIFF
--- a/src/codecs/slp/parsers.ts
+++ b/src/codecs/slp/parsers.ts
@@ -246,8 +246,12 @@ export function parseTracks(values: unknown[]): Track[] {
  * Video metadata extracted from videos_json without creating backends.
  */
 export interface VideoMetadata {
-  /** Original filename or "." for embedded */
-  filename: string;
+  /**
+   * Original filename, or "." for embedded. For image-sequence videos
+   * (Python `ImageVideo`) this is the FULL ordered list of image paths — one
+   * per frame — not just the first image.
+   */
+  filename: string | string[];
   /** HDF5 dataset path for embedded videos */
   dataset?: string;
   /** Video format (e.g., "mp4", "hdf5") */
@@ -271,6 +275,29 @@ export interface VideoMetadata {
 }
 
 /**
+ * Resolve the stored filename(s) for a video backend. Image-sequence videos
+ * (Python `ImageVideo`) serialize the FULL ordered image list under
+ * `backend.filenames` (plural) and only the first image under the singular
+ * `backend.filename`. Reading the singular field collapses an N-image sequence
+ * to a single frame (`createVideoBackend` builds a 1-image backend whose
+ * `shape[0]` is `filename.length`), so prefer the list when present; otherwise
+ * fall back to the singular `backend.filename`, then the top-level `filename`.
+ *
+ * Shared by the streaming reader ({@link parseVideosMetadata}) and the eager
+ * reader (read.ts) so both surface the whole sequence identically.
+ */
+export function resolveVideoFilename(
+  backendMeta: Record<string, unknown>,
+  parsed: Record<string, unknown>
+): string | string[] {
+  const filenames = backendMeta.filenames;
+  if (Array.isArray(filenames) && filenames.length > 0) {
+    return filenames as string[];
+  }
+  return (backendMeta.filename ?? parsed.filename ?? "") as string;
+}
+
+/**
  * Parse video metadata from videos_json dataset values.
  * Returns metadata objects WITHOUT creating video backends.
  */
@@ -291,7 +318,7 @@ export function parseVideosMetadata(values: unknown[], labelsPath?: string): Vid
     }
 
     const backendMeta = (parsed.backend ?? {}) as Record<string, unknown>;
-    let filename = (backendMeta.filename ?? parsed.filename ?? "") as string;
+    let filename = resolveVideoFilename(backendMeta, parsed);
     const dataset = (backendMeta.dataset ?? null) as string | null;
     let embedded = false;
 

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -357,7 +357,12 @@ async function readVideosStreaming(
       let backend = null;
       if (openVideos && meta.embedded && datasetPath) {
         backend = new StreamingHdf5VideoBackend({
-          filename: meta.filename,
+          // Embedded videos always carry a single string filename (the labels
+          // path); the array form is only for image sequences, which never
+          // reach this embedded branch. Narrow for the type checker.
+          filename: Array.isArray(meta.filename)
+            ? meta.filename[0] ?? ""
+            : meta.filename,
           h5file: file,
           datasetPath,
           frameNumbers,

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -1,5 +1,5 @@
 import { openH5File, OpenH5Options, SlpSource } from "./h5.js";
-import { attrToNumber, attrToString, parseJsonAttr, parseSkeletons, resolveCameraKey, reconstructInstance3D, resolveIdentity } from "./parsers.js";
+import { attrToNumber, attrToString, parseJsonAttr, parseSkeletons, resolveCameraKey, reconstructInstance3D, resolveIdentity, resolveVideoFilename } from "./parsers.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
 import { Instance, PredictedInstance, Track, pointsFromArray, predictedPointsFromArray } from "../../model/instance.js";
@@ -449,7 +449,7 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
     if (!entry) continue;
     const parsed = typeof entry === "string" ? JSON.parse(entry) : JSON.parse(textDecoder.decode(entry));
     const backendMeta = parsed.backend ?? {};
-    let filename = backendMeta.filename ?? parsed.filename ?? "";
+    let filename = resolveVideoFilename(backendMeta, parsed);
     let datasetPath = backendMeta.dataset ?? null;
     let embedded = false;
 

--- a/tests/codecs/imagevideo-load.test.ts
+++ b/tests/codecs/imagevideo-load.test.ts
@@ -36,6 +36,23 @@ describe("ImageVideo SLP loading", () => {
     expect(video.shape?.[2]).toBe(frame.width);
   });
 
+  it("loads ALL frames of a multi-image ImageVideo (filenames list, not just the first)", async () => {
+    // imgvideo.slp references a 3-image sequence: backend.filenames has 3 paths,
+    // but the singular backend.filename is only the first. Reading the singular
+    // field collapsed the video to 1 frame; the whole list must be surfaced.
+    const labels = await loadSlp(imgvideo, { openVideos: true });
+    const video = labels.videos[0];
+    expect(video.backend).toBeInstanceOf(ImageVideoBackend);
+    expect(Array.isArray(video.filename)).toBe(true);
+    expect((video.filename as string[]).length).toBe(3);
+    expect(video.shape?.[0]).toBe(3);
+    // The last frame must decode — proof the backend spans the whole list.
+    const last = (await video.getFrame(2)) as ImageData;
+    expect(last).not.toBeNull();
+    expect(last.width).toBeGreaterThan(0);
+    expect(last.height).toBeGreaterThan(0);
+  });
+
   it("crash-guard: a failing backend leaves the video backend null instead of aborting", async () => {
     setImageBytesReader(async () => {
       throw new Error("simulated missing image file");

--- a/tests/codecs/parse-videos-metadata.test.ts
+++ b/tests/codecs/parse-videos-metadata.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for `parseVideosMetadata` — the videos_json parser used by the
+ * streaming reader (read-streaming.ts), which is the path the browser AND the
+ * Tauri desktop app take.
+ *
+ * Image-sequence videos (Python `ImageVideo`) store the FULL ordered image list
+ * under `backend.filenames` (plural) AND only the first image under the singular
+ * `backend.filename`. Reading the singular field collapses an N-image sequence
+ * to a single frame, so the parser must surface the whole list.
+ */
+import { describe, it, expect } from "../bun-test";
+import { parseVideosMetadata } from "../../src/codecs/slp/parsers.js";
+
+describe("parseVideosMetadata", () => {
+  it("surfaces the full image list for an image-sequence (backend.filenames)", () => {
+    const entry = JSON.stringify({
+      filename: ["a.jpg", "b.jpg", "c.jpg"],
+      backend: {
+        type: "ImageVideo",
+        filename: "a.jpg",
+        filenames: ["a.jpg", "b.jpg", "c.jpg"],
+        shape: [3, 384, 384, 1],
+        height_: 384,
+        width_: 384,
+        channels_: 1,
+        grayscale: true,
+      },
+    });
+
+    const [meta] = parseVideosMetadata([entry]);
+
+    expect(Array.isArray(meta.filename)).toBe(true);
+    expect(meta.filename).toEqual(["a.jpg", "b.jpg", "c.jpg"]);
+    expect(meta.frameCount).toBe(3);
+    expect(meta.embedded).toBe(false);
+  });
+
+  it("falls back to the singular filename when no filenames list is present", () => {
+    const entry = JSON.stringify({
+      backend: {
+        type: "MediaVideo",
+        filename: "movie.mp4",
+        shape: [100, 480, 640, 3],
+      },
+    });
+
+    const [meta] = parseVideosMetadata([entry]);
+
+    expect(meta.filename).toBe("movie.mp4");
+    expect(meta.frameCount).toBe(100);
+    expect(meta.embedded).toBe(false);
+  });
+
+  it("treats an embedded '.' filename as embedded (not a 1-image sequence)", () => {
+    const entry = JSON.stringify({
+      backend: { type: "HDF5Video", filename: ".", dataset: "video0/video" },
+    });
+
+    const [meta] = parseVideosMetadata([entry], "/projects/labels.slp");
+
+    expect(meta.filename).toBe("/projects/labels.slp");
+    expect(meta.embedded).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Image-sequence videos (Python `ImageVideo`) store the **full ordered image list** under `backend.filenames` (plural), and only the **first** image under the singular `backend.filename`. Both SLP readers read only the singular field, so an N-image sequence loaded as a **single frame**:

- `createVideoBackend` got a 1-element list →
- `ImageVideoBackend` sets `shape[0] = filename.length` → frame count `1`, overriding the stored `shape[0] = N`.

Downstream (sleap-app) this surfaced as **"Frames: 1"** for 11,041-image sequences that PyQt navigates fully.

## Change

- Add a shared `resolveVideoFilename(backendMeta, parsed)` helper that prefers the `backend.filenames` list (falling back to the singular `filename`, then top-level `filename`).
- Use it in **both** `parseVideosMetadata` (streaming reader) and `readVideos` (eager reader) so they stay in parity.
- Widen `VideoMetadata.filename` to `string | string[]` (the `Video` model already supported array filenames).
- Narrow the embedded `StreamingHdf5VideoBackend` call site (embedded videos always carry a single string filename).

## Tests

- New `tests/codecs/parse-videos-metadata.test.ts` (3 cases: filenames-list, singular fallback, embedded `.`).
- Extended `tests/codecs/imagevideo-load.test.ts`: the `imgvideo.slp` fixture is a 3-image sequence — now asserts all 3 frames load and `getFrame(2)` decodes (previously collapsed to 1).
- Full suite green (1 pre-existing, unrelated Python-compat failure); typecheck clean.
- Verified on a real 14-video ImageVideo `.slp`: per-video frame counts now `11041 / 867 / 2560 / … / 869` instead of `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)