### PR TITLE
feat(video): two-tier frame cache + prefetch for ImageVideoBackend

### DIFF
--- a/src/video/image-video.ts
+++ b/src/video/image-video.ts
@@ -14,6 +14,7 @@
 import { VideoBackend, VideoFrame } from "./backend.js";
 import { decodeEncoded } from "./image-decode.js";
 import { getImageBytesReader, type ImageBytesReader } from "./image-source.js";
+import { LruCache } from "./lru-cache.js";
 
 export interface ImageVideoOptions {
   /** Image paths, one per frame. */
@@ -26,26 +27,95 @@ export interface ImageVideoOptions {
    * not decoded up front.
    */
   shape?: [number, number, number, number];
+  /** Byte budget for the raw-bytes cache tier (default 128 MB). */
+  bytesCacheBytes?: number;
+  /** Byte budget for the decoded-frame cache tier (default 64 MB). */
+  decodedCacheBytes?: number;
+  /** Max concurrent prefetch reads (default 6). */
+  prefetchConcurrency?: number;
+  /** Frames to read ahead in the direction of travel (default 8; 0 disables). */
+  prefetchAhead?: number;
+  /** Frames to read behind the direction of travel (default 2). */
+  prefetchBehind?: number;
 }
 
-/** Default max decoded frames held in the bounded (FIFO-evicted) cache. */
-const DEFAULT_CACHE_SIZE = 32;
+/**
+ * Indices to prefetch around `current`, biased ahead in the direction of travel
+ * (`current` vs the previous index `last`). Reading is the dominant cost, so we
+ * read ahead where the user is most likely to go next, plus a couple behind for
+ * back-stepping. Clamped to `[0, length)` and excludes `current`. Pure.
+ */
+export function computePrefetchWindow(
+  current: number,
+  last: number | null,
+  length: number,
+  ahead: number,
+  behind: number
+): number[] {
+  const dir = last === null || current >= last ? 1 : -1;
+  const out: number[] = [];
+  for (let k = 1; k <= ahead; k++) out.push(current + dir * k);
+  for (let k = 1; k <= behind; k++) out.push(current - dir * k);
+  return out.filter((i) => i >= 0 && i < length && i !== current);
+}
+
+/**
+ * Default byte budgets for the two cache tiers. Bytes (encoded jpgs, ~106 KB
+ * each) are cached generously because they are cheap and caching them kills the
+ * dominant cost — the network read. Decoded frames (~5 MB each, RGBA) are 50×
+ * larger, so the decoded tier is smaller; re-decoding from a cached jpg is ~4 ms.
+ */
+const DEFAULT_BYTES_CACHE = 128 * 1024 * 1024;
+const DEFAULT_DECODED_CACHE = 64 * 1024 * 1024;
+const DEFAULT_PREFETCH_CONCURRENCY = 6;
+const DEFAULT_PREFETCH_AHEAD = 8;
+const DEFAULT_PREFETCH_BEHIND = 2;
 
 export class ImageVideoBackend implements VideoBackend {
   filename: string[];
   shape: [number, number, number, number];
   private reader: ImageBytesReader;
-  private cache = new Map<number, VideoFrame>();
-  private maxCache = DEFAULT_CACHE_SIZE;
+  // Two-tier cache: a large tier of raw encoded bytes (kills the network read on
+  // revisit/prefetch) and a small tier of decoded frames (kills the re-decode).
+  private bytesCache: LruCache<number, Uint8Array>;
+  private decodedCache: LruCache<number, ImageData>;
+  // In-flight byte reads, so a getFrame and a prefetch of the same frame share
+  // one read instead of racing.
+  private inflight = new Map<number, Promise<Uint8Array>>();
+  private prefetchConcurrency: number;
+  private prefetchAhead: number;
+  private prefetchBehind: number;
+  private lastIndex: number | null = null;
+  // Bumped each time a new prefetch window is issued; in-flight prefetch workers
+  // stop pulling new frames once superseded (e.g. the user jumps away).
+  private prefetchGen = 0;
+  /**
+   * The in-flight auto-prefetch promise from the most recent `getFrame`. Resolves
+   * when that window finishes (or is superseded). Exposed for coordination/tests;
+   * callers normally ignore it.
+   */
+  lastPrefetch: Promise<void> = Promise.resolve();
 
   private constructor(
     filename: string[],
     reader: ImageBytesReader,
-    shape: [number, number, number, number]
+    shape: [number, number, number, number],
+    cfg: {
+      bytesCacheBytes: number;
+      decodedCacheBytes: number;
+      prefetchConcurrency: number;
+      prefetchAhead: number;
+      prefetchBehind: number;
+    }
   ) {
     this.filename = filename;
     this.reader = reader;
     this.shape = shape;
+    this.bytesCache = new LruCache(cfg.bytesCacheBytes, (b) => b.byteLength);
+    this.decodedCache = new LruCache(cfg.decodedCacheBytes, (f) => f.data.byteLength);
+    this.prefetchConcurrency = cfg.prefetchConcurrency;
+    this.prefetchAhead = cfg.prefetchAhead;
+    this.prefetchBehind = cfg.prefetchBehind;
   }
 
   /**
@@ -66,50 +136,118 @@ export class ImageVideoBackend implements VideoBackend {
     let height = 0;
     let width = 0;
     let channels = 0;
-    const seed = new Map<number, VideoFrame>();
+    let seedBytes: Uint8Array | undefined;
+    let seedFrame: ImageData | undefined;
 
     if (opts.shape) {
       [, height, width, channels] = opts.shape;
     } else if (frames > 0) {
-      const first = await decodeEncoded(await reader(opts.filename[0]));
-      seed.set(0, first);
-      height = first.height;
-      width = first.width;
-      channels = isGrayscale(first) ? 1 : 3;
+      seedBytes = await reader(opts.filename[0]);
+      seedFrame = await decodeEncoded(seedBytes);
+      height = seedFrame.height;
+      width = seedFrame.width;
+      channels = isGrayscale(seedFrame) ? 1 : 3;
     }
 
-    const be = new ImageVideoBackend(opts.filename, reader, [
-      frames,
-      height,
-      width,
-      channels,
-    ]);
-    for (const [k, v] of seed) be.cache.set(k, v);
+    const be = new ImageVideoBackend(
+      opts.filename,
+      reader,
+      [frames, height, width, channels],
+      {
+        bytesCacheBytes: opts.bytesCacheBytes ?? DEFAULT_BYTES_CACHE,
+        decodedCacheBytes: opts.decodedCacheBytes ?? DEFAULT_DECODED_CACHE,
+        prefetchConcurrency: opts.prefetchConcurrency ?? DEFAULT_PREFETCH_CONCURRENCY,
+        prefetchAhead: opts.prefetchAhead ?? DEFAULT_PREFETCH_AHEAD,
+        prefetchBehind: opts.prefetchBehind ?? DEFAULT_PREFETCH_BEHIND,
+      }
+    );
+    // Seed the cache with frame 0 (decoded up front when no shape was given).
+    if (seedBytes) be.bytesCache.set(0, seedBytes);
+    if (seedFrame) be.decodedCache.set(0, seedFrame);
     return be;
   }
 
   async getFrame(frameIndex: number): Promise<VideoFrame | null> {
     if (frameIndex < 0 || frameIndex >= this.filename.length) return null;
-    const cached = this.cache.get(frameIndex);
-    if (cached) return cached;
-    const frame = await decodeEncoded(await this.reader(this.filename[frameIndex]));
-    this.put(frameIndex, frame);
+    // Kick off read-ahead before serving (so cache hits still prefetch ahead).
+    this.triggerPrefetch(frameIndex);
+    const decoded = this.decodedCache.get(frameIndex);
+    if (decoded) return decoded;
+    const bytes = await this.startRead(frameIndex);
+    const frame = await decodeEncoded(bytes);
+    this.decodedCache.set(frameIndex, frame);
     return frame;
   }
 
-  private put(index: number, frame: VideoFrame): void {
-    // Bounded cache with FIFO eviction (Map preserves insertion order): evict
-    // the oldest-inserted frame once at capacity. Cheap and adequate for the
-    // mostly-sequential scrubbing/playback access pattern.
-    if (this.cache.size >= this.maxCache) {
-      const oldest = this.cache.keys().next().value;
-      if (oldest !== undefined) this.cache.delete(oldest);
-    }
-    this.cache.set(index, frame);
+  /**
+   * Read a frame's encoded bytes, serving from the bytes tier when present (no
+   * network) and coalescing concurrent reads of the same frame via `inflight` so
+   * a getFrame and a prefetch never read the same file twice.
+   */
+  private startRead(frameIndex: number): Promise<Uint8Array> {
+    const cached = this.bytesCache.get(frameIndex);
+    if (cached) return Promise.resolve(cached);
+    const existing = this.inflight.get(frameIndex);
+    if (existing) return existing;
+    const p = (async () => {
+      try {
+        const bytes = await this.reader(this.filename[frameIndex]);
+        this.bytesCache.set(frameIndex, bytes);
+        return bytes;
+      } finally {
+        this.inflight.delete(frameIndex);
+      }
+    })();
+    this.inflight.set(frameIndex, p);
+    return p;
+  }
+
+  /**
+   * Read a window of frames' bytes into the bytes tier, concurrency-capped, and
+   * cancellable: a later prefetch (or a jump) bumps the generation so in-flight
+   * workers stop pulling new frames. Resolves when this window finishes or is
+   * superseded. Frames already cached or in flight are skipped.
+   */
+  prefetch(indices: number[]): Promise<void> {
+    const gen = ++this.prefetchGen;
+    const queue = [...new Set(indices)].filter(
+      (i) => i >= 0 && i < this.filename.length && !this.bytesCache.has(i)
+    );
+    let next = 0;
+    const worker = async (): Promise<void> => {
+      while (next < queue.length && gen === this.prefetchGen) {
+        const i = queue[next++];
+        if (this.bytesCache.has(i)) continue;
+        try {
+          await this.startRead(i);
+        } catch {
+          // Leave uncached; a real getFrame for this index will surface the error.
+        }
+      }
+    };
+    const n = Math.min(this.prefetchConcurrency, queue.length);
+    return Promise.all(Array.from({ length: n }, () => worker())).then(
+      () => undefined
+    );
+  }
+
+  /** Compute and launch the read-ahead window for `frameIndex` (fire-and-forget). */
+  private triggerPrefetch(frameIndex: number): void {
+    const window = computePrefetchWindow(
+      frameIndex,
+      this.lastIndex,
+      this.filename.length,
+      this.prefetchAhead,
+      this.prefetchBehind
+    );
+    this.lastIndex = frameIndex;
+    this.lastPrefetch = this.prefetch(window);
   }
 
   close(): void {
-    this.cache.clear();
+    this.bytesCache.clear();
+    this.decodedCache.clear();
+    this.inflight.clear();
   }
 }
 

--- a/src/video/lru-cache.ts
+++ b/src/video/lru-cache.ts
@@ -1,0 +1,85 @@
+// src/video/lru-cache.ts
+//
+// A least-recently-used cache bounded by a BYTE budget (not entry count),
+// because the entries it holds vary in size — raw jpg bytes (~100 KB) in one
+// tier, decoded frames (~5 MB) in another. Recency order is the `Map` insertion
+// order: `get`/`set` move a key to the end (most-recently-used); eviction drops
+// from the front (least-recently-used) until back under budget.
+
+export class LruCache<K, V> {
+  private map = new Map<K, { value: V; size: number }>();
+  private bytes = 0;
+
+  /**
+   * @param maxBytes Soft byte budget. Eviction runs after each `set` until the
+   *   total is within budget — except the entry just set is never evicted, so a
+   *   single oversized entry is kept (you still need it to render).
+   * @param sizeOf Byte size of a value. Must be deterministic for a given value.
+   */
+  constructor(
+    private readonly maxBytes: number,
+    private readonly sizeOf: (value: V) => number
+  ) {}
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  get totalBytes(): number {
+    return this.bytes;
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.map.get(key);
+    if (!entry) return undefined;
+    // Move to most-recently-used (re-insert at the end of the Map).
+    this.map.delete(key);
+    this.map.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: K, value: V): void {
+    const existing = this.map.get(key);
+    if (existing) {
+      this.bytes -= existing.size;
+      this.map.delete(key);
+    }
+    const size = this.sizeOf(value);
+    this.map.set(key, { value, size });
+    this.bytes += size;
+    this.evict();
+  }
+
+  delete(key: K): boolean {
+    const entry = this.map.get(key);
+    if (!entry) return false;
+    this.bytes -= entry.size;
+    return this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+    this.bytes = 0;
+  }
+
+  keys(): IterableIterator<K> {
+    return this.map.keys();
+  }
+
+  private evict(): void {
+    // Drop least-recently-used (front of the Map) until within budget, but never
+    // the most-recently-set entry — a single entry larger than the whole budget
+    // is kept rather than looping forever.
+    while (this.bytes > this.maxBytes && this.map.size > 1) {
+      const oldest = this.map.keys().next().value as K;
+      const entry = this.map.get(oldest);
+      if (!entry) break;
+      this.bytes -= entry.size;
+      this.map.delete(oldest);
+    }
+  }
+}

--- a/tests/video/image-video-cache.test.ts
+++ b/tests/video/image-video-cache.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Two-tier frame cache in ImageVideoBackend: a large raw-bytes tier (kills
+ * network re-reads) and a small decoded tier (kills re-decode). The defining new
+ * property over the old single decoded cache: a frame evicted from the DECODED
+ * tier but still present in the BYTES tier re-decodes WITHOUT another reader
+ * (network) call.
+ *
+ * Tests inject a counting reader that returns a real fixture jpg, so decode is
+ * exercised for real while reader calls are observable.
+ */
+import { describe, it, expect } from "../bun-test";
+import { ImageVideoBackend } from "../../src/video/image-video.js";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
+
+const jpgPath = fileURLToPath(
+  new URL("../data/videos/imgs/img.00.jpg", import.meta.url)
+);
+const realJpg = new Uint8Array(fs.readFileSync(jpgPath));
+
+function names(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `img${i}.jpg`);
+}
+
+/** A reader that records each requested path and returns the real jpg bytes. */
+function countingReader() {
+  const reads: string[] = [];
+  const reader = async (p: string): Promise<Uint8Array> => {
+    reads.push(p);
+    return realJpg;
+  };
+  return { reader, reads };
+}
+
+describe("ImageVideoBackend two-tier cache", () => {
+  it("serves a repeated frame from the decoded tier (one reader call)", async () => {
+    const { reader, reads } = countingReader();
+    const be = await ImageVideoBackend.create({
+      filename: names(20),
+      shape: [20, 8, 8, 3],
+      reader,
+    });
+    await be.getFrame(3);
+    await be.getFrame(3);
+    expect(reads.filter((p) => p === "img3.jpg").length).toBe(1);
+  });
+
+  it("re-decodes from the bytes tier after a decoded eviction (no re-read)", async () => {
+    const { reader, reads } = countingReader();
+    const be = await ImageVideoBackend.create({
+      filename: names(50),
+      shape: [50, 8, 8, 3],
+      reader,
+      // Decoded tier holds ~one frame (prior decodes evicted); bytes tier roomy
+      // enough for all 41 frames touched below.
+      decodedCacheBytes: 1,
+      bytesCacheBytes: 10_000_000,
+    });
+    await be.getFrame(0); // read img0, decode
+    // Touch 40 more distinct frames — enough to evict decoded[0] from any
+    // reasonable decoded tier (and from the old 32-entry FIFO cache).
+    for (let i = 1; i <= 40; i++) await be.getFrame(i);
+    await be.getFrame(0); // decoded[0] gone -> bytes[0] hit -> decode, NO re-read
+    expect(reads.filter((p) => p === "img0.jpg").length).toBe(1);
+  });
+
+  it("returns a decoded frame with real dimensions", async () => {
+    const { reader } = countingReader();
+    const be = await ImageVideoBackend.create({
+      filename: names(5),
+      shape: [5, 8, 8, 3],
+      reader,
+    });
+    const frame = (await be.getFrame(2)) as ImageData;
+    expect(frame).not.toBeNull();
+    expect(frame.width).toBeGreaterThan(0);
+    expect(frame.height).toBeGreaterThan(0);
+  });
+
+  it("returns null for out-of-range indices", async () => {
+    const { reader } = countingReader();
+    const be = await ImageVideoBackend.create({
+      filename: names(5),
+      shape: [5, 8, 8, 3],
+      reader,
+    });
+    expect(await be.getFrame(-1)).toBeNull();
+    expect(await be.getFrame(5)).toBeNull();
+  });
+});

--- a/tests/video/image-video-prefetch.test.ts
+++ b/tests/video/image-video-prefetch.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Prefetch for ImageVideoBackend — split into a pure window policy and the
+ * capped/dedup'd read mechanism.
+ */
+import { describe, it, expect } from "../bun-test";
+import {
+  ImageVideoBackend,
+  computePrefetchWindow,
+} from "../../src/video/image-video.js";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+
+const realJpg = new Uint8Array(
+  fs.readFileSync(
+    fileURLToPath(new URL("../data/videos/imgs/img.00.jpg", import.meta.url))
+  )
+);
+const names = (n: number) => Array.from({ length: n }, (_, i) => `img${i}.jpg`);
+
+describe("computePrefetchWindow (policy)", () => {
+  it("biases ahead in the forward direction of travel", () => {
+    // current 5, came from 4 -> moving forward
+    expect(computePrefetchWindow(5, 4, 100, 3, 1)).toEqual([6, 7, 8, 4]);
+  });
+
+  it("biases ahead in the backward direction of travel", () => {
+    expect(computePrefetchWindow(5, 6, 100, 3, 1)).toEqual([4, 3, 2, 6]);
+  });
+
+  it("defaults to forward when there is no prior index", () => {
+    expect(computePrefetchWindow(0, null, 100, 2, 0)).toEqual([1, 2]);
+  });
+
+  it("clamps to [0, length) and excludes the current index", () => {
+    expect(computePrefetchWindow(98, 97, 100, 3, 0)).toEqual([99]);
+    expect(computePrefetchWindow(0, null, 100, 0, 2)).toEqual([]); // behind of 0 is <0
+  });
+
+  it("dedupes and never includes the current index", () => {
+    const w = computePrefetchWindow(10, 9, 100, 5, 5);
+    expect(w).not.toContain(10);
+    expect(new Set(w).size).toBe(w.length);
+  });
+});
+
+describe("ImageVideoBackend.prefetch (mechanism)", () => {
+  // A reader that tracks concurrency (max simultaneous in-flight reads).
+  function trackingReader() {
+    let active = 0;
+    let maxActive = 0;
+    const reads: string[] = [];
+    const reader = async (p: string): Promise<Uint8Array> => {
+      reads.push(p);
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      await Promise.resolve();
+      active--;
+      return realJpg;
+    };
+    return { reader, reads, get maxActive() { return maxActive; } };
+  }
+
+  async function make(t: { reader: (p: string) => Promise<Uint8Array> }, opts = {}) {
+    return ImageVideoBackend.create({
+      filename: names(50),
+      shape: [50, 8, 8, 3],
+      reader: t.reader,
+      bytesCacheBytes: 50_000_000,
+      prefetchConcurrency: 6,
+      // Disable auto-prefetch by default so the mechanism tests are deterministic;
+      // the auto-prefetch test below re-enables it explicitly.
+      prefetchAhead: 0,
+      prefetchBehind: 0,
+      ...opts,
+    });
+  }
+
+  it("reads the requested frames into the bytes tier", async () => {
+    const t = trackingReader();
+    const be = await make(t);
+    await be.prefetch([2, 4, 6]);
+    expect(t.reads.filter((p) => ["img2.jpg", "img4.jpg", "img6.jpg"].includes(p)).length).toBe(3);
+    // Now getFrame(4) must NOT trigger another read (bytes already cached).
+    const before = t.reads.length;
+    await be.getFrame(4);
+    expect(t.reads.filter((p) => p === "img4.jpg").length).toBe(1);
+    expect(t.reads.length).toBe(before);
+  });
+
+  it("respects the concurrency cap", async () => {
+    const t = trackingReader();
+    const be = await make(t); // cap 6
+    await be.prefetch(Array.from({ length: 20 }, (_, i) => i + 1));
+    expect(t.maxActive).toBe(6);
+    expect(t.reads.length).toBe(20);
+  });
+
+  it("skips frames already in the bytes cache", async () => {
+    const t = trackingReader();
+    const be = await make(t);
+    await be.getFrame(3); // caches bytes[3]
+    const before = t.reads.length;
+    await be.prefetch([3, 4]);
+    expect(t.reads.filter((p) => p === "img3.jpg").length).toBe(1); // not re-read
+    expect(t.reads.filter((p) => p === "img4.jpg").length).toBe(1);
+    expect(t.reads.length).toBe(before + 1);
+  });
+
+  it("dedupes a concurrent getFrame and prefetch of the same frame", async () => {
+    const t = trackingReader();
+    const be = await make(t);
+    await Promise.all([be.getFrame(7), be.prefetch([7])]);
+    expect(t.reads.filter((p) => p === "img7.jpg").length).toBe(1);
+  });
+
+  it("auto-prefetches ahead when stepping forward", async () => {
+    const t = trackingReader();
+    const be = await make(t, { prefetchAhead: 4, prefetchBehind: 1 });
+    await be.getFrame(9); // establish position
+    await be.getFrame(10); // forward step -> should read-ahead 11,12,...
+    await be.lastPrefetch; // await the in-flight auto-prefetch
+    expect(t.reads).toContain("img11.jpg");
+    expect(t.reads).toContain("img12.jpg");
+  });
+});

--- a/tests/video/lru-cache.test.ts
+++ b/tests/video/lru-cache.test.ts
@@ -1,0 +1,77 @@
+/**
+ * LruCache — a byte-budgeted least-recently-used cache. Backs the two-tier frame
+ * cache in ImageVideoBackend (a large raw-bytes tier + a small decoded tier),
+ * where entries vary in size so the budget is in bytes, not entry count.
+ */
+import { describe, it, expect } from "../bun-test";
+import { LruCache } from "../../src/video/lru-cache.js";
+
+// Value IS its own byte size, so budgets are easy to reason about in tests.
+const sizeIsValue = (v: number) => v;
+
+describe("LruCache", () => {
+  it("stores and retrieves a value", () => {
+    const c = new LruCache<string, number>(100, sizeIsValue);
+    c.set("a", 10);
+    expect(c.has("a")).toBe(true);
+    expect(c.get("a")).toBe(10);
+    expect(c.totalBytes).toBe(10);
+    expect(c.size).toBe(1);
+  });
+
+  it("evicts the least-recently-used entry when over the byte budget", () => {
+    const c = new LruCache<string, number>(100, sizeIsValue);
+    c.set("a", 40);
+    c.set("b", 40);
+    c.set("c", 40); // 120 > 100 -> evict oldest (a)
+    expect(c.has("a")).toBe(false);
+    expect(c.has("b")).toBe(true);
+    expect(c.has("c")).toBe(true);
+    expect(c.totalBytes).toBe(80);
+  });
+
+  it("get() marks an entry most-recently-used, protecting it from eviction", () => {
+    const c = new LruCache<string, number>(100, sizeIsValue);
+    c.set("a", 40);
+    c.set("b", 40);
+    c.get("a"); // a is now MRU; b is LRU
+    c.set("c", 40); // evict LRU -> b
+    expect(c.has("a")).toBe(true);
+    expect(c.has("b")).toBe(false);
+    expect(c.has("c")).toBe(true);
+  });
+
+  it("updating an existing key replaces its size and recency", () => {
+    const c = new LruCache<string, number>(100, sizeIsValue);
+    c.set("a", 10);
+    c.set("a", 50);
+    expect(c.size).toBe(1);
+    expect(c.totalBytes).toBe(50);
+    expect(c.get("a")).toBe(50);
+  });
+
+  it("never evicts the entry just set, even if it alone exceeds the budget", () => {
+    const c = new LruCache<string, number>(10, sizeIsValue);
+    c.set("big", 100);
+    expect(c.has("big")).toBe(true);
+    expect(c.size).toBe(1);
+  });
+
+  it("delete() removes an entry and frees its bytes", () => {
+    const c = new LruCache<string, number>(100, sizeIsValue);
+    c.set("a", 30);
+    expect(c.delete("a")).toBe(true);
+    expect(c.has("a")).toBe(false);
+    expect(c.totalBytes).toBe(0);
+    expect(c.delete("a")).toBe(false);
+  });
+
+  it("clear() empties the cache", () => {
+    const c = new LruCache<string, number>(100, sizeIsValue);
+    c.set("a", 30);
+    c.set("b", 30);
+    c.clear();
+    expect(c.size).toBe(0);
+    expect(c.totalBytes).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

ImageVideoBackend (image-sequence videos) read one image per displayed frame, with only a small FIFO decoded cache and **no read-ahead** — so scrubbing/stepping/playback re-read and re-decoded frames repeatedly.

## Change

- **`LruCache`** — a byte-budgeted (not count-bounded) LRU, since cached entries vary in size.
- **Two-tier cache** in `ImageVideoBackend`: a large **raw-bytes** tier (kills the network re-read on revisit/prefetch) + a small **decoded** tier (kills the re-decode). Bytes are ~50× smaller than decoded RGBA, so we cache many frames' bytes but few decoded.
- **Prefetch**: a pure ahead-biased window policy (`computePrefetchWindow`), plus a concurrency-capped, generation-cancellable read mechanism. `getFrame` auto-triggers read-ahead; concurrent `getFrame`/prefetch reads of the same frame are coalesced via an in-flight map.

All ImageVideo-scoped — no other backend is touched.

## Tests

- `lru-cache` (7): LRU eviction, byte budget, recency, never-evict-just-set.
- `image-video-cache` (4): decoded-tier hit, **bytes-tier survives a decoded eviction without re-reading**, dimensions, bounds.
- `image-video-prefetch` (10): window policy, concurrency cap, dedup, in-flight coalescing, auto-trigger.

Typecheck clean; full suite green (the one pre-existing Python-compat failure is unrelated).

## Context

Part of making ImageVideo playback feel instant in sleap-app (alongside an app-side native image read + seekbar perf fix). The read-layer cache complements those — it makes revisits ~instant and read-ahead hides per-frame read latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)