### PR TITLE
build(bun): finalize Bun-only toolchain and add Biome lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,24 @@ jobs:
       - uses: actions/checkout@v5
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          # Single source of truth: read the pinned Bun from package.json's
+          # "packageManager" field instead of hardcoding it here.
+          bun-version-file: package.json
+      # uv is required by tests/python-compat-gen.test.ts, which shells out to
+      # `uv run --with sleap-io` to verify cross-language SLP compatibility.
       - uses: astral-sh/setup-uv@v7
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Lint
+      - name: Lint (types)
         run: bun run lint
+      - name: Check (Biome)
+        if: matrix.os == 'ubuntu-latest'
+        run: bun run check
       - name: Build
         run: bun run build
+      - name: Check package (publint + are-the-types-wrong)
+        if: matrix.os == 'ubuntu-latest'
+        run: bun run check:pack
       - name: Test with coverage
         run: bun run test:coverage
       - name: Upload coverage

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version-file: package.json
 
       - name: Install JS dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version-file: package.json
 
       - name: Install JS dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version-file: package.json
 
       # npm trusted publishing (OIDC, tokenless) requires npm >= 11.5.1.
       # Node 22 bundles npm 10.x, which can sign provenance but cannot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,21 +3,26 @@
 ## Toolchain
 
 This project uses [**Bun**](https://bun.com) as its package manager, script
-runner, and test runner. The version is pinned to **`bun@1.3.14`** via the
-`packageManager` field in `package.json`; please use that version locally to
-match CI. There is no npm/Node fallback in the dev workflow — the only place npm
-is still used is the release workflow's `npm publish` step (npm's OIDC trusted
-publishing and provenance are registry features Bun's publisher does not
-support).
+runner, and test runner. The Bun version is pinned in exactly one place — the
+`packageManager` field in `package.json` (**`bun@1.3.14`**). CI reads that same
+field via `setup-bun`'s `bun-version-file: package.json`, and a `preinstall`
+guard fails fast if the Bun running `bun install` locally doesn't match the pin,
+so local and CI never drift. There is no npm/Node fallback in the dev workflow —
+the only place npm is still used is the release workflow's `npm publish` step
+(npm's OIDC trusted publishing and provenance are registry features Bun's
+publisher does not support).
 
-[Install Bun](https://bun.com/docs/installation), then:
+[Install Bun](https://bun.com/docs/installation) (the pinned version), then:
 
 ```bash
 bun install              # install deps from the committed bun.lock
 bun run build            # bundle src/ to dist/ with tsup (ESM + d.ts)
 bun run lint             # type-check only: tsc -p tsconfig.json --noEmit
-bun test                 # run the unit suite
+bun run check            # lint check with Biome (no writes)
+bun run format           # apply Biome's safe lint fixes
+bun test                 # run the unit suite (tests/)
 bun run test:coverage    # run the suite and write coverage/lcov.info
+bun run check:pack       # validate the publishable tarball (publint + attw)
 ```
 
 `bun install --frozen-lockfile` (what CI runs) installs exactly what `bun.lock`
@@ -35,12 +40,42 @@ nothing new is blocked:
 bun pm untrusted         # should report 0 untrusted dependencies with scripts
 ```
 
+### Linting & formatting
+
+[**Biome**](https://biomejs.dev) is the linter (config in `biome.json`, scoped to
+`src/` and `tests/`, version pinned **exactly** in `package.json` so local and CI
+never drift on lint rules). `bun run check` is the read-only lint gate CI runs;
+`bun run format` applies Biome's safe lint fixes. Two recommended rules are
+disabled because they fight intentional patterns in this parsing-heavy codebase:
+`noExplicitAny` (untyped HDF5/JSON payloads) and `noNonNullAssertion`. Biome also
+reports a number of pre-existing warnings (e.g. unused imports, `noGlobalIsNan`);
+these are non-blocking and fine to clean up incrementally — note `noGlobalIsNan`
+is **not** auto-fixed because `isNaN` and `Number.isNaN` differ in coercion
+semantics.
+
+Biome's **formatter is intentionally disabled** for now (`formatter.enabled:
+false` in `biome.json`). Turning it on reflows nearly every file, so that churn is
+deferred to a dedicated follow-up PR — flip `formatter.enabled` to `true` and run
+`bun run format` — to keep this Bun migration reviewable.
+
+### Publishable-package check
+
+`bun run check:pack` runs [`publint`](https://publint.dev) and
+[`@arethetypeswrong/cli`](https://arethetypes.wrong) against the built `dist/` to
+catch broken `exports`/`types` conditions or accidental `bun:`/Node-only imports
+before they reach consumers. It uses the `esm-only` attw profile (the package is
+intentionally ESM-only, so the CJS/`node10` resolutions are expected and
+ignored). Run `bun run build` first.
+
 ## Tests
 
 The suite lives in `tests/**/*.test.ts` and runs on Bun's native test runner.
 
-- **`bun test --parallel`** is the configured `test` script. `--parallel` runs
-  each test file in its own worker process (implying `--isolate`). That process
+- **`bun test --parallel ./tests/`** is the configured `test` script. The
+  explicit `./tests/` path scopes discovery to the suite so stray `*.test.ts` /
+  `*.spec.ts` files elsewhere in a working tree (e.g. a local `scratch/`) aren't
+  picked up. `--parallel` runs each test file in its own worker process
+  (implying `--isolate`). That process
   isolation is required: the mediabunny/mp4box backend tests use `mock.module`
   (via the `vi` shim), and Bun's module mocks are process-global and cannot be
   undone — without a fresh process per file they would leak into the real-WebM
@@ -65,6 +100,8 @@ tests have already passed. It does not affect the test results or the exit code
 ## Submitting changes
 
 1. Branch off `main`.
-2. Make sure `bun run lint`, `bun run build`, and `bun test` all pass.
-3. Open a PR. CI runs lint + build + the coverage suite on both Ubuntu and
-   Windows with `bun@1.3.14`.
+2. Make sure `bun run lint`, `bun run check`, `bun run build`, `bun test`, and
+   `bun run check:pack` all pass.
+3. Open a PR. CI runs lint, the Biome check, build, the package check, and the
+   coverage suite (lint/build/coverage on both Ubuntu and Windows) with the Bun
+   version pinned in `packageManager`.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": ["src/**", "tests/**", "!tests/data"]
+  },
+  "formatter": {
+    "enabled": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "off"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "yaml": "^2.6.1",
       },
       "devDependencies": {
+        "@biomejs/biome": "2.5.1",
         "@types/bun": "^1.3.14",
         "@types/node": "^22.10.5",
         "@types/pako": "^2.0.4",
@@ -30,6 +31,24 @@
     "esbuild",
   ],
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],

--- a/demo/README.md
+++ b/demo/README.md
@@ -5,13 +5,13 @@
 1. Build the package:
 
 ```bash
-npm run build
+bun run build
 ```
 
 2. Serve the repo root (needs static server for module imports):
 
 ```bash
-npx serve -p 8080 --cors --no-clipboard
+bunx serve -p 8080 --cors --no-clipboard
 ```
 
 3. Open the demo page:

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ JavaScript/TypeScript utilities for reading and writing SLEAP `.slp` files with 
 ## Quick start
 
 ```bash
-npm install
-npm run build
+bun install
+bun run build
 ```
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -28,10 +28,14 @@
     "url": "https://github.com/talmolab/sleap-io.js.git"
   },
   "scripts": {
+    "preinstall": "node -e \"const fs=require('fs');if(!fs.existsSync('bunfig.toml'))process.exit(0);const ua=process.env.npm_config_user_agent||'';const m=ua.match(/bun[/](\\d+\\.\\d+\\.\\d+)/);if(!m)process.exit(0);const want=require('./package.json').packageManager.split('@')[1];if(m[1]!==want){console.error('\\nError: Bun '+want+' is required (package.json packageManager) but Bun '+m[1]+' is running.\\nInstall the pinned version with:\\n  curl -fsSL https://bun.com/install | bash -s bun-v'+want+'\\n');process.exit(1);}\"",
     "build": "tsup src/index.ts src/index.browser.ts src/lite.ts --format esm --dts --external skia-canvas --external mediabunny --external tiff",
-    "test": "bun test --parallel",
-    "test:coverage": "bun test --parallel --coverage",
-    "lint": "tsc -p tsconfig.json --noEmit"
+    "test": "bun test --parallel ./tests/",
+    "test:coverage": "bun test --parallel --coverage ./tests/",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "check": "biome check .",
+    "format": "biome check --write .",
+    "check:pack": "bunx publint && bunx @arethetypeswrong/cli@latest --pack --profile esm-only"
   },
   "dependencies": {
     "h5wasm": "^0.10.2",
@@ -46,6 +50,7 @@
     "tiff": "^7.1.3"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.1",
     "@types/bun": "^1.3.14",
     "@types/node": "^22.10.5",
     "@types/pako": "^2.0.4",

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -820,7 +820,9 @@ function writeIdentities(file: any, identities: Identity[]): void {
 
 function writeSessions(file: any, sessions: RecordingSession[], videos: Video[], labeledFrames: LabeledFrame[], identities?: Identity[]): void {
   const labeledFrameIndex = new Map<LabeledFrame, number>();
-  labeledFrames.forEach((lf, idx) => labeledFrameIndex.set(lf, idx));
+  labeledFrames.forEach((lf, idx) => {
+    labeledFrameIndex.set(lf, idx);
+  });
 
   const payload = sessions.map((session) => JSON.stringify(serializeSession(session, videos, labeledFrameIndex, identities)));
   file.create_dataset({ name: "sessions_json", data: payload });
@@ -1392,7 +1394,9 @@ function writeMasks(
   // from_predicted). Keyed by the object itself (object identity) — the JS
   // analog of Python's id(mask).
   const maskIdToIdx = new Map<SegmentationMask, number>();
-  masks.forEach((m, i) => maskIdToIdx.set(m, i));
+  masks.forEach((m, i) => {
+    maskIdToIdx.set(m, i);
+  });
 
   for (let i = 0; i < masks.length; i++) {
     const mask = masks[i];

--- a/src/io/analysis-h5.ts
+++ b/src/io/analysis-h5.ts
@@ -864,7 +864,9 @@ export function toAnalysisArrays(
   } else {
     nTracks = labels.tracks.length;
     trackToSlot = new Map<Track, number>();
-    labels.tracks.forEach((track, i) => trackToSlot!.set(track, i));
+    labels.tracks.forEach((track, i) => {
+      trackToSlot!.set(track, i);
+    });
   }
 
   // Canonical-shape matrices.
@@ -886,7 +888,9 @@ export function toAnalysisArrays(
     const slotted: Array<[number, InstanceLike]> = [];
     if (untracked) {
       const insts = untrackedFrameInstances(lf, isSingleInstance);
-      insts.forEach((inst, i) => slotted.push([i, inst]));
+      insts.forEach((inst, i) => {
+        slotted.push([i, inst]);
+      });
     } else {
       for (const [track, inst] of trackedFrameInstances(lf)) {
         const slot = trackToSlot!.get(track);

--- a/src/io/ultralytics.ts
+++ b/src/io/ultralytics.ts
@@ -107,7 +107,9 @@ export function classNamesFromConfig(config: Record<string, unknown>): Map<numbe
   const raw = config["names"];
   const result = new Map<number, string>();
   if (Array.isArray(raw)) {
-    raw.forEach((name, i) => result.set(i, String(name)));
+    raw.forEach((name, i) => {
+      result.set(i, String(name));
+    });
   } else if (raw && typeof raw === "object") {
     for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
       const id = Number(k);
@@ -602,7 +604,9 @@ function buildClassNames(categories: string[]): Map<number, string> {
     result.set(0, "object");
     return result;
   }
-  distinct.forEach((name, i) => result.set(i, name));
+  distinct.forEach((name, i) => {
+    result.set(i, name);
+  });
   return result;
 }
 

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -2370,7 +2370,9 @@ export class Labels {
 
     // Keep the track list in the same relative order as the source by NAME.
     const trackToInd = new Map<string, number>();
-    this.tracks.forEach((t, i) => trackToInd.set(t.name, i));
+    this.tracks.forEach((t, i) => {
+      trackToInd.set(t.name, i);
+    });
     labels.tracks = labels.tracks
       .map((t, i) => [t, i] as const)
       .sort((a, b) => {
@@ -2382,7 +2384,9 @@ export class Labels {
 
     // Keep the skeleton list in source order by NAME.
     const skelToInd = new Map<string, number>();
-    this.skeletons.forEach((s, i) => skelToInd.set(s.name ?? "", i));
+    this.skeletons.forEach((s, i) => {
+      skelToInd.set(s.name ?? "", i);
+    });
     labels.skeletons = labels.skeletons
       .map((s, i) => [s, i] as const)
       .sort((a, b) => {

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -502,7 +502,9 @@ function extractSourceData(
     }
     const tracks = Array.from(trackSet);
     const trackIndexMap = new Map<Track, number>();
-    tracks.forEach((t, i) => trackIndexMap.set(t, i));
+    tracks.forEach((t, i) => {
+      trackIndexMap.set(t, i);
+    });
 
     return {
       instances,
@@ -527,7 +529,9 @@ function extractSourceData(
     }
     const tracks = Array.from(trackSet);
     const trackIndexMap = new Map<Track, number>();
-    tracks.forEach((t, i) => trackIndexMap.set(t, i));
+    tracks.forEach((t, i) => {
+      trackIndexMap.set(t, i);
+    });
 
     // Try to get video dimensions
     let frameSize: [number, number] = [options.width ?? 0, options.height ?? 0];
@@ -557,7 +561,9 @@ function extractSourceData(
   if (labels.labeledFrames.length === 0) {
     const tracks = labels.tracks ?? [];
     const trackIndexMap = new Map<Track, number>();
-    tracks.forEach((t, i) => trackIndexMap.set(t, i));
+    tracks.forEach((t, i) => {
+      trackIndexMap.set(t, i);
+    });
     return {
       instances: [],
       skeleton: labels.skeletons?.[0] ?? null,
@@ -590,7 +596,9 @@ function extractSourceData(
 
   const tracks = labels.tracks ?? [];
   const trackIndexMap = new Map<Track, number>();
-  tracks.forEach((t, i) => trackIndexMap.set(t, i));
+  tracks.forEach((t, i) => {
+    trackIndexMap.set(t, i);
+  });
 
   return {
     instances: firstFrame.instances,

--- a/src/video/embedded-frame.ts
+++ b/src/video/embedded-frame.ts
@@ -351,7 +351,8 @@ export async function readEmbeddedFrameBytes(
 
   // 1D concatenated with known sizes: exact byte-range slice.
   if (layout === "concat" && reader.frameSizes && reader.frameSizes.length > index) {
-    const offsets = (reader.legacy.offsets ??= computeOffsetsFromSizes(reader.frameSizes));
+    reader.legacy.offsets ??= computeOffsetsFromSizes(reader.frameSizes);
+    const offsets = reader.legacy.offsets;
     const start = offsets[index];
     const end = start + reader.frameSizes[index];
     const { value } = await reader.readSlice([[start, end]]);

--- a/src/video/mp4box-video.ts
+++ b/src/video/mp4box-video.ts
@@ -112,14 +112,15 @@ export class Mp4BoxVideoBackend implements VideoBackend {
 
     this.latestRequestedFrame = frameIndex;
 
-    await (this.decodeQueue = this.decodeQueue.then(async () => {
+    this.decodeQueue = this.decodeQueue.then(async () => {
       if (this.latestRequestedFrame !== frameIndex) return;
       if (signal?.aborted) return;
 
       const keyframe = this.findKeyframeBefore(frameIndex);
       const end = Math.min(frameIndex + this.lookahead, this.samples.length - 1);
       await this.decodeRange(keyframe, end, frameIndex);
-    }));
+    });
+    await this.decodeQueue;
 
     return this.cache.get(frameIndex) ?? null;
   }
@@ -138,7 +139,9 @@ export class Mp4BoxVideoBackend implements VideoBackend {
       }
     }
     this.decoder = null;
-    this.cache.forEach((bitmap) => bitmap.close());
+    this.cache.forEach((bitmap) => {
+      bitmap.close();
+    });
     this.cache.clear();
     this.fileBlob = null;
   }

--- a/tests/codecs/dictionary.test.ts
+++ b/tests/codecs/dictionary.test.ts
@@ -52,7 +52,9 @@ describe("dictionary codec", () => {
     const labels = await loadFixture("typical.slp");
     const video = labels.videos[0];
     const filtered = toDict(labels, { video });
-    filtered.labeled_frames.forEach((frame) => expect(frame.video_idx).toBe(0));
+    filtered.labeled_frames.forEach((frame) => {
+      expect(frame.video_idx).toBe(0);
+    });
 
     const nonEmptyCount = labels.labeledFrames.filter((lf) => lf.instances.length > 0).length;
     const skipped = toDict(labels, { skipEmptyFrames: true });

--- a/tests/model/labels-merge.test.ts
+++ b/tests/model/labels-merge.test.ts
@@ -834,7 +834,7 @@ describe("Labels.merge — samefile matching (GROUP H)", () => {
     labels.videos = [videoA];
 
     const originalCwd = process.cwd();
-    let result;
+    let result: Awaited<ReturnType<typeof labels.merge>>;
     try {
       process.chdir(tmp);
       const relativePath = path.join("data", "video.mp4");


### PR DESCRIPTION
## What & why

The repo was already ~90% on Bun (installs, scripts, tests). This closes the remaining gaps so **Bun is the single dev toolchain**, and adds **Biome** as a linter. The primary goal of this PR is to **verify the GitHub Actions workflows** under the new setup.

> **This is PR 1 of 2.** Biome's *formatter* is intentionally disabled here (`formatter.enabled: false`) because turning it on reflows nearly every file (~7.6k lines). That whole-repo reformat is deferred to a dedicated follow-up PR so this migration stays reviewable.

## Toolchain changes
- **Single-source Bun pin:** the version lives only in `package.json` `"packageManager"` (`bun@1.3.14`); CI reads it via `setup-bun`'s `bun-version-file: package.json`. A `preinstall` guard fails fast if a mismatched Bun runs `bun install` locally — it's gated on `bunfig.toml` (excluded from the published tarball), so it **no-ops for consumers**.
- **Scoped test scripts** to `./tests/` so stray `*.test.ts` elsewhere in a working tree aren't picked up.
- **`bun run check:pack`** — validates the publishable tarball with `publint` + `are-the-types-wrong` (esm-only profile).
- **Workflows/docs moved to Bun.** `npm` is kept *only* for `npm publish` (OIDC trusted publishing + provenance, unsupported by `bun publish`); `uv` is kept *only* for the Python cross-compat test — each with an explanatory comment.

## Biome (lint-only)
- `@biomejs/biome` pinned **exactly** to `2.5.1` (linters shouldn't drift between local and CI). Config scoped to `src/` + `tests/`.
- Disabled `noExplicitAny` + `noNonNullAssertion` (intentional in this parsing-heavy codebase).
- Fixed the **16 real lint errors** Biome surfaced — all behavior-preserving:
  - `useIterableCallbackReturn` — `forEach` callbacks with implicit returns → block bodies (13×)
  - `noAssignInExpressions` — split assign-then-await / assign-then-read (2×)
  - `noImplicitAnyLet` — typed a bare `let` (1×)

## What CI should confirm here
- `setup-bun` resolves the pin via `bun-version-file` on **Ubuntu + Windows**
- `bun install --frozen-lockfile` (lockfile diff is Biome-only; esbuild & transitive build deps unchanged)
- New **Biome lint** + **check:pack** steps (Ubuntu)
- The **uv-dependent** Python cross-compat test still runs
- The docs / PR-preview workflows

## Local verification (all green)
`frozen install + guard` · `0 untrusted deps` · `tsc` · `biome check` · `tsup build` (9 dist files, browser-isolated) · `check:pack` (🟢 esm-only) · **1286 pass / 1 skip / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)