### PR TITLE
feat(slp): onProgress callback for verbose load progress

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -296,6 +296,37 @@ labels.materialize();
 > const [frame] = labels.find({ video, frameIdx: 42 });   // LabeledFrame | undefined
 > ```
 
+### Tracking load progress
+
+Pass an `onProgress` callback to `loadSlp` to surface load progress (for example,
+to drive a progress bar). It fires `(current, total, message?)` as the loader
+advances through its stages: `current` counts completed stages out of `total`,
+and `message` labels the stage about to run. The final call is always
+`(total, total, "Finalizing")`. This matches the `(current, total, message?)`
+convention used elsewhere in the library (`Labels.merge`,
+`RenderOptions.onProgress`).
+
+```ts
+import { loadSlp } from "@talmolab/sleap-io.js";
+
+const labels = await loadSlp("dataset.slp", {
+  onProgress: (current, total, message) => {
+    // Update a progress bar: current / total, with a stage label.
+    const pct = Math.round((current / total) * 100);
+    console.log(`[${pct}%] ${message ?? ""}`);
+  },
+});
+```
+
+All reader paths emit progress — the streaming reader (browser, HTTP range
+requests), the eager reader, and the lazy reader (Node, or the no-Worker browser
+fallback). The stage lists differ per path (the streaming reader reports finer
+stages than the eager/lazy readers), but the `(current, total, message?)`
+contract is identical, so a single bar works for any path. When `openVideos` is
+enabled, the videos stage additionally reports `"Opening videos (i/n)"` as each
+embedded video backend is opened. Reporting is a pure side effect and never
+changes the loaded `Labels`.
+
 ## Saving with Embedded Frames
 
 Embed video frames directly into the SLP file:
@@ -602,6 +633,7 @@ See [lite.md](./lite.md) for full documentation.
 | `h5.stream` | `"auto"` \| `"range"` \| `"download"` | `"auto"` | HDF5 streaming mode |
 | `h5.filenameHint` | `string` | `undefined` | Filename hint for embedded video paths |
 | `lazy` | `boolean` | `false` | Use lazy loading for on-demand frame materialization |
+| `onProgress` | `(current, total, message?) => void` | `undefined` | Progress callback fired per load stage; ends with `(total, total, "Finalizing")`. Emitted by all reader paths (streaming/eager/lazy). See [Tracking load progress](#tracking-load-progress). |
 
 ### `loadVideo(source)`
 

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -63,6 +63,13 @@ export interface StreamingSlpOptions {
   filenameHint?: string;
   /** Whether to open video backends for embedded videos (default: false) */
   openVideos?: boolean;
+  /**
+   * Optional progress callback fired as loading advances through its stages.
+   * `current` counts completed stages out of `total`; `message` labels the
+   * stage about to run. Matches the (current, total, message?) convention used
+   * elsewhere in the library (Labels.merge, RenderOptions.onProgress).
+   */
+  onProgress?: (current: number, total: number, message?: string) => void;
 }
 
 /**
@@ -129,6 +136,7 @@ export async function readSlpStreaming(
       sourcePath,
       options?.filenameHint,
       openVideos,
+      options?.onProgress,
     );
   } finally {
     // Only close the file if we're NOT opening video backends.
@@ -147,8 +155,18 @@ async function readFromStreamingFile(
   url: string,
   filenameHint?: string,
   openVideos: boolean = false,
+  onProgress?: (current: number, total: number, message?: string) => void,
 ): Promise<Labels> {
-  // Read metadata
+  // Stage-level progress. The orchestration in this function runs on the MAIN
+  // thread — only the low-level HDF5 byte reads are delegated to the worker via
+  // `file` — so each phase can be surfaced as it starts without any cross-worker
+  // messaging. `current` counts completed stages; `message` labels the stage
+  // about to run. (Shape matches Labels.merge / RenderOptions.onProgress.)
+  const STAGES = 10;
+  const report = (n: number, message: string) =>
+    onProgress?.(n, STAGES, message);
+
+  report(0, "Reading metadata");
   const metadataAttrs = await file.getAttrs("metadata");
   const formatId = Number(
     (metadataAttrs["format_id"] as { value?: number })?.value ??
@@ -164,31 +182,39 @@ async function readFromStreamingFile(
     filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
   const skeletons = parseSkeletons(metadataJson);
 
-  // Read tracks
+  report(1, "Reading tracks");
   const tracks = await readTracksStreaming(file);
 
   // Read per-video crop records (SLP 2.3; empty on old/uncropped files).
+  report(2, "Reading video metadata");
   const videoCrops = await readVideoCropsStreaming(file);
 
-  // Read video metadata (and optionally create backends for embedded videos)
+  // Read video metadata (and optionally create backends for embedded videos).
+  // When opening videos, the per-video reporter keeps the bar at this stage
+  // while the label counts videos (probeShape per embedded backend is slow).
   const videos = await readVideosStreaming(
     file,
     labelsPath,
     openVideos,
     formatId,
     videoCrops,
+    openVideos ? (i, n) => report(2, `Opening videos (${i}/${n})`) : undefined,
   );
 
-  // Read suggestions
+  report(3, "Reading suggestions");
   const suggestions = await readSuggestionsStreaming(file, videos);
 
   // Read frame/instance/point data
+  report(4, "Reading frames");
   const framesData = await readStructDatasetStreaming(file, "frames");
+  report(5, "Reading instances");
   const instancesData = await readStructDatasetStreaming(file, "instances");
+  report(6, "Reading points");
   const pointsData = await readStructDatasetStreaming(file, "points");
   const predPointsData = await readStructDatasetStreaming(file, "pred_points");
 
   // Build labeled frames
+  report(7, "Building labeled frames");
   const labeledFrames = buildLabeledFrames({
     framesData,
     instancesData,
@@ -201,9 +227,11 @@ async function readFromStreamingFile(
   });
 
   // Read identities
+  report(8, "Reading identities");
   const identities = await readIdentitiesStreaming(file);
 
   // Read sessions
+  report(9, "Reading sessions");
   const sessions = await readSessionsStreaming(
     file,
     videos,
@@ -212,6 +240,7 @@ async function readFromStreamingFile(
     identities,
   );
 
+  onProgress?.(STAGES, STAGES, "Finalizing");
   return new Labels({
     labeledFrames,
     videos,
@@ -316,6 +345,7 @@ async function readVideosStreaming(
   openVideos: boolean = false,
   formatId: number = 1.0,
   videoCrops?: Map<number, VideoCropEntry>,
+  onVideoProgress?: (current: number, total: number) => void,
 ): Promise<Video[]> {
   try {
     const keys = file.keys();
@@ -328,6 +358,7 @@ async function readVideosStreaming(
     const videos: Video[] = [];
 
     for (let videoIndex = 0; videoIndex < metadataList.length; videoIndex++) {
+      onVideoProgress?.(videoIndex + 1, metadataList.length);
       const meta = metadataList[videoIndex];
 
       // Auto-detect dataset path when embedded but not specified in metadata

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -162,11 +162,26 @@ async function readFromStreamingFile(
   // `file` — so each phase can be surfaced as it starts without any cross-worker
   // messaging. `current` counts completed stages; `message` labels the stage
   // about to run. (Shape matches Labels.merge / RenderOptions.onProgress.)
-  const STAGES = 10;
-  const report = (n: number, message: string) =>
-    onProgress?.(n, STAGES, message);
+  //
+  // `total` is DERIVED from this ordered label list (single source of truth) so
+  // the count can never drift from the stages. report(i) fires STAGES[i].
+  const STAGES = [
+    "Reading metadata", // 0
+    "Reading tracks", // 1
+    "Reading video metadata", // 2 (also holds the bar for "Opening videos (i/n)")
+    "Reading suggestions", // 3
+    "Reading frames", // 4
+    "Reading instances", // 5
+    "Reading points", // 6
+    "Building labeled frames", // 7
+    "Reading identities", // 8
+    "Reading sessions", // 9
+  ] as const;
+  const total = STAGES.length;
+  const report = (n: number, message?: string) =>
+    onProgress?.(n, total, message ?? STAGES[n]);
 
-  report(0, "Reading metadata");
+  report(0);
   const metadataAttrs = await file.getAttrs("metadata");
   const formatId = Number(
     (metadataAttrs["format_id"] as { value?: number })?.value ??
@@ -182,11 +197,11 @@ async function readFromStreamingFile(
     filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
   const skeletons = parseSkeletons(metadataJson);
 
-  report(1, "Reading tracks");
+  report(1);
   const tracks = await readTracksStreaming(file);
 
   // Read per-video crop records (SLP 2.3; empty on old/uncropped files).
-  report(2, "Reading video metadata");
+  report(2);
   const videoCrops = await readVideoCropsStreaming(file);
 
   // Read video metadata (and optionally create backends for embedded videos).
@@ -201,20 +216,20 @@ async function readFromStreamingFile(
     openVideos ? (i, n) => report(2, `Opening videos (${i}/${n})`) : undefined,
   );
 
-  report(3, "Reading suggestions");
+  report(3);
   const suggestions = await readSuggestionsStreaming(file, videos);
 
   // Read frame/instance/point data
-  report(4, "Reading frames");
+  report(4);
   const framesData = await readStructDatasetStreaming(file, "frames");
-  report(5, "Reading instances");
+  report(5);
   const instancesData = await readStructDatasetStreaming(file, "instances");
-  report(6, "Reading points");
+  report(6);
   const pointsData = await readStructDatasetStreaming(file, "points");
   const predPointsData = await readStructDatasetStreaming(file, "pred_points");
 
   // Build labeled frames
-  report(7, "Building labeled frames");
+  report(7);
   const labeledFrames = buildLabeledFrames({
     framesData,
     instancesData,
@@ -227,11 +242,11 @@ async function readFromStreamingFile(
   });
 
   // Read identities
-  report(8, "Reading identities");
+  report(8);
   const identities = await readIdentitiesStreaming(file);
 
   // Read sessions
-  report(9, "Reading sessions");
+  report(9);
   const sessions = await readSessionsStreaming(
     file,
     videos,
@@ -240,7 +255,7 @@ async function readFromStreamingFile(
     identities,
   );
 
-  onProgress?.(STAGES, STAGES, "Finalizing");
+  onProgress?.(total, total, "Finalizing");
   return new Labels({
     labeledFrames,
     videos,

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -73,7 +73,15 @@ const textDecoder = new TextDecoder();
 
 export async function readSlp(
   source: SlpSource,
-  options?: { openVideos?: boolean; h5?: OpenH5Options },
+  options?: {
+    openVideos?: boolean;
+    h5?: OpenH5Options;
+    // Accepted for API parity with loadSlp / the streaming reader. The eager
+    // and lazy main-thread paths (Node, or the no-Worker browser fallback) do
+    // not yet emit progress; instrumenting them mirrors readFromStreamingFile
+    // (read-streaming.ts) and is a follow-up.
+    onProgress?: (current: number, total: number, message?: string) => void;
+  },
 ): Promise<Labels> {
   const { file, close } = await openH5File(source, options?.h5);
   try {
@@ -271,7 +279,15 @@ export async function readSlp(
  */
 export async function readSlpLazy(
   source: SlpSource,
-  options?: { openVideos?: boolean; h5?: OpenH5Options },
+  options?: {
+    openVideos?: boolean;
+    h5?: OpenH5Options;
+    // Accepted for API parity with loadSlp / the streaming reader. The eager
+    // and lazy main-thread paths (Node, or the no-Worker browser fallback) do
+    // not yet emit progress; instrumenting them mirrors readFromStreamingFile
+    // (read-streaming.ts) and is a follow-up.
+    onProgress?: (current: number, total: number, message?: string) => void;
+  },
 ): Promise<Labels> {
   const { file, close } = await openH5File(source, options?.h5);
   try {

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -71,20 +71,50 @@ import { inflate } from "pako";
 
 const textDecoder = new TextDecoder();
 
+/**
+ * Ordered stage labels for the eager reader. `total` is derived from
+ * `EAGER_STAGES.length` so the count can never drift from the labels — the
+ * single source of truth for the eager path's progress. These are coarser than
+ * the streaming reader's stages (frames/instances/points are read together as
+ * one "Building labeled frames" step), which is fine: the consumer always gets
+ * a consistent (current, total, message).
+ */
+const EAGER_STAGES = [
+  "Reading metadata",
+  "Reading tracks",
+  "Reading videos",
+  "Reading suggestions",
+  "Building labeled frames",
+  "Reading identities",
+  "Reading sessions",
+  "Reading annotations",
+] as const;
+
 export async function readSlp(
   source: SlpSource,
   options?: {
     openVideos?: boolean;
     h5?: OpenH5Options;
-    // Accepted for API parity with loadSlp / the streaming reader. The eager
-    // and lazy main-thread paths (Node, or the no-Worker browser fallback) do
-    // not yet emit progress; instrumenting them mirrors readFromStreamingFile
-    // (read-streaming.ts) and is a follow-up.
+    /**
+     * Optional progress callback fired as loading advances through its stages.
+     * `current` counts completed stages out of `total`; `message` labels the
+     * stage about to run. Matches the (current, total, message?) convention used
+     * elsewhere in the library (Labels.merge, RenderOptions.onProgress). The
+     * stages are coarser than the streaming reader's, but the contract is the
+     * same. Reporting is a pure side effect and never alters the loaded Labels.
+     */
     onProgress?: (current: number, total: number, message?: string) => void;
   },
 ): Promise<Labels> {
+  // `total` is derived from the stage list (single source of truth) so the
+  // count cannot drift from the labels. `report(i)` fires the i-th stage label.
+  const total = EAGER_STAGES.length;
+  const onProgress = options?.onProgress;
+  const report = (i: number) => onProgress?.(i, total, EAGER_STAGES[i]);
+
   const { file, close } = await openH5File(source, options?.h5);
   try {
+    report(0); // Reading metadata
     const metadataGroup = file.get("metadata");
     if (!metadataGroup) {
       throw new Error("Missing /metadata group in SLP file");
@@ -105,18 +135,29 @@ export async function readSlp(
         ? source
         : (options?.h5?.filenameHint ?? "slp-data.slp");
     const skeletons = parseSkeletons(metadataJson);
+    report(1); // Reading tracks
     const tracks = readTracks(file.get("tracks_json"));
     const videoCrops = readVideoCrops(file);
+    // Hold the bar at the "Reading videos" stage while videos open; the
+    // per-video sub-reporter surfaces "Opening videos (i/n)" when openVideos is
+    // true (probing embedded backends can be slow). Mirrors the streaming path.
+    report(2); // Reading videos
+    const openVideos = options?.openVideos ?? true;
     const videos = await readVideos(
       file.get("videos_json"),
       labelsPath,
-      options?.openVideos ?? true,
+      openVideos,
       file,
       formatId,
       videoCrops,
+      openVideos
+        ? (i, n) => onProgress?.(2, total, `Opening videos (${i}/${n})`)
+        : undefined,
     );
+    report(3); // Reading suggestions
     const suggestions = readSuggestions(file.get("suggestions_json"), videos);
 
+    report(4); // Building labeled frames
     const framesData = normalizeStructDataset(file.get("frames"));
     const instancesData = normalizeStructDataset(file.get("instances"));
     const pointsData = normalizeStructDataset(file.get("points"));
@@ -151,7 +192,9 @@ export async function readSlp(
       }
     }
 
+    report(5); // Reading identities
     const identities = readIdentities(file.get("identities_json"));
+    report(6); // Reading sessions
     const sessions = readSessions(
       file.get("sessions_json"),
       videos,
@@ -159,6 +202,7 @@ export async function readSlp(
       labeledFrames,
       identities,
     );
+    report(7); // Reading annotations
     const allInstances = labeledFrames.flatMap((f) => f.instances);
     const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(
       file,
@@ -257,6 +301,7 @@ export async function readSlp(
       }
     }
 
+    onProgress?.(total, total, "Finalizing");
     return new Labels({
       labeledFrames,
       videos,
@@ -274,6 +319,25 @@ export async function readSlp(
 }
 
 /**
+ * Ordered stage labels for the lazy reader. As with EAGER_STAGES, `total` is
+ * derived from `LAZY_STAGES.length` (single source of truth). The lazy path
+ * does NOT materialize labeled frames up front — it reads the raw frame/
+ * instance/point columns into a LazyDataStore — so the "Reading frame data"
+ * stage reads raw data rather than constructing LabeledFrames. The stages
+ * otherwise mirror the eager reader's real steps.
+ */
+const LAZY_STAGES = [
+  "Reading metadata",
+  "Reading tracks",
+  "Reading videos",
+  "Reading suggestions",
+  "Reading frame data",
+  "Reading identities",
+  "Reading sessions",
+  "Reading annotations",
+] as const;
+
+/**
  * Read an SLP file in lazy mode. Frames are not materialized until accessed.
  * Returns a Labels object with a LazyFrameList that loads frames on demand.
  */
@@ -282,15 +346,26 @@ export async function readSlpLazy(
   options?: {
     openVideos?: boolean;
     h5?: OpenH5Options;
-    // Accepted for API parity with loadSlp / the streaming reader. The eager
-    // and lazy main-thread paths (Node, or the no-Worker browser fallback) do
-    // not yet emit progress; instrumenting them mirrors readFromStreamingFile
-    // (read-streaming.ts) and is a follow-up.
+    /**
+     * Optional progress callback fired as loading advances through its stages.
+     * `current` counts completed stages out of `total`; `message` labels the
+     * stage about to run. Matches the (current, total, message?) convention used
+     * elsewhere in the library (Labels.merge, RenderOptions.onProgress). The
+     * lazy path's stages are coarser than the streaming reader's. Reporting is a
+     * pure side effect and never alters the loaded Labels.
+     */
     onProgress?: (current: number, total: number, message?: string) => void;
   },
 ): Promise<Labels> {
+  // `total` is derived from the stage list (single source of truth) so the
+  // count cannot drift from the labels. `report(i)` fires the i-th stage label.
+  const total = LAZY_STAGES.length;
+  const onProgress = options?.onProgress;
+  const report = (i: number) => onProgress?.(i, total, LAZY_STAGES[i]);
+
   const { file, close } = await openH5File(source, options?.h5);
   try {
+    report(0); // Reading metadata
     const metadataGroup = file.get("metadata");
     if (!metadataGroup) {
       throw new Error("Missing /metadata group in SLP file");
@@ -311,18 +386,29 @@ export async function readSlpLazy(
         ? source
         : (options?.h5?.filenameHint ?? "slp-data.slp");
     const skeletons = parseSkeletons(metadataJson);
+    report(1); // Reading tracks
     const tracks = readTracks(file.get("tracks_json"));
     const videoCrops = readVideoCrops(file);
+    // Hold the bar at the "Reading videos" stage while videos open; the
+    // per-video sub-reporter surfaces "Opening videos (i/n)" when openVideos is
+    // true. Mirrors the streaming and eager paths.
+    report(2); // Reading videos
+    const openVideos = options?.openVideos ?? true;
     const videos = await readVideos(
       file.get("videos_json"),
       labelsPath,
-      options?.openVideos ?? true,
+      openVideos,
       file,
       formatId,
       videoCrops,
+      openVideos
+        ? (i, n) => onProgress?.(2, total, `Opening videos (${i}/${n})`)
+        : undefined,
     );
+    report(3); // Reading suggestions
     const suggestions = readSuggestions(file.get("suggestions_json"), videos);
 
+    report(4); // Reading frame data
     // Read raw data but don't build frames yet
     const framesData = normalizeStructDataset(file.get("frames"));
     const instancesData = normalizeStructDataset(file.get("instances"));
@@ -357,7 +443,9 @@ export async function readSlpLazy(
 
     // Read sessions eagerly - they don't depend on frame data.
     // Pass empty labeledFrames since frames aren't materialized yet.
+    report(5); // Reading identities
     const identities = readIdentities(file.get("identities_json"));
+    report(6); // Reading sessions
     const sessions = readSessions(
       file.get("sessions_json"),
       videos,
@@ -365,6 +453,7 @@ export async function readSlpLazy(
       [],
       identities,
     );
+    report(7); // Reading annotations
     const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(
       file,
       videos,
@@ -466,6 +555,7 @@ export async function readSlpLazy(
     labels._lazyFrameList = lazyFrames;
     labels._lazyDataStore = store;
 
+    onProgress?.(total, total, "Finalizing");
     return labels;
   } finally {
     close();
@@ -570,12 +660,14 @@ async function readVideos(
   file: any,
   formatId: number,
   videoCrops?: Map<number, VideoCropEntry>,
+  onVideoProgress?: (current: number, total: number) => void,
 ): Promise<Video[]> {
   if (!dataset) return [];
   const values = dataset.value ?? [];
   const videos: Video[] = [];
 
   for (let videoIndex = 0; videoIndex < values.length; videoIndex++) {
+    onVideoProgress?.(videoIndex + 1, values.length);
     const entry = values[videoIndex];
     if (!entry) continue;
     const parsed =

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -45,11 +45,20 @@ function isBrowserWithWorkerSupport(): boolean {
  * @param options.openVideos - Whether to open video backends (default: true)
  * @param options.h5 - HDF5 opening options (stream mode, filename hint)
  * @param options.lazy - If true, use lazy loading for on-demand frame materialization (default: false)
+ * @param options.onProgress - Optional callback fired as loading advances through
+ *   its stages: (current, total, message?), where current/total count completed
+ *   stages and message labels the stage about to run. Only the streaming reader
+ *   currently emits these (the path used in browser/Tauri).
  * @returns Loaded Labels object
  */
 export async function loadSlp(
   source: SlpSource,
-  options?: { openVideos?: boolean; h5?: OpenH5Options; lazy?: boolean },
+  options?: {
+    openVideos?: boolean;
+    h5?: OpenH5Options;
+    lazy?: boolean;
+    onProgress?: (current: number, total: number, message?: string) => void;
+  },
 ): Promise<Labels> {
   const streamMode = options?.h5?.stream ?? "auto";
   const openVideos = options?.openVideos ?? true;
@@ -78,6 +87,7 @@ export async function loadSlp(
         return await readSlpStreaming(streamingSource, {
           filenameHint: options?.h5?.filenameHint,
           openVideos,
+          onProgress: options?.onProgress,
         });
       } catch (e) {
         if (streamMode === "auto") {
@@ -94,9 +104,17 @@ export async function loadSlp(
 
   // Fall back to standard reader (Node.js, or browser without Worker support, or download mode)
   if (lazy) {
-    return readSlpLazy(source, { openVideos, h5: options?.h5 });
+    return readSlpLazy(source, {
+      openVideos,
+      h5: options?.h5,
+      onProgress: options?.onProgress,
+    });
   }
-  return readSlp(source, { openVideos, h5: options?.h5 });
+  return readSlp(source, {
+    openVideos,
+    h5: options?.h5,
+    onProgress: options?.onProgress,
+  });
 }
 
 /**

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -47,8 +47,9 @@ function isBrowserWithWorkerSupport(): boolean {
  * @param options.lazy - If true, use lazy loading for on-demand frame materialization (default: false)
  * @param options.onProgress - Optional callback fired as loading advances through
  *   its stages: (current, total, message?), where current/total count completed
- *   stages and message labels the stage about to run. Only the streaming reader
- *   currently emits these (the path used in browser/Tauri).
+ *   stages and message labels the stage about to run. Emitted by all reader
+ *   paths (streaming, eager, and lazy); the final call is (total, total,
+ *   "Finalizing"). Stage counts differ by path (streaming is finer-grained).
  * @returns Loaded Labels object
  */
 export async function loadSlp(

--- a/tests/codecs/slp-load-progress.test.ts
+++ b/tests/codecs/slp-load-progress.test.ts
@@ -154,7 +154,11 @@ describe("SLP load progress — onProgress callback", () => {
         onProgress: spy.onProgress,
       });
       const without = await loadSlp(PLAIN, { lazy: true, openVideos: false });
-      // Materialize lazy frames before fingerprinting (length forces it).
+      // Materialize lazy frames so labeledFrames is populated; a LazyFrameList
+      // reports length 0 until materialized, which would make the frame/instance
+      // comparison vacuous (0 === 0).
+      withSpy.materialize();
+      without.materialize();
       expect(fingerprint(withSpy)).toEqual(fingerprint(without));
       expect(spy.calls.length).toBeGreaterThan(0);
     });

--- a/tests/codecs/slp-load-progress.test.ts
+++ b/tests/codecs/slp-load-progress.test.ts
@@ -1,0 +1,212 @@
+/**
+ * LOAD PROGRESS — `onProgress` callback coverage for all three reader paths.
+ *
+ * PR #176 added an `onProgress?: (current, total, message?) => void` load
+ * callback. Originally only the streaming reader emitted; the eager (`readSlp`)
+ * and lazy (`readSlpLazy`) main-thread readers now emit too. Each path derives
+ * `total` from an ordered stage-label list (the single source of truth), so the
+ * number of distinct stage indices reported must equal `total`.
+ *
+ * These tests assert, for each path, the shared progress CONTRACT:
+ *   - onProgress is called at least once,
+ *   - `current` is monotonically non-decreasing from 0 to `total`,
+ *   - the final call is exactly `(total, total)`,
+ *   - the count of DISTINCT stage indices reported equals `total` (this pins the
+ *     stage list ↔ count: a drift would change the distinct count),
+ *   - every `message` is a non-empty string,
+ *   - `total` is identical across every call within a single load.
+ * Plus: progress is a pure side effect (Labels load identically with/without a
+ * spy), and the openVideos path emits an "Opening videos (i/n)" sub-message.
+ *
+ * The streaming reader is Worker/browser-gated and unreachable from the all-Node
+ * bun suite (the in-Worker `importScripts` global is absent, so
+ * `readSlpStreaming` throws "importScripts is not defined") — see
+ * tests/streaming-field-names.test.ts and tests/codecs/slp-crop-streaming.test.ts.
+ * The streaming case therefore ATTEMPTS the real path and asserts the contract
+ * only if the Worker runs (browser/CI); otherwise it is skipped.
+ */
+import { describe, it, expect } from "../bun-test";
+import { loadSlp } from "../../src/io/main.js";
+import { readSlpStreaming } from "../../src/codecs/slp/read-streaming.js";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+const PLAIN = path.join(fixtureRoot, "slp", "minimal_instance.slp");
+const EMBEDDED = path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp");
+
+/** A single recorded onProgress call. */
+type Call = { current: number; total: number; message?: string };
+
+/** A spy that records every onProgress call. */
+function makeProgressSpy(): {
+  onProgress: (current: number, total: number, message?: string) => void;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  return {
+    calls,
+    onProgress: (current, total, message) =>
+      calls.push({ current, total, message }),
+  };
+}
+
+/**
+ * Assert the shared progress contract over a recorded call list. `total` is the
+ * derived stage count the reader reported; the assertions pin both the shape of
+ * the progression and the stage-list ↔ count invariant.
+ */
+function assertProgressContract(calls: Call[]): void {
+  expect(calls.length).toBeGreaterThan(0);
+
+  // `total` identical across every call within the load.
+  const total = calls[0].total;
+  expect(total).toBeGreaterThan(0);
+  for (const c of calls) {
+    expect(c.total).toBe(total);
+  }
+
+  // Starts at 0, ends at total, monotonically non-decreasing.
+  expect(calls[0].current).toBe(0);
+  const last = calls[calls.length - 1];
+  expect(last.current).toBe(total);
+  expect(last.total).toBe(total);
+  for (let i = 1; i < calls.length; i++) {
+    expect(calls[i].current).toBeGreaterThanOrEqual(calls[i - 1].current);
+  }
+
+  // Every message is a non-empty string.
+  for (const c of calls) {
+    expect(typeof c.message).toBe("string");
+    expect((c.message ?? "").length).toBeGreaterThan(0);
+  }
+
+  // Distinct stage indices == total. The stages run at indices 0..total-1 plus a
+  // final (total, total) "Finalizing" call, so the distinct set is exactly
+  // {0, 1, ..., total}, of size total + 1. This pins the stage list ↔ count: if
+  // a stage were added/removed without updating the derived total, this breaks.
+  const distinct = new Set(calls.map((c) => c.current));
+  expect(distinct.size).toBe(total + 1);
+  for (let i = 0; i <= total; i++) {
+    expect(distinct.has(i)).toBe(true);
+  }
+}
+
+/** Lightweight structural fingerprint to assert progress is side-effect-free. */
+function fingerprint(labels: {
+  labeledFrames: { instances: unknown[] }[];
+  videos: unknown[];
+  skeletons: unknown[];
+  tracks: unknown[];
+}): {
+  frames: number;
+  instances: number;
+  videos: number;
+  skeletons: number;
+  tracks: number;
+} {
+  return {
+    frames: labels.labeledFrames.length,
+    instances: labels.labeledFrames.reduce((n, f) => n + f.instances.length, 0),
+    videos: labels.videos.length,
+    skeletons: labels.skeletons.length,
+    tracks: labels.tracks.length,
+  };
+}
+
+describe("SLP load progress — onProgress callback", () => {
+  describe("eager reader (readSlp via loadSlp)", () => {
+    it("emits a well-formed, monotonic progress sequence", async () => {
+      const spy = makeProgressSpy();
+      await loadSlp(PLAIN, { openVideos: false, onProgress: spy.onProgress });
+      assertProgressContract(spy.calls);
+    });
+
+    it("is a pure side effect: Labels match with and without a spy", async () => {
+      const spy = makeProgressSpy();
+      const withSpy = await loadSlp(PLAIN, {
+        openVideos: false,
+        onProgress: spy.onProgress,
+      });
+      const without = await loadSlp(PLAIN, { openVideos: false });
+      expect(fingerprint(withSpy)).toEqual(fingerprint(without));
+      expect(spy.calls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("lazy reader (readSlpLazy via loadSlp)", () => {
+    it("emits a well-formed, monotonic progress sequence", async () => {
+      const spy = makeProgressSpy();
+      await loadSlp(PLAIN, {
+        lazy: true,
+        openVideos: false,
+        onProgress: spy.onProgress,
+      });
+      assertProgressContract(spy.calls);
+    });
+
+    it("is a pure side effect: Labels match with and without a spy", async () => {
+      const spy = makeProgressSpy();
+      const withSpy = await loadSlp(PLAIN, {
+        lazy: true,
+        openVideos: false,
+        onProgress: spy.onProgress,
+      });
+      const without = await loadSlp(PLAIN, { lazy: true, openVideos: false });
+      // Materialize lazy frames before fingerprinting (length forces it).
+      expect(fingerprint(withSpy)).toEqual(fingerprint(without));
+      expect(spy.calls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("streaming reader (readSlpStreaming)", () => {
+    it("emits the same contract when the Worker is available (else skipped)", async () => {
+      const spy = makeProgressSpy();
+      const buf = readFileSync(PLAIN);
+      try {
+        await readSlpStreaming(new Uint8Array(buf).buffer as ArrayBuffer, {
+          openVideos: false,
+          filenameHint: "minimal_instance.slp",
+          onProgress: spy.onProgress,
+        });
+      } catch {
+        // Worker path unreachable in this Node runtime (importScripts absent) —
+        // documented in tests/streaming-field-names.test.ts. Skip the contract
+        // assertion; the eager/lazy cases cover the shared invariants in Node.
+        expect(spy.calls.length).toBe(0);
+        return;
+      }
+      assertProgressContract(spy.calls);
+    }, 120_000);
+  });
+
+  describe("openVideos sub-progress (embedded fixture)", () => {
+    it("eager reader emits an 'Opening videos (i/n)' message", async () => {
+      const spy = makeProgressSpy();
+      await loadSlp(EMBEDDED, {
+        openVideos: true,
+        onProgress: spy.onProgress,
+      });
+      assertProgressContract(spy.calls);
+      const hasOpening = spy.calls.some((c) =>
+        /Opening videos \(\d+\/\d+\)/.test(c.message ?? ""),
+      );
+      expect(hasOpening).toBe(true);
+    });
+
+    it("lazy reader emits an 'Opening videos (i/n)' message", async () => {
+      const spy = makeProgressSpy();
+      await loadSlp(EMBEDDED, {
+        lazy: true,
+        openVideos: true,
+        onProgress: spy.onProgress,
+      });
+      assertProgressContract(spy.calls);
+      const hasOpening = spy.calls.some((c) =>
+        /Opening videos \(\d+\/\d+\)/.test(c.message ?? ""),
+      );
+      expect(hasOpening).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional `onProgress?: (current, total, message?) => void` callback to `.slp` loading so a UI can render a load progress bar/spinner. The signature matches the existing `Labels.merge` / `RenderOptions.onProgress` convention.

## What emits

**All three reader paths now emit progress** (not just streaming):

- **Streaming** (`readFromStreamingFile`) — 10 stages (metadata, tracks, video metadata, suggestions, frames, instances, points, building frames, identities, sessions).
- **Eager** (`readSlp`) — 8 coarser stages (frames/instances/points read together under one build step).
- **Lazy** (`readSlpLazy`) — 8 stages (raw frame/instance/point columns read into a LazyDataStore; frames not materialized up front).

Each path derives `total` from an ordered stage-label array (single source of truth — no hardcoded count that can drift), reports at each stage start, and ends with `(total, total, "Finalizing")`. When `openVideos` is set, the bar holds at the video stage with an `"Opening videos (i/n)"` sub-message. Progress is a **pure side effect** — the loaded `Labels` is unchanged.

## Tests

`tests/codecs/slp-load-progress.test.ts` asserts the full contract (called; `current` monotonic 0→`total`; final `(total,total)`; distinct stage count == `total`; non-empty messages; `total` constant) for eager + lazy (run in Node), plus side-effect-freeness and the `openVideos` sub-progress on an embedded fixture. The streaming path uses the same mechanism but is Worker-gated in Node (consistent with the repo's other streaming tests), so it is asserted when a Worker is available.

## Docs

`docs/usage.md`: a runnable "Tracking load progress" example + the `onProgress` row in the `loadSlp` Options Reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm