### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Bump version to 0.4.1

One-line `package.json` bump (`0.4.0` → `0.4.1`), mirroring the 0.4.0 bump (#145). This cuts a release of everything merged to `main` since 0.4.0 so the downstream **sleap-app** PRs can install a published `0.4.1` and go green.

### What's in 0.4.1 (merged since v0.4.0)

**ImageVideo (image-sequence) support + perf**
- #171 `ImageVideoBackend` (image-sequence decode) + `setImageBytesReader` + resilient SLP video loading
- #173 read the full image list (`backend.filenames`) — fixes N-image sequences collapsing to 1 frame
- #172 resolve embedded pkg.slp frame count without a decode probe (fixes Windows Frames=0)
- #174 two-tier frame cache + prefetch for `ImageVideoBackend`

**Video model / IO**
- #147 virtual on-read cropping + SLP format 2.3 round-trip (`Video.cropRect` / `CropVideoBackend`)
- #155 expose embedded frame numbers via `Video.embeddedFrameIndices`
- #158 read vlen embedded frames per-element (no memory blow-up; fixes black frames)
- #168 stop routing `.avi`/`.mpeg` to MediaBunny; throw clean `UnsupportedVideoFormatError`
- #170 `Labels.removeVideo` / `removeVideos`

**Codecs / rendering / tests**
- #169 `writeSkeletonJson` (jsonpickle encoder)
- #157 mask human-in-the-loop (`toUser()` + persisted `fromPredicted` + link-first merge)
- #146 segmentation overlay rendering (Node raster path)
- #154 edge-less / isolated-node skeleton regression suite (tests only)

### Downstream sleap-app PRs unblocked by 0.4.1

| sleap-app PR | Needs | Source |
|---|---|---|
| #174 ImageVideo desktop support | `setImageBytesReader`, `ImageVideoBackend`, filenames-list, cache/prefetch | #171, #173, #174 |
| #173 Remove Video | `Labels.removeVideo` | #170 |
| #154 Frames column (embedded count) | `Video.embeddedFrameIndices` | #155 |
| #151 Tri-state frame navigation | `Video.embeddedFrameIndices` | #155 |
| #150 Cropped-video instance placement | `Video.cropRect` / `CropVideoBackend` | #147 |

Each consumes only `^0.4.0`-range APIs, so those PRs need no `package.json` range change — only a `bun.lock` bump to `0.4.1` after publish.

### Not included (still open, not a downstream dependency)
sleap-io.js #161 (effective-shape matching), #163 (overlay auto-draw), #164 (gzip masks) — none are required by the blocked sleap-app PRs; they can ride a later release.

### ⚠️ Publishing — required after merge
`release.yml` publishes to npm **only on a GitHub Release `published`** event (or manual `workflow_dispatch`). Merging this PR does **not** publish. To make 0.4.1 available (and let sleap-app CI install it):

1. Merge this PR to `main`.
2. **Create + publish a GitHub Release `v0.4.1`** (tag on `main`) → `release.yml` builds and `npm publish`es `@talmolab/sleap-io.js@0.4.1`.
3. In each sleap-app PR, bump `bun.lock` to `0.4.1` and un-draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
