### PR TITLE
style: enable Biome formatter and reformat src + tests

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Bulk-reformatting commits to skip in `git blame`.
+#
+# Opt in locally (one-time):
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# (GitHub applies this file automatically in its blame view.)
+#
+# Enable Biome formatter + reformat src/ and tests/.
+# The squash-merge commit hash is added here once this PR lands on main:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ publisher does not support).
 bun install              # install deps from the committed bun.lock
 bun run build            # bundle src/ to dist/ with tsup (ESM + d.ts)
 bun run lint             # type-check only: tsc -p tsconfig.json --noEmit
-bun run check            # lint check with Biome (no writes)
-bun run format           # apply Biome's safe lint fixes
+bun run check            # lint + format check with Biome (no writes)
+bun run format           # apply Biome formatting + safe lint fixes
 bun test                 # run the unit suite (tests/)
 bun run test:coverage    # run the suite and write coverage/lcov.info
 bun run check:pack       # validate the publishable tarball (publint + attw)
@@ -42,21 +42,23 @@ bun pm untrusted         # should report 0 untrusted dependencies with scripts
 
 ### Linting & formatting
 
-[**Biome**](https://biomejs.dev) is the linter (config in `biome.json`, scoped to
-`src/` and `tests/`, version pinned **exactly** in `package.json` so local and CI
-never drift on lint rules). `bun run check` is the read-only lint gate CI runs;
-`bun run format` applies Biome's safe lint fixes. Two recommended rules are
-disabled because they fight intentional patterns in this parsing-heavy codebase:
+[**Biome**](https://biomejs.dev) is the linter/formatter (config in `biome.json`,
+scoped to `src/` and `tests/`, version pinned **exactly** in `package.json` so
+local and CI never drift on rules or formatting). `bun run check` is the read-only
+gate CI runs (lint + formatting); `bun run format` applies Biome's formatting and
+safe lint fixes. The formatter uses 2-space indent, 80-column width, double
+quotes, semicolons, and trailing commas. Two recommended lint rules are disabled
+because they fight intentional patterns in this parsing-heavy codebase:
 `noExplicitAny` (untyped HDF5/JSON payloads) and `noNonNullAssertion`. Biome also
 reports a number of pre-existing warnings (e.g. unused imports, `noGlobalIsNan`);
 these are non-blocking and fine to clean up incrementally — note `noGlobalIsNan`
 is **not** auto-fixed because `isNaN` and `Number.isNaN` differ in coercion
 semantics.
 
-Biome's **formatter is intentionally disabled** for now (`formatter.enabled:
-false` in `biome.json`). Turning it on reflows nearly every file, so that churn is
-deferred to a dedicated follow-up PR — flip `formatter.enabled` to `true` and run
-`bun run format` — to keep this Bun migration reviewable.
+The whole `src/` + `tests/` tree was reformatted in one commit when the formatter
+was enabled; that commit is listed in `.git-blame-ignore-revs` so `git blame`
+skips it (configure once with `git config blame.ignoreRevsFile
+.git-blame-ignore-revs`).
 
 ### Publishable-package check
 

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,7 @@
     "includes": ["src/**", "tests/**", "!tests/data"]
   },
   "formatter": {
-    "enabled": false,
+    "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 80

--- a/src/codecs/dictionary.ts
+++ b/src/codecs/dictionary.ts
@@ -1,6 +1,12 @@
 import { Labels } from "../model/labels.js";
 import { LabeledFrame } from "../model/labeled-frame.js";
-import { Instance, PredictedInstance, Track, pointsFromArray, predictedPointsFromArray } from "../model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+  pointsFromArray,
+  predictedPointsFromArray,
+} from "../model/instance.js";
 import { Skeleton, Edge, Node, Symmetry } from "../model/skeleton.js";
 import { Video } from "../model/video.js";
 import { SuggestionFrame } from "../model/suggestions.js";
@@ -34,7 +40,7 @@ export type LabelsDict = {
 
 export function toDict(
   labels: Labels,
-  options?: { video?: Video | number; skipEmptyFrames?: boolean }
+  options?: { video?: Video | number; skipEmptyFrames?: boolean },
 ): LabelsDict {
   const videoFilter = resolveVideoFilter(labels, options?.video);
   const videos = videoFilter ? [videoFilter.video] : labels.videos;
@@ -47,10 +53,12 @@ export function toDict(
       skeleton.index(edge.source.name),
       skeleton.index(edge.destination.name),
     ]);
-    const symmetries: Array<[number, number]> = skeleton.symmetries.map((sym) => {
-      const [left, right] = sym.nodes;
-      return [skeleton.index(left.name), skeleton.index(right.name)];
-    });
+    const symmetries: Array<[number, number]> = skeleton.symmetries.map(
+      (sym) => {
+        const [left, right] = sym.nodes;
+        return [skeleton.index(left.name), skeleton.index(right.name)];
+      },
+    );
     return {
       name: skeleton.name ?? undefined,
       nodes: skeleton.nodeNames,
@@ -61,20 +69,31 @@ export function toDict(
 
   const labeledFrames: LabelsDict["labeled_frames"] = [];
   for (const frame of labels.labeledFrames) {
-    if (videoFilter && !frame.video.matchesPath(videoFilter.video, true)) continue;
-    if (options?.skipEmptyFrames && frame.instances.length === 0 && !frame.isNegative) continue;
+    if (videoFilter && !frame.video.matchesPath(videoFilter.video, true))
+      continue;
+    if (
+      options?.skipEmptyFrames &&
+      frame.instances.length === 0 &&
+      !frame.isNegative
+    )
+      continue;
     const videoIdx = videos.indexOf(frame.video);
     if (videoIdx < 0) continue;
     labeledFrames.push({
       frame_idx: frame.frameIdx,
       video_idx: videoIdx,
-      instances: frame.instances.map((instance) => instanceToDict(instance, labels, trackIndex)),
+      instances: frame.instances.map((instance) =>
+        instanceToDict(instance, labels, trackIndex),
+      ),
       ...(frame.isNegative ? { is_negative: true } : {}),
     });
   }
 
   const suggestions = labels.suggestions
-    .filter((suggestion) => !videoFilter || suggestion.video.matchesPath(videoFilter.video, true))
+    .filter(
+      (suggestion) =>
+        !videoFilter || suggestion.video.matchesPath(videoFilter.video, true),
+    )
     .map((suggestion) => ({
       frame_idx: suggestion.frameIdx,
       video_idx: videos.indexOf(suggestion.video),
@@ -83,7 +102,9 @@ export function toDict(
 
   const videoDicts = videos.map((video) => {
     const backendType = resolveBackendType(video);
-    const backend: Record<string, unknown> | undefined = backendType ? { type: backendType } : undefined;
+    const backend: Record<string, unknown> | undefined = backendType
+      ? { type: backendType }
+      : undefined;
     const shape = video.shape ? Array.from(video.shape) : undefined;
     const fps = video.fps ?? undefined;
     return {
@@ -110,26 +131,43 @@ export function fromDict(data: LabelsDict): Labels {
 
   const skeletons = data.skeletons.map((skeleton) => {
     const nodes = skeleton.nodes.map((name) => new Node(name));
-    const edges = skeleton.edges.map(([sourceIdx, destIdx]) => new Edge(nodes[sourceIdx], nodes[destIdx]));
+    const edges = skeleton.edges.map(
+      ([sourceIdx, destIdx]) => new Edge(nodes[sourceIdx], nodes[destIdx]),
+    );
     const symmetries = (skeleton.symmetries ?? []).map(
-      ([leftIdx, rightIdx]) => new Symmetry([nodes[leftIdx], nodes[rightIdx]])
+      ([leftIdx, rightIdx]) => new Symmetry([nodes[leftIdx], nodes[rightIdx]]),
     );
     return new Skeleton({ name: skeleton.name, nodes, edges, symmetries });
   });
 
-  const videos = data.videos.map((video) => new Video({ filename: video.filename }));
-  const tracks = data.tracks.map((track) => new Track(String(track.name ?? "")));
+  const videos = data.videos.map(
+    (video) => new Video({ filename: video.filename }),
+  );
+  const tracks = data.tracks.map(
+    (track) => new Track(String(track.name ?? "")),
+  );
 
   const labeledFrames = data.labeled_frames.map((frame) => {
     const video = videos[frame.video_idx];
-    const instances = frame.instances.map((inst) => dictToInstance(inst, skeletons, tracks));
-    return new LabeledFrame({ video, frameIdx: frame.frame_idx, instances, isNegative: frame.is_negative ?? false });
+    const instances = frame.instances.map((inst) =>
+      dictToInstance(inst, skeletons, tracks),
+    );
+    return new LabeledFrame({
+      video,
+      frameIdx: frame.frame_idx,
+      instances,
+      isNegative: frame.is_negative ?? false,
+    });
   });
 
   const suggestions = data.suggestions.map((suggestion) => {
     const entry = suggestion as Record<string, unknown>;
     const video = videos[(entry.video_idx as number | undefined) ?? 0];
-    return new SuggestionFrame({ video, frameIdx: (entry.frame_idx as number) ?? 0, metadata: entry });
+    return new SuggestionFrame({
+      video,
+      frameIdx: (entry.frame_idx as number) ?? 0,
+      metadata: entry,
+    });
   });
 
   return new Labels({
@@ -169,7 +207,7 @@ function collectTracks(labels: Labels, video?: Video): Track[] {
 function instanceToDict(
   instance: Instance | PredictedInstance,
   labels: Labels,
-  trackIndex: Map<Track, number>
+  trackIndex: Map<Track, number>,
 ): Record<string, unknown> {
   const skeletonIdx = labels.skeletons.indexOf(instance.skeleton);
   const isPredicted = instance instanceof PredictedInstance;
@@ -214,14 +252,17 @@ function instanceToDict(
 function dictToInstance(
   data: Record<string, unknown>,
   skeletons: Skeleton[],
-  tracks: Track[]
+  tracks: Track[],
 ): Instance | PredictedInstance {
   const type = data.type === "predicted_instance" ? "predicted" : "instance";
-  const skeleton = skeletons[(data.skeleton_idx as number) ?? 0] ?? skeletons[0];
+  const skeleton =
+    skeletons[(data.skeleton_idx as number) ?? 0] ?? skeletons[0];
   const trackIdx = data.track_idx as number | undefined;
   const track = trackIdx !== undefined ? tracks[trackIdx] : undefined;
 
-  const points = Array.isArray(data.points) ? (data.points as Array<Record<string, unknown>>) : [];
+  const points = Array.isArray(data.points)
+    ? (data.points as Array<Record<string, unknown>>)
+    : [];
   if (type === "predicted") {
     const pointRows = points.map((point) => [
       Number(point.x),
@@ -270,7 +311,15 @@ function trackToDict(track: Track): Record<string, unknown> {
 }
 
 function validateDict(data: LabelsDict): void {
-  const required = ["version", "skeletons", "videos", "tracks", "labeled_frames", "suggestions", "provenance"] as const;
+  const required = [
+    "version",
+    "skeletons",
+    "videos",
+    "tracks",
+    "labeled_frames",
+    "suggestions",
+    "provenance",
+  ] as const;
   for (const key of required) {
     if (!(key in data)) {
       throw new Error(`Missing required key: ${key}`);

--- a/src/codecs/numpy.ts
+++ b/src/codecs/numpy.ts
@@ -1,6 +1,10 @@
 import { Labels } from "../model/labels.js";
 import { LabeledFrame } from "../model/labeled-frame.js";
-import { PredictedInstance, Track, predictedPointsFromArray } from "../model/instance.js";
+import {
+  PredictedInstance,
+  Track,
+  predictedPointsFromArray,
+} from "../model/instance.js";
 import { Skeleton } from "../model/skeleton.js";
 import { Video } from "../model/video.js";
 
@@ -17,7 +21,7 @@ import { Video } from "../model/video.js";
  */
 export function toNumpy(
   labels: Labels,
-  options?: { returnConfidence?: boolean; video?: Video; numFrames?: number }
+  options?: { returnConfidence?: boolean; video?: Video; numFrames?: number },
 ): number[][][][] {
   return labels.numpy({
     returnConfidence: options?.returnConfidence,
@@ -36,7 +40,7 @@ export function fromNumpy(
     returnConfidence?: boolean;
     trackNames?: string[];
     firstFrame?: number;
-  }
+  },
 ): Labels {
   if (data.length === 0 || data[0].length === undefined) {
     throw new Error("Input array must have 4 dimensions.");
@@ -66,7 +70,7 @@ export function labelsFromNumpy(
     trackNames?: string[];
     firstFrame?: number;
     returnConfidence?: boolean;
-  }
+  },
 ): Labels {
   const frameCount = data.length;
   if (!frameCount || data[0].length === undefined) {
@@ -78,7 +82,9 @@ export function labelsFromNumpy(
     throw new Error("Input array must have node dimension.");
   }
 
-  const trackNames = options.trackNames ?? Array.from({ length: trackCount }, (_, idx) => `track${idx}`);
+  const trackNames =
+    options.trackNames ??
+    Array.from({ length: trackCount }, (_, idx) => `track${idx}`);
   const tracks = trackNames.map((name) => new Track(name));
   const labeledFrames: LabeledFrame[] = [];
   const startFrame = options.firstFrame ?? 0;
@@ -88,7 +94,9 @@ export function labelsFromNumpy(
     for (let trackIdx = 0; trackIdx < trackCount; trackIdx += 1) {
       const points = data[frameIdx][trackIdx];
       if (!points) continue;
-      const hasData = points.some((point) => point.some((value) => !Number.isNaN(value)));
+      const hasData = points.some((point) =>
+        point.some((value) => !Number.isNaN(value)),
+      );
       if (!hasData) continue;
 
       const arrayPoints = points.map((point) => {
@@ -99,18 +107,23 @@ export function labelsFromNumpy(
       });
 
       const instance = new PredictedInstance({
-        points: predictedPointsFromArray(arrayPoints, options.skeleton.nodeNames),
+        points: predictedPointsFromArray(
+          arrayPoints,
+          options.skeleton.nodeNames,
+        ),
         skeleton: options.skeleton,
         track: tracks[trackIdx],
       });
       instances.push(instance);
     }
 
-    labeledFrames.push(new LabeledFrame({
-      video: options.video,
-      frameIdx: startFrame + frameIdx,
-      instances,
-    }));
+    labeledFrames.push(
+      new LabeledFrame({
+        video: options.video,
+        frameIdx: startFrame + frameIdx,
+        instances,
+      }),
+    );
   }
 
   return new Labels({
@@ -121,9 +134,14 @@ export function labelsFromNumpy(
   });
 }
 
-function resolveSkeleton(options: { skeleton?: Skeleton; skeletons?: Skeleton[] | Skeleton }): Skeleton {
+function resolveSkeleton(options: {
+  skeleton?: Skeleton;
+  skeletons?: Skeleton[] | Skeleton;
+}): Skeleton {
   if (options.skeleton) return options.skeleton;
-  if (Array.isArray(options.skeletons) && options.skeletons.length) return options.skeletons[0];
-  if (options.skeletons && !Array.isArray(options.skeletons)) return options.skeletons;
+  if (Array.isArray(options.skeletons) && options.skeletons.length)
+    return options.skeletons[0];
+  if (options.skeletons && !Array.isArray(options.skeletons))
+    return options.skeletons;
   throw new Error("fromNumpy requires a skeleton.");
 }

--- a/src/codecs/skeleton-json.ts
+++ b/src/codecs/skeleton-json.ts
@@ -39,7 +39,7 @@ interface JsonPickleSkeletonData {
  * We use separate ID registries for nodes and edge types to handle both.
  */
 export function readSkeletonJson(
-  json: string | Record<string, unknown>
+  json: string | Record<string, unknown>,
 ): Skeleton {
   const data: JsonPickleSkeletonData =
     typeof json === "string"
@@ -54,7 +54,8 @@ export function readSkeletonJson(
 
   // Detect format: check if any link source/target uses py/id
   const usesSharedNodeRefs = data.links.some(
-    (link) => link.source["py/id"] !== undefined || link.target["py/id"] !== undefined
+    (link) =>
+      link.source["py/id"] !== undefined || link.target["py/id"] !== undefined,
   );
 
   // Edge type registry (separate from node registry for duplicate-object format)
@@ -142,7 +143,8 @@ export function readSkeletonJson(
         }
       }
     }
-    nodeNames = orderedNames.length === nodeNameSet.size ? orderedNames : allNodeNames;
+    nodeNames =
+      orderedNames.length === nodeNameSet.size ? orderedNames : allNodeNames;
   } else {
     // Duplicate-object format or no links at all.
     // Check nodes array for any py/object definitions not seen in links.
@@ -163,7 +165,7 @@ export function readSkeletonJson(
   const nodeMap = new Map(nodes.map((n) => [n.name, n]));
 
   const edges = edgePairs.map(
-    ([src, dst]) => new Edge(nodeMap.get(src)!, nodeMap.get(dst)!)
+    ([src, dst]) => new Edge(nodeMap.get(src)!, nodeMap.get(dst)!),
   );
 
   // Deduplicate symmetries (each pair appears twice in jsonpickle format)
@@ -258,7 +260,7 @@ function encodeSkeleton(skeleton: Skeleton): JsonPickleSkeletonData {
   const nodes = skeleton.nodes.map((node) =>
     linkedNodes.has(node.name)
       ? { id: { "py/id": nodePyId.get(node.name)! } }
-      : { id: encodeNode(node.name) }
+      : { id: encodeNode(node.name) },
   );
 
   return {

--- a/src/codecs/skeleton-yaml.ts
+++ b/src/codecs/skeleton-yaml.ts
@@ -1,13 +1,24 @@
 import YAML from "yaml";
-import { Skeleton, Node, Edge, Symmetry, NodeOrIndex } from "../model/skeleton.js";
+import {
+  Skeleton,
+  Node,
+  Edge,
+  Symmetry,
+  NodeOrIndex,
+} from "../model/skeleton.js";
 
 type YAMLNodeEntry = { name: string } | string;
 
 type YAMLEdgeEntry =
-  | { source: { name: string } | string; destination: { name: string } | string }
+  | {
+      source: { name: string } | string;
+      destination: { name: string } | string;
+    }
   | [NodeOrIndex, NodeOrIndex];
 
-type YAMLSymmetryEntry = Array<{ name: string } | string> | [NodeOrIndex, NodeOrIndex];
+type YAMLSymmetryEntry =
+  | Array<{ name: string } | string>
+  | [NodeOrIndex, NodeOrIndex];
 
 type YAMLSkeletonData = {
   nodes: YAMLNodeEntry[];
@@ -28,7 +39,10 @@ function resolveName(value: { name?: string } | string): string {
   throw new Error("Invalid name reference in skeleton YAML.");
 }
 
-function decodeSkeleton(data: YAMLSkeletonData, fallbackName?: string): Skeleton {
+function decodeSkeleton(
+  data: YAMLSkeletonData,
+  fallbackName?: string,
+): Skeleton {
   if (!data?.nodes) throw new Error("Skeleton YAML missing nodes.");
   const nodes = data.nodes.map((entry) => new Node(getNodeName(entry)));
 
@@ -54,7 +68,8 @@ function decodeSkeleton(data: YAMLSkeletonData, fallbackName?: string): Skeleton
     const rightName = resolveName(right as { name?: string } | string);
     const leftNode = nodes.find((node) => node.name === leftName);
     const rightNode = nodes.find((node) => node.name === rightName);
-    if (!leftNode || !rightNode) throw new Error("Symmetry references unknown node.");
+    if (!leftNode || !rightNode)
+      throw new Error("Symmetry references unknown node.");
     return new Symmetry([leftNode, rightNode]);
   });
 
@@ -75,7 +90,7 @@ export function decodeYamlSkeleton(yamlData: string): Skeleton | Skeleton[] {
   }
 
   return Object.entries(parsed).map(([name, skeletonData]) =>
-    decodeSkeleton(skeletonData as YAMLSkeletonData, name)
+    decodeSkeleton(skeletonData as YAMLSkeletonData, name),
   );
 }
 

--- a/src/codecs/slp/h5-node.ts
+++ b/src/codecs/slp/h5-node.ts
@@ -9,7 +9,13 @@
  * The browser entry point never imports this file, ensuring the browser
  * bundle contains no references to Node built-in modules.
  */
-import { _registerNodeH5, _registerNodeFileOps, type H5Module, type SlpSource, type H5File } from "./h5.js";
+import {
+  _registerNodeH5,
+  _registerNodeFileOps,
+  type H5Module,
+  type SlpSource,
+  type H5File,
+} from "./h5.js";
 import { _registerFileWriter } from "./write.js";
 
 let modulePromise: Promise<H5Module> | null = null;
@@ -27,7 +33,7 @@ async function getH5ModuleNode(): Promise<H5Module> {
 
 async function openH5FileNode(
   module: H5Module,
-  source: SlpSource
+  source: SlpSource,
 ): Promise<{ file: H5File; close: () => void }> {
   if (typeof source === "string") {
     const file = new module.File(source, "r");
@@ -39,7 +45,10 @@ async function openH5FileNode(
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
     const data = source instanceof Uint8Array ? source : new Uint8Array(source);
-    const tempPath = join(tmpdir(), `sleap-io-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`);
+    const tempPath = join(
+      tmpdir(),
+      `sleap-io-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`,
+    );
     writeFileSync(tempPath, data);
     const file = new module.File(tempPath, "r");
     return {
@@ -51,7 +60,9 @@ async function openH5FileNode(
     };
   }
 
-  throw new Error("Node environments only support string paths or byte buffers for SLP inputs.");
+  throw new Error(
+    "Node environments only support string paths or byte buffers for SLP inputs.",
+  );
 }
 
 // Register Node providers on import (side-effect)

--- a/src/codecs/slp/h5-streaming.ts
+++ b/src/codecs/slp/h5-streaming.ts
@@ -43,8 +43,14 @@ function reconstructValue(data: unknown): unknown {
     };
 
     if (typed.type === "typedarray" && typed.buffer) {
-      const TypedArrayConstructor = getTypedArrayConstructor(typed.dtype || "Uint8Array");
-      return new TypedArrayConstructor(typed.buffer, typed.byteOffset || 0, typed.length);
+      const TypedArrayConstructor = getTypedArrayConstructor(
+        typed.dtype || "Uint8Array",
+      );
+      return new TypedArrayConstructor(
+        typed.buffer,
+        typed.byteOffset || 0,
+        typed.length,
+      );
     }
 
     if (typed.type === "arraybuffer" && typed.buffer) {
@@ -56,9 +62,20 @@ function reconstructValue(data: unknown): unknown {
 }
 
 function getTypedArrayConstructor(
-  name: string
-): new (buffer: ArrayBuffer, byteOffset: number, length?: number) => ArrayBufferView {
-  const constructors: Record<string, new (buffer: ArrayBuffer, byteOffset: number, length?: number) => ArrayBufferView> = {
+  name: string,
+): new (
+  buffer: ArrayBuffer,
+  byteOffset: number,
+  length?: number,
+) => ArrayBufferView {
+  const constructors: Record<
+    string,
+    new (
+      buffer: ArrayBuffer,
+      byteOffset: number,
+      length?: number,
+    ) => ArrayBufferView
+  > = {
     Int8Array,
     Uint8Array,
     Uint8ClampedArray,
@@ -85,7 +102,10 @@ export class StreamingH5File {
   private messageId = 0;
   private pendingMessages = new Map<
     number,
-    { resolve: (value: H5WorkerResponse) => void; reject: (error: Error) => void }
+    {
+      resolve: (value: H5WorkerResponse) => void;
+      reject: (error: Error) => void;
+    }
   >();
   private _keys: string[] = [];
   private _isOpen = false;
@@ -127,7 +147,7 @@ export class StreamingH5File {
 
   private send(
     type: H5WorkerMessage["type"],
-    payload?: Record<string, unknown>
+    payload?: Record<string, unknown>,
   ): Promise<H5WorkerResponse> {
     return new Promise((resolve, reject) => {
       const id = ++this.messageId;
@@ -153,7 +173,8 @@ export class StreamingH5File {
     // Initialize if not already done
     await this.init(options);
 
-    const filename = options?.filenameHint || url.split("/").pop()?.split("?")[0] || "data.h5";
+    const filename =
+      options?.filenameHint || url.split("/").pop()?.split("?")[0] || "data.h5";
     const result = await this.send("openUrl", { url, filename });
     this._keys = (result.keys as string[]) || [];
     this._isOpen = true;
@@ -181,7 +202,10 @@ export class StreamingH5File {
    * @param buffer - ArrayBuffer or Uint8Array containing the HDF5 file data
    * @param options - Optional settings
    */
-  async openBuffer(buffer: ArrayBuffer | Uint8Array, options?: StreamingH5Options): Promise<void> {
+  async openBuffer(
+    buffer: ArrayBuffer | Uint8Array,
+    options?: StreamingH5Options,
+  ): Promise<void> {
     // Initialize if not already done
     await this.init(options);
 
@@ -199,7 +223,10 @@ export class StreamingH5File {
    * @param source - URL string, File, ArrayBuffer, or Uint8Array
    * @param options - Optional settings
    */
-  async openAny(source: StreamingH5Source, options?: StreamingH5Options): Promise<void> {
+  async openAny(
+    source: StreamingH5Source,
+    options?: StreamingH5Options,
+  ): Promise<void> {
     if (typeof source === "string") {
       return this.open(source, options);
     }
@@ -253,7 +280,9 @@ export class StreamingH5File {
   /**
    * Get dataset metadata (shape, dtype) without reading values.
    */
-  async getDatasetMeta(path: string): Promise<{ shape: number[]; dtype: string }> {
+  async getDatasetMeta(
+    path: string,
+  ): Promise<{ shape: number[]; dtype: string }> {
     const result = await this.send("getDatasetMeta", { path });
     const meta = result.meta as { shape: number[]; dtype: string };
     return meta;
@@ -267,10 +296,14 @@ export class StreamingH5File {
    */
   async getDatasetValue(
     path: string,
-    slice?: Array<[number, number] | []>
+    slice?: Array<[number, number] | []>,
   ): Promise<{ value: unknown; shape: number[]; dtype: string }> {
     const result = await this.send("getDatasetValue", { path, slice });
-    const data = result.data as { value: unknown; shape: number[]; dtype: string };
+    const data = result.data as {
+      value: unknown;
+      shape: number[];
+      dtype: string;
+    };
     return {
       value: reconstructValue(data.value),
       shape: data.shape,
@@ -295,7 +328,11 @@ export class StreamingH5File {
  * Check if streaming via Web Worker is supported in the current environment.
  */
 export function isStreamingSupported(): boolean {
-  return typeof Worker !== "undefined" && typeof Blob !== "undefined" && typeof URL !== "undefined";
+  return (
+    typeof Worker !== "undefined" &&
+    typeof Blob !== "undefined" &&
+    typeof URL !== "undefined"
+  );
 }
 
 /**
@@ -307,7 +344,7 @@ export function isStreamingSupported(): boolean {
  */
 export async function openStreamingH5(
   url: string,
-  options?: StreamingH5Options
+  options?: StreamingH5Options,
 ): Promise<StreamingH5File> {
   if (!isStreamingSupported()) {
     throw new Error("Streaming HDF5 requires Web Worker support");
@@ -342,7 +379,7 @@ export async function openStreamingH5(
  */
 export async function openH5Worker(
   source: StreamingH5Source,
-  options?: StreamingH5Options
+  options?: StreamingH5Options,
 ): Promise<StreamingH5File> {
   if (!isStreamingSupported()) {
     throw new Error("Web Worker HDF5 access requires Worker/Blob/URL support");

--- a/src/codecs/slp/h5-worker.ts
+++ b/src/codecs/slp/h5-worker.ts
@@ -417,7 +417,7 @@ export function createH5Worker(): Worker {
     () => {
       URL.revokeObjectURL(url);
     },
-    { once: true }
+    { once: true },
   );
 
   return worker;

--- a/src/codecs/slp/h5.ts
+++ b/src/codecs/slp/h5.ts
@@ -1,7 +1,12 @@
 export type H5Module = typeof import("h5wasm");
 export type H5File = InstanceType<H5Module["File"]>;
 
-export type SlpSource = string | ArrayBuffer | Uint8Array | File | FileSystemFileHandle;
+export type SlpSource =
+  | string
+  | ArrayBuffer
+  | Uint8Array
+  | File
+  | FileSystemFileHandle;
 export type StreamMode = "auto" | "range" | "download";
 
 export type OpenH5Options = {
@@ -17,7 +22,11 @@ export type OpenH5Options = {
 };
 
 // Re-export streaming utilities for advanced use cases
-export { StreamingH5File, openStreamingH5, isStreamingSupported } from "./h5-streaming.js";
+export {
+  StreamingH5File,
+  openStreamingH5,
+  isStreamingSupported,
+} from "./h5-streaming.js";
 
 type H5FileSystem = {
   writeFile: (path: string, data: Uint8Array) => void;
@@ -27,14 +36,25 @@ type H5FileSystem = {
   rmdir?: (path: string) => void;
   mount?: (fs: unknown, opts: unknown, mountpoint: string) => void;
   unmount?: (mountpoint: string) => void;
-  createLazyFile?: (parent: string, name: string, url: string, canRead: boolean, canWrite: boolean) => void;
+  createLazyFile?: (
+    parent: string,
+    name: string,
+    url: string,
+    canRead: boolean,
+    canWrite: boolean,
+  ) => void;
   filesystems?: Record<string, unknown>;
 };
 
 // Node provider hooks — registered by h5-node.ts (imported as side-effect from Node entry point).
 // When null, only browser code paths are used, keeping the browser bundle free of Node-only imports.
 let _nodeGetModule: (() => Promise<H5Module>) | null = null;
-let _nodeOpenFile: ((module: H5Module, source: SlpSource) => Promise<{ file: H5File; close: () => void }>) | null = null;
+let _nodeOpenFile:
+  | ((
+      module: H5Module,
+      source: SlpSource,
+    ) => Promise<{ file: H5File; close: () => void }>)
+  | null = null;
 
 /**
  * Register Node.js-specific h5wasm provider.
@@ -43,7 +63,10 @@ let _nodeOpenFile: ((module: H5Module, source: SlpSource) => Promise<{ file: H5F
  */
 export function _registerNodeH5(
   getModule: () => Promise<H5Module>,
-  openFile: (module: H5Module, source: SlpSource) => Promise<{ file: H5File; close: () => void }>
+  openFile: (
+    module: H5Module,
+    source: SlpSource,
+  ) => Promise<{ file: H5File; close: () => void }>,
 ): void {
   _nodeGetModule = getModule;
   _nodeOpenFile = openFile;
@@ -52,7 +75,9 @@ export function _registerNodeH5(
 // Node-only filesystem ops — registered by h5-node.ts (imported as a side-effect
 // from the Node entry point). They stay null in the browser so this shared,
 // browser-safe module never references Node built-ins (issue #70).
-let _nodeWriteFile: ((path: string, bytes: Uint8Array) => Promise<void>) | null = null;
+let _nodeWriteFile:
+  | ((path: string, bytes: Uint8Array) => Promise<void>)
+  | null = null;
 let _nodeFileExists: ((path: string) => Promise<boolean>) | null = null;
 let _nodeReadPackageVersion: (() => Promise<string | null>) | null = null;
 
@@ -73,10 +98,13 @@ export function _registerNodeFileOps(ops: {
 }
 
 /** Write bytes to a path via the Node provider. Throws in the browser. */
-export async function nodeWriteFile(path: string, bytes: Uint8Array): Promise<void> {
+export async function nodeWriteFile(
+  path: string,
+  bytes: Uint8Array,
+): Promise<void> {
   if (!_nodeWriteFile) {
     throw new Error(
-      "Writing files requires a Node.js environment. This codec's writer is Node-only."
+      "Writing files requires a Node.js environment. This codec's writer is Node-only.",
     );
   }
   await _nodeWriteFile(path, bytes);
@@ -138,7 +166,7 @@ export async function getH5EmscriptenModule(): Promise<unknown> {
 
 export async function openH5File(
   source: SlpSource,
-  options?: OpenH5Options
+  options?: OpenH5Options,
 ): Promise<{ file: H5File; close: () => void }> {
   const module = await getH5Module();
 
@@ -160,7 +188,7 @@ function isFileHandle(value: SlpSource): value is FileSystemFileHandle {
 async function openH5FileBrowser(
   module: H5Module,
   source: SlpSource,
-  options?: OpenH5Options
+  options?: OpenH5Options,
 ): Promise<{ file: H5File; close: () => void }> {
   const fs = getH5FileSystem(module);
 
@@ -196,9 +224,12 @@ async function openFromUrl(
   module: H5Module,
   fs: H5FileSystem,
   url: string,
-  options?: OpenH5Options
+  options?: OpenH5Options,
 ): Promise<{ file: H5File; close: () => void }> {
-  const filename = options?.filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
+  const filename =
+    options?.filenameHint ??
+    url.split("/").pop()?.split("?")[0] ??
+    "slp-data.slp";
   const streamMode = options?.stream ?? "auto";
 
   if (fs.createLazyFile && (streamMode === "auto" || streamMode === "range")) {
@@ -222,7 +253,9 @@ async function openFromUrl(
 
   const response = await fetch(url);
   if (!response.ok) {
-    throw new Error(`Failed to fetch SLP file: ${response.status} ${response.statusText}`);
+    throw new Error(
+      `Failed to fetch SLP file: ${response.status} ${response.statusText}`,
+    );
   }
   const buffer = new Uint8Array(await response.arrayBuffer());
   const localPath = "/tmp-slp.slp";
@@ -235,7 +268,7 @@ async function openFromFile(
   module: H5Module,
   fs: H5FileSystem,
   file: File,
-  options?: OpenH5Options
+  options?: OpenH5Options,
 ): Promise<{ file: H5File; close: () => void }> {
   const mountPath = `/slp-local-${Date.now()}`;
   fs.mkdir?.(mountPath);

--- a/src/codecs/slp/jsfive.ts
+++ b/src/codecs/slp/jsfive.ts
@@ -33,11 +33,17 @@ export interface JsfiveFile {
  * @param filename - Optional filename hint for error messages
  * @returns JsfiveFile interface for reading the file
  */
-export function openJsfiveFile(source: JsfiveSource, filename?: string): JsfiveFile {
+export function openJsfiveFile(
+  source: JsfiveSource,
+  filename?: string,
+): JsfiveFile {
   let buffer: ArrayBuffer;
   if (source instanceof Uint8Array) {
     // Create a proper ArrayBuffer copy to avoid SharedArrayBuffer issues
-    const slice = source.buffer.slice(source.byteOffset, source.byteOffset + source.byteLength);
+    const slice = source.buffer.slice(
+      source.byteOffset,
+      source.byteOffset + source.byteLength,
+    );
     buffer = slice as ArrayBuffer;
   } else {
     buffer = source;
@@ -64,7 +70,9 @@ export function openJsfiveFile(source: JsfiveSource, filename?: string): JsfiveF
 /**
  * Check if an item is a jsfive dataset (has value property).
  */
-export function isDataset(item: JsfiveDataset | JsfiveGroup | null): item is JsfiveDataset {
+export function isDataset(
+  item: JsfiveDataset | JsfiveGroup | null,
+): item is JsfiveDataset {
   if (!item) return false;
   return "value" in item || "shape" in item;
 }
@@ -72,7 +80,9 @@ export function isDataset(item: JsfiveDataset | JsfiveGroup | null): item is Jsf
 /**
  * Check if an item is a jsfive group (has keys property but no value).
  */
-export function isGroup(item: JsfiveDataset | JsfiveGroup | null): item is JsfiveGroup {
+export function isGroup(
+  item: JsfiveDataset | JsfiveGroup | null,
+): item is JsfiveGroup {
   if (!item) return false;
   return "keys" in item && !("value" in item);
 }
@@ -80,7 +90,9 @@ export function isGroup(item: JsfiveDataset | JsfiveGroup | null): item is Jsfiv
 /**
  * Safely get attributes from a dataset or group.
  */
-export function getAttrs(item: JsfiveDataset | JsfiveGroup | null): Record<string, unknown> {
+export function getAttrs(
+  item: JsfiveDataset | JsfiveGroup | null,
+): Record<string, unknown> {
   if (!item) return {};
   return (item.attrs ?? {}) as Record<string, unknown>;
 }

--- a/src/codecs/slp/parsers.ts
+++ b/src/codecs/slp/parsers.ts
@@ -21,7 +21,11 @@ export function parseJsonAttr(attr: unknown): unknown {
   if (typeof value === "string") return JSON.parse(value);
   if (value instanceof Uint8Array) return JSON.parse(textDecoder.decode(value));
   if (value && typeof value === "object" && "buffer" in value) {
-    return JSON.parse(textDecoder.decode(new Uint8Array((value as { buffer: ArrayBuffer }).buffer)));
+    return JSON.parse(
+      textDecoder.decode(
+        new Uint8Array((value as { buffer: ArrayBuffer }).buffer),
+      ),
+    );
   }
   // If value is already a parsed object (e.g., from streaming worker), return as-is
   if (value && typeof value === "object") {
@@ -48,7 +52,8 @@ function trimHdf5String(str: string): string {
 export function attrToString(attr: unknown): string | undefined {
   if (attr === undefined || attr === null) return undefined;
   if (typeof attr === "string") return trimHdf5String(attr);
-  if (attr instanceof Uint8Array) return trimHdf5String(textDecoder.decode(attr));
+  if (attr instanceof Uint8Array)
+    return trimHdf5String(textDecoder.decode(attr));
   if (typeof attr === "object" && "value" in attr) {
     const v = (attr as { value: unknown }).value;
     if (typeof v === "string") return trimHdf5String(v);
@@ -70,7 +75,11 @@ export function attrToNumber(attr: unknown): number | undefined {
   if (typeof attr === "object" && "value" in attr) {
     raw = (attr as { value: unknown }).value;
   }
-  if (typeof raw !== "number" && typeof raw !== "bigint" && typeof raw !== "string") {
+  if (
+    typeof raw !== "number" &&
+    typeof raw !== "bigint" &&
+    typeof raw !== "string"
+  ) {
     return undefined;
   }
   const num = typeof raw === "bigint" ? Number(raw) : Number(raw);
@@ -84,9 +93,16 @@ export function attrToNumber(attr: unknown): number | undefined {
  */
 export function parseJsonEntry(entry: unknown): unknown {
   if (typeof entry === "string") return JSON.parse(trimHdf5String(entry));
-  if (entry instanceof Uint8Array) return JSON.parse(trimHdf5String(textDecoder.decode(entry)));
+  if (entry instanceof Uint8Array)
+    return JSON.parse(trimHdf5String(textDecoder.decode(entry)));
   if (entry && typeof entry === "object" && "buffer" in entry) {
-    return JSON.parse(trimHdf5String(textDecoder.decode(new Uint8Array((entry as { buffer: ArrayBuffer }).buffer))));
+    return JSON.parse(
+      trimHdf5String(
+        textDecoder.decode(
+          new Uint8Array((entry as { buffer: ArrayBuffer }).buffer),
+        ),
+      ),
+    );
   }
   return entry;
 }
@@ -98,14 +114,16 @@ export function parseJsonEntry(entry: unknown): unknown {
 export function resolveEdgeType(
   edgeType: unknown,
   cache: Map<number, number>,
-  state: { nextId: number }
+  state: { nextId: number },
 ): number {
   if (!edgeType || typeof edgeType !== "object") return 1;
   const et = edgeType as Record<string, unknown>;
 
   if (et["py/reduce"]) {
     const reduce = et["py/reduce"] as unknown[];
-    const tuple = (reduce[1] as Record<string, unknown>)?.["py/tuple"] as number[] | undefined;
+    const tuple = (reduce[1] as Record<string, unknown>)?.["py/tuple"] as
+      | number[]
+      | undefined;
     const typeId = tuple?.[0] ?? 1;
     cache.set(state.nextId, typeId);
     state.nextId += 1;
@@ -133,10 +151,13 @@ export function parseSkeletons(metadataJson: unknown): Skeleton[] {
   if (!metadataJson || typeof metadataJson !== "object") return [];
 
   const meta = metadataJson as Record<string, unknown>;
-  const nodeNames = (meta.nodes as Array<{ name?: string } | string> ?? []).map(
-    (node) => (typeof node === "object" ? node.name ?? "" : String(node))
+  const nodeNames = (
+    (meta.nodes as Array<{ name?: string } | string>) ?? []
+  ).map((node) =>
+    typeof node === "object" ? (node.name ?? "") : String(node),
   );
-  const skeletonEntries = meta.skeletons as Array<Record<string, unknown>> ?? [];
+  const skeletonEntries =
+    (meta.skeletons as Array<Record<string, unknown>>) ?? [];
   const skeletons: Skeleton[] = [];
 
   for (const entry of skeletonEntries) {
@@ -145,9 +166,9 @@ export function parseSkeletons(metadataJson: unknown): Skeleton[] {
     const typeCache = new Map<number, number>();
     const typeState = { nextId: 1 };
 
-    const entryNodes = entry.nodes as Array<{ id?: number } | number> ?? [];
+    const entryNodes = (entry.nodes as Array<{ id?: number } | number>) ?? [];
     const skeletonNodeIds = entryNodes.map((node) =>
-      Number(typeof node === "object" ? node.id ?? 0 : node)
+      Number(typeof node === "object" ? (node.id ?? 0) : node),
     );
     const nodeOrder = skeletonNodeIds.length
       ? skeletonNodeIds
@@ -163,7 +184,12 @@ export function parseSkeletons(metadataJson: unknown): Skeleton[] {
       nodeIndexById.set(Number(nodeId), index);
     });
 
-    const links = entry.links as Array<{ source: number; target: number; type?: unknown }> ?? [];
+    const links =
+      (entry.links as Array<{
+        source: number;
+        target: number;
+        type?: unknown;
+      }>) ?? [];
     for (const link of links) {
       const source = Number(link.source);
       const target = Number(link.target);
@@ -288,7 +314,7 @@ export interface VideoMetadata {
  */
 export function resolveVideoFilename(
   backendMeta: Record<string, unknown>,
-  parsed: Record<string, unknown>
+  parsed: Record<string, unknown>,
 ): string | string[] {
   const filenames = backendMeta.filenames;
   if (Array.isArray(filenames) && filenames.length > 0) {
@@ -301,7 +327,10 @@ export function resolveVideoFilename(
  * Parse video metadata from videos_json dataset values.
  * Returns metadata objects WITHOUT creating video backends.
  */
-export function parseVideosMetadata(values: unknown[], labelsPath?: string): VideoMetadata[] {
+export function parseVideosMetadata(
+  values: unknown[],
+  labelsPath?: string,
+): VideoMetadata[] {
   const videos: VideoMetadata[] = [];
 
   for (const entry of values) {
@@ -312,7 +341,10 @@ export function parseVideosMetadata(values: unknown[], labelsPath?: string): Vid
       // jsfive returns fixed-width strings with trailing spaces/nulls - trim before parsing
       parsed = JSON.parse(trimHdf5String(entry)) as Record<string, unknown>;
     } else if (entry instanceof Uint8Array) {
-      parsed = JSON.parse(trimHdf5String(textDecoder.decode(entry))) as Record<string, unknown>;
+      parsed = JSON.parse(trimHdf5String(textDecoder.decode(entry))) as Record<
+        string,
+        unknown
+      >;
     } else {
       parsed = entry as Record<string, unknown>;
     }
@@ -427,7 +459,10 @@ export function parseSessionsMetadata(values: unknown[]): SessionMetadata[] {
     }
 
     const videosByCamera: Record<string, number> = {};
-    const map = (parsed.camcorder_to_video_idx_map ?? {}) as Record<string, unknown>;
+    const map = (parsed.camcorder_to_video_idx_map ?? {}) as Record<
+      string,
+      unknown
+    >;
     for (const [cameraKey, videoIdx] of Object.entries(map)) {
       videosByCamera[cameraKey] = Number(videoIdx);
     }
@@ -469,7 +504,9 @@ export function reconstructInstance3D(
   skeletons: Skeleton[],
 ): Instance3D | undefined {
   const rawPoints = record.points;
-  const pointsValue = Array.isArray(rawPoints) ? (rawPoints as number[][]) : undefined;
+  const pointsValue = Array.isArray(rawPoints)
+    ? (rawPoints as number[][])
+    : undefined;
   if (!pointsValue) return undefined;
 
   const skeleton = skeletons[0] ?? new Skeleton({ nodes: [] });
@@ -477,7 +514,12 @@ export function reconstructInstance3D(
   const pointScores = record.instance_3d_point_scores as number[] | undefined;
 
   if (pointScores) {
-    return new PredictedInstance3D({ points: pointsValue, skeleton, score, pointScores });
+    return new PredictedInstance3D({
+      points: pointsValue,
+      skeleton,
+      score,
+      pointScores,
+    });
   }
   return new Instance3D({ points: pointsValue, skeleton, score });
 }
@@ -496,6 +538,8 @@ export function resolveIdentity(
   if (idx >= 0 && idx < identities.length) {
     return identities[idx];
   }
-  console.warn(`identity_idx ${idx} is out of bounds (${identities.length} identities available) — skipping identity for this instance group.`);
+  console.warn(
+    `identity_idx ${idx} is out of bounds (${identities.length} identities available) — skipping identity for this instance group.`,
+  );
   return undefined;
 }

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -8,15 +8,44 @@
  * @module
  */
 
-import { openH5Worker, StreamingH5File, isStreamingSupported, type StreamingH5Source } from "./h5-streaming.js";
-import { attrToNumber, attrToString, parseJsonAttr, parseJsonEntry, parseSkeletons, parseTracks, parseVideosMetadata, parseSuggestions, resolveCameraKey, reconstructInstance3D, resolveIdentity } from "./parsers.js";
+import {
+  openH5Worker,
+  StreamingH5File,
+  isStreamingSupported,
+  type StreamingH5Source,
+} from "./h5-streaming.js";
+import {
+  attrToNumber,
+  attrToString,
+  parseJsonAttr,
+  parseJsonEntry,
+  parseSkeletons,
+  parseTracks,
+  parseVideosMetadata,
+  parseSuggestions,
+  resolveCameraKey,
+  reconstructInstance3D,
+  resolveIdentity,
+} from "./parsers.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
-import { Instance, PredictedInstance, Track, pointsFromArray, predictedPointsFromArray } from "../../model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+  pointsFromArray,
+  predictedPointsFromArray,
+} from "../../model/instance.js";
 import { Skeleton } from "../../model/skeleton.js";
 import { SuggestionFrame } from "../../model/suggestions.js";
 import { Video } from "../../model/video.js";
-import { Camera, CameraGroup, FrameGroup, InstanceGroup, RecordingSession } from "../../model/camera.js";
+import {
+  Camera,
+  CameraGroup,
+  FrameGroup,
+  InstanceGroup,
+  RecordingSession,
+} from "../../model/camera.js";
 import { Identity } from "../../model/identity.js";
 import { StreamingHdf5VideoBackend } from "../../video/streaming-hdf5-video.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
@@ -71,10 +100,12 @@ export interface StreamingSlpOptions {
  */
 export async function readSlpStreaming(
   source: StreamingH5Source,
-  options?: StreamingSlpOptions
+  options?: StreamingSlpOptions,
 ): Promise<Labels> {
   if (!isStreamingSupported()) {
-    throw new Error("Streaming HDF5 requires Web Worker support (browser environment)");
+    throw new Error(
+      "Streaming HDF5 requires Web Worker support (browser environment)",
+    );
   }
 
   const file = await openH5Worker(source, {
@@ -85,14 +116,20 @@ export async function readSlpStreaming(
   const openVideos = options?.openVideos ?? false;
 
   // Determine the source path for video resolution
-  const sourcePath = typeof source === "string"
-    ? source
-    : (typeof File !== "undefined" && source instanceof File)
-      ? source.name
-      : options?.filenameHint ?? "slp-data.slp";
+  const sourcePath =
+    typeof source === "string"
+      ? source
+      : typeof File !== "undefined" && source instanceof File
+        ? source.name
+        : (options?.filenameHint ?? "slp-data.slp");
 
   try {
-    return await readFromStreamingFile(file, sourcePath, options?.filenameHint, openVideos);
+    return await readFromStreamingFile(
+      file,
+      sourcePath,
+      options?.filenameHint,
+      openVideos,
+    );
   } finally {
     // Only close the file if we're NOT opening video backends.
     // When openVideos is true, the file must remain open for video frame access.
@@ -109,18 +146,22 @@ async function readFromStreamingFile(
   file: StreamingH5File,
   url: string,
   filenameHint?: string,
-  openVideos: boolean = false
+  openVideos: boolean = false,
 ): Promise<Labels> {
   // Read metadata
   const metadataAttrs = await file.getAttrs("metadata");
   const formatId = Number(
     (metadataAttrs["format_id"] as { value?: number })?.value ??
-    metadataAttrs["format_id"] ??
-    1.0
+      metadataAttrs["format_id"] ??
+      1.0,
   );
-  const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<string, unknown> | null;
+  const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<
+    string,
+    unknown
+  > | null;
 
-  const labelsPath = filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
+  const labelsPath =
+    filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
   const skeletons = parseSkeletons(metadataJson);
 
   // Read tracks
@@ -130,7 +171,13 @@ async function readFromStreamingFile(
   const videoCrops = await readVideoCropsStreaming(file);
 
   // Read video metadata (and optionally create backends for embedded videos)
-  const videos = await readVideosStreaming(file, labelsPath, openVideos, formatId, videoCrops);
+  const videos = await readVideosStreaming(
+    file,
+    labelsPath,
+    openVideos,
+    formatId,
+    videoCrops,
+  );
 
   // Read suggestions
   const suggestions = await readSuggestionsStreaming(file, videos);
@@ -157,7 +204,13 @@ async function readFromStreamingFile(
   const identities = await readIdentitiesStreaming(file);
 
   // Read sessions
-  const sessions = await readSessionsStreaming(file, videos, skeletons, labeledFrames, identities);
+  const sessions = await readSessionsStreaming(
+    file,
+    videos,
+    skeletons,
+    labeledFrames,
+    identities,
+  );
 
   return new Labels({
     labeledFrames,
@@ -202,7 +255,7 @@ interface VideoCropEntry {
  * array, raw bytes); not part of the public API.
  */
 export async function readVideoCropsStreaming(
-  file: StreamingH5File
+  file: StreamingH5File,
 ): Promise<Map<number, VideoCropEntry>> {
   const out = new Map<number, VideoCropEntry>();
   try {
@@ -262,7 +315,7 @@ async function readVideosStreaming(
   labelsPath: string,
   openVideos: boolean = false,
   formatId: number = 1.0,
-  videoCrops?: Map<number, VideoCropEntry>
+  videoCrops?: Map<number, VideoCropEntry>,
 ): Promise<Video[]> {
   try {
     const keys = file.keys();
@@ -280,7 +333,8 @@ async function readVideosStreaming(
       // Auto-detect dataset path when embedded but not specified in metadata
       let datasetPath: string | undefined = meta.dataset;
       if (meta.embedded && !datasetPath) {
-        datasetPath = (await findVideoDatasetStreaming(file, videoIndex)) ?? undefined;
+        datasetPath =
+          (await findVideoDatasetStreaming(file, videoIndex)) ?? undefined;
       }
 
       // Read format/channel_order/frames from HDF5 dataset attributes when a
@@ -308,8 +362,10 @@ async function readVideosStreaming(
           // is missing (common for pkg.slp files)
           const readNumAttr = (attr: unknown): number | undefined => {
             if (attr === undefined || attr === null) return undefined;
-            const v = typeof attr === "object" && attr !== null && "value" in attr
-              ? (attr as { value: unknown }).value : attr;
+            const v =
+              typeof attr === "object" && attr !== null && "value" in attr
+                ? (attr as { value: unknown }).value
+                : attr;
             const n = Number(v);
             return Number.isFinite(n) && n > 0 ? n : undefined;
           };
@@ -343,7 +399,7 @@ async function readVideosStreaming(
         frameNumbers,
       });
       const shape: [number, number, number, number] | undefined =
-        (meta.height && meta.width && meta.channels)
+        meta.height && meta.width && meta.channels
           ? [frameCount ?? 0, meta.height, meta.width, meta.channels]
           : undefined;
 
@@ -351,7 +407,10 @@ async function readVideosStreaming(
       // 1. JSON metadata (meta.channelOrder)
       // 2. HDF5 dataset attribute (channelOrderFromAttrs)
       // 3. Legacy fallback based on format_id (BGR for < 1.4)
-      const channelOrder = meta.channelOrder ?? channelOrderFromAttrs ?? (formatId < 1.4 ? "BGR" : "RGB");
+      const channelOrder =
+        meta.channelOrder ??
+        channelOrderFromAttrs ??
+        (formatId < 1.4 ? "BGR" : "RGB");
 
       // Create streaming backend for embedded videos when openVideos is true
       let backend = null;
@@ -361,7 +420,7 @@ async function readVideosStreaming(
           // path); the array form is only for image sequences, which never
           // reach this embedded branch. Narrow for the type checker.
           filename: Array.isArray(meta.filename)
-            ? meta.filename[0] ?? ""
+            ? (meta.filename[0] ?? "")
             : meta.filename,
           h5file: file,
           datasetPath,
@@ -412,14 +471,18 @@ async function readVideosStreaming(
         backendMetadata.crop_fill = cropEntry.fill;
       }
 
-      videos.push(new Video({
-        filename: meta.filename,
-        backend: videoBackend,
-        backendMetadata,
-        sourceVideo: meta.sourceVideo ? new Video({ filename: meta.sourceVideo.filename }) : null,
-        openBackend: openVideos && meta.embedded,
-        embedded: meta.embedded,
-      }));
+      videos.push(
+        new Video({
+          filename: meta.filename,
+          backend: videoBackend,
+          backendMetadata,
+          sourceVideo: meta.sourceVideo
+            ? new Video({ filename: meta.sourceVideo.filename })
+            : null,
+          openBackend: openVideos && meta.embedded,
+          embedded: meta.embedded,
+        }),
+      );
     }
 
     return videos;
@@ -434,7 +497,7 @@ async function readVideosStreaming(
  */
 async function readFrameNumbersStreaming(
   file: StreamingH5File,
-  datasetPath: string
+  datasetPath: string,
 ): Promise<number[]> {
   try {
     // Extract group path from dataset path (e.g., "video0/video" -> "video0")
@@ -476,7 +539,7 @@ async function readFrameNumbersStreaming(
  */
 async function readFrameSizesStreaming(
   file: StreamingH5File,
-  datasetPath: string
+  datasetPath: string,
 ): Promise<number[] | undefined> {
   try {
     const groupPath = datasetPath.endsWith("/video")
@@ -509,7 +572,7 @@ async function readFrameSizesStreaming(
  */
 async function findVideoDatasetStreaming(
   file: StreamingH5File,
-  videoIndex: number
+  videoIndex: number,
 ): Promise<string | null> {
   try {
     // Try explicit path first (video0/video, video1/video, etc.)
@@ -557,7 +620,10 @@ async function findVideoDatasetStreaming(
 /**
  * Read suggestions from suggestions_json dataset.
  */
-async function readSuggestionsStreaming(file: StreamingH5File, videos: Video[]): Promise<SuggestionFrame[]> {
+async function readSuggestionsStreaming(
+  file: StreamingH5File,
+  videos: Video[],
+): Promise<SuggestionFrame[]> {
   try {
     const keys = file.keys();
     if (!keys.includes("suggestions_json")) return [];
@@ -567,7 +633,7 @@ async function readSuggestionsStreaming(file: StreamingH5File, videos: Video[]):
     const metadataList = parseSuggestions(values);
 
     return metadataList
-      .map(meta => {
+      .map((meta) => {
         const video = videos[meta.video];
         if (!video) return null;
         return new SuggestionFrame({
@@ -585,7 +651,9 @@ async function readSuggestionsStreaming(file: StreamingH5File, videos: Video[]):
 /**
  * Read identities from identities_json dataset.
  */
-async function readIdentitiesStreaming(file: StreamingH5File): Promise<Identity[]> {
+async function readIdentitiesStreaming(
+  file: StreamingH5File,
+): Promise<Identity[]> {
   try {
     const keys = file.keys();
     if (!keys.includes("identities_json")) return [];
@@ -596,11 +664,13 @@ async function readIdentitiesStreaming(file: StreamingH5File): Promise<Identity[
     for (const entry of values) {
       const parsed = parseJsonEntry(entry) as Record<string, unknown>;
       const { name, color, ...rest } = parsed;
-      identities.push(new Identity({
-        name: (name as string) ?? "",
-        color: color as string | undefined,
-        metadata: rest,
-      }));
+      identities.push(
+        new Identity({
+          name: (name as string) ?? "",
+          color: color as string | undefined,
+          metadata: rest,
+        }),
+      );
     }
     return identities;
   } catch {
@@ -616,7 +686,7 @@ async function readSessionsStreaming(
   videos: Video[],
   skeletons: Skeleton[],
   labeledFrames: LabeledFrame[],
-  identities?: Identity[]
+  identities?: Identity[],
 ): Promise<RecordingSession[]> {
   try {
     const keys = file.keys();
@@ -648,44 +718,81 @@ async function readSessionsStreaming(
         cameraMap.set(String(key), camera);
       }
 
-      const session = new RecordingSession({ cameraGroup, metadata: (parsed.metadata as Record<string, unknown> | undefined) ?? {} });
+      const session = new RecordingSession({
+        cameraGroup,
+        metadata:
+          (parsed.metadata as Record<string, unknown> | undefined) ?? {},
+      });
 
-      const map = (parsed.camcorder_to_video_idx_map ?? {}) as Record<string, unknown>;
+      const map = (parsed.camcorder_to_video_idx_map ?? {}) as Record<
+        string,
+        unknown
+      >;
       for (const [cameraKey, videoIdx] of Object.entries(map)) {
-        const camera = resolveCameraKey(cameraKey, cameraMap, cameraGroup.cameras);
+        const camera = resolveCameraKey(
+          cameraKey,
+          cameraMap,
+          cameraGroup.cameras,
+        );
         const video = videos[Number(videoIdx)];
         if (camera && video) {
           session.addVideo(video, camera);
         }
       }
 
-      const frameGroups = Array.isArray(parsed.frame_group_dicts) ? parsed.frame_group_dicts : [];
+      const frameGroups = Array.isArray(parsed.frame_group_dicts)
+        ? parsed.frame_group_dicts
+        : [];
       for (const group of frameGroups) {
         const groupRecord = group as Record<string, unknown>;
-        const frameIdx = (groupRecord.frame_idx as number | undefined) ?? (groupRecord.frameIdx as number | undefined) ?? 0;
+        const frameIdx =
+          (groupRecord.frame_idx as number | undefined) ??
+          (groupRecord.frameIdx as number | undefined) ??
+          0;
         const instanceGroups: InstanceGroup[] = [];
-        const instanceGroupList = Array.isArray(groupRecord.instance_groups) ? groupRecord.instance_groups : [];
+        const instanceGroupList = Array.isArray(groupRecord.instance_groups)
+          ? groupRecord.instance_groups
+          : [];
         for (const instanceGroup of instanceGroupList) {
           const instanceGroupRecord = instanceGroup as Record<string, unknown>;
           const instanceByCamera = new Map<Camera, Instance>();
 
           // Read JS-format instances (camera key -> point data)
-          const instancesRecord = (instanceGroupRecord.instances ?? {}) as Record<string, unknown>;
+          const instancesRecord = (instanceGroupRecord.instances ??
+            {}) as Record<string, unknown>;
           for (const [cameraKey, points] of Object.entries(instancesRecord)) {
-            const camera = resolveCameraKey(cameraKey, cameraMap, cameraGroup.cameras);
+            const camera = resolveCameraKey(
+              cameraKey,
+              cameraMap,
+              cameraGroup.cameras,
+            );
             if (!camera) {
-              console.warn(`Camera key "${cameraKey}" not found in session calibration — skipping 2D instance data for this camera.`);
+              console.warn(
+                `Camera key "${cameraKey}" not found in session calibration — skipping 2D instance data for this camera.`,
+              );
               continue;
             }
             const skeleton = skeletons[0] ?? new Skeleton({ nodes: [] });
-            instanceByCamera.set(camera, new Instance({ points: points as Record<string, number[]>, skeleton }));
+            instanceByCamera.set(
+              camera,
+              new Instance({
+                points: points as Record<string, number[]>,
+                skeleton,
+              }),
+            );
           }
 
           // Fall back to Python-format camcorder_to_lf_and_inst_idx_map
           if (instanceByCamera.size === 0) {
-            const lfInstMap = (instanceGroupRecord.camcorder_to_lf_and_inst_idx_map ?? {}) as Record<string, unknown>;
+            const lfInstMap =
+              (instanceGroupRecord.camcorder_to_lf_and_inst_idx_map ??
+                {}) as Record<string, unknown>;
             for (const [camIdx, value] of Object.entries(lfInstMap)) {
-              const camera = resolveCameraKey(camIdx, cameraMap, cameraGroup.cameras);
+              const camera = resolveCameraKey(
+                camIdx,
+                cameraMap,
+                cameraGroup.cameras,
+              );
               if (!camera) continue;
               const pair = value as unknown as [number, number];
               const lf = labeledFrames[Number(pair[0])];
@@ -696,7 +803,10 @@ async function readSessionsStreaming(
             }
           }
 
-          const instance3d = reconstructInstance3D(instanceGroupRecord, skeletons);
+          const instance3d = reconstructInstance3D(
+            instanceGroupRecord,
+            skeletons,
+          );
           const identity = resolveIdentity(instanceGroupRecord, identities);
 
           instanceGroups.push(
@@ -705,17 +815,29 @@ async function readSessionsStreaming(
               score: instanceGroupRecord.score as number | undefined,
               instance3d,
               identity,
-              metadata: (instanceGroupRecord.metadata as Record<string, unknown> | undefined) ?? {},
-            })
+              metadata:
+                (instanceGroupRecord.metadata as
+                  | Record<string, unknown>
+                  | undefined) ?? {},
+            }),
           );
         }
 
         const labeledFrameByCamera = new Map<Camera, LabeledFrame>();
-        const labeledFrameMap = (groupRecord.labeled_frame_by_camera ?? {}) as Record<string, unknown>;
-        for (const [cameraKey, labeledFrameIdx] of Object.entries(labeledFrameMap)) {
-          const camera = resolveCameraKey(cameraKey, cameraMap, cameraGroup.cameras);
+        const labeledFrameMap = (groupRecord.labeled_frame_by_camera ??
+          {}) as Record<string, unknown>;
+        for (const [cameraKey, labeledFrameIdx] of Object.entries(
+          labeledFrameMap,
+        )) {
+          const camera = resolveCameraKey(
+            cameraKey,
+            cameraMap,
+            cameraGroup.cameras,
+          );
           if (!camera) {
-            console.warn(`Camera key "${cameraKey}" not found in session calibration — skipping labeled frame mapping.`);
+            console.warn(
+              `Camera key "${cameraKey}" not found in session calibration — skipping labeled frame mapping.`,
+            );
             continue;
           }
           const labeledFrame = labeledFrames[Number(labeledFrameIdx)];
@@ -728,9 +850,14 @@ async function readSessionsStreaming(
         if (labeledFrameByCamera.size === 0) {
           for (const instanceGroup of instanceGroupList) {
             const igRecord = instanceGroup as Record<string, unknown>;
-            const lfInstMap = (igRecord.camcorder_to_lf_and_inst_idx_map ?? {}) as Record<string, unknown>;
+            const lfInstMap = (igRecord.camcorder_to_lf_and_inst_idx_map ??
+              {}) as Record<string, unknown>;
             for (const [camIdx, value] of Object.entries(lfInstMap)) {
-              const camera = resolveCameraKey(camIdx, cameraMap, cameraGroup.cameras);
+              const camera = resolveCameraKey(
+                camIdx,
+                cameraMap,
+                cameraGroup.cameras,
+              );
               if (!camera) continue;
               const pair = value as unknown as [number, number];
               const lf = labeledFrames[Number(pair[0])];
@@ -745,8 +872,10 @@ async function readSessionsStreaming(
             frameIdx: Number(frameIdx),
             instanceGroups,
             labeledFrameByCamera,
-            metadata: (groupRecord.metadata as Record<string, unknown> | undefined) ?? {},
-          })
+            metadata:
+              (groupRecord.metadata as Record<string, unknown> | undefined) ??
+              {},
+          }),
         );
       }
       sessions.push(session);
@@ -762,7 +891,7 @@ async function readSessionsStreaming(
  */
 async function readStructDatasetStreaming(
   file: StreamingH5File,
-  path: string
+  path: string,
 ): Promise<Record<string, unknown[]>> {
   try {
     const keys = file.keys();
@@ -779,19 +908,30 @@ async function readStructDatasetStreaming(
         const attrs = await file.getAttrs(path);
         const fnAttr = attrs.field_names ?? attrs.fieldNames;
         if (fnAttr) {
-          let raw = Array.isArray(fnAttr) ? fnAttr
+          let raw = Array.isArray(fnAttr)
+            ? fnAttr
             : (fnAttr as { value?: unknown })?.value;
           if (typeof raw === "string") {
-            try { raw = JSON.parse(raw); } catch { /* not JSON */ }
+            try {
+              raw = JSON.parse(raw);
+            } catch {
+              /* not JSON */
+            }
           }
           if (raw instanceof Uint8Array) {
-            try { raw = JSON.parse(new TextDecoder().decode(raw)); } catch { /* not JSON */ }
+            try {
+              raw = JSON.parse(new TextDecoder().decode(raw));
+            } catch {
+              /* not JSON */
+            }
           }
           if (Array.isArray(raw)) {
             fieldNames = raw.map(String);
           }
         }
-      } catch { /* ignore attribute read errors */ }
+      } catch {
+        /* ignore attribute read errors */
+      }
     }
 
     return normalizeStructData(data.value, data.shape, fieldNames);
@@ -818,7 +958,7 @@ export function getFieldNamesFromMeta(meta: {
       const namesStr = namesMatch[1];
       const names = namesStr.match(/'([^']+)'/g);
       if (names) {
-        return names.map(n => n.replace(/'/g, ""));
+        return names.map((n) => n.replace(/'/g, ""));
       }
     }
   }
@@ -830,10 +970,12 @@ export function getFieldNamesFromMeta(meta: {
   if (typeof dtype === "object" && dtype !== null) {
     const dtypeObj = dtype as Record<string, unknown>;
     if (dtypeObj.compound_type && typeof dtypeObj.compound_type === "object") {
-      const compound = dtypeObj.compound_type as { members?: Array<{ name?: string }> };
+      const compound = dtypeObj.compound_type as {
+        members?: Array<{ name?: string }>;
+      };
       if (compound.members) {
         return compound.members
-          .map(m => m.name)
+          .map((m) => m.name)
           .filter((n): n is string => !!n);
       }
     }
@@ -848,12 +990,17 @@ export function getFieldNamesFromMeta(meta: {
 function normalizeStructData(
   value: unknown,
   shape: number[],
-  fieldNames: string[]
+  fieldNames: string[],
 ): Record<string, unknown[]> {
   if (!value) return {};
 
   // If value is already an object with arrays (column format)
-  if (value && typeof value === "object" && !Array.isArray(value) && !ArrayBuffer.isView(value)) {
+  if (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    !ArrayBuffer.isView(value)
+  ) {
     const obj = value as Record<string, unknown>;
     // Check if it looks like column data
     const firstKey = Object.keys(obj)[0];
@@ -886,7 +1033,7 @@ function normalizeStructData(
     if (fieldNames.length) {
       const result: Record<string, unknown[]> = {};
       fieldNames.forEach((field, colIdx) => {
-        result[field] = rows.map(row => row[colIdx]);
+        result[field] = rows.map((row) => row[colIdx]);
       });
       return result;
     }
@@ -922,7 +1069,16 @@ function buildLabeledFrames(options: {
   formatId: number;
 }): LabeledFrame[] {
   const frames: LabeledFrame[] = [];
-  const { framesData, instancesData, pointsData, predPointsData, skeletons, tracks, videos, formatId } = options;
+  const {
+    framesData,
+    instancesData,
+    pointsData,
+    predPointsData,
+    skeletons,
+    tracks,
+    videos,
+    formatId,
+  } = options;
   const frameIds = (framesData.frame_id ?? []) as number[];
   const videoIdToIndex = buildVideoIdMap(framesData, videos);
   const instanceById = new Map<number, Instance | PredictedInstance>();
@@ -931,30 +1087,59 @@ function buildLabeledFrames(options: {
   for (let frameIdx = 0; frameIdx < frameIds.length; frameIdx += 1) {
     const rawVideoId = Number((framesData.video as number[])?.[frameIdx] ?? 0);
     const videoIndex = videoIdToIndex.get(rawVideoId) ?? rawVideoId;
-    const frameIndex = Number((framesData.frame_idx as number[])?.[frameIdx] ?? 0);
-    const instStart = Number((framesData.instance_id_start as number[])?.[frameIdx] ?? 0);
-    const instEnd = Number((framesData.instance_id_end as number[])?.[frameIdx] ?? 0);
+    const frameIndex = Number(
+      (framesData.frame_idx as number[])?.[frameIdx] ?? 0,
+    );
+    const instStart = Number(
+      (framesData.instance_id_start as number[])?.[frameIdx] ?? 0,
+    );
+    const instEnd = Number(
+      (framesData.instance_id_end as number[])?.[frameIdx] ?? 0,
+    );
     const video = videos[videoIndex];
     if (!video) continue;
 
     const instances: Array<Instance | PredictedInstance> = [];
     for (let instIdx = instStart; instIdx < instEnd; instIdx += 1) {
-      const instanceType = Number((instancesData.instance_type as number[])?.[instIdx] ?? 0);
-      const skeletonId = Number((instancesData.skeleton as number[])?.[instIdx] ?? 0);
-      const trackId = Number((instancesData.track as number[])?.[instIdx] ?? -1);
-      const pointStart = Number((instancesData.point_id_start as number[])?.[instIdx] ?? 0);
-      const pointEnd = Number((instancesData.point_id_end as number[])?.[instIdx] ?? 0);
+      const instanceType = Number(
+        (instancesData.instance_type as number[])?.[instIdx] ?? 0,
+      );
+      const skeletonId = Number(
+        (instancesData.skeleton as number[])?.[instIdx] ?? 0,
+      );
+      const trackId = Number(
+        (instancesData.track as number[])?.[instIdx] ?? -1,
+      );
+      const pointStart = Number(
+        (instancesData.point_id_start as number[])?.[instIdx] ?? 0,
+      );
+      const pointEnd = Number(
+        (instancesData.point_id_end as number[])?.[instIdx] ?? 0,
+      );
       const score = Number((instancesData.score as number[])?.[instIdx] ?? 0);
-      const rawTrackingScore = formatId < 1.2 ? 0 : Number((instancesData.tracking_score as number[])?.[instIdx] ?? 0);
-      const trackingScore = Number.isNaN(rawTrackingScore) ? 0 : rawTrackingScore;
-      const fromPredicted = Number((instancesData.from_predicted as number[])?.[instIdx] ?? -1);
-      const skeleton = skeletons[skeletonId] ?? skeletons[0] ?? new Skeleton({ nodes: [] });
+      const rawTrackingScore =
+        formatId < 1.2
+          ? 0
+          : Number((instancesData.tracking_score as number[])?.[instIdx] ?? 0);
+      const trackingScore = Number.isNaN(rawTrackingScore)
+        ? 0
+        : rawTrackingScore;
+      const fromPredicted = Number(
+        (instancesData.from_predicted as number[])?.[instIdx] ?? -1,
+      );
+      const skeleton =
+        skeletons[skeletonId] ?? skeletons[0] ?? new Skeleton({ nodes: [] });
       const track = trackId >= 0 ? tracks[trackId] : null;
 
       let instance: Instance | PredictedInstance;
       if (instanceType === 0) {
         const points = slicePoints(pointsData, pointStart, pointEnd);
-        instance = new Instance({ points: pointsFromArray(points, skeleton.nodeNames), skeleton, track, trackingScore });
+        instance = new Instance({
+          points: pointsFromArray(points, skeleton.nodeNames),
+          skeleton,
+          track,
+          trackingScore,
+        });
         if (formatId < 1.1) {
           instance.points.forEach((point) => {
             point.xy = [point.xy[0] - 0.5, point.xy[1] - 0.5];
@@ -965,7 +1150,13 @@ function buildLabeledFrames(options: {
         }
       } else {
         const points = slicePoints(predPointsData, pointStart, pointEnd, true);
-        instance = new PredictedInstance({ points: predictedPointsFromArray(points, skeleton.nodeNames), skeleton, track, score, trackingScore });
+        instance = new PredictedInstance({
+          points: predictedPointsFromArray(points, skeleton.nodeNames),
+          skeleton,
+          track,
+          score,
+          trackingScore,
+        });
         if (formatId < 1.1) {
           instance.points.forEach((point) => {
             point.xy = [point.xy[0] - 0.5, point.xy[1] - 0.5];
@@ -983,7 +1174,11 @@ function buildLabeledFrames(options: {
   for (const [instanceId, fromPredictedId] of fromPredictedPairs) {
     const instance = instanceById.get(instanceId);
     const predicted = instanceById.get(fromPredictedId);
-    if (instance && predicted instanceof PredictedInstance && instance instanceof Instance) {
+    if (
+      instance &&
+      predicted instanceof PredictedInstance &&
+      instance instanceof Instance
+    ) {
       instance.fromPredicted = predicted;
     }
   }
@@ -991,7 +1186,10 @@ function buildLabeledFrames(options: {
   return frames;
 }
 
-function buildVideoIdMap(framesData: Record<string, unknown[]>, videos: Video[]): Map<number, number> {
+function buildVideoIdMap(
+  framesData: Record<string, unknown[]>,
+  videos: Video[],
+): Map<number, number> {
   const videoIds = new Set<number>();
   for (const value of (framesData.video ?? []) as number[]) {
     videoIds.add(Number(value));
@@ -1010,7 +1208,8 @@ function buildVideoIdMap(framesData: Record<string, unknown[]>, videos: Video[])
   const map = new Map<number, number>();
   for (let index = 0; index < videos.length; index += 1) {
     const video = videos[index];
-    const dataset = (video.backendMetadata?.dataset as string | undefined) ?? "";
+    const dataset =
+      (video.backendMetadata?.dataset as string | undefined) ?? "";
     const parsedId = parseVideoIdFromDataset(dataset);
     if (parsedId != null) {
       map.set(parsedId, index);
@@ -1027,7 +1226,12 @@ function parseVideoIdFromDataset(dataset: string): number | null {
   return Number.isNaN(id) ? null : id;
 }
 
-function slicePoints(data: Record<string, unknown[]>, start: number, end: number, predicted = false): number[][] {
+function slicePoints(
+  data: Record<string, unknown[]>,
+  start: number,
+  end: number,
+  predicted = false,
+): number[][] {
   const xs = (data.x ?? []) as number[];
   const ys = (data.y ?? []) as number[];
   const visible = (data.visible ?? []) as number[];

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -1,8 +1,23 @@
 import { openH5File, OpenH5Options, SlpSource } from "./h5.js";
-import { attrToNumber, attrToString, parseJsonAttr, parseSkeletons, resolveCameraKey, reconstructInstance3D, resolveIdentity, resolveVideoFilename } from "./parsers.js";
+import {
+  attrToNumber,
+  attrToString,
+  parseJsonAttr,
+  parseSkeletons,
+  resolveCameraKey,
+  reconstructInstance3D,
+  resolveIdentity,
+  resolveVideoFilename,
+} from "./parsers.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
-import { Instance, PredictedInstance, Track, pointsFromArray, predictedPointsFromArray } from "../../model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+  pointsFromArray,
+  predictedPointsFromArray,
+} from "../../model/instance.js";
 import { Skeleton } from "../../model/skeleton.js";
 import { SuggestionFrame } from "../../model/suggestions.js";
 import { Video, type VideoBackendError } from "../../model/video.js";
@@ -15,14 +30,42 @@ import { CropVideoBackend } from "../../video/crop-backend.js";
 import { resolveSourceFrameCount } from "./frame-count.js";
 import type { CropRect } from "../../transform/points.js";
 import type { Fill } from "../../transform/frame.js";
-import { Camera, CameraGroup, FrameGroup, InstanceGroup, RecordingSession } from "../../model/camera.js";
+import {
+  Camera,
+  CameraGroup,
+  FrameGroup,
+  InstanceGroup,
+  RecordingSession,
+} from "../../model/camera.js";
 import { Identity } from "../../model/identity.js";
 import { LazyDataStore, LazyFrameList } from "../../model/lazy.js";
-import { ROI, UserROI, PredictedROI, AnnotationType, decodeWkb } from "../../model/roi.js";
-import { SegmentationMask, UserSegmentationMask, PredictedSegmentationMask } from "../../model/mask.js";
-import { BoundingBox, UserBoundingBox, PredictedBoundingBox } from "../../model/bbox.js";
-import { Centroid, UserCentroid, PredictedCentroid } from "../../model/centroid.js";
-import { LabelImage, UserLabelImage, PredictedLabelImage } from "../../model/label-image.js";
+import {
+  ROI,
+  UserROI,
+  PredictedROI,
+  AnnotationType,
+  decodeWkb,
+} from "../../model/roi.js";
+import {
+  SegmentationMask,
+  UserSegmentationMask,
+  PredictedSegmentationMask,
+} from "../../model/mask.js";
+import {
+  BoundingBox,
+  UserBoundingBox,
+  PredictedBoundingBox,
+} from "../../model/bbox.js";
+import {
+  Centroid,
+  UserCentroid,
+  PredictedCentroid,
+} from "../../model/centroid.js";
+import {
+  LabelImage,
+  UserLabelImage,
+  PredictedLabelImage,
+} from "../../model/label-image.js";
 import type { LabelImageObjectInfo } from "../../model/label-image.js";
 import { inflate } from "pako";
 
@@ -30,7 +73,7 @@ const textDecoder = new TextDecoder();
 
 export async function readSlp(
   source: SlpSource,
-  options?: { openVideos?: boolean; h5?: OpenH5Options }
+  options?: { openVideos?: boolean; h5?: OpenH5Options },
 ): Promise<Labels> {
   const { file, close } = await openH5File(source, options?.h5);
   try {
@@ -39,15 +82,31 @@ export async function readSlp(
       throw new Error("Missing /metadata group in SLP file");
     }
 
-    const metadataAttrs = (metadataGroup as unknown as { attrs?: Record<string, any> }).attrs ?? {};
-    const formatId = Number(metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0);
-    const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<string, unknown> | null;
+    const metadataAttrs =
+      (metadataGroup as unknown as { attrs?: Record<string, any> }).attrs ?? {};
+    const formatId = Number(
+      metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0,
+    );
+    const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<
+      string,
+      unknown
+    > | null;
 
-    const labelsPath = typeof source === "string" ? source : options?.h5?.filenameHint ?? "slp-data.slp";
+    const labelsPath =
+      typeof source === "string"
+        ? source
+        : (options?.h5?.filenameHint ?? "slp-data.slp");
     const skeletons = parseSkeletons(metadataJson);
     const tracks = readTracks(file.get("tracks_json"));
     const videoCrops = readVideoCrops(file);
-    const videos = await readVideos(file.get("videos_json"), labelsPath, options?.openVideos ?? true, file, formatId, videoCrops);
+    const videos = await readVideos(
+      file.get("videos_json"),
+      labelsPath,
+      options?.openVideos ?? true,
+      file,
+      formatId,
+      videoCrops,
+    );
     const suggestions = readSuggestions(file.get("suggestions_json"), videos);
 
     const framesData = normalizeStructDataset(file.get("frames"));
@@ -65,7 +124,6 @@ export async function readSlp(
       videos,
       formatId,
     });
-
 
     // Read negative frames
     const negativeFramesDs = file.get("negative_frames");
@@ -86,12 +144,28 @@ export async function readSlp(
     }
 
     const identities = readIdentities(file.get("identities_json"));
-    const sessions = readSessions(file.get("sessions_json"), videos, skeletons, labeledFrames, identities);
+    const sessions = readSessions(
+      file.get("sessions_json"),
+      videos,
+      skeletons,
+      labeledFrames,
+      identities,
+    );
     const allInstances = labeledFrames.flatMap((f) => f.instances);
-    const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(file, videos, tracks, allInstances);
+    const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(
+      file,
+      videos,
+      tracks,
+      allInstances,
+    );
     const maskTuples = readMasks(file, videos, tracks);
     const centroidTuples = readCentroids(file, videos, tracks);
-    const labelImageTuples = readLabelImages(file, videos, tracks, allInstances);
+    const labelImageTuples = readLabelImages(
+      file,
+      videos,
+      tracks,
+      allInstances,
+    );
 
     // Distribute annotations into LabeledFrames using routing tuples
     const frameMap = new Map<string, LabeledFrame>();
@@ -99,7 +173,10 @@ export async function readSlp(
       const vidIdx = videos.indexOf(lf.video);
       frameMap.set(`${vidIdx}:${lf.frameIdx}`, lf);
     }
-    const getOrCreateFrame = (vidIdx: number, frameIdx: number): LabeledFrame => {
+    const getOrCreateFrame = (
+      vidIdx: number,
+      frameIdx: number,
+    ): LabeledFrame => {
       const key = `${vidIdx}:${frameIdx}`;
       let lf = frameMap.get(key);
       if (!lf) {
@@ -141,8 +218,15 @@ export async function readSlp(
     // labelImages get their .instance set on read (ROIs are already resolved
     // in readRoisWithMigration since it receives `instances`).
     const allInstancesFlat = labeledFrames.flatMap((lf) => lf.instances);
-    const resolveInstanceRef = (ann: { _instanceIdx: number | null; instance: Instance | null }): void => {
-      if (ann._instanceIdx !== null && ann._instanceIdx >= 0 && ann._instanceIdx < allInstancesFlat.length) {
+    const resolveInstanceRef = (ann: {
+      _instanceIdx: number | null;
+      instance: Instance | null;
+    }): void => {
+      if (
+        ann._instanceIdx !== null &&
+        ann._instanceIdx >= 0 &&
+        ann._instanceIdx < allInstancesFlat.length
+      ) {
         ann.instance = allInstancesFlat[ann._instanceIdx];
         ann._instanceIdx = null;
       }
@@ -181,15 +265,13 @@ export async function readSlp(
   }
 }
 
-
-
 /**
  * Read an SLP file in lazy mode. Frames are not materialized until accessed.
  * Returns a Labels object with a LazyFrameList that loads frames on demand.
  */
 export async function readSlpLazy(
   source: SlpSource,
-  options?: { openVideos?: boolean; h5?: OpenH5Options }
+  options?: { openVideos?: boolean; h5?: OpenH5Options },
 ): Promise<Labels> {
   const { file, close } = await openH5File(source, options?.h5);
   try {
@@ -198,15 +280,31 @@ export async function readSlpLazy(
       throw new Error("Missing /metadata group in SLP file");
     }
 
-    const metadataAttrs = (metadataGroup as unknown as { attrs?: Record<string, any> }).attrs ?? {};
-    const formatId = Number(metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0);
-    const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<string, unknown> | null;
+    const metadataAttrs =
+      (metadataGroup as unknown as { attrs?: Record<string, any> }).attrs ?? {};
+    const formatId = Number(
+      metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0,
+    );
+    const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<
+      string,
+      unknown
+    > | null;
 
-    const labelsPath = typeof source === "string" ? source : options?.h5?.filenameHint ?? "slp-data.slp";
+    const labelsPath =
+      typeof source === "string"
+        ? source
+        : (options?.h5?.filenameHint ?? "slp-data.slp");
     const skeletons = parseSkeletons(metadataJson);
     const tracks = readTracks(file.get("tracks_json"));
     const videoCrops = readVideoCrops(file);
-    const videos = await readVideos(file.get("videos_json"), labelsPath, options?.openVideos ?? true, file, formatId, videoCrops);
+    const videos = await readVideos(
+      file.get("videos_json"),
+      labelsPath,
+      options?.openVideos ?? true,
+      file,
+      formatId,
+      videoCrops,
+    );
     const suggestions = readSuggestions(file.get("suggestions_json"), videos);
 
     // Read raw data but don't build frames yet
@@ -244,8 +342,18 @@ export async function readSlpLazy(
     // Read sessions eagerly - they don't depend on frame data.
     // Pass empty labeledFrames since frames aren't materialized yet.
     const identities = readIdentities(file.get("identities_json"));
-    const sessions = readSessions(file.get("sessions_json"), videos, skeletons, [], identities);
-    const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(file, videos, tracks);
+    const sessions = readSessions(
+      file.get("sessions_json"),
+      videos,
+      skeletons,
+      [],
+      identities,
+    );
+    const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(
+      file,
+      videos,
+      tracks,
+    );
     const maskTuples = readMasks(file, videos, tracks);
     const centroidTuples = readCentroids(file, videos, tracks);
     const labelImageTuples = readLabelImages(file, videos, tracks);
@@ -439,7 +547,14 @@ function readVideoCrops(file: any): Map<number, VideoCropEntry> {
   return out;
 }
 
-async function readVideos(dataset: any, labelsPath: string, openVideos: boolean, file: any, formatId: number, videoCrops?: Map<number, VideoCropEntry>): Promise<Video[]> {
+async function readVideos(
+  dataset: any,
+  labelsPath: string,
+  openVideos: boolean,
+  file: any,
+  formatId: number,
+  videoCrops?: Map<number, VideoCropEntry>,
+): Promise<Video[]> {
   if (!dataset) return [];
   const values = dataset.value ?? [];
   const videos: Video[] = [];
@@ -447,7 +562,10 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
   for (let videoIndex = 0; videoIndex < values.length; videoIndex++) {
     const entry = values[videoIndex];
     if (!entry) continue;
-    const parsed = typeof entry === "string" ? JSON.parse(entry) : JSON.parse(textDecoder.decode(entry));
+    const parsed =
+      typeof entry === "string"
+        ? JSON.parse(entry)
+        : JSON.parse(textDecoder.decode(entry));
     const backendMeta = parsed.backend ?? {};
     let filename = resolveVideoFilename(backendMeta, parsed);
     let datasetPath = backendMeta.dataset ?? null;
@@ -478,7 +596,8 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
     if (datasetPath) {
       const videoDs = file.get(datasetPath);
       if (videoDs) {
-        const attrs = (videoDs as { attrs?: Record<string, unknown> }).attrs ?? {};
+        const attrs =
+          (videoDs as { attrs?: Record<string, unknown> }).attrs ?? {};
         if (!format) {
           format = attrToString(attrs.format);
         }
@@ -528,7 +647,10 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
     // 1. JSON metadata (backendMeta.channel_order)
     // 2. HDF5 dataset attribute (channelOrderFromAttrs)
     // 3. Legacy fallback based on format_id (BGR for < 1.4)
-    const channelOrder = (backendMeta.channel_order as string | undefined) ?? channelOrderFromAttrs ?? (formatId < 1.4 ? "BGR" : "RGB");
+    const channelOrder =
+      (backendMeta.channel_order as string | undefined) ??
+      channelOrderFromAttrs ??
+      (formatId < 1.4 ? "BGR" : "RGB");
 
     let backend = null;
     let backendError: VideoBackendError | null = null;
@@ -552,17 +674,20 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
         // actionable message / resolver instead of the load throwing.
         backend = null;
         backendError = {
-          kind: err instanceof UnsupportedVideoFormatError
-            ? "unsupported-format"
-            : isImageSource(filename)
-              ? "image-sequence"
-              : "decode",
+          kind:
+            err instanceof UnsupportedVideoFormatError
+              ? "unsupported-format"
+              : isImageSource(filename)
+                ? "image-sequence"
+                : "decode",
           message: err instanceof Error ? err.message : String(err),
         };
       }
     }
 
-    const sourceVideo = parsed.source_video ? new Video({ filename: parsed.source_video.filename ?? "" }) : null;
+    const sourceVideo = parsed.source_video
+      ? new Video({ filename: parsed.source_video.filename ?? "" })
+      : null;
 
     // Crop reconstruction (SLP 2.3): the backend just built from videos_json is
     // the UNCROPPED inner. If a /video_crops entry exists for this index, wrap it
@@ -586,7 +711,12 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
       const innerShape = backendMetadata.shape as number[] | undefined;
       if (innerShape && innerShape.length === 4) {
         backendMetadata.source_shape = [...innerShape];
-        backendMetadata.shape = [innerShape[0], cy2 - cy1, cx2 - cx1, innerShape[3]];
+        backendMetadata.shape = [
+          innerShape[0],
+          cy2 - cy1,
+          cx2 - cx1,
+          innerShape[3],
+        ];
       }
       backendMetadata.crop = [...cropEntry.crop];
       backendMetadata.crop_fill = cropEntry.fill;
@@ -601,7 +731,7 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
         sourceVideo,
         openBackend: openVideos,
         embedded,
-      })
+      }),
     );
   }
 
@@ -610,16 +740,23 @@ async function readVideos(dataset: any, labelsPath: string, openVideos: boolean,
 
 function readFrameNumbers(file: any, datasetPath: string | null): number[] {
   if (!datasetPath) return [];
-  const groupPath = datasetPath.endsWith("/video") ? datasetPath.slice(0, -6) : datasetPath;
+  const groupPath = datasetPath.endsWith("/video")
+    ? datasetPath.slice(0, -6)
+    : datasetPath;
   const frameDataset = file.get(`${groupPath}/frame_numbers`);
   if (!frameDataset) return [];
   const values = frameDataset.value ?? [];
   return Array.from(values).map((v: any) => Number(v));
 }
 
-function readFrameSizes(file: any, datasetPath: string | null): number[] | undefined {
+function readFrameSizes(
+  file: any,
+  datasetPath: string | null,
+): number[] | undefined {
   if (!datasetPath) return undefined;
-  const groupPath = datasetPath.endsWith("/video") ? datasetPath.slice(0, -6) : datasetPath;
+  const groupPath = datasetPath.endsWith("/video")
+    ? datasetPath.slice(0, -6)
+    : datasetPath;
   const sizesDataset = file.get(`${groupPath}/frame_sizes`);
   if (!sizesDataset) return undefined;
   const values = sizesDataset.value ?? [];
@@ -664,11 +801,21 @@ function readSuggestions(dataset: any, videos: Video[]): SuggestionFrame[] {
   const values = dataset.value ?? [];
   const suggestions: SuggestionFrame[] = [];
   for (const entry of values) {
-    const parsed = typeof entry === "string" ? JSON.parse(entry) : JSON.parse(textDecoder.decode(entry));
+    const parsed =
+      typeof entry === "string"
+        ? JSON.parse(entry)
+        : JSON.parse(textDecoder.decode(entry));
     const videoIndex = Number(parsed.video ?? 0);
     const video = videos[videoIndex];
     if (!video) continue;
-    suggestions.push(new SuggestionFrame({ video, frameIdx: parsed.frame_idx ?? parsed.frameIdx ?? 0, group: parsed.group != null ? String(parsed.group) : undefined, metadata: parsed }));
+    suggestions.push(
+      new SuggestionFrame({
+        video,
+        frameIdx: parsed.frame_idx ?? parsed.frameIdx ?? 0,
+        group: parsed.group != null ? String(parsed.group) : undefined,
+        metadata: parsed,
+      }),
+    );
   }
   return suggestions;
 }
@@ -678,23 +825,37 @@ function readIdentities(dataset: any): Identity[] {
   const values = dataset.value ?? [];
   const identities: Identity[] = [];
   for (const entry of values) {
-    const parsed = typeof entry === "string" ? JSON.parse(entry) : JSON.parse(textDecoder.decode(entry));
+    const parsed =
+      typeof entry === "string"
+        ? JSON.parse(entry)
+        : JSON.parse(textDecoder.decode(entry));
     const { name, color, ...rest } = parsed;
-    identities.push(new Identity({
-      name: name ?? "",
-      color: color ?? undefined,
-      metadata: rest,
-    }));
+    identities.push(
+      new Identity({
+        name: name ?? "",
+        color: color ?? undefined,
+        metadata: rest,
+      }),
+    );
   }
   return identities;
 }
 
-function readSessions(dataset: any, videos: Video[], skeletons: Skeleton[], labeledFrames: LabeledFrame[], identities?: Identity[]): RecordingSession[] {
+function readSessions(
+  dataset: any,
+  videos: Video[],
+  skeletons: Skeleton[],
+  labeledFrames: LabeledFrame[],
+  identities?: Identity[],
+): RecordingSession[] {
   if (!dataset) return [];
   const values = dataset.value ?? [];
   const sessions: RecordingSession[] = [];
   for (const entry of values) {
-    const parsed = typeof entry === "string" ? JSON.parse(entry) : JSON.parse(textDecoder.decode(entry));
+    const parsed =
+      typeof entry === "string"
+        ? JSON.parse(entry)
+        : JSON.parse(textDecoder.decode(entry));
     const cameraGroup = new CameraGroup();
     const cameraMap = new Map<string, Camera>();
     const calibration = asRecord(parsed.calibration);
@@ -713,22 +874,36 @@ function readSessions(dataset: any, videos: Video[], skeletons: Skeleton[], labe
       cameraMap.set(String(key), camera);
     }
 
-    const session = new RecordingSession({ cameraGroup, metadata: (parsed.metadata as Record<string, unknown> | undefined) ?? {} });
+    const session = new RecordingSession({
+      cameraGroup,
+      metadata: (parsed.metadata as Record<string, unknown> | undefined) ?? {},
+    });
     const map = asRecord(parsed.camcorder_to_video_idx_map);
     for (const [cameraKey, videoIdx] of Object.entries(map)) {
-      const camera = resolveCameraKey(cameraKey, cameraMap, cameraGroup.cameras);
+      const camera = resolveCameraKey(
+        cameraKey,
+        cameraMap,
+        cameraGroup.cameras,
+      );
       const video = videos[Number(videoIdx)];
       if (camera && video) {
         session.addVideo(video, camera);
       }
     }
 
-    const frameGroups = Array.isArray(parsed.frame_group_dicts) ? parsed.frame_group_dicts : [];
+    const frameGroups = Array.isArray(parsed.frame_group_dicts)
+      ? parsed.frame_group_dicts
+      : [];
     for (const group of frameGroups) {
       const groupRecord = asRecord(group);
-      const frameIdx = (groupRecord.frame_idx as number | undefined) ?? (groupRecord.frameIdx as number | undefined) ?? 0;
+      const frameIdx =
+        (groupRecord.frame_idx as number | undefined) ??
+        (groupRecord.frameIdx as number | undefined) ??
+        0;
       const instanceGroups: InstanceGroup[] = [];
-      const instanceGroupList = Array.isArray(groupRecord.instance_groups) ? groupRecord.instance_groups : [];
+      const instanceGroupList = Array.isArray(groupRecord.instance_groups)
+        ? groupRecord.instance_groups
+        : [];
       for (const instanceGroup of instanceGroupList) {
         const instanceGroupRecord = asRecord(instanceGroup);
         const instanceByCamera = new Map<Camera, Instance>();
@@ -736,20 +911,38 @@ function readSessions(dataset: any, videos: Video[], skeletons: Skeleton[], labe
         // Read JS-format instances (camera key -> point data)
         const instancesRecord = asRecord(instanceGroupRecord.instances);
         for (const [cameraKey, points] of Object.entries(instancesRecord)) {
-          const camera = resolveCameraKey(cameraKey, cameraMap, cameraGroup.cameras);
+          const camera = resolveCameraKey(
+            cameraKey,
+            cameraMap,
+            cameraGroup.cameras,
+          );
           if (!camera) {
-            console.warn(`Camera key "${cameraKey}" not found in session calibration — skipping 2D instance data for this camera.`);
+            console.warn(
+              `Camera key "${cameraKey}" not found in session calibration — skipping 2D instance data for this camera.`,
+            );
             continue;
           }
           const skeleton = skeletons[0] ?? new Skeleton({ nodes: [] });
-          instanceByCamera.set(camera, new Instance({ points: points as Record<string, number[]>, skeleton }));
+          instanceByCamera.set(
+            camera,
+            new Instance({
+              points: points as Record<string, number[]>,
+              skeleton,
+            }),
+          );
         }
 
         // Fall back to Python-format camcorder_to_lf_and_inst_idx_map
         if (instanceByCamera.size === 0) {
-          const lfInstMap = asRecord(instanceGroupRecord.camcorder_to_lf_and_inst_idx_map);
+          const lfInstMap = asRecord(
+            instanceGroupRecord.camcorder_to_lf_and_inst_idx_map,
+          );
           for (const [camIdx, value] of Object.entries(lfInstMap)) {
-            const camera = resolveCameraKey(camIdx, cameraMap, cameraGroup.cameras);
+            const camera = resolveCameraKey(
+              camIdx,
+              cameraMap,
+              cameraGroup.cameras,
+            );
             if (!camera) continue;
             const pair = value as unknown as [number, number];
             const lf = labeledFrames[Number(pair[0])];
@@ -760,7 +953,10 @@ function readSessions(dataset: any, videos: Video[], skeletons: Skeleton[], labe
           }
         }
 
-        const instance3d = reconstructInstance3D(instanceGroupRecord, skeletons);
+        const instance3d = reconstructInstance3D(
+          instanceGroupRecord,
+          skeletons,
+        );
         const identity = resolveIdentity(instanceGroupRecord, identities);
 
         instanceGroups.push(
@@ -769,17 +965,28 @@ function readSessions(dataset: any, videos: Video[], skeletons: Skeleton[], labe
             score: instanceGroupRecord.score as number | undefined,
             instance3d,
             identity,
-            metadata: (instanceGroupRecord.metadata as Record<string, unknown> | undefined) ?? {},
-          })
+            metadata:
+              (instanceGroupRecord.metadata as
+                | Record<string, unknown>
+                | undefined) ?? {},
+          }),
         );
       }
 
       const labeledFrameByCamera = new Map<Camera, LabeledFrame>();
       const labeledFrameMap = asRecord(groupRecord.labeled_frame_by_camera);
-      for (const [cameraKey, labeledFrameIdx] of Object.entries(labeledFrameMap)) {
-        const camera = resolveCameraKey(cameraKey, cameraMap, cameraGroup.cameras);
+      for (const [cameraKey, labeledFrameIdx] of Object.entries(
+        labeledFrameMap,
+      )) {
+        const camera = resolveCameraKey(
+          cameraKey,
+          cameraMap,
+          cameraGroup.cameras,
+        );
         if (!camera) {
-          console.warn(`Camera key "${cameraKey}" not found in session calibration — skipping labeled frame mapping.`);
+          console.warn(
+            `Camera key "${cameraKey}" not found in session calibration — skipping labeled frame mapping.`,
+          );
           continue;
         }
         const labeledFrame = labeledFrames[Number(labeledFrameIdx)];
@@ -794,7 +1001,11 @@ function readSessions(dataset: any, videos: Video[], skeletons: Skeleton[], labe
           const igRecord = asRecord(instanceGroup);
           const lfInstMap = asRecord(igRecord.camcorder_to_lf_and_inst_idx_map);
           for (const [camIdx, value] of Object.entries(lfInstMap)) {
-            const camera = resolveCameraKey(camIdx, cameraMap, cameraGroup.cameras);
+            const camera = resolveCameraKey(
+              camIdx,
+              cameraMap,
+              cameraGroup.cameras,
+            );
             if (!camera) continue;
             const pair = value as unknown as [number, number];
             const lf = labeledFrames[Number(pair[0])];
@@ -809,8 +1020,9 @@ function readSessions(dataset: any, videos: Video[], skeletons: Skeleton[], labe
           frameIdx: Number(frameIdx),
           instanceGroups,
           labeledFrameByCamera,
-          metadata: (groupRecord.metadata as Record<string, unknown> | undefined) ?? {},
-        })
+          metadata:
+            (groupRecord.metadata as Record<string, unknown> | undefined) ?? {},
+        }),
       );
     }
     sessions.push(session);
@@ -825,17 +1037,24 @@ function asRecord(value: unknown): Record<string, unknown> {
   return {};
 }
 
-
 function readAttrString(dataset: any, name: string): string[] {
   const attrs = (dataset as { attrs?: Record<string, any> }).attrs ?? {};
   const raw = attrs[name];
   if (!raw) return [];
   const value = raw.value ?? raw;
   if (typeof value === "string") {
-    try { return JSON.parse(value); } catch { return []; }
+    try {
+      return JSON.parse(value);
+    } catch {
+      return [];
+    }
   }
   if (value instanceof Uint8Array) {
-    try { return JSON.parse(textDecoder.decode(value)); } catch { return []; }
+    try {
+      return JSON.parse(textDecoder.decode(value));
+    } catch {
+      return [];
+    }
   }
   if (Array.isArray(value)) return value.map(String);
   return [];
@@ -847,7 +1066,12 @@ function readRoisAndBboxes(
   tracks: Track[],
   instances?: Array<Instance | PredictedInstance>,
 ): { rois: [ROI, number, number][]; bboxes: [BoundingBox, number, number][] } {
-  const { rois, migratedBboxes } = readRoisWithMigration(file, videos, tracks, instances);
+  const { rois, migratedBboxes } = readRoisWithMigration(
+    file,
+    videos,
+    tracks,
+    instances,
+  );
   let bboxes = readBboxes(file, videos, tracks);
   if (bboxes.length === 0 && migratedBboxes.length > 0) {
     bboxes = migratedBboxes;
@@ -860,7 +1084,10 @@ function readRoisWithMigration(
   videos: Video[],
   tracks: Track[],
   instances?: Array<Instance | PredictedInstance>,
-): { rois: [ROI, number, number][]; migratedBboxes: [BoundingBox, number, number][] } {
+): {
+  rois: [ROI, number, number][];
+  migratedBboxes: [BoundingBox, number, number][];
+} {
   const roisDs = file.get("rois");
   if (!roisDs) return { rois: [], migratedBboxes: [] };
   const roisData = normalizeStructDataset(roisDs);
@@ -869,12 +1096,18 @@ function readRoisWithMigration(
 
   const wkbDs = file.get("roi_wkb");
   if (!wkbDs) return { rois: [], migratedBboxes: [] };
-  const wkbFlat: Uint8Array = wkbDs.value instanceof Uint8Array
-    ? wkbDs.value
-    : new Uint8Array(wkbDs.value ?? []);
+  const wkbFlat: Uint8Array =
+    wkbDs.value instanceof Uint8Array
+      ? wkbDs.value
+      : new Uint8Array(wkbDs.value ?? []);
 
   // v1.9+: string datasets; fallback to JSON attrs
-  const categories = readStringMetadata(file, "roi_categories", roisDs, "categories");
+  const categories = readStringMetadata(
+    file,
+    "roi_categories",
+    roisDs,
+    "categories",
+  );
   const names = readStringMetadata(file, "roi_names", roisDs, "names");
   const sources = readStringMetadata(file, "roi_sources", roisDs, "sources");
 
@@ -899,24 +1132,35 @@ function readRoisWithMigration(
     const geometry = decodeWkb(wkbBytes);
 
     const videoIdx = Number(videoIndices[i]);
-    const video = videoIdx >= 0 && videoIdx < videos.length ? videos[videoIdx] : null;
+    const video =
+      videoIdx >= 0 && videoIdx < videos.length ? videos[videoIdx] : null;
 
     const frameIdxVal = Number(frameIndices[i]);
 
     const trackIdx = Number(trackIndices[i]);
-    const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
+    const track =
+      trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
 
     const annotType = Number(annotationTypes[i]);
 
-    const isPred = isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
+    const isPred =
+      isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
 
-    const roiTsVal = trackingScoresCol.length > i ? Number(trackingScoresCol[i]) : Number.NaN;
+    const roiTsVal =
+      trackingScoresCol.length > i ? Number(trackingScoresCol[i]) : Number.NaN;
     const roiTrackingScore = Number.isNaN(roiTsVal) ? null : roiTsVal;
 
     // Migration: annotation_type === 1 (BOUNDING_BOX) -> BoundingBox object
     // Skip predicted ROIs during bbox migration (only migrate user-type box-shaped ROIs)
     if (annotType === AnnotationType.BOUNDING_BOX && !isPred) {
-      const tmpRoi = new UserROI({ geometry, name: names[i] ?? "", category: categories[i] ?? "", source: sources[i] ?? "", video, track });
+      const tmpRoi = new UserROI({
+        geometry,
+        name: names[i] ?? "",
+        category: categories[i] ?? "",
+        source: sources[i] ?? "",
+        video,
+        track,
+      });
       const b = tmpRoi.bounds;
       const scoreVal = Number(scores[i]);
       const bboxScore = Number.isNaN(scoreVal) ? null : scoreVal;
@@ -965,7 +1209,10 @@ function readRoisWithMigration(
       let roi: ROI;
       if (isPred) {
         const scoreVal = Number(scores[i]);
-        roi = new PredictedROI({ ...roiOptions, score: Number.isNaN(scoreVal) ? 0 : scoreVal });
+        roi = new PredictedROI({
+          ...roiOptions,
+          score: Number.isNaN(scoreVal) ? 0 : scoreVal,
+        });
       } else {
         roi = new UserROI(roiOptions);
       }
@@ -987,7 +1234,11 @@ function readRoisWithMigration(
   return { rois, migratedBboxes };
 }
 
-function readBboxes(file: any, _videos: Video[], tracks: Track[]): [BoundingBox, number, number][] {
+function readBboxes(
+  file: any,
+  _videos: Video[],
+  tracks: Track[],
+): [BoundingBox, number, number][] {
   const bboxesDs = file.get("bboxes");
   if (!bboxesDs) return [];
   const bboxesData = normalizeStructDataset(bboxesDs);
@@ -1002,7 +1253,12 @@ function readBboxes(file: any, _videos: Video[], tracks: Track[]): [BoundingBox,
   if (!count) return [];
 
   // v1.9+: string datasets at root level; fallback to JSON attrs on dataset
-  const categories = readStringMetadata(file, "bbox_categories", bboxesDs, "categories");
+  const categories = readStringMetadata(
+    file,
+    "bbox_categories",
+    bboxesDs,
+    "categories",
+  );
   const names = readStringMetadata(file, "bbox_names", bboxesDs, "names");
   const sources = readStringMetadata(file, "bbox_sources", bboxesDs, "sources");
 
@@ -1027,7 +1283,8 @@ function readBboxes(file: any, _videos: Video[], tracks: Track[]): [BoundingBox,
     const frameIdxVal = Number(frameIndices[i]);
 
     const trackIdx = Number(trackIndices[i]);
-    const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
+    const track =
+      trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
 
     const scoreVal = Number(bboxScores[i]);
     const instanceIdx = Number(instanceIndices[i]);
@@ -1050,7 +1307,8 @@ function readBboxes(file: any, _videos: Video[], tracks: Track[]): [BoundingBox,
       by2 = Number(y2s[i]);
     }
 
-    const tsVal = trackingScores.length > i ? Number(trackingScores[i]) : Number.NaN;
+    const tsVal =
+      trackingScores.length > i ? Number(trackingScores[i]) : Number.NaN;
     const trackingScore = Number.isNaN(tsVal) ? null : tsVal;
 
     const options = {
@@ -1086,7 +1344,12 @@ function readBboxes(file: any, _videos: Video[], tracks: Track[]): [BoundingBox,
  * Read string metadata from a root-level dataset or fall back to a JSON attribute.
  * v1.9+ writes string datasets; older files use JSON-encoded attrs.
  */
-function readStringMetadata(file: any, datasetPath: string, dataset: any, attrName: string): string[] {
+function readStringMetadata(
+  file: any,
+  datasetPath: string,
+  dataset: any,
+  attrName: string,
+): string[] {
   const ds = file.get(datasetPath);
   if (ds) {
     // Try the "json" attribute on the string dataset first
@@ -1095,7 +1358,7 @@ function readStringMetadata(file: any, datasetPath: string, dataset: any, attrNa
     // Fall back to raw value
     const val = ds.value;
     if (Array.isArray(val)) {
-      return val.map((v: any) => typeof v === "string" ? v : String(v ?? ""));
+      return val.map((v: any) => (typeof v === "string" ? v : String(v ?? "")));
     }
   }
   return readAttrString(dataset, attrName);
@@ -1105,8 +1368,15 @@ function readStringMetadata(file: any, datasetPath: string, dataset: any, attrNa
  * Read score maps from index + data datasets.
  * Returns a Map from annotation index to { scoreMap, height, width }.
  */
-function readScoreMaps(file: any, indexPath: string, dataPath: string): Map<number, { scoreMap: Float32Array; height: number; width: number }> {
-  const result = new Map<number, { scoreMap: Float32Array; height: number; width: number }>();
+function readScoreMaps(
+  file: any,
+  indexPath: string,
+  dataPath: string,
+): Map<number, { scoreMap: Float32Array; height: number; width: number }> {
+  const result = new Map<
+    number,
+    { scoreMap: Float32Array; height: number; width: number }
+  >();
   const indexDs = file.get(indexPath);
   const dataDs = file.get(dataPath);
   if (!indexDs || !dataDs) return result;
@@ -1118,8 +1388,10 @@ function readScoreMaps(file: any, indexPath: string, dataPath: string): Map<numb
   const smHeights = indexData.height ?? [];
   const smWidths = indexData.width ?? [];
 
-  const dataFlat: Uint8Array = dataDs.value instanceof Uint8Array
-    ? dataDs.value : new Uint8Array(dataDs.value ?? []);
+  const dataFlat: Uint8Array =
+    dataDs.value instanceof Uint8Array
+      ? dataDs.value
+      : new Uint8Array(dataDs.value ?? []);
 
   for (let i = 0; i < idxCol.length; i++) {
     const annotIdx = Number(idxCol[i]);
@@ -1137,7 +1409,10 @@ function readScoreMaps(file: any, indexPath: string, dataPath: string): Map<numb
       );
     }
     const scoreMap = new Float32Array(
-      decompressed.buffer.slice(decompressed.byteOffset, decompressed.byteOffset + decompressed.byteLength),
+      decompressed.buffer.slice(
+        decompressed.byteOffset,
+        decompressed.byteOffset + decompressed.byteLength,
+      ),
     );
 
     result.set(annotIdx, { scoreMap, height: h, width: w });
@@ -1145,7 +1420,11 @@ function readScoreMaps(file: any, indexPath: string, dataPath: string): Map<numb
   return result;
 }
 
-function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationMask, number, number][] {
+function readMasks(
+  file: any,
+  _videos: Video[],
+  tracks: Track[],
+): [SegmentationMask, number, number][] {
   const masksDs = file.get("masks");
   if (!masksDs) return [];
   const masksData = normalizeStructDataset(masksDs);
@@ -1154,12 +1433,18 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
 
   const rleDs = file.get("mask_rle");
   if (!rleDs) return [];
-  const rleFlat: Uint8Array = rleDs.value instanceof Uint8Array
-    ? rleDs.value
-    : new Uint8Array(rleDs.value ?? []);
+  const rleFlat: Uint8Array =
+    rleDs.value instanceof Uint8Array
+      ? rleDs.value
+      : new Uint8Array(rleDs.value ?? []);
 
   // v1.9+: string datasets at root level; fallback to JSON attrs on mask dataset
-  const categories = readStringMetadata(file, "mask_categories", masksDs, "categories");
+  const categories = readStringMetadata(
+    file,
+    "mask_categories",
+    masksDs,
+    "categories",
+  );
   const names = readStringMetadata(file, "mask_names", masksDs, "names");
   const sources = readStringMetadata(file, "mask_sources", masksDs, "sources");
 
@@ -1185,7 +1470,11 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
   const offsetYCol = masksData.offset_y ?? [];
 
   // Read score maps if present
-  const scoreMaps = readScoreMaps(file, "mask_score_map_index", "mask_score_maps");
+  const scoreMaps = readScoreMaps(
+    file,
+    "mask_score_map_index",
+    "mask_score_maps",
+  );
 
   const masks: [SegmentationMask, number, number][] = [];
   // Deferred from_predicted re-link: collect (userMaskIdx, srcIdx) pairs and
@@ -1200,7 +1489,11 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
     // Convert packed uint8 bytes back to Uint32Array (4 bytes per count, little-endian)
     const numCounts = rleRaw.byteLength / 4;
     const rleCounts = new Uint32Array(numCounts);
-    const rleView = new DataView(rleRaw.buffer, rleRaw.byteOffset, rleRaw.byteLength);
+    const rleView = new DataView(
+      rleRaw.buffer,
+      rleRaw.byteOffset,
+      rleRaw.byteLength,
+    );
     for (let j = 0; j < numCounts; j++) {
       rleCounts[j] = rleView.getUint32(j * 4, true);
     }
@@ -1210,14 +1503,18 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
     const frameIdxVal = Number(frameIndices[i]);
 
     const trackIdx = Number(trackIndices[i]);
-    const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
+    const track =
+      trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
 
     const scaleX = scaleXCol.length > i ? Number(scaleXCol[i]) : 1;
     const scaleY = scaleYCol.length > i ? Number(scaleYCol[i]) : 1;
     const offsetX = offsetXCol.length > i ? Number(offsetXCol[i]) : 0;
     const offsetY = offsetYCol.length > i ? Number(offsetYCol[i]) : 0;
 
-    const maskTsVal = maskTrackingScoreCol.length > i ? Number(maskTrackingScoreCol[i]) : Number.NaN;
+    const maskTsVal =
+      maskTrackingScoreCol.length > i
+        ? Number(maskTrackingScoreCol[i])
+        : Number.NaN;
     const maskTrackingScore = Number.isNaN(maskTsVal) ? null : maskTsVal;
 
     const baseOptions = {
@@ -1234,7 +1531,8 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
     };
 
     // Determine if predicted based on is_predicted column or NaN score fallback
-    const isPred = isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
+    const isPred =
+      isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
     let mask: SegmentationMask;
 
     if (isPred) {
@@ -1248,7 +1546,8 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
     } else {
       mask = new UserSegmentationMask(baseOptions);
       // Collect from_predicted link for deferred re-link (user masks only).
-      const fpIdx = fromPredictedCol.length > i ? Number(fromPredictedCol[i]) : -1;
+      const fpIdx =
+        fromPredictedCol.length > i ? Number(fromPredictedCol[i]) : -1;
       if (fpIdx >= 0) fromPredictedPairs.push([i, fpIdx]);
     }
 
@@ -1265,8 +1564,9 @@ function readMasks(file: any, _videos: Video[], tracks: Track[]): [SegmentationM
   // indices leave fromPredicted at its constructor default (null).
   for (const [i, fpIdx] of fromPredictedPairs) {
     if (fpIdx >= 0 && fpIdx < masks.length) {
-      (masks[i][0] as UserSegmentationMask).fromPredicted =
-        masks[fpIdx][0] as PredictedSegmentationMask;
+      (masks[i][0] as UserSegmentationMask).fromPredicted = masks[
+        fpIdx
+      ][0] as PredictedSegmentationMask;
     }
   }
 
@@ -1299,7 +1599,12 @@ function readLabelImages(
   const dataEnds = liData.data_end ?? [];
 
   // v1.9+: string datasets; fallback to JSON attrs
-  const sources = readStringMetadata(file, "label_image_sources", liDs, "sources");
+  const sources = readStringMetadata(
+    file,
+    "label_image_sources",
+    liDs,
+    "sources",
+  );
 
   // v1.9+ columns (may not exist in older files)
   const isPredictedCol = liData.is_predicted ?? [];
@@ -1323,8 +1628,10 @@ function readLabelImages(
   if (isChunked) {
     dataChunked = dataDs.value; // 3D array or flat typed array with shape metadata
   } else {
-    dataFlat = dataDs.value instanceof Uint8Array
-      ? dataDs.value : new Uint8Array(dataDs.value ?? []);
+    dataFlat =
+      dataDs.value instanceof Uint8Array
+        ? dataDs.value
+        : new Uint8Array(dataDs.value ?? []);
   }
 
   // Read objects table (may not exist if all label images have 0 objects)
@@ -1343,14 +1650,28 @@ function readLabelImages(
     objTrackIndices = objData.track ?? [];
     objInstanceIndices = objData.instance ?? [];
     // v1.9+: string datasets at root level
-    objCategories = readStringMetadata(file, "label_image_obj_categories", objDs, "categories");
-    objNames = readStringMetadata(file, "label_image_obj_names", objDs, "names");
+    objCategories = readStringMetadata(
+      file,
+      "label_image_obj_categories",
+      objDs,
+      "categories",
+    );
+    objNames = readStringMetadata(
+      file,
+      "label_image_obj_names",
+      objDs,
+      "names",
+    );
     objScoreCol = objData.score ?? [];
     objTrackingScoreCol = objData.tracking_score ?? [];
   }
 
   // Read score maps if present
-  const liScoreMaps = readScoreMaps(file, "label_image_score_map_index", "label_image_score_maps");
+  const liScoreMaps = readScoreMaps(
+    file,
+    "label_image_score_map_index",
+    "label_image_score_maps",
+  );
 
   const labelImages: [LabelImage, number, number][] = [];
   for (let i = 0; i < videoIndices.length; i++) {
@@ -1367,7 +1688,11 @@ function readLabelImages(
       const frameSize = height * width;
       if (dataChunked instanceof Int32Array) {
         // Flat typed array with shape [T, H, W] — slice by frame index
-        pixelData = new Int32Array(dataChunked.buffer, dataChunked.byteOffset + i * frameSize * 4, frameSize);
+        pixelData = new Int32Array(
+          dataChunked.buffer,
+          dataChunked.byteOffset + i * frameSize * 4,
+          frameSize,
+        );
       } else if (ArrayBuffer.isView(dataChunked)) {
         // Other typed array — convert to Int32Array
         const offset = i * frameSize;
@@ -1388,7 +1713,10 @@ function readLabelImages(
       // Convert bytes back to Int32Array (little-endian, matches native).
       // Use buffer.slice() to guarantee 4-byte alignment for Int32Array.
       pixelData = new Int32Array(
-        decompressed.buffer.slice(decompressed.byteOffset, decompressed.byteOffset + decompressed.byteLength)
+        decompressed.buffer.slice(
+          decompressed.byteOffset,
+          decompressed.byteOffset + decompressed.byteLength,
+        ),
       );
     }
 
@@ -1401,7 +1729,8 @@ function readLabelImages(
     for (let j = objStart; j < objStart + nObj; j++) {
       const labelId = Number(objLabelIds[j]);
       const trackIdx = Number(objTrackIndices[j]);
-      const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
+      const track =
+        trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
       const instIdx = Number(objInstanceIndices[j]);
       let instance: Instance | null = null;
 
@@ -1412,21 +1741,24 @@ function readLabelImages(
       }
 
       const objScore = objScoreCol.length > j ? Number(objScoreCol[j]) : null;
-      const objTsVal = objTrackingScoreCol.length > j ? Number(objTrackingScoreCol[j]) : null;
+      const objTsVal =
+        objTrackingScoreCol.length > j ? Number(objTrackingScoreCol[j]) : null;
 
       objects.set(labelId, {
         track,
         category: objCategories[j] ?? "",
         name: objNames[j] ?? "",
         instance,
-        score: (objScore !== null && !Number.isNaN(objScore)) ? objScore : null,
-        trackingScore: (objTsVal !== null && !Number.isNaN(objTsVal)) ? objTsVal : null,
+        score: objScore !== null && !Number.isNaN(objScore) ? objScore : null,
+        trackingScore:
+          objTsVal !== null && !Number.isNaN(objTsVal) ? objTsVal : null,
         _instanceIdx: instIdx >= 0 ? instIdx : -1,
       });
     }
 
     // Determine if predicted
-    const isPred = isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
+    const isPred =
+      isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
 
     // v2.1+: spatial metadata
     const liScaleX = liScaleXCol.length > i ? Number(liScaleXCol[i]) : 1;
@@ -1483,7 +1815,12 @@ function normalizeStructDataset(dataset: any): Record<string, any[]> {
     return mapStructuredRows(raw, fieldNames);
   }
 
-  if (raw && ArrayBuffer.isView(raw) && Array.isArray(dataset.shape) && dataset.shape.length === 2) {
+  if (
+    raw &&
+    ArrayBuffer.isView(raw) &&
+    Array.isArray(dataset.shape) &&
+    dataset.shape.length === 2
+  ) {
     const [rowCount, colCount] = dataset.shape as [number, number];
     const rows: any[][] = [];
     for (let i = 0; i < rowCount; i += 1) {
@@ -1502,7 +1839,10 @@ function normalizeStructDataset(dataset: any): Record<string, any[]> {
   return {};
 }
 
-function mapStructuredRows(rows: any[][], fieldNames: string[]): Record<string, any[]> {
+function mapStructuredRows(
+  rows: any[][],
+  fieldNames: string[],
+): Record<string, any[]> {
   if (!fieldNames.length) {
     return rows.reduce((acc: Record<string, any[]>, row: any[], idx) => {
       acc[String(idx)] = row;
@@ -1521,7 +1861,9 @@ function getFieldNames(dataset: any): string[] {
   if (fields.length) return fields;
   const compoundMembers = dataset.metadata?.compound_type?.members;
   if (Array.isArray(compoundMembers) && compoundMembers.length) {
-    const names = compoundMembers.map((member: { name?: string }) => member.name).filter((name: string | undefined): name is string => !!name);
+    const names = compoundMembers
+      .map((member: { name?: string }) => member.name)
+      .filter((name: string | undefined): name is string => !!name);
     if (names.length) return names;
   }
   const attr = dataset.attrs?.field_names ?? dataset.attrs?.fieldNames;
@@ -1533,7 +1875,10 @@ function getFieldNames(dataset: any): string[] {
       const parsed = JSON.parse(value);
       if (Array.isArray(parsed)) return parsed.map((entry) => String(entry));
     } catch {
-      return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+      return value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean);
     }
   }
   if (value instanceof Uint8Array) {
@@ -1558,7 +1903,16 @@ function buildLabeledFrames(options: {
   formatId: number;
 }): LabeledFrame[] {
   const frames: LabeledFrame[] = [];
-  const { framesData, instancesData, pointsData, predPointsData, skeletons, tracks, videos, formatId } = options;
+  const {
+    framesData,
+    instancesData,
+    pointsData,
+    predPointsData,
+    skeletons,
+    tracks,
+    videos,
+    formatId,
+  } = options;
   const frameIds = framesData.frame_id ?? [];
   const videoIdToIndex = buildVideoIdMap(framesData, videos);
   const instanceById = new Map<number, Instance | PredictedInstance>();
@@ -1581,16 +1935,28 @@ function buildLabeledFrames(options: {
       const pointStart = Number(instancesData.point_id_start?.[instIdx] ?? 0);
       const pointEnd = Number(instancesData.point_id_end?.[instIdx] ?? 0);
       const score = Number(instancesData.score?.[instIdx] ?? 0);
-      const rawTrackingScore = formatId < 1.2 ? 0 : Number(instancesData.tracking_score?.[instIdx] ?? 0);
-      const trackingScore = Number.isNaN(rawTrackingScore) ? 0 : rawTrackingScore;
-      const fromPredicted = Number(instancesData.from_predicted?.[instIdx] ?? -1);
+      const rawTrackingScore =
+        formatId < 1.2
+          ? 0
+          : Number(instancesData.tracking_score?.[instIdx] ?? 0);
+      const trackingScore = Number.isNaN(rawTrackingScore)
+        ? 0
+        : rawTrackingScore;
+      const fromPredicted = Number(
+        instancesData.from_predicted?.[instIdx] ?? -1,
+      );
       const skeleton = skeletons[skeletonId] ?? skeletons[0];
       const track = trackId >= 0 ? tracks[trackId] : null;
 
       let instance: Instance | PredictedInstance;
       if (instanceType === 0) {
         const points = slicePoints(pointsData, pointStart, pointEnd);
-        instance = new Instance({ points: pointsFromArray(points, skeleton.nodeNames), skeleton, track, trackingScore });
+        instance = new Instance({
+          points: pointsFromArray(points, skeleton.nodeNames),
+          skeleton,
+          track,
+          trackingScore,
+        });
         if (formatId < 1.1) {
           instance.points.forEach((point) => {
             point.xy = [point.xy[0] - 0.5, point.xy[1] - 0.5];
@@ -1601,7 +1967,13 @@ function buildLabeledFrames(options: {
         }
       } else {
         const points = slicePoints(predPointsData, pointStart, pointEnd, true);
-        instance = new PredictedInstance({ points: predictedPointsFromArray(points, skeleton.nodeNames), skeleton, track, score, trackingScore });
+        instance = new PredictedInstance({
+          points: predictedPointsFromArray(points, skeleton.nodeNames),
+          skeleton,
+          track,
+          score,
+          trackingScore,
+        });
         if (formatId < 1.1) {
           instance.points.forEach((point) => {
             point.xy = [point.xy[0] - 0.5, point.xy[1] - 0.5];
@@ -1619,7 +1991,11 @@ function buildLabeledFrames(options: {
   for (const [instanceId, fromPredictedId] of fromPredictedPairs) {
     const instance = instanceById.get(instanceId);
     const predicted = instanceById.get(fromPredictedId);
-    if (instance && predicted instanceof PredictedInstance && instance instanceof Instance) {
+    if (
+      instance &&
+      predicted instanceof PredictedInstance &&
+      instance instanceof Instance
+    ) {
       instance.fromPredicted = predicted;
     }
   }
@@ -1627,7 +2003,10 @@ function buildLabeledFrames(options: {
   return frames;
 }
 
-function buildVideoIdMap(framesData: Record<string, any[]>, videos: Video[]): Map<number, number> {
+function buildVideoIdMap(
+  framesData: Record<string, any[]>,
+  videos: Video[],
+): Map<number, number> {
   const videoIds = new Set<number>();
   for (const value of framesData.video ?? []) {
     videoIds.add(Number(value));
@@ -1646,7 +2025,10 @@ function buildVideoIdMap(framesData: Record<string, any[]>, videos: Video[]): Ma
   const map = new Map<number, number>();
   for (let index = 0; index < videos.length; index += 1) {
     const video = videos[index];
-    const dataset = (video.backend?.dataset ?? (video.backendMetadata?.dataset as string | undefined)) ?? "";
+    const dataset =
+      video.backend?.dataset ??
+      (video.backendMetadata?.dataset as string | undefined) ??
+      "";
     const parsedId = parseVideoIdFromDataset(dataset);
     if (parsedId != null) {
       map.set(parsedId, index);
@@ -1663,7 +2045,11 @@ function parseVideoIdFromDataset(dataset: string): number | null {
   return Number.isNaN(id) ? null : id;
 }
 
-function readCentroids(file: any, _videos: Video[], tracks: Track[]): [Centroid, number, number][] {
+function readCentroids(
+  file: any,
+  _videos: Video[],
+  tracks: Track[],
+): [Centroid, number, number][] {
   const centroidsDs = file.get("centroids");
   if (!centroidsDs) return [];
   const data = normalizeStructDataset(centroidsDs);
@@ -1671,9 +2057,24 @@ function readCentroids(file: any, _videos: Video[], tracks: Track[]): [Centroid,
   const count = xs.length;
   if (!count) return [];
 
-  const categories = readStringMetadata(file, "centroid_categories", centroidsDs, "categories");
-  const names = readStringMetadata(file, "centroid_names", centroidsDs, "names");
-  const sources = readStringMetadata(file, "centroid_sources", centroidsDs, "sources");
+  const categories = readStringMetadata(
+    file,
+    "centroid_categories",
+    centroidsDs,
+    "categories",
+  );
+  const names = readStringMetadata(
+    file,
+    "centroid_names",
+    centroidsDs,
+    "names",
+  );
+  const sources = readStringMetadata(
+    file,
+    "centroid_sources",
+    centroidsDs,
+    "sources",
+  );
 
   const ys = data.y ?? [];
   const zs = data.z ?? [];
@@ -1692,12 +2093,14 @@ function readCentroids(file: any, _videos: Video[], tracks: Track[]): [Centroid,
     const frameIdxVal = Number(frameIndices[i]);
 
     const trackIdx = Number(trackIndices[i]);
-    const track = trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
+    const track =
+      trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
 
     const zVal = zs.length > i ? Number(zs[i]) : Number.NaN;
     const z = Number.isNaN(zVal) ? null : zVal;
 
-    const tsVal = trackingScores.length > i ? Number(trackingScores[i]) : Number.NaN;
+    const tsVal =
+      trackingScores.length > i ? Number(trackingScores[i]) : Number.NaN;
     const trackingScore = Number.isNaN(tsVal) ? null : tsVal;
 
     const instanceIdx = Number(instanceIndices[i]);
@@ -1713,12 +2116,16 @@ function readCentroids(file: any, _videos: Video[], tracks: Track[]): [Centroid,
       source: sources[i] ?? "",
     };
 
-    const isPred = isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
+    const isPred =
+      isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
 
     let centroid: Centroid;
     if (isPred) {
       const scoreVal = Number(scores[i]);
-      centroid = new PredictedCentroid({ ...options, score: Number.isNaN(scoreVal) ? 0 : scoreVal });
+      centroid = new PredictedCentroid({
+        ...options,
+        score: Number.isNaN(scoreVal) ? 0 : scoreVal,
+      });
     } else {
       centroid = new UserCentroid(options);
     }
@@ -1732,7 +2139,12 @@ function readCentroids(file: any, _videos: Video[], tracks: Track[]): [Centroid,
   return centroids;
 }
 
-function slicePoints(data: Record<string, any[]>, start: number, end: number, predicted = false): number[][] {
+function slicePoints(
+  data: Record<string, any[]>,
+  start: number,
+  end: number,
+  predicted = false,
+): number[][] {
   const xs = data.x ?? [];
   const ys = data.y ?? [];
   const visible = data.visible ?? [];

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -2,14 +2,23 @@ import { Labels } from "../../model/labels.js";
 import { Instance, PredictedInstance } from "../../model/instance.js";
 import type { Track } from "../../model/instance.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
-import { RecordingSession, Camera, InstanceGroup, FrameGroup } from "../../model/camera.js";
+import {
+  RecordingSession,
+  Camera,
+  InstanceGroup,
+  FrameGroup,
+} from "../../model/camera.js";
 import { Skeleton } from "../../model/skeleton.js";
 import { SuggestionFrame } from "../../model/suggestions.js";
 import { Video } from "../../model/video.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
 import { getH5Module, getH5FileSystem, ensureH5StagingDir } from "./h5.js";
 import { ROI, PredictedROI, encodeWkb } from "../../model/roi.js";
-import { SegmentationMask, UserSegmentationMask, PredictedSegmentationMask } from "../../model/mask.js";
+import {
+  SegmentationMask,
+  UserSegmentationMask,
+  PredictedSegmentationMask,
+} from "../../model/mask.js";
 import { BoundingBox, PredictedBoundingBox } from "../../model/bbox.js";
 import { Centroid, PredictedCentroid } from "../../model/centroid.js";
 import { LabelImage, PredictedLabelImage } from "../../model/label-image.js";
@@ -19,7 +28,9 @@ import { Instance3D, PredictedInstance3D } from "../../model/instance3d.js";
 import type { LazyDataStore } from "../../model/lazy.js";
 
 // File writer hook — registered by h5-node.ts (imported as side-effect from Node entry point).
-let _writeToFile: ((filename: string, bytes: Uint8Array) => Promise<void>) | null = null;
+let _writeToFile:
+  | ((filename: string, bytes: Uint8Array) => Promise<void>)
+  | null = null;
 
 /**
  * Register a file writer for Node.js environments.
@@ -27,7 +38,7 @@ let _writeToFile: ((filename: string, bytes: Uint8Array) => Promise<void>) | nul
  * @internal
  */
 export function _registerFileWriter(
-  writer: (filename: string, bytes: Uint8Array) => Promise<void>
+  writer: (filename: string, bytes: Uint8Array) => Promise<void>,
 ): void {
   _writeToFile = writer;
 }
@@ -48,7 +59,12 @@ function setStringAttr(target: any, name: string, value: string): void {
 function writeStringDataset(file: any, name: string, values: string[]): void {
   const json = JSON.stringify(values);
   const bytes = textEncoder.encode(json);
-  file.create_dataset({ name, data: bytes, shape: [bytes.length], dtype: "<B" });
+  file.create_dataset({
+    name,
+    data: bytes,
+    shape: [bytes.length],
+    dtype: "<B",
+  });
   const ds = file.get(name);
   setStringAttr(ds, "json", json);
 }
@@ -74,7 +90,11 @@ interface EmbeddedVideoFrames {
   channelOrder: string;
 }
 
-function writeSlpToFile(file: any, labels: Labels, embeddedVideoData?: Map<number, EmbeddedVideoFrames> | null): void {
+function writeSlpToFile(
+  file: any,
+  labels: Labels,
+  embeddedVideoData?: Map<number, EmbeddedVideoFrames> | null,
+): void {
   writeMetadata(file, labels);
 
   if (embeddedVideoData && embeddedVideoData.size > 0) {
@@ -87,7 +107,13 @@ function writeSlpToFile(file: any, labels: Labels, embeddedVideoData?: Map<numbe
   writeTracks(file, labels.tracks);
   writeSuggestions(file, labels.suggestions, labels.videos);
   writeIdentities(file, labels.identities);
-  writeSessions(file, labels.sessions, labels.videos, labels.labeledFrames, labels.identities);
+  writeSessions(
+    file,
+    labels.sessions,
+    labels.videos,
+    labels.labeledFrames,
+    labels.identities,
+  );
   writeLabeledFrames(file, labels);
   writeNegativeFrames(file, labels);
   const allInstances = labels.labeledFrames.flatMap((f) => f.instances);
@@ -106,11 +132,26 @@ function writeSlpToFile(file: any, labels: Labels, embeddedVideoData?: Map<numbe
 
   for (const lf of labels.labeledFrames) {
     const vidIdx = labels.videos.indexOf(lf.video);
-    for (const r of lf.rois) { allRois.push(r); roiCtx.push([vidIdx, lf.frameIdx]); }
-    for (const m of lf.masks) { allMasks.push(m); maskCtx.push([vidIdx, lf.frameIdx]); }
-    for (const b of lf.bboxes) { allBboxes.push(b); bboxCtx.push([vidIdx, lf.frameIdx]); }
-    for (const c of lf.centroids) { allCentroids.push(c); centroidCtx.push([vidIdx, lf.frameIdx]); }
-    for (const li of lf.labelImages) { allLabelImages.push(li); liCtx.push([vidIdx, lf.frameIdx]); }
+    for (const r of lf.rois) {
+      allRois.push(r);
+      roiCtx.push([vidIdx, lf.frameIdx]);
+    }
+    for (const m of lf.masks) {
+      allMasks.push(m);
+      maskCtx.push([vidIdx, lf.frameIdx]);
+    }
+    for (const b of lf.bboxes) {
+      allBboxes.push(b);
+      bboxCtx.push([vidIdx, lf.frameIdx]);
+    }
+    for (const c of lf.centroids) {
+      allCentroids.push(c);
+      centroidCtx.push([vidIdx, lf.frameIdx]);
+    }
+    for (const li of lf.labelImages) {
+      allLabelImages.push(li);
+      liCtx.push([vidIdx, lf.frameIdx]);
+    }
   }
   // Static ROIs
   for (const r of labels._staticRois) {
@@ -119,10 +160,38 @@ function writeSlpToFile(file: any, labels: Labels, embeddedVideoData?: Map<numbe
   }
 
   writeRois(file, allRois, labels.videos, labels.tracks, allInstances, roiCtx);
-  writeMasks(file, allMasks, labels.videos, labels.tracks, allInstances, maskCtx);
-  writeBboxes(file, allBboxes, labels.videos, labels.tracks, allInstances, bboxCtx);
-  writeCentroids(file, allCentroids, labels.videos, labels.tracks, allInstances, centroidCtx);
-  writeLabelImages(file, allLabelImages, labels.videos, labels.tracks, allInstances, liCtx);
+  writeMasks(
+    file,
+    allMasks,
+    labels.videos,
+    labels.tracks,
+    allInstances,
+    maskCtx,
+  );
+  writeBboxes(
+    file,
+    allBboxes,
+    labels.videos,
+    labels.tracks,
+    allInstances,
+    bboxCtx,
+  );
+  writeCentroids(
+    file,
+    allCentroids,
+    labels.videos,
+    labels.tracks,
+    allInstances,
+    centroidCtx,
+  );
+  writeLabelImages(
+    file,
+    allLabelImages,
+    labels.videos,
+    labels.tracks,
+    allInstances,
+    liCtx,
+  );
 }
 
 /**
@@ -285,7 +354,13 @@ function writeLazyNegativeFrames(file: any, store: LazyDataStore): void {
   }
   // Deterministic ordering for byte-stable output.
   rows.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
-  createMatrixDataset(file, "negative_frames", rows, ["video_id", "frame_idx"], "<i8");
+  createMatrixDataset(
+    file,
+    "negative_frames",
+    rows,
+    ["video_id", "frame_idx"],
+    "<i8",
+  );
 }
 
 /**
@@ -308,7 +383,9 @@ function writeLazyNegativeFrames(file: any, store: LazyDataStore): void {
 function writeSlpToFileLazy(file: any, labels: Labels): void {
   const store = labels._lazyDataStore;
   if (!labels.isLazy || !store) {
-    throw new Error("writeSlpToFileLazy requires lazy Labels with a data store");
+    throw new Error(
+      "writeSlpToFileLazy requires lazy Labels with a data store",
+    );
   }
 
   writeMetadata(file, labels);
@@ -393,8 +470,22 @@ function writeSlpToFileLazy(file: any, labels: Labels): void {
   writeRois(file, allRois, labels.videos, labels.tracks, undefined, roiCtx);
   writeMasks(file, allMasks, labels.videos, labels.tracks, [], maskCtx);
   writeBboxes(file, allBboxes, labels.videos, labels.tracks, [], bboxCtx);
-  writeCentroids(file, allCentroids, labels.videos, labels.tracks, [], centroidCtx);
-  writeLabelImages(file, allLabelImages, labels.videos, labels.tracks, [], liCtx);
+  writeCentroids(
+    file,
+    allCentroids,
+    labels.videos,
+    labels.tracks,
+    [],
+    centroidCtx,
+  );
+  writeLabelImages(
+    file,
+    allLabelImages,
+    labels.videos,
+    labels.tracks,
+    [],
+    liCtx,
+  );
 }
 
 /**
@@ -414,7 +505,7 @@ function writeSlpToFileLazy(file: any, labels: Labels): void {
  */
 export async function saveSlpToBytes(
   labels: Labels,
-  options?: SlpWriteOptions
+  options?: SlpWriteOptions,
 ): Promise<Uint8Array> {
   const embedMode = options?.embed ?? false;
 
@@ -478,7 +569,8 @@ export async function saveSlpToBytes(
     writeLabels = new Labels({
       labeledFrames: labels.labeledFrames.map((frame) => {
         const videoIdx = labels.videos.indexOf(frame.video);
-        const restoredVideo = videoIdx >= 0 ? restoredVideos[videoIdx] : frame.video;
+        const restoredVideo =
+          videoIdx >= 0 ? restoredVideos[videoIdx] : frame.video;
         return new LabeledFrame({
           video: restoredVideo,
           frameIdx: frame.frameIdx,
@@ -527,7 +619,7 @@ export async function saveSlpToBytes(
 export async function writeSlp(
   filename: string,
   labels: Labels,
-  options?: SlpWriteOptions
+  options?: SlpWriteOptions,
 ): Promise<void> {
   const bytes = await saveSlpToBytes(labels, options);
 
@@ -536,7 +628,7 @@ export async function writeSlp(
   } else {
     throw new Error(
       "writeSlp requires a Node.js environment for file I/O. " +
-      "Use saveSlpToBytes() to get the SLP data as a Uint8Array in the browser."
+        "Use saveSlpToBytes() to get the SLP data as a Uint8Array in the browser.",
     );
   }
 }
@@ -560,18 +652,22 @@ function writeMetadata(file: any, labels: Labels): void {
     labels.rois.some((r) => r.isPredicted) ||
     labels.masks.some((m) => m.isPredicted) ||
     (labels.labelImages ?? []).some((li) => li.isPredicted);
-  const hasMaskInstances = labels.masks.some((m) => m.instance !== null || (m._instanceIdx != null && m._instanceIdx >= 0));
-  let formatId = (labels.bboxes?.length ?? 0) > 0
-    ? 2.0
-    : (hasPredicted || hasMaskInstances)
-      ? 1.9
-      : (labels.labelImages?.length ?? 0) > 0
-        ? 1.8
-        : hasRoiInstance
-          ? 1.6
-          : (labels.rois.length > 0 || labels.masks.length > 0)
-            ? 1.5
-            : FORMAT_ID;
+  const hasMaskInstances = labels.masks.some(
+    (m) =>
+      m.instance !== null || (m._instanceIdx != null && m._instanceIdx >= 0),
+  );
+  let formatId =
+    (labels.bboxes?.length ?? 0) > 0
+      ? 2.0
+      : hasPredicted || hasMaskInstances
+        ? 1.9
+        : (labels.labelImages?.length ?? 0) > 0
+          ? 1.8
+          : hasRoiInstance
+            ? 1.6
+            : labels.rois.length > 0 || labels.masks.length > 0
+              ? 1.5
+              : FORMAT_ID;
   if (hasIdentities) {
     formatId = Math.max(formatId, 1.9);
   }
@@ -605,7 +701,9 @@ function writeMetadata(file: any, labels: Labels): void {
     savedMasks.some(
       (m) =>
         (m as UserSegmentationMask).fromPredicted != null &&
-        savedMaskSet.has((m as UserSegmentationMask).fromPredicted as SegmentationMask),
+        savedMaskSet.has(
+          (m as UserSegmentationMask).fromPredicted as SegmentationMask,
+        ),
     )
   ) {
     formatId = Math.max(formatId, 2.4);
@@ -617,7 +715,10 @@ function writeMetadata(file: any, labels: Labels): void {
   setStringAttr(metadataGroup, "json", JSON.stringify(metadata));
 }
 
-function serializeSkeletons(skeletons: Skeleton[]): { skeletons: any[]; nodes: Array<{ name: string }> } {
+function serializeSkeletons(skeletons: Skeleton[]): {
+  skeletons: any[];
+  nodes: Array<{ name: string }>;
+} {
   const nodes: Array<{ name: string }> = [];
   const nodeIndex = new Map<string, number>();
 
@@ -670,7 +771,9 @@ function serializeSkeletons(skeletons: Skeleton[]): { skeletons: any[]; nodes: A
     }
 
     // Build per-skeleton node index list (global indices of this skeleton's nodes)
-    const skeletonNodeIds = skeleton.nodeNames.map((name) => nodeIndex.get(name) ?? 0);
+    const skeletonNodeIds = skeleton.nodeNames.map(
+      (name) => nodeIndex.get(name) ?? 0,
+    );
 
     return {
       directed: true,
@@ -693,7 +796,10 @@ function writeVideos(file: any, videos: Video[]): void {
 }
 
 function serializeVideo(video: Video): Record<string, unknown> {
-  const backend = { ...(video.backendMetadata ?? {}) } as Record<string, unknown>;
+  const backend = { ...(video.backendMetadata ?? {}) } as Record<
+    string,
+    unknown
+  >;
   if (backend.filename == null) backend.filename = video.filename;
 
   // Crop unwrap (SLP 2.3): a cropped Video serializes as its UNCROPPED inner so
@@ -710,12 +816,14 @@ function serializeVideo(video: Video): Record<string, unknown> {
       throw new Error(
         "Cannot serialize a nested crop-of-crop video: the /video_crops format " +
           "stores a single crop per video. Flatten the crop (use matching fills " +
-          "and an in-bounds region) before saving."
+          "and an in-bounds region) before saving.",
       );
     }
     // Serialize the inner's full-frame shape/dataset/fps, not the cropped facade.
     const innerShape =
-      inner.shape ?? (backend.source_shape as number[] | undefined) ?? video.sourceVideo?.shape;
+      inner.shape ??
+      (backend.source_shape as number[] | undefined) ??
+      video.sourceVideo?.shape;
     if (innerShape != null) backend.shape = [...innerShape];
     else delete backend.shape;
     if (inner.dataset != null) backend.dataset = inner.dataset;
@@ -734,14 +842,17 @@ function serializeVideo(video: Video): Record<string, unknown> {
       throw new Error(
         "Cannot serialize closed cropped video: the uncropped source shape is " +
           "unavailable (no source_video and no recorded source_shape), so " +
-          "videos_json cannot describe the full frame."
+          "videos_json cannot describe the full frame.",
       );
     }
     backend.shape = srcShape;
   } else {
-    if (backend.dataset == null && liveBackend?.dataset) backend.dataset = liveBackend.dataset;
-    if (backend.shape == null && liveBackend?.shape) backend.shape = liveBackend.shape;
-    if (backend.fps == null && liveBackend?.fps != null) backend.fps = liveBackend.fps;
+    if (backend.dataset == null && liveBackend?.dataset)
+      backend.dataset = liveBackend.dataset;
+    if (backend.shape == null && liveBackend?.shape)
+      backend.shape = liveBackend.shape;
+    if (backend.fps == null && liveBackend?.fps != null)
+      backend.fps = liveBackend.fps;
   }
 
   // Strip crop keys from videos_json regardless of path (they ride /video_crops).
@@ -788,17 +899,23 @@ function writeVideoCrops(file: any, videos: Video[]): void {
 }
 
 function writeTracks(file: any, tracks: Array<{ name: string }>): void {
-  const payload = tracks.map((track) => JSON.stringify([SPAWNED_ON, track.name]));
+  const payload = tracks.map((track) =>
+    JSON.stringify([SPAWNED_ON, track.name]),
+  );
   file.create_dataset({ name: "tracks_json", data: payload });
 }
 
-function writeSuggestions(file: any, suggestions: SuggestionFrame[], videos: Video[]): void {
+function writeSuggestions(
+  file: any,
+  suggestions: SuggestionFrame[],
+  videos: Video[],
+): void {
   const payload = suggestions.map((suggestion) =>
     JSON.stringify({
       video: String(videos.indexOf(suggestion.video)),
       frame_idx: suggestion.frameIdx,
       group: suggestion.group ?? "default",
-    })
+    }),
   );
   file.create_dataset({ name: "suggestions_json", data: payload });
 }
@@ -818,13 +935,23 @@ function writeIdentities(file: any, identities: Identity[]): void {
   file.create_dataset({ name: "identities_json", data: payload });
 }
 
-function writeSessions(file: any, sessions: RecordingSession[], videos: Video[], labeledFrames: LabeledFrame[], identities?: Identity[]): void {
+function writeSessions(
+  file: any,
+  sessions: RecordingSession[],
+  videos: Video[],
+  labeledFrames: LabeledFrame[],
+  identities?: Identity[],
+): void {
   const labeledFrameIndex = new Map<LabeledFrame, number>();
   labeledFrames.forEach((lf, idx) => {
     labeledFrameIndex.set(lf, idx);
   });
 
-  const payload = sessions.map((session) => JSON.stringify(serializeSession(session, videos, labeledFrameIndex, identities)));
+  const payload = sessions.map((session) =>
+    JSON.stringify(
+      serializeSession(session, videos, labeledFrameIndex, identities),
+    ),
+  );
   file.create_dataset({ name: "sessions_json", data: payload });
 }
 
@@ -832,9 +959,11 @@ function serializeSession(
   session: RecordingSession,
   videos: Video[],
   labeledFrameIndex: Map<LabeledFrame, number>,
-  identities?: Identity[]
+  identities?: Identity[],
 ): Record<string, unknown> {
-  const calibration: Record<string, unknown> = { metadata: session.cameraGroup.metadata ?? {} };
+  const calibration: Record<string, unknown> = {
+    metadata: session.cameraGroup.metadata ?? {},
+  };
   session.cameraGroup.cameras.forEach((camera, idx) => {
     const key = camera.name ?? String(idx);
     const camData: Record<string, unknown> = {
@@ -860,7 +989,9 @@ function serializeSession(
   const frame_group_dicts: Record<string, unknown>[] = [];
   for (const frameGroup of session.frameGroups.values()) {
     if (!frameGroup.instanceGroups.length) continue;
-    frame_group_dicts.push(serializeFrameGroup(frameGroup, session, labeledFrameIndex, identities));
+    frame_group_dicts.push(
+      serializeFrameGroup(frameGroup, session, labeledFrameIndex, identities),
+    );
   }
 
   return {
@@ -875,11 +1006,22 @@ function serializeFrameGroup(
   frameGroup: FrameGroup,
   session: RecordingSession,
   labeledFrameIndex: Map<LabeledFrame, number>,
-  identities?: Identity[]
+  identities?: Identity[],
 ): Record<string, unknown> {
-  const instance_groups = frameGroup.instanceGroups.map((group) => serializeInstanceGroup(group, session, identities, frameGroup, labeledFrameIndex));
+  const instance_groups = frameGroup.instanceGroups.map((group) =>
+    serializeInstanceGroup(
+      group,
+      session,
+      identities,
+      frameGroup,
+      labeledFrameIndex,
+    ),
+  );
   const labeled_frame_by_camera: Record<string, number> = {};
-  for (const [camera, labeledFrame] of frameGroup.labeledFrameByCamera.entries()) {
+  for (const [
+    camera,
+    labeledFrame,
+  ] of frameGroup.labeledFrameByCamera.entries()) {
     const cameraKey = cameraKeyForSession(camera, session);
     const index = labeledFrameIndex.get(labeledFrame);
     if (index !== undefined) {
@@ -940,7 +1082,10 @@ function serializeInstanceGroup(
     if (group.instance3d.score != null) {
       payload.instance_3d_score = group.instance3d.score;
     }
-    if (group.instance3d instanceof PredictedInstance3D && group.instance3d.pointScores) {
+    if (
+      group.instance3d instanceof PredictedInstance3D &&
+      group.instance3d.pointScores
+    ) {
       payload.instance_3d_point_scores = group.instance3d.pointScores;
     }
   } else if (group.points != null) {
@@ -953,11 +1098,14 @@ function serializeInstanceGroup(
     if (identityIdx >= 0) {
       payload.identity_idx = identityIdx;
     } else {
-      console.warn(`InstanceGroup references an Identity ("${group.identity.name}") not found in Labels.identities — identity will be dropped on save.`);
+      console.warn(
+        `InstanceGroup references an Identity ("${group.identity.name}") not found in Labels.identities — identity will be dropped on save.`,
+      );
     }
   }
 
-  if (group.metadata && Object.keys(group.metadata).length) payload.metadata = group.metadata;
+  if (group.metadata && Object.keys(group.metadata).length)
+    payload.metadata = group.metadata;
   return payload;
 }
 
@@ -980,7 +1128,10 @@ function pointsToDict(instance: Instance): Record<string, number[]> {
   return dict;
 }
 
-function cameraKeyForSession(camera: Camera, session: RecordingSession): string {
+function cameraKeyForSession(
+  camera: Camera,
+  session: RecordingSession,
+): string {
   return String(session.cameraGroup.cameras.indexOf(camera));
 }
 
@@ -1001,8 +1152,13 @@ function writeLabeledFrames(file: any, labels: Labels): void {
       const instanceId = instances.length;
       instanceIndex.set(instance as Instance, instanceId);
 
-      const skeletonId = Math.max(0, labels.skeletons.indexOf(instance.skeleton));
-      const trackId = instance.track ? labels.tracks.indexOf(instance.track) : -1;
+      const skeletonId = Math.max(
+        0,
+        labels.skeletons.indexOf(instance.skeleton),
+      );
+      const trackId = instance.track
+        ? labels.tracks.indexOf(instance.track)
+        : -1;
       const trackingScore = instance.trackingScore ?? 0;
       let fromPredicted = -1;
       let score = 0;
@@ -1053,7 +1209,13 @@ function writeLabeledFrames(file: any, labels: Labels): void {
     }
 
     const instanceEnd = instances.length;
-    frames.push([frameId, videoIndex, labeledFrame.frameIdx, instanceStart, instanceEnd]);
+    frames.push([
+      frameId,
+      videoIndex,
+      labeledFrame.frameIdx,
+      instanceStart,
+      instanceEnd,
+    ]);
   }
 
   for (const [instanceId, fromPredictedInstance] of predictedLinks) {
@@ -1065,7 +1227,13 @@ function writeLabeledFrames(file: any, labels: Labels): void {
     }
   }
 
-  createMatrixDataset(file, "frames", frames, ["frame_id", "video", "frame_idx", "instance_id_start", "instance_id_end"], "<i8");
+  createMatrixDataset(
+    file,
+    "frames",
+    frames,
+    ["frame_id", "video", "frame_idx", "instance_id_start", "instance_id_end"],
+    "<i8",
+  );
   createMatrixDataset(
     file,
     "instances",
@@ -1082,10 +1250,22 @@ function writeLabeledFrames(file: any, labels: Labels): void {
       "point_id_end",
       "tracking_score",
     ],
-    "<f8"
+    "<f8",
   );
-  createMatrixDataset(file, "points", points, ["x", "y", "visible", "complete"], "<f8");
-  createMatrixDataset(file, "pred_points", predPoints, ["x", "y", "visible", "complete", "score"], "<f8");
+  createMatrixDataset(
+    file,
+    "points",
+    points,
+    ["x", "y", "visible", "complete"],
+    "<f8",
+  );
+  createMatrixDataset(
+    file,
+    "pred_points",
+    predPoints,
+    ["x", "y", "visible", "complete", "score"],
+    "<f8",
+  );
 }
 
 function writeNegativeFrames(file: any, labels: Labels): void {
@@ -1096,7 +1276,13 @@ function writeNegativeFrames(file: any, labels: Labels): void {
     const videoIndex = Math.max(0, labels.videos.indexOf(frame.video));
     rows.push([videoIndex, frame.frameIdx]);
   }
-  createMatrixDataset(file, "negative_frames", rows, ["video_id", "frame_idx"], "<i8");
+  createMatrixDataset(
+    file,
+    "negative_frames",
+    rows,
+    ["video_id", "frame_idx"],
+    "<i8",
+  );
 }
 
 /**
@@ -1104,7 +1290,7 @@ function writeNegativeFrames(file: any, labels: Labels): void {
  */
 async function collectFramesForEmbedding(
   labels: Labels,
-  embedMode: boolean | string
+  embedMode: boolean | string,
 ): Promise<Map<number, EmbeddedVideoFrames>> {
   const result = new Map<number, EmbeddedVideoFrames>();
 
@@ -1129,7 +1315,8 @@ async function collectFramesForEmbedding(
     }
 
     if (include) {
-      if (!framesByVideo.has(videoIndex)) framesByVideo.set(videoIndex, new Set());
+      if (!framesByVideo.has(videoIndex))
+        framesByVideo.set(videoIndex, new Set());
       framesByVideo.get(videoIndex)!.add(frame.frameIdx);
     }
   }
@@ -1139,7 +1326,8 @@ async function collectFramesForEmbedding(
     for (const suggestion of labels.suggestions) {
       const videoIndex = labels.videos.indexOf(suggestion.video);
       if (videoIndex < 0) continue;
-      if (!framesByVideo.has(videoIndex)) framesByVideo.set(videoIndex, new Set());
+      if (!framesByVideo.has(videoIndex))
+        framesByVideo.set(videoIndex, new Set());
       framesByVideo.get(videoIndex)!.add(suggestion.frameIdx);
     }
   }
@@ -1164,7 +1352,8 @@ async function collectFramesForEmbedding(
 
     if (frameData.size > 0) {
       const backendFormat = (video.backendMetadata?.format as string) ?? "png";
-      const backendChannelOrder = (video.backendMetadata?.channel_order as string) ?? "RGB";
+      const backendChannelOrder =
+        (video.backendMetadata?.channel_order as string) ?? "RGB";
       result.set(videoIndex, {
         videoIndex,
         frameNumbers: sortedFrames.filter((f) => frameData.has(f)),
@@ -1197,7 +1386,7 @@ function frameToBytes(frame: unknown): Uint8Array | null {
 function writeEmbeddedVideos(
   file: any,
   labels: Labels,
-  embeddedVideoData: Map<number, EmbeddedVideoFrames>
+  embeddedVideoData: Map<number, EmbeddedVideoFrames>,
 ): void {
   const payload = labels.videos.map((video, videoIndex) => {
     const embedData = embeddedVideoData.get(videoIndex);
@@ -1213,7 +1402,9 @@ function writeEmbeddedVideos(
       // (the crop rides /video_crops and is re-applied once on read); read the
       // shape/fps from the inner backend, not the cropped facade.
       const inner =
-        video.backend instanceof CropVideoBackend ? video.backend.inner : video.backend;
+        video.backend instanceof CropVideoBackend
+          ? video.backend.inner
+          : video.backend;
       const innerShape =
         inner?.shape ??
         (video.backendMetadata?.source_shape as number[] | undefined);
@@ -1229,7 +1420,11 @@ function writeEmbeddedVideos(
         entry.source_video = { filename: video.sourceVideo.filename };
       } else if (!video.hasEmbeddedImages) {
         // If this video wasn't already embedded, save original path as source
-        entry.source_video = { filename: Array.isArray(video.filename) ? video.filename[0] : video.filename };
+        entry.source_video = {
+          filename: Array.isArray(video.filename)
+            ? video.filename[0]
+            : video.filename,
+        };
       }
       return JSON.stringify(entry);
     } else {
@@ -1283,7 +1478,7 @@ function writeEmbeddedVideos(
     });
 
     // Write frame_sizes dataset for reliable frame boundary detection
-    const frameSizes = frameBytes.map(b => b.length);
+    const frameSizes = frameBytes.map((b) => b.length);
     file.create_dataset({
       name: `${groupName}/frame_sizes`,
       data: frameSizes,
@@ -1293,11 +1488,21 @@ function writeEmbeddedVideos(
   }
 }
 
-function createMatrixDataset(file: any, name: string, rows: number[][], fieldNames: string[], dtype: string): void {
+function createMatrixDataset(
+  file: any,
+  name: string,
+  rows: number[][],
+  fieldNames: string[],
+  dtype: string,
+): void {
   const rowCount = rows.length;
   const colCount = fieldNames.length;
   // Pre-allocate typed array to avoid intermediate .flat() allocation
-  const TypedArray = dtype.includes("i") ? (dtype.includes("4") ? Int32Array : Float64Array) : Float64Array;
+  const TypedArray = dtype.includes("i")
+    ? dtype.includes("4")
+      ? Int32Array
+      : Float64Array
+    : Float64Array;
   const data = new TypedArray(rowCount * colCount);
   for (let i = 0; i < rowCount; i++) {
     const row = rows[i];
@@ -1311,7 +1516,14 @@ function createMatrixDataset(file: any, name: string, rows: number[][], fieldNam
   setStringAttr(dataset, "field_names", JSON.stringify(fieldNames));
 }
 
-function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name: string }>, instances?: Array<Instance | PredictedInstance>, contexts?: [number, number][]): void {
+function writeRois(
+  file: any,
+  rois: ROI[],
+  videos: Video[],
+  tracks: Array<{ name: string }>,
+  instances?: Array<Instance | PredictedInstance>,
+  contexts?: [number, number][],
+): void {
   if (!rois.length) return;
 
   const rows: number[][] = [];
@@ -1330,7 +1542,11 @@ function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name
     wkbChunks.push(wkb);
     wkbOffset = wkbEnd;
 
-    const videoIdx = contexts ? contexts[i][0] : (roi.video ? videos.indexOf(roi.video) : -1);
+    const videoIdx = contexts
+      ? contexts[i][0]
+      : roi.video
+        ? videos.indexOf(roi.video)
+        : -1;
     const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = roi.track ? tracks.indexOf(roi.track as any) : -1;
     // Fall back to stored _instanceIdx when no live instance link (e.g., lazy mode).
@@ -1342,14 +1558,41 @@ function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name
     const isPredicted = roi.isPredicted ? 1 : 0;
     const trackingScore = roi.trackingScore ?? Number.NaN;
 
-    rows.push([0, videoIdx, frameIdx, trackIdx, score, trackingScore, wkbStart, wkbEnd, instanceIdx, isPredicted]);
+    rows.push([
+      0,
+      videoIdx,
+      frameIdx,
+      trackIdx,
+      score,
+      trackingScore,
+      wkbStart,
+      wkbEnd,
+      instanceIdx,
+      isPredicted,
+    ]);
     categories.push(roi.category);
     names.push(roi.name);
     sources.push(roi.source);
   }
 
-  createMatrixDataset(file, "rois", rows,
-    ["annotation_type", "video", "frame_idx", "track", "score", "tracking_score", "wkb_start", "wkb_end", "instance", "is_predicted"], "<f8");
+  createMatrixDataset(
+    file,
+    "rois",
+    rows,
+    [
+      "annotation_type",
+      "video",
+      "frame_idx",
+      "track",
+      "score",
+      "tracking_score",
+      "wkb_start",
+      "wkb_end",
+      "instance",
+      "is_predicted",
+    ],
+    "<f8",
+  );
 
   // Write string metadata as datasets at root level (v1.9+)
   writeStringDataset(file, "roi_categories", categories);
@@ -1364,7 +1607,12 @@ function writeRois(file: any, rois: ROI[], videos: Video[], tracks: Array<{ name
     wkbFlat.set(chunk, offset);
     offset += chunk.length;
   }
-  file.create_dataset({ name: "roi_wkb", data: wkbFlat, shape: [wkbFlat.length], dtype: "<B" });
+  file.create_dataset({
+    name: "roi_wkb",
+    data: wkbFlat,
+    shape: [wkbFlat.length],
+    dtype: "<B",
+  });
 }
 
 function writeMasks(
@@ -1414,23 +1662,41 @@ function writeMasks(
     const videoIdx = contexts ? contexts[i][0] : -1;
     const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = mask.track ? tracks.indexOf(mask.track as any) : -1;
-    const score = mask.isPredicted ? (mask as PredictedSegmentationMask).score : Number.NaN;
+    const score = mask.isPredicted
+      ? (mask as PredictedSegmentationMask).score
+      : Number.NaN;
     const isPredicted = mask.isPredicted ? 1 : 0;
-    const instanceIdx = mask.instance ? instances.indexOf(mask.instance as Instance) : (mask._instanceIdx ?? -1);
+    const instanceIdx = mask.instance
+      ? instances.indexOf(mask.instance as Instance)
+      : (mask._instanceIdx ?? -1);
     const maskTrackingScore = mask.trackingScore ?? Number.NaN;
 
     // Resolve the from_predicted provenance link to a global index into the
     // flat mask list. -1 sentinel when there is no link or the source
     // prediction is absent from the saved list (Map miss). Only user masks
     // carry fromPredicted; predicted masks always resolve to -1.
-    const fromPredictedSrc = (mask as UserSegmentationMask).fromPredicted ?? null;
+    const fromPredictedSrc =
+      (mask as UserSegmentationMask).fromPredicted ?? null;
     const fromPredictedIdx =
       fromPredictedSrc != null ? (maskIdToIdx.get(fromPredictedSrc) ?? -1) : -1;
 
     rows.push([
-      mask.height, mask.width, 2, videoIdx, frameIdx, trackIdx,
-      score, rleStart, rleEnd, isPredicted, instanceIdx, maskTrackingScore,
-      mask.scale[0], mask.scale[1], mask.offset[0], mask.offset[1],
+      mask.height,
+      mask.width,
+      2,
+      videoIdx,
+      frameIdx,
+      trackIdx,
+      score,
+      rleStart,
+      rleEnd,
+      isPredicted,
+      instanceIdx,
+      maskTrackingScore,
+      mask.scale[0],
+      mask.scale[1],
+      mask.offset[0],
+      mask.offset[1],
       fromPredictedIdx,
     ]);
     categories.push(mask.category);
@@ -1441,21 +1707,56 @@ function writeMasks(
     if (mask.isPredicted) {
       const pm = mask as PredictedSegmentationMask;
       if (pm.scoreMap) {
-        const smBytes = new Uint8Array(pm.scoreMap.buffer, pm.scoreMap.byteOffset, pm.scoreMap.byteLength);
+        const smBytes = new Uint8Array(
+          pm.scoreMap.buffer,
+          pm.scoreMap.byteOffset,
+          pm.scoreMap.byteLength,
+        );
         const compressed = deflate(smBytes);
         const smH = pm.scoreMap.length / mask.width;
         if (!Number.isInteger(smH)) {
-          throw new Error(`Score map size ${pm.scoreMap.length} not divisible by width ${mask.width}`);
+          throw new Error(
+            `Score map size ${pm.scoreMap.length} not divisible by width ${mask.width}`,
+          );
         }
-        scoreMapIndexRows.push([i, smOffset, smOffset + compressed.length, smH, mask.width]);
+        scoreMapIndexRows.push([
+          i,
+          smOffset,
+          smOffset + compressed.length,
+          smH,
+          mask.width,
+        ]);
         scoreMapChunks.push(compressed);
         smOffset += compressed.length;
       }
     }
   }
 
-  createMatrixDataset(file, "masks", rows,
-    ["height", "width", "annotation_type", "video", "frame_idx", "track", "score", "rle_start", "rle_end", "is_predicted", "instance", "tracking_score", "scale_x", "scale_y", "offset_x", "offset_y", "from_predicted"], "<f8");
+  createMatrixDataset(
+    file,
+    "masks",
+    rows,
+    [
+      "height",
+      "width",
+      "annotation_type",
+      "video",
+      "frame_idx",
+      "track",
+      "score",
+      "rle_start",
+      "rle_end",
+      "is_predicted",
+      "instance",
+      "tracking_score",
+      "scale_x",
+      "scale_y",
+      "offset_x",
+      "offset_y",
+      "from_predicted",
+    ],
+    "<f8",
+  );
 
   // Write string metadata as datasets at root level (v1.9+)
   writeStringDataset(file, "mask_categories", categories);
@@ -1470,12 +1771,22 @@ function writeMasks(
     rleFlat.set(chunk, offset);
     offset += chunk.length;
   }
-  file.create_dataset({ name: "mask_rle", data: rleFlat, shape: [rleFlat.length], dtype: "<B" });
+  file.create_dataset({
+    name: "mask_rle",
+    data: rleFlat,
+    shape: [rleFlat.length],
+    dtype: "<B",
+  });
 
   // Write score maps
   if (scoreMapIndexRows.length > 0) {
-    createMatrixDataset(file, "mask_score_map_index", scoreMapIndexRows,
-      ["mask_idx", "data_start", "data_end", "height", "width"], "<f8");
+    createMatrixDataset(
+      file,
+      "mask_score_map_index",
+      scoreMapIndexRows,
+      ["mask_idx", "data_start", "data_end", "height", "width"],
+      "<f8",
+    );
     const totalSm = scoreMapChunks.reduce((sum, c) => sum + c.length, 0);
     const smFlat = new Uint8Array(totalSm);
     let smOff = 0;
@@ -1483,7 +1794,12 @@ function writeMasks(
       smFlat.set(chunk, smOff);
       smOff += chunk.length;
     }
-    file.create_dataset({ name: "mask_score_maps", data: smFlat, shape: [smFlat.length], dtype: "<B" });
+    file.create_dataset({
+      name: "mask_score_maps",
+      data: smFlat,
+      shape: [smFlat.length],
+      dtype: "<B",
+    });
   }
 }
 
@@ -1507,7 +1823,9 @@ function writeBboxes(
     const videoIdx = contexts ? contexts[i][0] : -1;
     const frameIdx = contexts ? contexts[i][1] : -1;
     const trackIdx = bbox.track ? tracks.indexOf(bbox.track as any) : -1;
-    const score = bbox.isPredicted ? (bbox as PredictedBoundingBox).score : Number.NaN;
+    const score = bbox.isPredicted
+      ? (bbox as PredictedBoundingBox).score
+      : Number.NaN;
     // Fall back to stored _instanceIdx when no live instance link (e.g., lazy mode).
     const instanceIdx = bbox.instance
       ? instances.indexOf(bbox.instance as Instance)
@@ -1533,8 +1851,25 @@ function writeBboxes(
     sources.push(bbox.source);
   }
 
-  createMatrixDataset(file, "bboxes", rows,
-    ["x1", "y1", "x2", "y2", "angle", "video", "frame_idx", "track", "score", "instance", "tracking_score"], "<f8");
+  createMatrixDataset(
+    file,
+    "bboxes",
+    rows,
+    [
+      "x1",
+      "y1",
+      "x2",
+      "y2",
+      "angle",
+      "video",
+      "frame_idx",
+      "track",
+      "score",
+      "instance",
+      "tracking_score",
+    ],
+    "<f8",
+  );
 
   // Write string metadata as datasets at root level (v1.9+)
   writeStringDataset(file, "bbox_categories", categories);
@@ -1578,7 +1913,11 @@ function writeLabelImages(
     const frameIdx = contexts ? contexts[liIdx][1] : -1;
 
     // Compress pixel data: Int32Array -> raw bytes -> zlib
-    const pixelBytes = new Uint8Array(li.data.buffer, li.data.byteOffset, li.data.byteLength);
+    const pixelBytes = new Uint8Array(
+      li.data.buffer,
+      li.data.byteOffset,
+      li.data.byteLength,
+    );
     const compressed = deflate(pixelBytes);
     const dataStart = dataOffset;
     const dataEnd = dataOffset + compressed.length;
@@ -1586,7 +1925,9 @@ function writeLabelImages(
     dataOffset = dataEnd;
 
     const isPredicted = li.isPredicted ? 1 : 0;
-    const liScore = li.isPredicted ? (li as PredictedLabelImage).score : Number.NaN;
+    const liScore = li.isPredicted
+      ? (li as PredictedLabelImage).score
+      : Number.NaN;
 
     // Per-object entries
     const objectsStart = objectsOffset;
@@ -1601,28 +1942,61 @@ function writeLabelImages(
         instanceIdx = info._instanceIdx;
       }
       const objScore = info.score != null ? info.score : Number.NaN;
-      const objTrackingScore = info.trackingScore != null ? info.trackingScore : Number.NaN;
-      objectRows.push([labelId, trackIdx, instanceIdx, objScore, objTrackingScore]);
+      const objTrackingScore =
+        info.trackingScore != null ? info.trackingScore : Number.NaN;
+      objectRows.push([
+        labelId,
+        trackIdx,
+        instanceIdx,
+        objScore,
+        objTrackingScore,
+      ]);
       objectCategories.push(info.category);
       objectNames.push(info.name);
       objectsOffset++;
     }
 
-    rows.push([videoIdx, frameIdx, li.height, li.width, li.nObjects, objectsStart, dataStart, dataEnd, isPredicted, liScore,
-      li.scale[0], li.scale[1], li.offset[0], li.offset[1]]);
+    rows.push([
+      videoIdx,
+      frameIdx,
+      li.height,
+      li.width,
+      li.nObjects,
+      objectsStart,
+      dataStart,
+      dataEnd,
+      isPredicted,
+      liScore,
+      li.scale[0],
+      li.scale[1],
+      li.offset[0],
+      li.offset[1],
+    ]);
     sources.push(li.source);
 
     // Collect score maps for predicted label images
     if (li.isPredicted) {
       const pli = li as PredictedLabelImage;
       if (pli.scoreMap) {
-        const smBytes = new Uint8Array(pli.scoreMap.buffer, pli.scoreMap.byteOffset, pli.scoreMap.byteLength);
+        const smBytes = new Uint8Array(
+          pli.scoreMap.buffer,
+          pli.scoreMap.byteOffset,
+          pli.scoreMap.byteLength,
+        );
         const smCompressed = deflate(smBytes);
         const smH = pli.scoreMap.length / li.width;
         if (!Number.isInteger(smH)) {
-          throw new Error(`Score map size ${pli.scoreMap.length} not divisible by width ${li.width}`);
+          throw new Error(
+            `Score map size ${pli.scoreMap.length} not divisible by width ${li.width}`,
+          );
         }
-        smIndexRows.push([liIdx, smOffset, smOffset + smCompressed.length, smH, li.width]);
+        smIndexRows.push([
+          liIdx,
+          smOffset,
+          smOffset + smCompressed.length,
+          smH,
+          li.width,
+        ]);
         smChunks.push(smCompressed);
         smOffset += smCompressed.length;
       }
@@ -1630,17 +2004,41 @@ function writeLabelImages(
   }
 
   // Write main metadata table
-  createMatrixDataset(file, "label_images", rows,
-    ["video", "frame_idx", "height", "width", "n_objects", "objects_start", "data_start", "data_end", "is_predicted", "score",
-     "scale_x", "scale_y", "offset_x", "offset_y"], "<f8");
+  createMatrixDataset(
+    file,
+    "label_images",
+    rows,
+    [
+      "video",
+      "frame_idx",
+      "height",
+      "width",
+      "n_objects",
+      "objects_start",
+      "data_start",
+      "data_end",
+      "is_predicted",
+      "score",
+      "scale_x",
+      "scale_y",
+      "offset_x",
+      "offset_y",
+    ],
+    "<f8",
+  );
 
   // Write string metadata as datasets at root level (v1.9+)
   writeStringDataset(file, "label_image_sources", sources);
 
   // Write objects table (if any objects exist)
   if (objectRows.length > 0) {
-    createMatrixDataset(file, "label_image_objects", objectRows,
-      ["label_id", "track", "instance", "score", "tracking_score"], "<f8");
+    createMatrixDataset(
+      file,
+      "label_image_objects",
+      objectRows,
+      ["label_id", "track", "instance", "score", "tracking_score"],
+      "<f8",
+    );
     // Write string metadata as datasets at root level (v1.9+)
     writeStringDataset(file, "label_image_obj_categories", objectCategories);
     writeStringDataset(file, "label_image_obj_names", objectNames);
@@ -1654,12 +2052,22 @@ function writeLabelImages(
     dataFlat.set(chunk, offset);
     offset += chunk.length;
   }
-  file.create_dataset({ name: "label_image_data", data: dataFlat, shape: [dataFlat.length], dtype: "<B" });
+  file.create_dataset({
+    name: "label_image_data",
+    data: dataFlat,
+    shape: [dataFlat.length],
+    dtype: "<B",
+  });
 
   // Write score maps
   if (smIndexRows.length > 0) {
-    createMatrixDataset(file, "label_image_score_map_index", smIndexRows,
-      ["li_idx", "data_start", "data_end", "height", "width"], "<f8");
+    createMatrixDataset(
+      file,
+      "label_image_score_map_index",
+      smIndexRows,
+      ["li_idx", "data_start", "data_end", "height", "width"],
+      "<f8",
+    );
     const totalSm = smChunks.reduce((sum, c) => sum + c.length, 0);
     const smFlat = new Uint8Array(totalSm);
     let smOff = 0;
@@ -1667,7 +2075,12 @@ function writeLabelImages(
       smFlat.set(chunk, smOff);
       smOff += chunk.length;
     }
-    file.create_dataset({ name: "label_image_score_maps", data: smFlat, shape: [smFlat.length], dtype: "<B" });
+    file.create_dataset({
+      name: "label_image_score_maps",
+      data: smFlat,
+      shape: [smFlat.length],
+      dtype: "<B",
+    });
   }
 }
 
@@ -1700,17 +2113,40 @@ function writeCentroids(
     const trackingScore = c.trackingScore ?? Number.NaN;
 
     rows.push([
-      c.x, c.y, c.z ?? Number.NaN,
-      videoIdx, frameIdx, trackIdx, instanceIdx,
-      isPredicted, score, trackingScore,
+      c.x,
+      c.y,
+      c.z ?? Number.NaN,
+      videoIdx,
+      frameIdx,
+      trackIdx,
+      instanceIdx,
+      isPredicted,
+      score,
+      trackingScore,
     ]);
     categories.push(c.category);
     names.push(c.name);
     sources.push(c.source);
   }
 
-  createMatrixDataset(file, "centroids", rows,
-    ["x", "y", "z", "video", "frame_idx", "track", "instance", "is_predicted", "score", "tracking_score"], "<f8");
+  createMatrixDataset(
+    file,
+    "centroids",
+    rows,
+    [
+      "x",
+      "y",
+      "z",
+      "video",
+      "frame_idx",
+      "track",
+      "instance",
+      "is_predicted",
+      "score",
+      "tracking_score",
+    ],
+    "<f8",
+  );
 
   writeStringDataset(file, "centroid_categories", categories);
   writeStringDataset(file, "centroid_names", names);

--- a/src/codecs/training-config.ts
+++ b/src/codecs/training-config.ts
@@ -6,7 +6,7 @@ import { readSkeletonJson } from "./skeleton-json.js";
  * Training configs embed skeleton definitions in data.labels.skeletons[].
  */
 export function readTrainingConfigSkeletons(
-  json: string | Record<string, unknown>
+  json: string | Record<string, unknown>,
 ): Skeleton[] {
   const data =
     typeof json === "string"
@@ -30,7 +30,7 @@ export function readTrainingConfigSkeletons(
  * Extract the first skeleton from a SLEAP training config JSON file.
  */
 export function readTrainingConfigSkeleton(
-  json: string | Record<string, unknown>
+  json: string | Record<string, unknown>,
 ): Skeleton {
   const skeletons = readTrainingConfigSkeletons(json);
   return skeletons[0];
@@ -40,7 +40,7 @@ export function readTrainingConfigSkeleton(
  * Detect whether a JSON object or string is a training config format.
  */
 export function isTrainingConfig(
-  json: string | Record<string, unknown>
+  json: string | Record<string, unknown>,
 ): boolean {
   const data =
     typeof json === "string"

--- a/src/io/analysis-h5.ts
+++ b/src/io/analysis-h5.ts
@@ -290,7 +290,8 @@ function getDs(file: H5ReadFile, name: string): H5ReadDataset | null {
 function decodeStringElement(v: unknown): string {
   if (typeof v === "string") return v;
   if (v instanceof Uint8Array) return textDecoder.decode(v);
-  if (Array.isArray(v)) return textDecoder.decode(Uint8Array.from(v as number[]));
+  if (Array.isArray(v))
+    return textDecoder.decode(Uint8Array.from(v as number[]));
   return String(v);
 }
 
@@ -299,7 +300,8 @@ function decodeStringArray(value: unknown): string[] {
   if (value == null) return [];
   if (typeof value === "string") return [value];
   if (value instanceof Uint8Array) return [textDecoder.decode(value)];
-  if (Array.isArray(value)) return (value as unknown[]).map(decodeStringElement);
+  if (Array.isArray(value))
+    return (value as unknown[]).map(decodeStringElement);
   if (typeof (value as { length?: number }).length === "number") {
     return Array.from(value as ArrayLike<unknown>).map(decodeStringElement);
   }
@@ -474,7 +476,8 @@ export async function readLabels(
     } else {
       // Legacy file: check the transpose attribute (default true).
       const transposeRaw = unwrapAttr(fileAttrs["transpose"]);
-      const wasTransposed = transposeRaw === undefined ? true : Boolean(transposeRaw);
+      const wasTransposed =
+        transposeRaw === undefined ? true : Boolean(transposeRaw);
       if (wasTransposed) {
         storedOrder = PRESETS["matlab"];
       } else {
@@ -498,7 +501,11 @@ export async function readLabels(
     const tracksData = tracksT.data; // canonical (frame, track, node, xy)
 
     // --- Build 3D / 2D stored orders by dropping dims and renumbering. ---
-    const storedOrder3d = renumberOrder(storedOrder, ["frame", "track", "node"]);
+    const storedOrder3d = renumberOrder(storedOrder, [
+      "frame",
+      "track",
+      "node",
+    ]);
     const storedOrder2d = renumberOrder(storedOrder, ["frame", "track"]);
 
     const axes3d = getTransposeAxes(storedOrder3d, canonicalOrder3d, 3);
@@ -533,7 +540,9 @@ export async function readLabels(
 
     // --- String arrays. ---
     const trackNamesDs = getDs(file, "track_names");
-    const trackNames = trackNamesDs ? decodeStringArray(trackNamesDs.value) : [];
+    const trackNames = trackNamesDs
+      ? decodeStringArray(trackNamesDs.value)
+      : [];
 
     const nodeNamesDs = getDs(file, "node_names");
     const nodeNames = nodeNamesDs ? decodeStringArray(nodeNamesDs.value) : [];
@@ -682,7 +691,9 @@ export async function readLabels(
           skeleton,
           score: Number.isNaN(instanceScore) ? 0.0 : instanceScore,
           track: tracks[trackIdx] ?? undefined,
-          trackingScore: Number.isNaN(trackingScore) ? undefined : trackingScore,
+          trackingScore: Number.isNaN(trackingScore)
+            ? undefined
+            : trackingScore,
         });
         instances.push(inst);
       }
@@ -774,7 +785,8 @@ function untrackedFrameInstances(
       let skip = false;
       for (const userInst of userInsts) {
         if (
-          (userInst as { fromPredicted?: unknown }).fromPredicted !== undefined &&
+          (userInst as { fromPredicted?: unknown }).fromPredicted !==
+            undefined &&
           (userInst as { fromPredicted?: unknown }).fromPredicted === inst
         ) {
           skip = true;
@@ -801,7 +813,8 @@ function untrackedFrameInstances(
 /** One instance per track (port of `_tracked_frame_instances`). */
 function trackedFrameInstances(lf: LabeledFrame): Map<Track, InstanceLike> {
   const trackToInstance = new Map<Track, InstanceLike>();
-  for (const inst of (lf.predictedInstances ?? []) as unknown as InstanceLike[]) {
+  for (const inst of (lf.predictedInstances ??
+    []) as unknown as InstanceLike[]) {
     if (inst.track != null) trackToInstance.set(inst.track, inst);
   }
   for (const inst of (lf.userInstances ?? []) as unknown as InstanceLike[]) {
@@ -871,7 +884,9 @@ export function toAnalysisArrays(
 
   // Canonical-shape matrices.
   const occupancy = new Float64Array(nFrames * nTracks); // 0-filled
-  const locations = new Float64Array(nFrames * nTracks * nodeCount * 2).fill(NaN);
+  const locations = new Float64Array(nFrames * nTracks * nodeCount * 2).fill(
+    NaN,
+  );
   const pointScores = new Float64Array(nFrames * nTracks * nodeCount).fill(NaN);
   const instanceScores = new Float64Array(nFrames * nTracks).fill(NaN);
   const trackingScores = new Float64Array(nFrames * nTracks).fill(NaN);
@@ -1043,8 +1058,15 @@ interface H5WriteFile {
     compression?: string | number;
     compression_opts?: number | number[];
   }): void;
-  create_attribute(name: string, value: unknown, shape?: unknown, dtype?: unknown): void;
-  get(name: string): { create_attribute: (n: string, v: unknown) => void } | null;
+  create_attribute(
+    name: string,
+    value: unknown,
+    shape?: unknown,
+    dtype?: unknown,
+  ): void;
+  get(
+    name: string,
+  ): { create_attribute: (n: string, v: unknown) => void } | null;
   close(): void;
 }
 
@@ -1139,7 +1161,11 @@ export async function writeLabels(
   const axes4d = getTransposeAxes(canonicalOrder4d, axisOrder, 4);
   const axes3d = getTransposeAxes(canonicalOrder3d, targetOrder3d, 3);
   const axes2d = getTransposeAxes(canonicalOrder2d, targetOrder2d, 2);
-  const axesOccupancy = getTransposeAxes(canonicalOrder2d, targetOrderOccupancy, 2);
+  const axesOccupancy = getTransposeAxes(
+    canonicalOrder2d,
+    targetOrderOccupancy,
+    2,
+  );
 
   // Reorder arrays.
   const locationsT = transposeFlat(
@@ -1162,7 +1188,11 @@ export async function writeLabels(
     [nFrames, nTracks],
     axes2d,
   );
-  const occupancyT = transposeFlat(arrays.occupancy, [nFrames, nTracks], axesOccupancy);
+  const occupancyT = transposeFlat(
+    arrays.occupancy,
+    [nFrames, nTracks],
+    axesOccupancy,
+  );
 
   // Dimension-name attributes.
   const dims4d = getDimsTuple(axisOrder, 4);
@@ -1184,10 +1214,9 @@ export async function writeLabels(
   const module = await getH5Module();
   ensureH5StagingDir(module);
   const memPath = `/tmp/analysis_${Date.now()}_${Math.random().toString(16).slice(2)}.h5`;
-  const f = new (module as unknown as { File: new (p: string, m: string) => H5WriteFile }).File(
-    memPath,
-    "w",
-  );
+  const f = new (
+    module as unknown as { File: new (p: string, m: string) => H5WriteFile }
+  ).File(memPath, "w");
 
   try {
     // Numeric dataset writer with a JSON-array-string `dims` attribute.
@@ -1225,10 +1254,25 @@ export async function writeLabels(
 
     // Core matrices.
     writeNumeric("tracks", locationsT.data, locationsT.shape, dims4d);
-    writeNumeric("track_occupancy", occupancyT.data, occupancyT.shape, dimsOccupancy);
+    writeNumeric(
+      "track_occupancy",
+      occupancyT.data,
+      occupancyT.shape,
+      dimsOccupancy,
+    );
     writeNumeric("point_scores", pointScoresT.data, pointScoresT.shape, dims3d);
-    writeNumeric("instance_scores", instanceScoresT.data, instanceScoresT.shape, dims2d);
-    writeNumeric("tracking_scores", trackingScoresT.data, trackingScoresT.shape, dims2d);
+    writeNumeric(
+      "instance_scores",
+      instanceScoresT.data,
+      instanceScoresT.shape,
+      dims2d,
+    );
+    writeNumeric(
+      "tracking_scores",
+      trackingScoresT.data,
+      trackingScoresT.shape,
+      dims2d,
+    );
 
     // String datasets (h5py-native).
     f.create_dataset({ name: "track_names", data: arrays.trackNames });

--- a/src/io/geojson.ts
+++ b/src/io/geojson.ts
@@ -28,7 +28,7 @@ export function roisToGeoJSON(rois: ROI[]): GeoJSONFeatureCollection {
  * Accepts either a FeatureCollection or a single Feature.
  */
 export function roisFromGeoJSON(
-  geojson: GeoJSONFeatureCollection | GeoJSONFeature
+  geojson: GeoJSONFeatureCollection | GeoJSONFeature,
 ): ROI[] {
   const features =
     geojson.type === "FeatureCollection" ? geojson.features : [geojson];

--- a/src/io/jabs.ts
+++ b/src/io/jabs.ts
@@ -80,7 +80,9 @@ export const JABS_DEFAULT_SYMMETRY_INDICES: Array<[number, number]> = [
 /** Build a fresh copy of the default JABS "Mouse" skeleton. */
 export function makeJabsDefaultSkeleton(): Skeleton {
   const nodes = JABS_DEFAULT_KEYPOINT_NAMES.map((name) => new Node(name));
-  const edges = JABS_DEFAULT_EDGE_INDICES.map(([a, b]) => new Edge(nodes[a], nodes[b]));
+  const edges = JABS_DEFAULT_EDGE_INDICES.map(
+    ([a, b]) => new Edge(nodes[a], nodes[b]),
+  );
   const symmetries = JABS_DEFAULT_SYMMETRY_INDICES.map(
     ([a, b]) => new Symmetry([nodes[a], nodes[b]]),
   );
@@ -103,8 +105,14 @@ export const JABS_DEFAULT_SKELETON: Skeleton = makeJabsDefaultSkeleton();
 
 /** Create a `Skeleton` with `numPoints` nodes connected in a line. */
 export function makeSimpleSkeleton(name: string, numPoints: number): Skeleton {
-  const nodes = Array.from({ length: numPoints }, (_, i) => new Node(`${name}_kp${i}`));
-  const edges = Array.from({ length: Math.max(0, numPoints - 1) }, (_, i) => new Edge(nodes[i], nodes[i + 1]));
+  const nodes = Array.from(
+    { length: numPoints },
+    (_, i) => new Node(`${name}_kp${i}`),
+  );
+  const edges = Array.from(
+    { length: Math.max(0, numPoints - 1) },
+    (_, i) => new Edge(nodes[i], nodes[i + 1]),
+  );
   return new Skeleton({ nodes, edges, name });
 }
 
@@ -145,7 +153,12 @@ export function predictionToInstance(
 
   if (scores.length === 0) return null;
   const meanScore = scores.reduce((a, b) => a + b, 0) / scores.length;
-  return PredictedInstance.fromNumpy({ pointsData, skeleton, track: track ?? null, score: meanScore });
+  return PredictedInstance.fromNumpy({
+    pointsData,
+    skeleton,
+    track: track ?? null,
+    score: meanScore,
+  });
 }
 
 /**
@@ -156,12 +169,19 @@ export function predictionToInstance(
  * NOT y/x-flipped, unlike poses). Category is `"arena"` for `corners`,
  * `"anchor"` otherwise; `source` is `"jabs"`.
  */
-export function staticObjectToRoi(name: string, coords: number[][], video: Video): UserROI {
+export function staticObjectToRoi(
+  name: string,
+  coords: number[][],
+  video: Video,
+): UserROI {
   let geometry: Geometry;
   if (coords.length === 1) {
     geometry = { type: "Point", coordinates: [coords[0][0], coords[0][1]] };
   } else {
-    geometry = { type: "MultiPoint", coordinates: coords.map(([x, y]) => [x, y]) };
+    geometry = {
+      type: "MultiPoint",
+      coordinates: coords.map(([x, y]) => [x, y]),
+    };
   }
   const category = name === "corners" ? "arena" : "anchor";
   return new UserROI({ geometry, name, category, source: "jabs", video });
@@ -241,7 +261,10 @@ export interface LoadJabsOptions {
  * @param labelsPath - Path to the JABS pose file.
  * @param options - Optional `skeleton` override.
  */
-export async function loadJabs(labelsPath: string, options?: LoadJabsOptions): Promise<Labels> {
+export async function loadJabs(
+  labelsPath: string,
+  options?: LoadJabsOptions,
+): Promise<Labels> {
   const skeleton = options?.skeleton ?? JABS_DEFAULT_SKELETON;
 
   // Video name is the pose file minus the pose-est suffix.
@@ -263,14 +286,18 @@ export async function loadJabs(labelsPath: string, options?: LoadJabsOptions): P
   try {
     const pointsDs = getDataset(file, "poseest/points");
     if (pointsDs == null) {
-      throw new Error(`JABS pose file is missing 'poseest/points': ${labelsPath}`);
+      throw new Error(
+        `JABS pose file is missing 'poseest/points': ${labelsPath}`,
+      );
     }
     const pShape = Array.from(pointsDs.shape, num);
     const numFrames = pShape[0];
 
     // Resolve pose version from the `poseest` group's `version` attribute.
     const poseest = file.get("poseest") as H5Group | null;
-    const verRaw = poseest?.attrs ? attrValue(poseest.attrs["version"]) : undefined;
+    const verRaw = poseest?.attrs
+      ? attrValue(poseest.attrs["version"])
+      : undefined;
     let poseVersion: number;
     if (verRaw != null && (verRaw as ArrayLike<unknown>).length > 0) {
       poseVersion = Number((verRaw as ArrayLike<number | bigint>)[0]);
@@ -291,7 +318,8 @@ export async function loadJabs(labelsPath: string, options?: LoadJabsOptions): P
     const N = pShape[pShape.length - 2];
 
     const pointsVal = pointsDs.value;
-    const confVal = (getDataset(file, "poseest/confidence")?.value ?? []) as ArrayLike<number | bigint>;
+    const confVal = (getDataset(file, "poseest/confidence")?.value ??
+      []) as ArrayLike<number | bigint>;
 
     if (poseVersion === 2) {
       tracks.set(1, new Track("1"));
@@ -308,23 +336,32 @@ export async function loadJabs(labelsPath: string, options?: LoadJabsOptions): P
       const idDs = getDataset(file, "poseest/instance_track_id");
       const countDs = getDataset(file, "poseest/instance_count");
       if (idDs == null) {
-        throw new Error(`JABS pose file is missing 'poseest/instance_track_id': ${labelsPath}`);
+        throw new Error(
+          `JABS pose file is missing 'poseest/instance_track_id': ${labelsPath}`,
+        );
       }
       if (countDs == null) {
-        throw new Error(`JABS pose file is missing 'poseest/instance_count': ${labelsPath}`);
+        throw new Error(
+          `JABS pose file is missing 'poseest/instance_count': ${labelsPath}`,
+        );
       }
       idVal = idDs.value;
       instanceCountVal = countDs.value;
     } else if (poseVersion > 3) {
       const idDs = getDataset(file, "poseest/instance_embed_id");
       if (idDs == null) {
-        throw new Error(`JABS pose file is missing 'poseest/instance_embed_id': ${labelsPath}`);
+        throw new Error(
+          `JABS pose file is missing 'poseest/instance_embed_id': ${labelsPath}`,
+        );
       }
       idVal = idDs.value;
     }
 
     /** Extract one instance's [x, y] keypoints (flipped from y,x) + confidence. */
-    const extractInstance = (f: number, slot: number): { data: number[][]; conf: number[] } => {
+    const extractInstance = (
+      f: number,
+      slot: number,
+    ): { data: number[][]; conf: number[] } => {
       const data: number[][] = [];
       const conf: number[] = [];
       for (let n = 0; n < N; n++) {
@@ -365,7 +402,12 @@ export async function loadJabs(labelsPath: string, options?: LoadJabsOptions): P
             tracks.set(poseId, new Track(String(poseId)));
           }
           const { data, conf } = extractInstance(frameIdx, curId);
-          const inst = predictionToInstance(data, conf, skeleton, tracks.get(poseId));
+          const inst = predictionToInstance(
+            data,
+            conf,
+            skeleton,
+            tracks.get(poseId),
+          );
           if (inst) instances.push(inst);
         }
       }
@@ -378,7 +420,8 @@ export async function loadJabs(labelsPath: string, options?: LoadJabsOptions): P
     const rootKeys = typeof file.keys === "function" ? file.keys() : [];
     if (poseVersion >= 5 && rootKeys.includes("static_objects")) {
       const soGroup = file.get("static_objects") as H5Group | null;
-      const objNames = soGroup && typeof soGroup.keys === "function" ? soGroup.keys() : [];
+      const objNames =
+        soGroup && typeof soGroup.keys === "function" ? soGroup.keys() : [];
       for (const objName of objNames) {
         const ds = getDataset(file, `static_objects/${objName}`);
         if (ds == null) continue;

--- a/src/io/label-images-node.ts
+++ b/src/io/label-images-node.ts
@@ -16,7 +16,7 @@ import { setLabelImageFileReader } from "./label-images.js";
  * matching Python `read_label_images`.
  */
 async function readTiffPath(
-  path: string
+  path: string,
 ): Promise<Uint8Array | { files: Uint8Array[] }> {
   const stat = fs.statSync(path);
   if (stat.isDirectory()) {
@@ -25,7 +25,7 @@ async function readTiffPath(
       .filter((name) => /\.tiff?$/i.test(name))
       .sort();
     const files = entries.map(
-      (name) => new Uint8Array(fs.readFileSync(nodePath.join(path, name)))
+      (name) => new Uint8Array(fs.readFileSync(nodePath.join(path, name))),
     );
     return { files };
   }

--- a/src/io/label-images.ts
+++ b/src/io/label-images.ts
@@ -44,7 +44,7 @@ export interface LoadLabelImagesOptions {
  * `label-images-node.ts`; absent in the browser graph (issue #70).
  */
 export type LabelImageFileReader = (
-  path: string
+  path: string,
 ) => Promise<Uint8Array | { files: Uint8Array[] }>;
 
 let fileReader: LabelImageFileReader | null = null;
@@ -73,7 +73,7 @@ const warnedMessages = new Set<string>();
 
 async function decodeTiff(
   bytes: Uint8Array,
-  opts?: { pages?: number[]; ignoreImageData?: boolean }
+  opts?: { pages?: number[]; ignoreImageData?: boolean },
 ): Promise<TiffIfdLike[]> {
   // `tiff` is an optionalDependency (issue #140 decision 3): externalized in the
   // tsup build and lazy-imported here so it resolves from the consumer's install
@@ -85,7 +85,7 @@ async function decodeTiff(
   } catch {
     throw new Error(
       "Reading TIFF label images requires the optional `tiff` package. " +
-        "Install it with: npm install tiff"
+        "Install it with: npm install tiff",
     );
   }
   try {
@@ -98,7 +98,7 @@ async function decodeTiff(
     if (/bit\s*depth/i.test(m) && /(32|64)/.test(m)) {
       throw new Error(
         `32-bit integer TIFFs are not yet supported (${m}). Re-export the label ` +
-          "image as uint16, or split into <=65535 objects."
+          "image as uint16, or split into <=65535 objects.",
       );
     }
     throw err;
@@ -115,12 +115,12 @@ async function decodeTiff(
  */
 export async function loadLabelImages(
   source: string | File | Blob,
-  options: LoadLabelImagesOptions = {}
+  options: LoadLabelImagesOptions = {},
 ): Promise<UserLabelImage[]> {
   const pagesAs: PagesAs = options.pagesAs ?? "auto";
   if (pagesAs !== "auto" && pagesAs !== "time" && pagesAs !== "classes") {
     throw new Error(
-      `pagesAs must be 'auto', 'time', or 'classes'; got ${JSON.stringify(pagesAs)}.`
+      `pagesAs must be 'auto', 'time', or 'classes'; got ${JSON.stringify(pagesAs)}.`,
     );
   }
 
@@ -134,7 +134,7 @@ export async function loadLabelImages(
   if (!fileReader) {
     throw new Error(
       "Reading TIFF label images from a path requires the Node entry point " +
-        "(`@talmolab/sleap-io.js`). In the browser, pass a File/Blob instead."
+        "(`@talmolab/sleap-io.js`). In the browser, pass a File/Blob instead.",
     );
   }
   const read = await fileReader(source as string);
@@ -150,7 +150,7 @@ async function decodeSingleFile(
   bytes: Uint8Array,
   pagesAs: PagesAs,
   options: LoadLabelImagesOptions,
-  source: string
+  source: string,
 ): Promise<UserLabelImage[]> {
   // Cheap header scan: validate dtype, count pages, read page-0 metadata.
   const meta = await decodeTiff(bytes, { ignoreImageData: true });
@@ -167,7 +167,7 @@ async function decodeSingleFile(
   if (layout === "TCYX") {
     throw new Error(
       "4D TCYX (time + channel) TIFF stacks are not yet supported. Pass " +
-        "pagesAs: 'time' or 'classes' explicitly, or split the stack by channel."
+        "pagesAs: 'time' or 'classes' explicitly, or split the stack by channel.",
     );
   }
 
@@ -199,7 +199,7 @@ async function decodeDirectory(
   files: Uint8Array[],
   pagesAs: PagesAs,
   options: LoadLabelImagesOptions,
-  source: string
+  source: string,
 ): Promise<UserLabelImage[]> {
   if (files.length === 0) return [];
   const fileIndices = normalizeFrames(options.frames, files.length);
@@ -222,7 +222,7 @@ function validatePageDtype(ifd: TiffIfdLike): void {
   if (ifd.samplesPerPixel !== 1) {
     throw new Error(
       `Expected a single-channel (2D) label-image page, got ${ifd.samplesPerPixel} ` +
-        "samples per pixel. Multi-channel/RGB TIFFs are not supported."
+        "samples per pixel. Multi-channel/RGB TIFFs are not supported.",
     );
   }
   // MVP supports only unsigned 8/16-bit label rasters. Float, signed, and 32-bit
@@ -232,18 +232,18 @@ function validatePageDtype(ifd: TiffIfdLike): void {
   if (fmt === 3) {
     throw new Error(
       `Floating-point TIFFs are not supported as label images (bitsPerSample=${ifd.bitsPerSample}). ` +
-        "Re-export as uint8 or uint16."
+        "Re-export as uint8 or uint16.",
     );
   }
   if (fmt === 2) {
     throw new Error(
-      "Signed-integer TIFFs are not supported as label images. Re-export as uint8 or uint16."
+      "Signed-integer TIFFs are not supported as label images. Re-export as uint8 or uint16.",
     );
   }
   if (ifd.bitsPerSample !== 8 && ifd.bitsPerSample !== 16) {
     throw new Error(
       `Only 8- and 16-bit unsigned label images are supported (got ${ifd.bitsPerSample}-bit). ` +
-        "Re-export as uint16, or split into <=65535 objects."
+        "Re-export as uint16, or split into <=65535 objects.",
     );
   }
 }
@@ -261,7 +261,10 @@ function dtypeName(ifd: TiffIfdLike): string {
  * ImageJ-hyperstack and OME-XML metadata are authoritative; a plain multi-page
  * TIFF reports `"unknown"`. A single page is always `"YX"`.
  */
-export function inferAxes(description: string | undefined, nPages: number): Layout {
+export function inferAxes(
+  description: string | undefined,
+  nPages: number,
+): Layout {
   if (nPages === 1) return "YX";
   if (!description) return "unknown";
 
@@ -280,7 +283,7 @@ function dimsToLayout(c: number, z: number, t: number): Layout {
 
 /** Parse ImageJ-hyperstack `key=value` ImageDescription. */
 function parseImageJDims(
-  desc: string
+  desc: string,
 ): { c: number; z: number; t: number } | null {
   if (!/(^|\n)ImageJ=/.test(desc)) return null;
   const get = (key: string): number => {
@@ -291,7 +294,9 @@ function parseImageJDims(
 }
 
 /** Parse OME-XML `<Pixels SizeC/SizeT/SizeZ=...>` ImageDescription. */
-function parseOmeDims(desc: string): { c: number; z: number; t: number } | null {
+function parseOmeDims(
+  desc: string,
+): { c: number; z: number; t: number } | null {
   if (!/<\s*OME[\s>]|openmicroscopy\.org/i.test(desc)) return null;
   const pixels = desc.match(/<\s*Pixels\b[^>]*>/i);
   const attrs = pixels ? pixels[0] : desc;
@@ -350,7 +355,7 @@ function pagesCouldBeClassStack(pages: number[][][]): boolean {
 function buildTimeStack(
   pages: number[][][],
   options: LoadLabelImagesOptions,
-  source: string
+  source: string,
 ): UserLabelImage[] {
   return LabelImage.fromStack({
     data: pages,
@@ -364,10 +369,12 @@ function buildTimeStack(
 function buildClassStack(
   pages: number[][][],
   options: LoadLabelImagesOptions,
-  source: string
+  source: string,
 ): UserLabelImage {
   const labelIds = inferLabelIdsFromPages(pages);
-  const masks = pages.map((page) => page.map((row) => row.map((v) => (v > 0 ? 1 : 0))));
+  const masks = pages.map((page) =>
+    page.map((row) => row.map((v) => (v > 0 ? 1 : 0))),
+  );
   const categories = coerceCategoriesToList(options.categories, pages.length);
   return LabelImage.fromBinaryMasks(masks, {
     labelIds: labelIds ?? undefined,
@@ -379,7 +386,7 @@ function buildClassStack(
 /** Coerce categories to a positional list of length `n`, or `null` if all empty. */
 function coerceCategoriesToList(
   categories: Map<number, string> | string[] | null | undefined,
-  n: number
+  n: number,
 ): string[] | null {
   if (categories == null) return null;
   let list: string[];
@@ -397,7 +404,7 @@ function coerceCategoriesToList(
 
 function normalizeFrames(
   frames: number[] | null | undefined,
-  n: number
+  n: number,
 ): number[] {
   if (frames == null) return Array.from({ length: n }, (_, i) => i);
   return frames.filter((i) => i >= 0 && i < n);

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -5,8 +5,15 @@ import { readSlp, readSlpLazy } from "../codecs/slp/read.js";
 import { readSlpStreaming } from "../codecs/slp/read-streaming.js";
 import { writeSlp, saveSlpToBytes } from "../codecs/slp/write.js";
 import { createVideoBackend, VideoBackendType } from "../video/factory.js";
-import { OpenH5Options, SlpSource, isStreamingSupported } from "../codecs/slp/h5.js";
-import { readLabels as readAnalysisH5, writeLabels as writeAnalysisH5 } from "./analysis-h5.js";
+import {
+  OpenH5Options,
+  SlpSource,
+  isStreamingSupported,
+} from "../codecs/slp/h5.js";
+import {
+  readLabels as readAnalysisH5,
+  writeLabels as writeAnalysisH5,
+} from "./analysis-h5.js";
 
 // TIFF label-image reader (browser-safe core; Node path reading is registered
 // via the side-effect import of ./label-images-node.js in the Node entry).
@@ -42,7 +49,7 @@ function isBrowserWithWorkerSupport(): boolean {
  */
 export async function loadSlp(
   source: SlpSource,
-  options?: { openVideos?: boolean; h5?: OpenH5Options; lazy?: boolean }
+  options?: { openVideos?: boolean; h5?: OpenH5Options; lazy?: boolean },
 ): Promise<Labels> {
   const streamMode = options?.h5?.stream ?? "auto";
   const openVideos = options?.openVideos ?? true;
@@ -57,7 +64,10 @@ export async function loadSlp(
       streamingSource = source;
     } else if (typeof File !== "undefined" && source instanceof File) {
       streamingSource = source;
-    } else if (typeof FileSystemFileHandle !== "undefined" && "getFile" in source) {
+    } else if (
+      typeof FileSystemFileHandle !== "undefined" &&
+      "getFile" in source
+    ) {
       streamingSource = await (source as FileSystemFileHandle).getFile();
     } else {
       streamingSource = null as unknown as File;
@@ -71,7 +81,10 @@ export async function loadSlp(
         });
       } catch (e) {
         if (streamMode === "auto") {
-          console.warn("[sleap-io] Worker-based loading failed, falling back to main thread:", e);
+          console.warn(
+            "[sleap-io] Worker-based loading failed, falling back to main thread:",
+            e,
+          );
         } else {
           throw e;
         }
@@ -101,7 +114,7 @@ export async function saveSlp(
   options?: {
     embed?: boolean | string;
     restoreOriginalVideos?: boolean;
-  }
+  },
 ): Promise<void> {
   await writeSlp(filename, labels, {
     embed: options?.embed ?? false,
@@ -126,7 +139,7 @@ export { saveSlpToBytes } from "../codecs/slp/write.js";
  */
 export async function loadAnalysisH5(
   filename: string,
-  options?: { video?: Video | string }
+  options?: { video?: Video | string },
 ): Promise<Labels> {
   return readAnalysisH5(filename, { video: options?.video });
 }
@@ -165,7 +178,7 @@ export async function saveAnalysisH5(
     nodeDim?: number;
     xyDim?: number;
     saveMetadata?: boolean;
-  }
+  },
 ): Promise<void> {
   await writeAnalysisH5(labels, filename, {
     video: options?.video,
@@ -199,18 +212,22 @@ export { isAnalysisH5File } from "./analysis-h5.js";
  */
 export async function loadSlpSet(
   sources: string[] | Record<string, string>,
-  options?: { openVideos?: boolean; h5?: OpenH5Options }
+  options?: { openVideos?: boolean; h5?: OpenH5Options },
 ): Promise<LabelsSet> {
   const set = new LabelsSet();
 
   if (Array.isArray(sources)) {
-    const results = await Promise.all(sources.map(src => loadSlp(src, options)));
+    const results = await Promise.all(
+      sources.map((src) => loadSlp(src, options)),
+    );
     for (let i = 0; i < sources.length; i++) {
       set.set(sources[i], results[i]);
     }
   } else {
     const entries = Object.entries(sources);
-    const results = await Promise.all(entries.map(([, src]) => loadSlp(src, options)));
+    const results = await Promise.all(
+      entries.map(([, src]) => loadSlp(src, options)),
+    );
     for (let i = 0; i < entries.length; i++) {
       set.set(entries[i][0], results[i]);
     }
@@ -233,7 +250,7 @@ export async function saveSlpSet(
   options?: {
     embed?: boolean | string;
     restoreOriginalVideos?: boolean;
-  }
+  },
 ): Promise<void> {
   const promises: Promise<void>[] = [];
   for (const [filename, labels] of labelsSet) {
@@ -254,12 +271,20 @@ export async function saveSlpSet(
  */
 export async function loadVideo(
   source: string | File,
-  options?: { dataset?: string; openBackend?: boolean; backend?: VideoBackendType }
+  options?: {
+    dataset?: string;
+    openBackend?: boolean;
+    backend?: VideoBackendType;
+  },
 ): Promise<Video> {
   const filename = typeof source === "string" ? source : source.name;
   const backend = await createVideoBackend(source, {
     dataset: options?.dataset,
     backend: options?.backend,
   });
-  return new Video({ filename, backend, openBackend: options?.openBackend ?? true });
+  return new Video({
+    filename,
+    backend,
+    openBackend: options?.openBackend ?? true,
+  });
 }

--- a/src/io/trackmate.ts
+++ b/src/io/trackmate.ts
@@ -21,7 +21,14 @@ import { Video } from "../model/video.js";
 const HEADER_ROWS = 4;
 
 /** Required columns in a spots CSV (used for format detection). */
-const SPOTS_SIGNATURE = ["LABEL", "ID", "TRACK_ID", "QUALITY", "POSITION_X", "POSITION_Y"];
+const SPOTS_SIGNATURE = [
+  "LABEL",
+  "ID",
+  "TRACK_ID",
+  "QUALITY",
+  "POSITION_X",
+  "POSITION_Y",
+];
 
 /** Options for loading TrackMate CSV files. */
 export interface TrackMateOptions {
@@ -42,7 +49,8 @@ export function isTrackMateFile(filePath: string): boolean {
     const buf = Buffer.alloc(1024);
     const bytesRead = fs.readSync(fd, buf, 0, 1024, 0);
     fs.closeSync(fd);
-    const firstLine = buf.toString("utf-8", 0, bytesRead).split("\n")[0]?.trim() ?? "";
+    const firstLine =
+      buf.toString("utf-8", 0, bytesRead).split("\n")[0]?.trim() ?? "";
     const cols = firstLine.split(",");
     return SPOTS_SIGNATURE.every((sig, i) => cols[i] === sig);
   } catch {
@@ -143,7 +151,9 @@ export function readTrackMateCsv(
   }
 
   // Parse edges if available
-  const targetToCost = edgesPath ? parseEdges(edgesPath) : new Map<number, number>();
+  const targetToCost = edgesPath
+    ? parseEdges(edgesPath)
+    : new Map<number, number>();
 
   // Parse spots CSV
   const content = fs.readFileSync(spotsPath, "utf-8");
@@ -151,7 +161,10 @@ export function readTrackMateCsv(
 
   // Read header to find column indices and validate
   const header = lines[0]?.split(",") ?? [];
-  if (header.length < SPOTS_SIGNATURE.length || !SPOTS_SIGNATURE.every((sig, i) => header[i] === sig)) {
+  if (
+    header.length < SPOTS_SIGNATURE.length ||
+    !SPOTS_SIGNATURE.every((sig, i) => header[i] === sig)
+  ) {
     throw new Error(
       `Not a TrackMate spots CSV. Expected columns starting with ${SPOTS_SIGNATURE.join(", ")}.`,
     );
@@ -193,15 +206,17 @@ export function readTrackMateCsv(
     const x = parseFloat(row[col["POSITION_X"]]);
     const y = parseFloat(row[col["POSITION_Y"]]);
 
-    const zVal = col["POSITION_Z"] !== undefined ? parseFloat(row[col["POSITION_Z"]]) : 0;
+    const zVal =
+      col["POSITION_Z"] !== undefined ? parseFloat(row[col["POSITION_Z"]]) : 0;
     const z = zVal !== 0 ? zVal : null;
 
     const frameIdx = parseInt(row[col["FRAME"]], 10);
     const score = parseFloat(row[col["QUALITY"]]);
 
-    const track = tidStr ? trackMap.get(parseInt(tidStr, 10)) ?? null : null;
+    const track = tidStr ? (trackMap.get(parseInt(tidStr, 10)) ?? null) : null;
     const trackingScore = targetToCost.get(spotId) ?? null;
-    const label = col["LABEL"] !== undefined ? row[col["LABEL"]] : `ID${spotId}`;
+    const label =
+      col["LABEL"] !== undefined ? row[col["LABEL"]] : `ID${spotId}`;
 
     const centroid = new PredictedCentroid({
       x,
@@ -213,15 +228,22 @@ export function readTrackMateCsv(
       name: label,
       source: "trackmate",
     });
-    centroidsByFrame.set(frameIdx, [...(centroidsByFrame.get(frameIdx) ?? []), centroid]);
+    centroidsByFrame.set(frameIdx, [
+      ...(centroidsByFrame.get(frameIdx) ?? []),
+      centroid,
+    ]);
   }
 
   // Assemble Labels with LabeledFrames
   const videos = videoObj ? [videoObj] : [];
   const video = videoObj ?? new Video({ filename: "" });
   const labeledFrames: LabeledFrame[] = [];
-  for (const [frameIdx, frameCentroids] of [...centroidsByFrame.entries()].sort((a, b) => a[0] - b[0])) {
-    labeledFrames.push(new LabeledFrame({ video, frameIdx, centroids: frameCentroids }));
+  for (const [frameIdx, frameCentroids] of [...centroidsByFrame.entries()].sort(
+    (a, b) => a[0] - b[0],
+  )) {
+    labeledFrames.push(
+      new LabeledFrame({ video, frameIdx, centroids: frameCentroids }),
+    );
   }
   const labels = new Labels({ labeledFrames, videos, tracks });
   labels.provenance["filename"] = spotsPath;

--- a/src/io/ultralytics.ts
+++ b/src/io/ultralytics.ts
@@ -53,7 +53,11 @@ import { Instance, Track } from "../model/instance.js";
 import { Skeleton, Node, Edge } from "../model/skeleton.js";
 import { Video } from "../model/video.js";
 import { ROI, UserROI } from "../model/roi.js";
-import { BoundingBox, UserBoundingBox, PredictedBoundingBox } from "../model/bbox.js";
+import {
+  BoundingBox,
+  UserBoundingBox,
+  PredictedBoundingBox,
+} from "../model/bbox.js";
 
 // =============================================================================
 // Types
@@ -63,7 +67,11 @@ import { BoundingBox, UserBoundingBox, PredictedBoundingBox } from "../model/bbo
 export type ImageShape = [number, number];
 
 /** Auto-detected YOLO annotation format for a single label line. */
-export type LineFormat = "detection" | "detection_conf" | "segmentation" | "pose";
+export type LineFormat =
+  | "detection"
+  | "detection_conf"
+  | "segmentation"
+  | "pose";
 
 /** Result of {@link parseLabelFile}: the 3-tuple of parsed annotations. */
 export interface ParsedLabelFile {
@@ -84,7 +92,15 @@ const READ_IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".bmp"];
  * {@link READ_IMAGE_EXTENSIONS} (the writer's copy path is a documented JS
  * image-I/O divergence, so it accepts a few more on-disk formats).
  */
-const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".tiff", ".tif", ".bmp", ".gif"];
+const IMAGE_EXTENSIONS = [
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".tiff",
+  ".tif",
+  ".bmp",
+  ".gif",
+];
 
 // =============================================================================
 // data.yaml parsing / skeleton construction
@@ -103,7 +119,9 @@ export function parseDataYaml(yamlPath: string): Record<string, unknown> {
  * (`names: {0: cat, 1: dog}`). Keys are coerced to integers so lookups work
  * regardless of how the YAML parser represented numeric keys.
  */
-export function classNamesFromConfig(config: Record<string, unknown>): Map<number, string> {
+export function classNamesFromConfig(
+  config: Record<string, unknown>,
+): Map<number, string> {
   const raw = config["names"];
   const result = new Map<number, string>();
   if (Array.isArray(raw)) {
@@ -120,21 +138,31 @@ export function classNamesFromConfig(config: Record<string, unknown>): Map<numbe
 }
 
 /** Create a {@link Skeleton} from an Ultralytics configuration object. */
-export function createSkeletonFromConfig(config: Record<string, unknown>): Skeleton {
+export function createSkeletonFromConfig(
+  config: Record<string, unknown>,
+): Skeleton {
   const kptShape = (config["kpt_shape"] as number[] | undefined) ?? [1, 3];
   const numKeypoints = kptShape[0];
 
   const nodeNames =
     (config["node_names"] as string[] | undefined) ??
     Array.from({ length: numKeypoints }, (_, i) => `point_${i}`);
-  const nodes = nodeNames.slice(0, numKeypoints).map((name) => new Node(String(name)));
+  const nodes = nodeNames
+    .slice(0, numKeypoints)
+    .map((name) => new Node(String(name)));
 
   const edges: Edge[] = [];
-  const connections = (config["skeleton"] as Array<[number, number]> | undefined) ?? [];
+  const connections =
+    (config["skeleton"] as Array<[number, number]> | undefined) ?? [];
   for (const connection of connections) {
     if (Array.isArray(connection) && connection.length === 2) {
       const [srcIdx, dstIdx] = connection;
-      if (srcIdx >= 0 && srcIdx < nodes.length && dstIdx >= 0 && dstIdx < nodes.length) {
+      if (
+        srcIdx >= 0 &&
+        srcIdx < nodes.length &&
+        dstIdx >= 0 &&
+        dstIdx < nodes.length
+      ) {
         edges.push(new Edge(nodes[srcIdx], nodes[dstIdx]));
       }
     }
@@ -267,13 +295,15 @@ export function parseLabelFile(
     try {
       const parts = line.split(/\s+/);
       if (parts.length < 5) {
-        console.warn(`Invalid line ${lineNum} in ${labelPath}: insufficient data`);
+        console.warn(
+          `Invalid line ${lineNum} in ${labelPath}: insufficient data`,
+        );
         continue;
       }
 
       const fmt = detectLineFormat(parts);
       const classId = parseStrictInt(parts[0]);
-      const category = classNames ? classNames.get(classId) ?? "" : "";
+      const category = classNames ? (classNames.get(classId) ?? "") : "";
 
       if (fmt === "detection" || fmt === "detection_conf") {
         const xCenterNorm = parseStrictFloat(parts[1]);
@@ -293,17 +323,35 @@ export function parseLabelFile(
         if (fmt === "detection_conf") {
           const score = parseStrictFloat(parts[5]);
           bboxes.push(
-            new PredictedBoundingBox({ x1, y1, x2: x1 + wPx, y2: y1 + hPx, category, score }),
+            new PredictedBoundingBox({
+              x1,
+              y1,
+              x2: x1 + wPx,
+              y2: y1 + hPx,
+              category,
+              score,
+            }),
           );
         } else {
-          bboxes.push(new UserBoundingBox({ x1, y1, x2: x1 + wPx, y2: y1 + hPx, category }));
+          bboxes.push(
+            new UserBoundingBox({
+              x1,
+              y1,
+              x2: x1 + wPx,
+              y2: y1 + hPx,
+              category,
+            }),
+          );
         }
       } else if (fmt === "segmentation") {
         // class_id x1 y1 x2 y2 ... xn yn
         const coordValues = parts.slice(1).map(parseStrictFloat);
         const coords: number[][] = [];
         for (let i = 0; i + 1 < coordValues.length; i += 2) {
-          coords.push([coordValues[i] * widthPx, coordValues[i + 1] * heightPx]);
+          coords.push([
+            coordValues[i] * widthPx,
+            coordValues[i + 1] * heightPx,
+          ]);
         }
         rois.push(UserROI.fromPolygon(coords, { category }));
       } else {
@@ -344,7 +392,9 @@ export function parseLabelFile(
         instances.push(Instance.fromNumpy({ pointsData: points, skeleton }));
       }
     } catch (e) {
-      console.warn(`Error parsing line ${lineNum} in ${labelPath}: ${(e as Error).message}`);
+      console.warn(
+        `Error parsing line ${lineNum} in ${labelPath}: ${(e as Error).message}`,
+      );
       continue;
     }
   }
@@ -485,7 +535,9 @@ export function writeRoiLabelFile(
       const w = (maxX - minX) / widthPx;
       const h = (maxY - minY) / heightPx;
       out.push(
-        [String(classId), fmt6(xCenter), fmt6(yCenter), fmt6(w), fmt6(h)].join(" "),
+        [String(classId), fmt6(xCenter), fmt6(yCenter), fmt6(w), fmt6(h)].join(
+          " ",
+        ),
       );
     }
   }
@@ -551,7 +603,8 @@ export function createDataYaml(
   options?: CreateDataYamlOptions,
 ): void {
   const task = options?.task ?? "pose";
-  const classNames = options?.classNames ?? new Map<number, string>([[0, "animal"]]);
+  const classNames =
+    options?.classNames ?? new Map<number, string>([[0, "animal"]]);
 
   // Pass `names` as a Map so the YAML emitter writes integer keys
   // (`0: animal`) matching Ultralytics/Python output rather than quoted
@@ -567,10 +620,16 @@ export function createDataYaml(
     // Pose-specific fields.
     const connections: Array<[number, number]> = [];
     for (const edge of skeleton.edges) {
-      connections.push([skeleton.index(edge.source), skeleton.index(edge.destination)]);
+      connections.push([
+        skeleton.index(edge.source),
+        skeleton.index(edge.destination),
+      ]);
     }
     config["kpt_shape"] = [skeleton.nodes.length, 3];
-    config["flip_idx"] = Array.from({ length: skeleton.nodes.length }, (_, i) => i);
+    config["flip_idx"] = Array.from(
+      { length: skeleton.nodes.length },
+      (_, i) => i,
+    );
     config["skeleton"] = connections;
     config["node_names"] = skeleton.nodes.map((node) => node.name);
   }
@@ -593,7 +652,9 @@ export function buildClassNamesFromRois(rois: ROI[]): Map<number, string> {
 }
 
 /** Build a class-id → name map from the distinct, sorted bbox categories. */
-export function buildClassNamesFromBboxes(bboxes: BoundingBox[]): Map<number, string> {
+export function buildClassNamesFromBboxes(
+  bboxes: BoundingBox[],
+): Map<number, string> {
   return buildClassNames(bboxes.map((bbox) => bbox.category));
 }
 
@@ -635,7 +696,10 @@ export interface ReadLabelsOptions {
  *   the `data.yaml` file itself.
  * @param options - Optional split / skeleton / fallback image size.
  */
-export function readLabels(datasetPath: string, options?: ReadLabelsOptions): Labels {
+export function readLabels(
+  datasetPath: string,
+  options?: ReadLabelsOptions,
+): Labels {
   const split = options?.split ?? "train";
   const imageSize = options?.imageSize ?? [480, 640];
   let skeleton = options?.skeleton ?? null;
@@ -682,7 +746,9 @@ export function readLabels(datasetPath: string, options?: ReadLabelsOptions): La
 
   const imageFiles = fs
     .readdirSync(imagesDir)
-    .filter((name) => READ_IMAGE_EXTENSIONS.includes(path.extname(name).toLowerCase()))
+    .filter((name) =>
+      READ_IMAGE_EXTENSIONS.includes(path.extname(name).toLowerCase()),
+    )
     .sort();
 
   for (const imageName of imageFiles) {
@@ -699,11 +765,16 @@ export function readLabels(datasetPath: string, options?: ReadLabelsOptions): La
     if (fs.existsSync(labelFile)) {
       const imgShape = probeImageSize(imageFile) ?? imageSize;
       const parseSkeleton = skeleton ?? new Skeleton({ nodes: [] });
-      ({ instances, rois, bboxes } = parseLabelFile(labelFile, parseSkeleton, imgShape, {
-        classNames,
-        video,
-        frameIdx: 0,
-      }));
+      ({ instances, rois, bboxes } = parseLabelFile(
+        labelFile,
+        parseSkeleton,
+        imgShape,
+        {
+          classNames,
+          video,
+          frameIdx: 0,
+        },
+      ));
 
       // Assign synthetic tracks based on per-frame instance order.
       for (let i = 0; i < instances.length; i++) {
@@ -749,7 +820,10 @@ export interface ReadLabelsSetOptions {
  * @param datasetPath - Path to the dataset root directory.
  * @param options - Optional splits / skeleton / fallback image size.
  */
-export function readLabelsSet(datasetPath: string, options?: ReadLabelsSetOptions): LabelsSet {
+export function readLabelsSet(
+  datasetPath: string,
+  options?: ReadLabelsSetOptions,
+): LabelsSet {
   const imageSize = options?.imageSize;
   let skeleton = options?.skeleton ?? null;
   let splits = options?.splits;
@@ -783,7 +857,12 @@ export function readLabelsSet(datasetPath: string, options?: ReadLabelsSetOption
           for (const connection of connections) {
             if (Array.isArray(connection) && connection.length === 2) {
               const [srcIdx, dstIdx] = connection;
-              if (srcIdx >= 0 && srcIdx < nodes.length && dstIdx >= 0 && dstIdx < nodes.length) {
+              if (
+                srcIdx >= 0 &&
+                srcIdx < nodes.length &&
+                dstIdx >= 0 &&
+                dstIdx < nodes.length
+              ) {
                 edges.push(new Edge(nodes[srcIdx], nodes[dstIdx]));
               }
             }
@@ -799,7 +878,10 @@ export function readLabelsSet(datasetPath: string, options?: ReadLabelsSetOption
         const kptShape = dataConfig["kpt_shape"] as number[];
         if (Array.isArray(kptShape) && kptShape.length >= 2) {
           const nKeypoints = kptShape[0];
-          const nodes = Array.from({ length: nKeypoints }, (_, i) => new Node(String(i)));
+          const nodes = Array.from(
+            { length: nKeypoints },
+            (_, i) => new Node(String(i)),
+          );
           skeleton = new Skeleton({ nodes });
         }
       }
@@ -903,11 +985,25 @@ export async function writeLabels(
   });
 
   if (task === "detect") {
-    writeBboxLabels(labels, datasetPath, splitRatios, classNames, imageFormat, imageQuality);
+    writeBboxLabels(
+      labels,
+      datasetPath,
+      splitRatios,
+      classNames,
+      imageFormat,
+      imageQuality,
+    );
     return;
   }
   if (task === "segment") {
-    writeRoiLabels(labels, datasetPath, splitRatios, classNames, imageFormat, imageQuality);
+    writeRoiLabels(
+      labels,
+      datasetPath,
+      splitRatios,
+      classNames,
+      imageFormat,
+      imageQuality,
+    );
     return;
   }
 
@@ -932,9 +1028,17 @@ export async function writeLabels(
     const frames = splitData.labeledFrames;
     for (let lfIdx = 0; lfIdx < frames.length; lfIdx++) {
       const frame = frames[lfIdx];
-      const written = await writeFrameImage(frame, imagesDir, lfIdx, imageFormat, imageQuality);
+      const written = await writeFrameImage(
+        frame,
+        imagesDir,
+        lfIdx,
+        imageFormat,
+        imageQuality,
+      );
       if (written === null) {
-        console.warn(`Could not load frame ${frame.frameIdx} from video, skipping.`);
+        console.warn(
+          `Could not load frame ${frame.frameIdx} from video, skipping.`,
+        );
         continue;
       }
       const labelPath = path.join(labelsDir, `${pad7(lfIdx)}.txt`);
@@ -975,7 +1079,8 @@ function writeBboxLabels(
     splitRatios,
     imageFormat,
     imageQuality,
-    (labelPath, items, shape) => writeBboxLabelFile(labelPath, items, shape, nameToId),
+    (labelPath, items, shape) =>
+      writeBboxLabelFile(labelPath, items, shape, nameToId),
   );
 }
 
@@ -1010,7 +1115,8 @@ function writeRoiLabels(
     splitRatios,
     imageFormat,
     imageQuality,
-    (labelPath, items, shape) => writeRoiLabelFile(labelPath, items, shape, nameToId),
+    (labelPath, items, shape) =>
+      writeRoiLabelFile(labelPath, items, shape, nameToId),
   );
 }
 
@@ -1142,7 +1248,10 @@ export function createSplitsFromLabels(
  * @param datasetPath - Path to the dataset root or its `data.yaml` file.
  * @param options - Optional split / skeleton / fallback image size.
  */
-export function loadUltralytics(datasetPath: string, options?: ReadLabelsOptions): Labels {
+export function loadUltralytics(
+  datasetPath: string,
+  options?: ReadLabelsOptions,
+): Labels {
   return readLabels(datasetPath, options);
 }
 
@@ -1212,8 +1321,14 @@ async function writeFrameImage(
  * If `video` is backed by a readable on-disk image file, copy it into
  * `imagesDir` as `NNNNNNN.<sourceExt>` and return its probed shape; else `null`.
  */
-function copyImageFileFrom(video: Video, imagesDir: string, lfIdx: number): WrittenImage | null {
-  const filename = Array.isArray(video.filename) ? video.filename[0] : video.filename;
+function copyImageFileFrom(
+  video: Video,
+  imagesDir: string,
+  lfIdx: number,
+): WrittenImage | null {
+  const filename = Array.isArray(video.filename)
+    ? video.filename[0]
+    : video.filename;
   if (typeof filename !== "string" || filename.length === 0) return null;
   const ext = path.extname(filename).toLowerCase();
   if (!IMAGE_EXTENSIONS.includes(ext)) return null;
@@ -1241,7 +1356,12 @@ export function probeImageSize(filePath: string): ImageShape | null {
     if (n < 2) return null;
 
     // PNG: 8-byte signature, then IHDR with width/height as big-endian uint32.
-    if (head[0] === 0x89 && head[1] === 0x50 && head[2] === 0x4e && head[3] === 0x47) {
+    if (
+      head[0] === 0x89 &&
+      head[1] === 0x50 &&
+      head[2] === 0x4e &&
+      head[3] === 0x47
+    ) {
       const width = head.readUInt32BE(16);
       const height = head.readUInt32BE(20);
       return [height, width];
@@ -1303,14 +1423,22 @@ function probeJpegSize(fd: number): ImageShape | null {
     }
     const marker = buf[offset + 1];
     // Standalone markers without a length field.
-    if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+    if (
+      marker === 0xd8 ||
+      marker === 0xd9 ||
+      (marker >= 0xd0 && marker <= 0xd7)
+    ) {
       offset += 2;
       continue;
     }
     const segLen = buf.readUInt16BE(offset + 2);
     // SOF markers (baseline + progressive), excluding DHT(0xC4)/DAC(0xCC)/RSTn.
     const isSof =
-      marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      marker !== 0xc4 &&
+      marker !== 0xc8 &&
+      marker !== 0xcc;
     if (isSof) {
       const height = buf.readUInt16BE(offset + 5);
       const width = buf.readUInt16BE(offset + 7);
@@ -1329,8 +1457,10 @@ function probeTiffSize(fd: number): ImageShape | null {
   fs.readSync(fd, buf, 0, size, 0);
 
   const le = buf[0] === 0x49;
-  const readU16 = (o: number) => (le ? buf.readUInt16LE(o) : buf.readUInt16BE(o));
-  const readU32 = (o: number) => (le ? buf.readUInt32LE(o) : buf.readUInt32BE(o));
+  const readU16 = (o: number) =>
+    le ? buf.readUInt16LE(o) : buf.readUInt16BE(o);
+  const readU32 = (o: number) =>
+    le ? buf.readUInt32LE(o) : buf.readUInt32BE(o);
 
   const ifdOffset = readU32(4);
   if (ifdOffset + 2 > buf.length) return null;
@@ -1385,16 +1515,22 @@ export function encodePng(
   height: number,
   compressLevel: number | null = null,
 ): Uint8Array {
-  const level = compressLevel == null ? 6 : Math.min(9, Math.max(0, compressLevel));
+  const level =
+    compressLevel == null ? 6 : Math.min(9, Math.max(0, compressLevel));
 
   // Filtered raw scanlines: each row prefixed with filter-type byte 0 (None).
   const stride = width * 4;
   const raw = new Uint8Array((stride + 1) * height);
   for (let y = 0; y < height; y++) {
     raw[y * (stride + 1)] = 0;
-    raw.set(rgba.subarray(y * stride, y * stride + stride), y * (stride + 1) + 1);
+    raw.set(
+      rgba.subarray(y * stride, y * stride + stride),
+      y * (stride + 1) + 1,
+    );
   }
-  const compressed = deflate(raw, { level: level as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 });
+  const compressed = deflate(raw, {
+    level: level as 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9,
+  });
 
   const ihdr = new Uint8Array(13);
   const dv = new DataView(ihdr.buffer);
@@ -1406,7 +1542,9 @@ export function encodePng(
   ihdr[11] = 0; // filter
   ihdr[12] = 0; // interlace
 
-  const signature = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const signature = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ]);
   const chunks = [
     signature,
     pngChunk("IHDR", ihdr),
@@ -1530,11 +1668,15 @@ function parseStrictFloat(s: string): number {
 
 /** Source-video grouping key (first filename element for image sequences). */
 function videoKey(video: Video): string {
-  return Array.isArray(video.filename) ? String(video.filename[0]) : String(video.filename);
+  return Array.isArray(video.filename)
+    ? String(video.filename[0])
+    : String(video.filename);
 }
 
 /** Invert a class-id → name map to a name → class-id map. */
-function invertClassNames(classNames: Map<number, string>): Map<string, number> {
+function invertClassNames(
+  classNames: Map<number, string>,
+): Map<string, number> {
   const result = new Map<string, number>();
   for (const [id, name] of classNames) result.set(name, id);
   return result;

--- a/src/lite.ts
+++ b/src/lite.ts
@@ -129,7 +129,7 @@ export interface SlpMetadata {
  */
 export async function loadSlpMetadata(
   source: JsfiveSource,
-  options?: { filename?: string }
+  options?: { filename?: string },
 ): Promise<SlpMetadata> {
   const file = openJsfiveFile(source, options?.filename);
 
@@ -152,9 +152,12 @@ export async function loadSlpMetadata(
     const formatId = Number(
       (metadataAttrs.format_id as { value?: unknown })?.value ??
         metadataAttrs.format_id ??
-        1.0
+        1.0,
     );
-    const metadataJson = parseJsonAttr(metadataAttrs.json) as Record<string, unknown> | null;
+    const metadataJson = parseJsonAttr(metadataAttrs.json) as Record<
+      string,
+      unknown
+    > | null;
 
     if (!metadataJson) {
       throw new Error("Invalid SLP file: missing metadata.attrs.json");
@@ -190,7 +193,8 @@ export async function loadSlpMetadata(
       if (attrs.format !== undefined) enriched.format = String(attrs.format);
       if (attrs.width !== undefined) enriched.width = Number(attrs.width);
       if (attrs.height !== undefined) enriched.height = Number(attrs.height);
-      if (attrs.channels !== undefined) enriched.channels = Number(attrs.channels);
+      if (attrs.channels !== undefined)
+        enriched.channels = Number(attrs.channels);
 
       // Try to get frame count from shape
       const shape = getShape(videoDs);
@@ -230,7 +234,7 @@ export async function loadSlpMetadata(
 
     // Check for embedded images by looking at video metadata
     const hasEmbeddedImages = videos.some(
-      (v) => v.embedded && (v.format || v.width)
+      (v) => v.embedded && (v.format || v.width),
     );
 
     return {
@@ -243,7 +247,9 @@ export async function loadSlpMetadata(
       sessions,
       counts,
       hasEmbeddedImages,
-      provenance: metadataJson.provenance as Record<string, unknown> | undefined,
+      provenance: metadataJson.provenance as
+        | Record<string, unknown>
+        | undefined,
     };
   } finally {
     file.close();

--- a/src/model/bbox.ts
+++ b/src/model/bbox.ts
@@ -71,7 +71,13 @@ export class BoundingBox {
     h: number,
     options?: Omit<BoundingBoxOptions, "x1" | "y1" | "x2" | "y2">,
   ): UserBoundingBox {
-    return new UserBoundingBox({ x1: x, y1: y, x2: x + w, y2: y + h, ...options });
+    return new UserBoundingBox({
+      x1: x,
+      y1: y,
+      x2: x + w,
+      y2: y + h,
+      ...options,
+    });
   }
 
   /** Center X coordinate (computed from x1, x2). */

--- a/src/model/camera.ts
+++ b/src/model/camera.ts
@@ -4,12 +4,22 @@ import { Video } from "./video.js";
 import { Identity } from "./identity.js";
 import { Instance3D } from "./instance3d.js";
 
-export function rodriguesTransformation(input: number[][] | number[]): { matrix: number[][]; vector: number[] } {
+export function rodriguesTransformation(input: number[][] | number[]): {
+  matrix: number[][];
+  vector: number[];
+} {
   if (input.length === 3 && Array.isArray(input[0]) === false) {
     const rvec = input as number[];
     const theta = Math.hypot(rvec[0], rvec[1], rvec[2]);
     if (theta === 0) {
-      return { matrix: [[1, 0, 0],[0, 1, 0],[0, 0, 1]], vector: rvec };
+      return {
+        matrix: [
+          [1, 0, 0],
+          [0, 1, 0],
+          [0, 0, 1],
+        ],
+        vector: rvec,
+      };
     }
     const axis = rvec.map((v) => v / theta);
     const [x, y, z] = axis;
@@ -20,7 +30,11 @@ export function rodriguesTransformation(input: number[][] | number[]): { matrix:
       [z, 0, -x],
       [-y, x, 0],
     ];
-    const I = [[1, 0, 0],[0, 1, 0],[0, 0, 1]];
+    const I = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ];
     const KK = multiply3x3(K, K);
     const matrix = add3x3(add3x3(I, scale3x3(K, sin)), scale3x3(KK, 1 - cos));
     return { matrix, vector: rvec };
@@ -65,7 +79,14 @@ export class Camera {
   distortions?: number[];
   size?: [number, number];
 
-  constructor(options: { name?: string; rvec: number[]; tvec: number[]; matrix?: number[][]; distortions?: number[]; size?: [number, number] }) {
+  constructor(options: {
+    name?: string;
+    rvec: number[];
+    tvec: number[];
+    matrix?: number[][];
+    distortions?: number[];
+    size?: [number, number];
+  }) {
     this.name = options.name;
     this.rvec = options.rvec;
     this.tvec = options.tvec;
@@ -79,7 +100,10 @@ export class CameraGroup {
   cameras: Camera[];
   metadata: Record<string, unknown>;
 
-  constructor(options?: { cameras?: Camera[]; metadata?: Record<string, unknown> }) {
+  constructor(options?: {
+    cameras?: Camera[];
+    metadata?: Record<string, unknown>;
+  }) {
     this.cameras = options?.cameras ?? [];
     this.metadata = options?.metadata ?? {};
   }
@@ -101,7 +125,10 @@ export class InstanceGroup {
     instance3d?: Instance3D;
     metadata?: Record<string, unknown>;
   }) {
-    this.instanceByCamera = options.instanceByCamera instanceof Map ? options.instanceByCamera : new Map();
+    this.instanceByCamera =
+      options.instanceByCamera instanceof Map
+        ? options.instanceByCamera
+        : new Map();
     if (!(options.instanceByCamera instanceof Map)) {
       for (const [key, value] of Object.entries(options.instanceByCamera)) {
         const camera = key as unknown as Camera;
@@ -122,7 +149,9 @@ export class InstanceGroup {
 
   set points(value: number[][] | undefined) {
     if (this.instance3d?.points && value != null) {
-      console.warn("Setting points on an InstanceGroup that has an Instance3D — the getter will return instance3d.points, not this value. Set instance3d.points directly instead.");
+      console.warn(
+        "Setting points on an InstanceGroup that has an Instance3D — the getter will return instance3d.points, not this value. Set instance3d.points directly instead.",
+      );
     }
     this._points = value;
   }
@@ -141,12 +170,17 @@ export class FrameGroup {
   constructor(options: {
     frameIdx: number;
     instanceGroups: InstanceGroup[];
-    labeledFrameByCamera: Map<Camera, LabeledFrame> | Record<string, LabeledFrame>;
+    labeledFrameByCamera:
+      | Map<Camera, LabeledFrame>
+      | Record<string, LabeledFrame>;
     metadata?: Record<string, unknown>;
   }) {
     this.frameIdx = options.frameIdx;
     this.instanceGroups = options.instanceGroups;
-    this.labeledFrameByCamera = options.labeledFrameByCamera instanceof Map ? options.labeledFrameByCamera : new Map();
+    this.labeledFrameByCamera =
+      options.labeledFrameByCamera instanceof Map
+        ? options.labeledFrameByCamera
+        : new Map();
     if (!(options.labeledFrameByCamera instanceof Map)) {
       for (const [key, value] of Object.entries(options.labeledFrameByCamera)) {
         const camera = key as unknown as Camera;

--- a/src/model/centroid.ts
+++ b/src/model/centroid.ts
@@ -1,5 +1,9 @@
 import type { Track } from "./instance.js";
-import { Instance, PredictedInstance, _registerCentroidFactory } from "./instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  _registerCentroidFactory,
+} from "./instance.js";
 import { Skeleton } from "./skeleton.js";
 
 /** Shared single-node skeleton for centroid-to-instance conversions. */
@@ -17,7 +21,8 @@ export function getCentroidSkeleton(): Skeleton {
  * Module-level constant for the centroid skeleton.
  * Lazily initialized on first access.
  */
-export const CENTROID_SKELETON: Skeleton = /* @__PURE__ */ (() => getCentroidSkeleton())();
+export const CENTROID_SKELETON: Skeleton = /* @__PURE__ */ (() =>
+  getCentroidSkeleton())();
 
 /** Options for constructing a Centroid. */
 export interface CentroidOptions {
@@ -144,14 +149,22 @@ export class Centroid {
    */
   static fromInstance(
     instance: Instance | PredictedInstance,
-    options?: { method?: string; node?: string | number; [key: string]: unknown },
+    options?: {
+      method?: string;
+      node?: string | number;
+      [key: string]: unknown;
+    },
   ): Centroid {
     const method = options?.method ?? "centerOfMass";
 
     // Gather visible points
     const visiblePoints: [number, number][] = [];
     for (const point of instance.points) {
-      if (point.visible && !Number.isNaN(point.xy[0]) && !Number.isNaN(point.xy[1])) {
+      if (
+        point.visible &&
+        !Number.isNaN(point.xy[0]) &&
+        !Number.isNaN(point.xy[1])
+      ) {
         visiblePoints.push(point.xy);
       }
     }
@@ -163,8 +176,10 @@ export class Centroid {
       if (!visiblePoints.length) {
         throw new Error("No visible points for centerOfMass.");
       }
-      x = visiblePoints.reduce((sum, p) => sum + p[0], 0) / visiblePoints.length;
-      y = visiblePoints.reduce((sum, p) => sum + p[1], 0) / visiblePoints.length;
+      x =
+        visiblePoints.reduce((sum, p) => sum + p[0], 0) / visiblePoints.length;
+      y =
+        visiblePoints.reduce((sum, p) => sum + p[1], 0) / visiblePoints.length;
     } else if (method === "bboxCenter") {
       if (!visiblePoints.length) {
         throw new Error("No visible points for bboxCenter.");
@@ -186,7 +201,9 @@ export class Centroid {
       }
       const pt = instance.points[nodeIdx];
       if (!pt || Number.isNaN(pt.xy[0])) {
-        throw new Error(`Anchor node ${JSON.stringify(node)} is not visible in this instance.`);
+        throw new Error(
+          `Anchor node ${JSON.stringify(node)} is not visible in this instance.`,
+        );
       }
       x = pt.xy[0];
       y = pt.xy[1];
@@ -208,7 +225,10 @@ export class Centroid {
     };
 
     // Check if instance is predicted (has score property)
-    if ("score" in instance && typeof (instance as PredictedInstance).score === "number") {
+    if (
+      "score" in instance &&
+      typeof (instance as PredictedInstance).score === "number"
+    ) {
       return new PredictedCentroid({
         ...centroidOptions,
         score: (instance as PredictedInstance).score,

--- a/src/model/identity.ts
+++ b/src/model/identity.ts
@@ -3,7 +3,11 @@ export class Identity {
   color?: string;
   metadata: Record<string, unknown>;
 
-  constructor(options?: { name?: string; color?: string; metadata?: Record<string, unknown> }) {
+  constructor(options?: {
+    name?: string;
+    color?: string;
+    metadata?: Record<string, unknown>;
+  }) {
     this.name = options?.name ?? "";
     this.color = options?.color;
     this.metadata = options?.metadata ?? {};

--- a/src/model/instance.ts
+++ b/src/model/instance.ts
@@ -2,7 +2,10 @@ import { Skeleton, Node } from "./skeleton.js";
 
 // Late-binding factory to avoid circular imports with centroid.ts.
 // Set by centroid.ts when it is imported.
-type CentroidFactory = (instance: Instance | PredictedInstance, options?: { method?: string; node?: string | number }) => any;
+type CentroidFactory = (
+  instance: Instance | PredictedInstance,
+  options?: { method?: string; node?: string | number },
+) => any;
 let _centroidFactory: CentroidFactory | null = null;
 export function _registerCentroidFactory(factory: CentroidFactory): void {
   _centroidFactory = factory;
@@ -52,7 +55,10 @@ export function pointsEmpty(length: number, names?: string[]): PointsArray {
   return pts;
 }
 
-export function predictedPointsEmpty(length: number, names?: string[]): PredictedPointsArray {
+export function predictedPointsEmpty(
+  length: number,
+  names?: string[],
+): PredictedPointsArray {
   const pts: PredictedPointsArray = [];
   for (let i = 0; i < length; i += 1) {
     pts.push({
@@ -66,18 +72,29 @@ export function predictedPointsEmpty(length: number, names?: string[]): Predicte
   return pts;
 }
 
-export function pointsFromArray(array: number[][], names?: string[]): PointsArray {
+export function pointsFromArray(
+  array: number[][],
+  names?: string[],
+): PointsArray {
   const pts: PointsArray = [];
   for (let i = 0; i < array.length; i += 1) {
     const row = array[i] ?? [Number.NaN, Number.NaN];
     const visible = row.length > 2 ? Boolean(row[2]) : !Number.isNaN(row[0]);
     const complete = row.length > 3 ? Boolean(row[3]) : false;
-    pts.push({ xy: [row[0] ?? Number.NaN, row[1] ?? Number.NaN], visible, complete, name: names?.[i] });
+    pts.push({
+      xy: [row[0] ?? Number.NaN, row[1] ?? Number.NaN],
+      visible,
+      complete,
+      name: names?.[i],
+    });
   }
   return pts;
 }
 
-export function predictedPointsFromArray(array: number[][], names?: string[]): PredictedPointsArray {
+export function predictedPointsFromArray(
+  array: number[][],
+  names?: string[],
+): PredictedPointsArray {
   const pts: PredictedPointsArray = [];
   for (let i = 0; i < array.length; i += 1) {
     const row = array[i] ?? [Number.NaN, Number.NaN, Number.NaN];
@@ -120,7 +137,10 @@ export class Instance {
   }
 
   static fromArray(points: number[][], skeleton: Skeleton): Instance {
-    return new Instance({ points: pointsFromArray(points, skeleton.nodeNames), skeleton });
+    return new Instance({
+      points: pointsFromArray(points, skeleton.nodeNames),
+      skeleton,
+    });
   }
 
   static fromNumpy(options: {
@@ -140,7 +160,13 @@ export class Instance {
   }
 
   static empty(options: { skeleton: Skeleton }): Instance {
-    return new Instance({ points: pointsEmpty(options.skeleton.nodeNames.length, options.skeleton.nodeNames), skeleton: options.skeleton });
+    return new Instance({
+      points: pointsEmpty(
+        options.skeleton.nodeNames.length,
+        options.skeleton.nodeNames,
+      ),
+      skeleton: options.skeleton,
+    });
   }
 
   get length(): number {
@@ -153,7 +179,8 @@ export class Instance {
 
   getPoint(target: number | string | Node): Point {
     if (typeof target === "number") {
-      if (target < 0 || target >= this.points.length) throw new Error("Point index out of range.");
+      if (target < 0 || target >= this.points.length)
+        throw new Error("Point index out of range.");
       return this.points[target];
     }
     if (typeof target === "string") {
@@ -181,9 +208,15 @@ export class Instance {
 
   /** Mean of visible point coordinates as `[x, y]`, or `null` if no points visible. */
   get centroidXy(): [number, number] | null {
-    let sumX = 0, sumY = 0, count = 0;
+    let sumX = 0,
+      sumY = 0,
+      count = 0;
     for (const point of this.points) {
-      if (point.visible && !Number.isNaN(point.xy[0]) && !Number.isNaN(point.xy[1])) {
+      if (
+        point.visible &&
+        !Number.isNaN(point.xy[0]) &&
+        !Number.isNaN(point.xy[1])
+      ) {
         sumX += point.xy[0];
         sumY += point.xy[1];
         count++;
@@ -210,7 +243,9 @@ export class Instance {
   }
 
   get isEmpty(): boolean {
-    return this.points.every((point) => !point.visible || Number.isNaN(point.xy[0]));
+    return this.points.every(
+      (point) => !point.visible || Number.isNaN(point.xy[0]),
+    );
   }
 
   /**
@@ -353,7 +388,10 @@ export class Instance {
     const maxX = Math.max(...xs);
     const minY = Math.min(...ys);
     const maxY = Math.max(...ys);
-    return [[minX, minY], [maxX, maxY]];
+    return [
+      [minX, minY],
+      [maxX, maxY],
+    ];
   }
 }
 
@@ -370,7 +408,10 @@ export class PredictedInstance extends Instance {
     const { score = 0, ...rest } = options;
     const pts = Array.isArray(rest.points)
       ? rest.points
-      : predictedPointsFromDict(rest.points as Record<string, number[]>, rest.skeleton);
+      : predictedPointsFromDict(
+          rest.points as Record<string, number[]>,
+          rest.skeleton,
+        );
     super({
       points: pts as PointsArray,
       skeleton: rest.skeleton,
@@ -380,7 +421,11 @@ export class PredictedInstance extends Instance {
     this.score = score;
   }
 
-  static fromArray(points: number[][], skeleton: Skeleton, score?: number): PredictedInstance {
+  static fromArray(
+    points: number[][],
+    skeleton: Skeleton,
+    score?: number,
+  ): PredictedInstance {
     return new PredictedInstance({
       points: predictedPointsFromArray(points, skeleton.nodeNames),
       skeleton,
@@ -396,7 +441,10 @@ export class PredictedInstance extends Instance {
     trackingScore?: number;
   }): PredictedInstance {
     return new PredictedInstance({
-      points: predictedPointsFromArray(options.pointsData, options.skeleton.nodeNames),
+      points: predictedPointsFromArray(
+        options.pointsData,
+        options.skeleton.nodeNames,
+      ),
       skeleton: options.skeleton,
       track: options.track ?? null,
       score: options.score,
@@ -405,13 +453,22 @@ export class PredictedInstance extends Instance {
   }
 
   static empty(options: { skeleton: Skeleton }): PredictedInstance {
-    return new PredictedInstance({ points: predictedPointsEmpty(options.skeleton.nodeNames.length, options.skeleton.nodeNames), skeleton: options.skeleton });
+    return new PredictedInstance({
+      points: predictedPointsEmpty(
+        options.skeleton.nodeNames.length,
+        options.skeleton.nodeNames,
+      ),
+      skeleton: options.skeleton,
+    });
   }
 
   numpy(options?: { scores?: boolean; invisibleAsNaN?: boolean }): number[][] {
     const invisibleAsNaN = options?.invisibleAsNaN ?? true;
     return this.points.map((point) => {
-      const xy = invisibleAsNaN && !point.visible ? [Number.NaN, Number.NaN] : [point.xy[0], point.xy[1]];
+      const xy =
+        invisibleAsNaN && !point.visible
+          ? [Number.NaN, Number.NaN]
+          : [point.xy[0], point.xy[1]];
       if (options?.scores) {
         return [xy[0], xy[1], point.score ?? 0];
       }
@@ -425,7 +482,10 @@ export class PredictedInstance extends Instance {
   }
 }
 
-export function pointsFromDict(pointsDict: Record<string, number[]>, skeleton: Skeleton): PointsArray {
+export function pointsFromDict(
+  pointsDict: Record<string, number[]>,
+  skeleton: Skeleton,
+): PointsArray {
   const points = pointsEmpty(skeleton.nodeNames.length, skeleton.nodeNames);
   for (const [nodeName, data] of Object.entries(pointsDict)) {
     const index = skeleton.index(nodeName);
@@ -439,8 +499,14 @@ export function pointsFromDict(pointsDict: Record<string, number[]>, skeleton: S
   return points;
 }
 
-export function predictedPointsFromDict(pointsDict: Record<string, number[]>, skeleton: Skeleton): PredictedPointsArray {
-  const points = predictedPointsEmpty(skeleton.nodeNames.length, skeleton.nodeNames);
+export function predictedPointsFromDict(
+  pointsDict: Record<string, number[]>,
+  skeleton: Skeleton,
+): PredictedPointsArray {
+  const points = predictedPointsEmpty(
+    skeleton.nodeNames.length,
+    skeleton.nodeNames,
+  );
   for (const [nodeName, data] of Object.entries(pointsDict)) {
     const index = skeleton.index(nodeName);
     points[index] = {
@@ -453,4 +519,3 @@ export function predictedPointsFromDict(pointsDict: Record<string, number[]>, sk
   }
   return points;
 }
-

--- a/src/model/label-image.ts
+++ b/src/model/label-image.ts
@@ -1,6 +1,10 @@
 import type { Instance } from "./instance.js";
 import { Track } from "./instance.js";
-import { type BoundingBox, UserBoundingBox, PredictedBoundingBox } from "./bbox.js";
+import {
+  type BoundingBox,
+  UserBoundingBox,
+  PredictedBoundingBox,
+} from "./bbox.js";
 import {
   SegmentationMask,
   UserSegmentationMask,
@@ -63,7 +67,9 @@ export class LabelImage {
     }
     const scale = options.scale ?? [1, 1];
     if (scale[0] <= 0 || scale[1] <= 0) {
-      throw new Error(`Scale must be positive, got [${scale[0]}, ${scale[1]}].`);
+      throw new Error(
+        `Scale must be positive, got [${scale[0]}, ${scale[1]}].`,
+      );
     }
     this.data = options.data;
     this.height = options.height;
@@ -138,7 +144,13 @@ export class LabelImage {
    * The returned label image has scale=[1,1] and offset=[0,0].
    */
   resampled(targetHeight: number, targetWidth: number): LabelImage {
-    const resizedData = resizeNearest(this.data, this.height, this.width, targetHeight, targetWidth);
+    const resizedData = resizeNearest(
+      this.data,
+      this.height,
+      this.width,
+      targetHeight,
+      targetWidth,
+    );
     const baseOpts: LabelImageOptions = {
       data: resizedData,
       height: targetHeight,
@@ -320,7 +332,11 @@ export class LabelImage {
     }
 
     // Build objects dict
-    const allIds = new Set([...sortedIds, ...trackMap.keys(), ...catMap.keys()]);
+    const allIds = new Set([
+      ...sortedIds,
+      ...trackMap.keys(),
+      ...catMap.keys(),
+    ]);
     const objects = new Map<number, LabelImageObjectInfo>();
     for (const lid of Array.from(allIds).sort((a, b) => a - b)) {
       objects.set(lid, {
@@ -616,9 +632,7 @@ export class LabelImage {
       const seen = new Set<number>();
       for (const id of options.labelIds) {
         if (id <= 0) {
-          throw new Error(
-            `All labelIds must be positive, got ${id}.`,
-          );
+          throw new Error(`All labelIds must be positive, got ${id}.`);
         }
         if (seen.has(id)) {
           throw new Error(`Duplicate labelId: ${id}.`);
@@ -730,10 +744,12 @@ export class LabelImage {
       };
       if (this instanceof PredictedLabelImage) {
         const pli = this as PredictedLabelImage;
-        result.push(new PredictedSegmentationMask({
-          ...baseOpts,
-          score: info.score ?? pli.score,
-        }));
+        result.push(
+          new PredictedSegmentationMask({
+            ...baseOpts,
+            score: info.score ?? pli.score,
+          }),
+        );
       } else {
         result.push(new UserSegmentationMask(baseOpts));
       }

--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -66,7 +66,7 @@ export function _annotationCentroidXy(
     const li = annotation as LabelImage;
     const [sx, sy] = li.scale;
     const [ox, oy] = li.offset;
-    return [(li.width / 2) / sx + ox, (li.height / 2) / sy + oy];
+    return [li.width / 2 / sx + ox, li.height / 2 / sy + oy];
   }
   return null;
 }
@@ -264,7 +264,9 @@ function _resolveAnnotationUpdateTracks(
 
   selfToOther.forEach(({ otherIdx }, selfIdx) => {
     (selfList[selfIdx] as any).track = (otherList[otherIdx] as any).track;
-    (selfList[selfIdx] as any).trackingScore = (otherList[otherIdx] as any).trackingScore;
+    (selfList[selfIdx] as any).trackingScore = (
+      otherList[otherIdx] as any
+    ).trackingScore;
   });
 }
 
@@ -345,11 +347,15 @@ export class LabeledFrame {
   get userInstances(): Instance[] {
     // Exact-type match: PredictedInstance extends Instance, so `instanceof Instance`
     // would wrongly include predictions. Mirrors Python `type(inst) is Instance`.
-    return this.instances.filter((inst) => inst.constructor === Instance) as Instance[];
+    return this.instances.filter(
+      (inst) => inst.constructor === Instance,
+    ) as Instance[];
   }
 
   get predictedInstances(): PredictedInstance[] {
-    return this.instances.filter((inst) => inst instanceof PredictedInstance) as PredictedInstance[];
+    return this.instances.filter(
+      (inst) => inst instanceof PredictedInstance,
+    ) as PredictedInstance[];
   }
 
   get hasUserInstances(): boolean {
@@ -364,7 +370,9 @@ export class LabeledFrame {
     return this.instances.map((inst) => inst.numpy());
   }
 
-  get image(): Promise<ImageData | ImageBitmap | ArrayBuffer | Uint8Array | null> {
+  get image(): Promise<
+    ImageData | ImageBitmap | ArrayBuffer | Uint8Array | null
+  > {
     return this.video.getFrame(this.frameIdx);
   }
 
@@ -376,10 +384,14 @@ export class LabeledFrame {
       }
     }
 
-    const tracks = this.instances.map((inst) => inst.track).filter((track) => track !== null && track !== undefined);
+    const tracks = this.instances
+      .map((inst) => inst.track)
+      .filter((track) => track !== null && track !== undefined);
     if (tracks.length) {
       const usedTracks = new Set(tracks);
-      return this.predictedInstances.filter((inst) => !inst.track || !usedTracks.has(inst.track));
+      return this.predictedInstances.filter(
+        (inst) => !inst.track || !usedTracks.has(inst.track),
+      );
     }
 
     return this.predictedInstances.filter((inst) => !usedPredicted.has(inst));
@@ -417,7 +429,12 @@ export class LabeledFrame {
     // mask whose bbox centroid is within 5 px.
     const remaining = predicted.filter((m) => !adopted.has(m));
     if (remaining.length && userMasks.length) {
-      const matches = _findAnnotationMatches(remaining, userMasks, "masks", 5.0);
+      const matches = _findAnnotationMatches(
+        remaining,
+        userMasks,
+        "masks",
+        5.0,
+      );
       for (const { selfIdx } of matches) {
         adopted.add(remaining[selfIdx]);
       }
@@ -427,7 +444,9 @@ export class LabeledFrame {
   }
 
   removePredictions(): void {
-    this.instances = this.instances.filter((inst) => !(inst instanceof PredictedInstance));
+    this.instances = this.instances.filter(
+      (inst) => !(inst instanceof PredictedInstance),
+    );
     this.centroids = this.centroids.filter((c) => !c.isPredicted);
     this.bboxes = this.bboxes.filter((b) => !b.isPredicted);
     this.masks = this.masks.filter((m) => !m.isPredicted);
@@ -733,7 +752,10 @@ export class LabeledFrame {
       | LabelImage
       | ROI,
   ): void {
-    if (annotation instanceof PredictedInstance || annotation instanceof Instance) {
+    if (
+      annotation instanceof PredictedInstance ||
+      annotation instanceof Instance
+    ) {
       this.instances.push(annotation);
     } else if (annotation instanceof Centroid) {
       this.centroids.push(annotation);

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -365,7 +365,10 @@ export class Labels {
     const annFrameIdx = new Map<unknown, number>();
     for (const lf of this.labeledFrames) {
       for (const ann of [
-        ...lf.centroids, ...lf.bboxes, ...lf.masks, ...lf.rois,
+        ...lf.centroids,
+        ...lf.bboxes,
+        ...lf.masks,
+        ...lf.rois,
         ...lf.instances,
       ]) {
         annFrameIdx.set(ann, lf.frameIdx);
@@ -491,7 +494,9 @@ export class Labels {
       // requireSameOrder: true — dedup reassigns instances to the canonical
       // skeleton without remapping point positions, so only skeletons whose
       // node ORDER also matches can be safely collapsed (points are positional).
-      const existing = canonicals.find((c) => skel.matches(c, { requireSameOrder: true }));
+      const existing = canonicals.find((c) =>
+        skel.matches(c, { requireSameOrder: true }),
+      );
       if (existing) {
         canonicalFor.set(skel, existing);
       } else {
@@ -586,8 +591,17 @@ export class Labels {
     // Resolve deferred instance references on per-frame annotations
     const allInstances = this.labeledFrames.flatMap((f) => f.instances);
     for (const lf of this.labeledFrames) {
-      for (const ann of [...lf.centroids, ...lf.bboxes, ...lf.masks, ...lf.rois] as DeferredInstanceRef[]) {
-        if (ann._instanceIdx !== null && ann._instanceIdx >= 0 && ann._instanceIdx < allInstances.length) {
+      for (const ann of [
+        ...lf.centroids,
+        ...lf.bboxes,
+        ...lf.masks,
+        ...lf.rois,
+      ] as DeferredInstanceRef[]) {
+        if (
+          ann._instanceIdx !== null &&
+          ann._instanceIdx >= 0 &&
+          ann._instanceIdx < allInstances.length
+        ) {
           ann.instance = allInstances[ann._instanceIdx];
           ann._instanceIdx = null;
         }
@@ -647,12 +661,15 @@ export class Labels {
    * still works. When the video does not resolve to a project video the foreign
    * reference is used as-is, so identity-based lookups yield no results.
    */
-  find(options: { video?: Video | string | URL; frameIdx?: number }): LabeledFrame[] {
+  find(options: {
+    video?: Video | string | URL;
+    frameIdx?: number;
+  }): LabeledFrame[] {
     if (this._lazyFrameList) this.materialize();
     // Canonicalize a foreign Video / filename to the matching project Video.
     const resolved =
       options.video !== undefined
-        ? this._resolveVideo(options.video) ?? undefined
+        ? (this._resolveVideo(options.video) ?? undefined)
         : undefined;
     // Fast path: O(1) lookup when both video and frameIdx are specified
     if (resolved !== undefined && options.frameIdx !== undefined) {
@@ -663,7 +680,10 @@ export class Labels {
       if (resolved && frame.video !== resolved) {
         return false;
       }
-      if (options.frameIdx !== undefined && frame.frameIdx !== options.frameIdx) {
+      if (
+        options.frameIdx !== undefined &&
+        frame.frameIdx !== options.frameIdx
+      ) {
         return false;
       }
       return true;
@@ -737,7 +757,7 @@ export class Labels {
     // `_resolveVideo` for its documented divergence from `matchVideo`).
     const video =
       filters.video !== undefined
-        ? this._resolveVideo(filters.video) ?? undefined
+        ? (this._resolveVideo(filters.video) ?? undefined)
         : undefined;
     let results: ROI[];
     if (video !== undefined && filters.frameIdx !== undefined) {
@@ -784,7 +804,7 @@ export class Labels {
     // `_resolveVideo` for its documented divergence from `matchVideo`).
     const video =
       filters.video !== undefined
-        ? this._resolveVideo(filters.video) ?? undefined
+        ? (this._resolveVideo(filters.video) ?? undefined)
         : undefined;
     let results: SegmentationMask[];
     if (video !== undefined && filters.frameIdx !== undefined) {
@@ -831,7 +851,7 @@ export class Labels {
     // `_resolveVideo` for its documented divergence from `matchVideo`).
     const video =
       filters.video !== undefined
-        ? this._resolveVideo(filters.video) ?? undefined
+        ? (this._resolveVideo(filters.video) ?? undefined)
         : undefined;
     let results: BoundingBox[];
     if (video !== undefined && filters.frameIdx !== undefined) {
@@ -878,7 +898,7 @@ export class Labels {
     // `_resolveVideo` for its documented divergence from `matchVideo`).
     const video =
       filters.video !== undefined
-        ? this._resolveVideo(filters.video) ?? undefined
+        ? (this._resolveVideo(filters.video) ?? undefined)
         : undefined;
     let results: Centroid[];
     if (video !== undefined && filters.frameIdx !== undefined) {
@@ -924,7 +944,7 @@ export class Labels {
     // `_resolveVideo` for its documented divergence from `matchVideo`).
     const video =
       filters.video !== undefined
-        ? this._resolveVideo(filters.video) ?? undefined
+        ? (this._resolveVideo(filters.video) ?? undefined)
         : undefined;
     let results: LabelImage[];
     if (video !== undefined && filters.frameIdx !== undefined) {
@@ -945,7 +965,9 @@ export class Labels {
     }
     if (filters.track !== undefined) {
       results = results.filter((li) =>
-        Array.from(li.objects.values()).some((info) => info.track === filters.track),
+        Array.from(li.objects.values()).some(
+          (info) => info.track === filters.track,
+        ),
       );
     }
     if (filters.category !== undefined) {
@@ -1008,7 +1030,8 @@ export class Labels {
 
     // Update static ROIs
     for (const roi of this._staticRois) {
-      if (roi.video && videoMap.has(roi.video)) roi.video = videoMap.get(roi.video)!;
+      if (roi.video && videoMap.has(roi.video))
+        roi.video = videoMap.get(roi.video)!;
     }
 
     this.videos = this.videos.map((v) => videoMap!.get(v) ?? v);
@@ -1034,11 +1057,11 @@ export class Labels {
     const toRemove = new Set(videos);
 
     this.labeledFrames = this.labeledFrames.filter(
-      (lf) => !toRemove.has(lf.video)
+      (lf) => !toRemove.has(lf.video),
     );
     this.suggestions = this.suggestions.filter((s) => !toRemove.has(s.video));
     this._staticRois = this._staticRois.filter(
-      (roi) => !roi.video || !toRemove.has(roi.video)
+      (roi) => !roi.video || !toRemove.has(roi.video),
     );
     this.videos = this.videos.filter((v) => !toRemove.has(v));
 
@@ -1093,7 +1116,12 @@ export class Labels {
         const nodes = [...sym.nodes];
         return new Symmetry([nodeMap.get(nodes[0])!, nodeMap.get(nodes[1])!]);
       });
-      const ns = new Skeleton({ nodes: newNodes, edges: newEdges, symmetries: newSymmetries, name: s.name });
+      const ns = new Skeleton({
+        nodes: newNodes,
+        edges: newEdges,
+        symmetries: newSymmetries,
+        name: s.name,
+      });
       skeletonMap.set(s, ns);
       return ns;
     });
@@ -1107,13 +1135,17 @@ export class Labels {
     });
 
     // Helper: clone an instance with remapped skeleton/track
-    const cloneInstance = (inst: Instance | PredictedInstance): Instance | PredictedInstance => {
+    const cloneInstance = (
+      inst: Instance | PredictedInstance,
+    ): Instance | PredictedInstance => {
       const newPoints = inst.points.map((p) => ({
         ...p,
         xy: [...p.xy] as [number, number],
       }));
       const newSkeleton = skeletonMap.get(inst.skeleton) ?? inst.skeleton;
-      const newTrack = inst.track ? (trackMap.get(inst.track) ?? inst.track) : null;
+      const newTrack = inst.track
+        ? (trackMap.get(inst.track) ?? inst.track)
+        : null;
       if (inst instanceof PredictedInstance) {
         return new PredictedInstance({
           points: newPoints as any,
@@ -1165,14 +1197,18 @@ export class Labels {
         if (objectRefs) {
           for (const [id, [track, inst]] of objectRefs) {
             const info = (item as any).objects.get(id);
-            if (info) { info.track = track; info.instance = inst; }
+            if (info) {
+              info.track = track;
+              info.instance = inst;
+            }
           }
         }
 
         // Remap refs on clone
         for (const [key, val] of saved) {
           if (key === "video") (clone as any).video = videoMap.get(val) ?? val;
-          else if (key === "track") (clone as any).track = trackMap.get(val) ?? val;
+          else if (key === "track")
+            (clone as any).track = trackMap.get(val) ?? val;
           else if (key === "instance") (clone as any).instance = null;
         }
         if (objectRefs) {
@@ -1202,19 +1238,21 @@ export class Labels {
 
       // Copy supplementary frames (annotation-only, non-lazy)
       if (this._lazyFrameList?._supplementary.length) {
-        newLazyFrames._supplementary = this._lazyFrameList._supplementary.map((lf) => {
-          return new LabeledFrame({
-            video: videoMap.get(lf.video) ?? lf.video,
-            frameIdx: lf.frameIdx,
-            instances: lf.instances.map(cloneInstance),
-            isNegative: lf.isNegative,
-            centroids: cloneAncillary(lf.centroids) as Centroid[],
-            bboxes: cloneAncillary(lf.bboxes) as BoundingBox[],
-            masks: cloneAncillary(lf.masks) as SegmentationMask[],
-            labelImages: cloneAncillary(lf.labelImages) as LabelImage[],
-            rois: cloneAncillary(lf.rois) as ROI[],
-          });
-        });
+        newLazyFrames._supplementary = this._lazyFrameList._supplementary.map(
+          (lf) => {
+            return new LabeledFrame({
+              video: videoMap.get(lf.video) ?? lf.video,
+              frameIdx: lf.frameIdx,
+              instances: lf.instances.map(cloneInstance),
+              isNegative: lf.isNegative,
+              centroids: cloneAncillary(lf.centroids) as Centroid[],
+              bboxes: cloneAncillary(lf.bboxes) as BoundingBox[],
+              masks: cloneAncillary(lf.masks) as SegmentationMask[],
+              labelImages: cloneAncillary(lf.labelImages) as LabelImage[],
+              rois: cloneAncillary(lf.rois) as ROI[],
+            });
+          },
+        );
       }
 
       labelsCopy = new Labels({
@@ -1287,14 +1325,28 @@ export class Labels {
 
   static fromNumpy(
     data: number[][][][],
-    options: { videos?: Video[]; video?: Video; skeletons?: Skeleton[] | Skeleton; skeleton?: Skeleton; trackNames?: string[]; firstFrame?: number; returnConfidence?: boolean }
+    options: {
+      videos?: Video[];
+      video?: Video;
+      skeletons?: Skeleton[] | Skeleton;
+      skeleton?: Skeleton;
+      trackNames?: string[];
+      firstFrame?: number;
+      returnConfidence?: boolean;
+    },
   ): Labels {
     const video = options.video ?? options.videos?.[0];
     if (!video) throw new Error("fromNumpy requires a video.");
     if (options.video && options.videos) {
       throw new Error("Cannot specify both video and videos.");
     }
-    const skeletons = Array.isArray(options.skeletons) ? options.skeletons : options.skeletons ? [options.skeletons] : options.skeleton ? [options.skeleton] : [];
+    const skeletons = Array.isArray(options.skeletons)
+      ? options.skeletons
+      : options.skeletons
+        ? [options.skeletons]
+        : options.skeleton
+          ? [options.skeleton]
+          : [];
     if (!skeletons.length) throw new Error("fromNumpy requires a skeleton.");
     return labelsFromNumpy(data, {
       video,
@@ -1335,24 +1387,36 @@ export class Labels {
     if (this._lazyDataStore) {
       return this._lazyDataStore.toNumpy({ ...options, video: targetVideo });
     }
-    const frames = this.labeledFrames.filter((frame) => frame.video.matchesPath(targetVideo, true));
+    const frames = this.labeledFrames.filter((frame) =>
+      frame.video.matchesPath(targetVideo, true),
+    );
     if (!frames.length) return [];
 
     let maxFrame = Math.max(...frames.map((frame) => frame.frameIdx));
     const rawOverride = options?.numFrames;
-    const override = Number.isFinite(rawOverride) && (rawOverride as number) > 0 ? Math.floor(rawOverride as number) : 0;
-    const effectiveLength = override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
+    const override =
+      Number.isFinite(rawOverride) && (rawOverride as number) > 0
+        ? Math.floor(rawOverride as number)
+        : 0;
+    const effectiveLength =
+      override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
     if (effectiveLength > 0) {
       maxFrame = Math.max(maxFrame, effectiveLength - 1);
     }
-    const tracks = this.tracks.length ? this.tracks.length : Math.max(1, ...frames.map((frame) => frame.instances.length));
+    const tracks = this.tracks.length
+      ? this.tracks.length
+      : Math.max(1, ...frames.map((frame) => frame.instances.length));
     const nodes = this.skeletons[0]?.nodes.length ?? 0;
     const channelCount = options?.returnConfidence ? 3 : 2;
 
-    const videoArray: number[][][][] = Array.from({ length: maxFrame + 1 }, () =>
-      Array.from({ length: tracks }, () =>
-        Array.from({ length: nodes }, () => Array.from({ length: channelCount }, () => Number.NaN))
-      )
+    const videoArray: number[][][][] = Array.from(
+      { length: maxFrame + 1 },
+      () =>
+        Array.from({ length: tracks }, () =>
+          Array.from({ length: nodes }, () =>
+            Array.from({ length: channelCount }, () => Number.NaN),
+          ),
+        ),
     );
 
     for (const frame of frames) {
@@ -1367,7 +1431,10 @@ export class Labels {
           if (!trackSlot[nodeIdx]) return;
           const row = [point.xy[0], point.xy[1]];
           if (options?.returnConfidence) {
-            const score = "score" in point ? (point as { score: number }).score : Number.NaN;
+            const score =
+              "score" in point
+                ? (point as { score: number }).score
+                : Number.NaN;
             row.push(score);
           }
           trackSlot[nodeIdx] = row;
@@ -1429,9 +1496,11 @@ export class Labels {
     videoMap: Map<Video, Video>,
     trackMap: Map<Track, Track>,
   ): void {
-    for (const ann of [...frame.centroids, ...frame.bboxes, ...frame.masks] as Array<
-      Centroid | BoundingBox | SegmentationMask
-    >) {
+    for (const ann of [
+      ...frame.centroids,
+      ...frame.bboxes,
+      ...frame.masks,
+    ] as Array<Centroid | BoundingBox | SegmentationMask>) {
       if (ann.track != null && trackMap.has(ann.track)) {
         ann.track = trackMap.get(ann.track)!;
       }
@@ -1472,9 +1541,10 @@ export class Labels {
     skeletonMap: Map<Skeleton, Skeleton>,
     trackMap: Map<Track, Track>,
   ): Instance | PredictedInstance {
-    const mappedSkeleton = skeletonMap.get(instance.skeleton) ?? instance.skeleton;
+    const mappedSkeleton =
+      skeletonMap.get(instance.skeleton) ?? instance.skeleton;
     const mappedTrack = instance.track
-      ? trackMap.get(instance.track) ?? instance.track
+      ? (trackMap.get(instance.track) ?? instance.track)
       : null;
 
     // Deep/independent copy of the points so the source is never aliased.
@@ -1656,7 +1726,8 @@ export class Labels {
                     Array.isArray(otherVideo.filename) &&
                     Array.isArray(selfVideo.filename)
                   ) {
-                    const otherBasenames = otherVideo.filename.map(pathBasename);
+                    const otherBasenames =
+                      otherVideo.filename.map(pathBasename);
                     const selfBasenames = selfVideo.filename.map(pathBasename);
                     otherBasenames.forEach((bn, oldIdx) => {
                       const newIdx = selfBasenames.indexOf(bn);
@@ -1673,7 +1744,8 @@ export class Labels {
                     Array.isArray(otherVideo.filename) &&
                     Array.isArray(dedupedVideo.filename)
                   ) {
-                    const otherBasenames = otherVideo.filename.map(pathBasename);
+                    const otherBasenames =
+                      otherVideo.filename.map(pathBasename);
                     const dedupedBasenames =
                       dedupedVideo.filename.map(pathBasename);
                     const selfBasenames = Array.isArray(selfVideo.filename)
@@ -1707,7 +1779,8 @@ export class Labels {
                   Array.isArray(mergedVideo.filename)
                 ) {
                   const otherBasenames = otherVideo.filename.map(pathBasename);
-                  const mergedBasenames = mergedVideo.filename.map(pathBasename);
+                  const mergedBasenames =
+                    mergedVideo.filename.map(pathBasename);
                   otherBasenames.forEach((bn, oldIdx) => {
                     const newIdx = mergedBasenames.indexOf(bn);
                     if (newIdx !== -1) {
@@ -2548,10 +2621,7 @@ export class Labels {
         );
         const newSymmetries = s.symmetries.map((sym) => {
           const nodes = [...sym.nodes];
-          return new Symmetry([
-            nodeMap.get(nodes[0])!,
-            nodeMap.get(nodes[1])!,
-          ]);
+          return new Symmetry([nodeMap.get(nodes[0])!, nodeMap.get(nodes[1])!]);
         });
         ns = new Skeleton({
           nodes: newNodes,
@@ -2622,11 +2692,11 @@ export class Labels {
           anyClone.instance = null;
         }
         // LabelImage: copy the objects Map and remap nested track refs.
-        if (
-          "objects" in anyClone &&
-          anyClone.objects instanceof Map
-        ) {
-          const oldObjects = anyClone.objects as Map<number, Record<string, unknown>>;
+        if ("objects" in anyClone && anyClone.objects instanceof Map) {
+          const oldObjects = anyClone.objects as Map<
+            number,
+            Record<string, unknown>
+          >;
           const newObjects = new Map<number, Record<string, unknown>>();
           for (const [id, info] of oldObjects) {
             const newInfo = { ...info };

--- a/src/model/lazy.ts
+++ b/src/model/lazy.ts
@@ -1,5 +1,11 @@
 import { LabeledFrame } from "./labeled-frame.js";
-import { Instance, PredictedInstance, Track, pointsFromArray, predictedPointsFromArray } from "./instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+  pointsFromArray,
+  predictedPointsFromArray,
+} from "./instance.js";
 import { Skeleton } from "./skeleton.js";
 import { Video } from "./video.js";
 import type { Centroid } from "./centroid.js";
@@ -126,7 +132,9 @@ export class LazyDataStore {
     const rawVideoId = Number(this.framesData.video?.[frameIdx] ?? 0);
     const videoIndex = rawVideoId;
     const frameIndex = Number(this.framesData.frame_idx?.[frameIdx] ?? 0);
-    const instStart = Number(this.framesData.instance_id_start?.[frameIdx] ?? 0);
+    const instStart = Number(
+      this.framesData.instance_id_start?.[frameIdx] ?? 0,
+    );
     const instEnd = Number(this.framesData.instance_id_end?.[frameIdx] ?? 0);
     const video = this.videos[videoIndex];
     if (!video) return null;
@@ -136,22 +144,38 @@ export class LazyDataStore {
     const fromPredictedPairs: Array<[number, number]> = [];
 
     for (let instIdx = instStart; instIdx < instEnd; instIdx++) {
-      const instanceType = Number(this.instancesData.instance_type?.[instIdx] ?? 0);
+      const instanceType = Number(
+        this.instancesData.instance_type?.[instIdx] ?? 0,
+      );
       const skeletonId = Number(this.instancesData.skeleton?.[instIdx] ?? 0);
       const trackId = Number(this.instancesData.track?.[instIdx] ?? -1);
-      const pointStart = Number(this.instancesData.point_id_start?.[instIdx] ?? 0);
+      const pointStart = Number(
+        this.instancesData.point_id_start?.[instIdx] ?? 0,
+      );
       const pointEnd = Number(this.instancesData.point_id_end?.[instIdx] ?? 0);
       const score = Number(this.instancesData.score?.[instIdx] ?? 0);
-      const rawTrackingScore = this.formatId < 1.2 ? 0 : Number(this.instancesData.tracking_score?.[instIdx] ?? 0);
-      const trackingScore = Number.isNaN(rawTrackingScore) ? 0 : rawTrackingScore;
-      const fromPredicted = Number(this.instancesData.from_predicted?.[instIdx] ?? -1);
+      const rawTrackingScore =
+        this.formatId < 1.2
+          ? 0
+          : Number(this.instancesData.tracking_score?.[instIdx] ?? 0);
+      const trackingScore = Number.isNaN(rawTrackingScore)
+        ? 0
+        : rawTrackingScore;
+      const fromPredicted = Number(
+        this.instancesData.from_predicted?.[instIdx] ?? -1,
+      );
       const skeleton = this.skeletons[skeletonId] ?? this.skeletons[0];
       const track = trackId >= 0 ? this.tracks[trackId] : null;
 
       let instance: Instance | PredictedInstance;
       if (instanceType === 0) {
         const points = this.slicePoints(this.pointsData, pointStart, pointEnd);
-        instance = new Instance({ points: pointsFromArray(points, skeleton.nodeNames), skeleton, track, trackingScore });
+        instance = new Instance({
+          points: pointsFromArray(points, skeleton.nodeNames),
+          skeleton,
+          track,
+          trackingScore,
+        });
         if (this.formatId < 1.1) {
           instance.points.forEach((point) => {
             point.xy = [point.xy[0] - 0.5, point.xy[1] - 0.5];
@@ -161,8 +185,19 @@ export class LazyDataStore {
           fromPredictedPairs.push([instIdx, fromPredicted]);
         }
       } else {
-        const points = this.slicePoints(this.predPointsData, pointStart, pointEnd, true);
-        instance = new PredictedInstance({ points: predictedPointsFromArray(points, skeleton.nodeNames), skeleton, track, score, trackingScore });
+        const points = this.slicePoints(
+          this.predPointsData,
+          pointStart,
+          pointEnd,
+          true,
+        );
+        instance = new PredictedInstance({
+          points: predictedPointsFromArray(points, skeleton.nodeNames),
+          skeleton,
+          track,
+          score,
+          trackingScore,
+        });
         if (this.formatId < 1.1) {
           instance.points.forEach((point) => {
             point.xy = [point.xy[0] - 0.5, point.xy[1] - 0.5];
@@ -178,7 +213,11 @@ export class LazyDataStore {
     for (const [instanceId, fromPredictedId] of fromPredictedPairs) {
       const instance = instanceById.get(instanceId);
       const predicted = instanceById.get(fromPredictedId);
-      if (instance && predicted instanceof PredictedInstance && instance instanceof Instance) {
+      if (
+        instance &&
+        predicted instanceof PredictedInstance &&
+        instance instanceof Instance
+      ) {
         instance.fromPredicted = predicted;
       }
     }
@@ -222,7 +261,11 @@ export class LazyDataStore {
    *   Non-finite, non-positive, or fractional values are sanitized via
    *   `Math.floor` and ignored when `<= 0`.
    */
-  toNumpy(options?: { video?: Video; returnConfidence?: boolean; numFrames?: number }): number[][][][] {
+  toNumpy(options?: {
+    video?: Video;
+    returnConfidence?: boolean;
+    numFrames?: number;
+  }): number[][][][] {
     const targetVideo = options?.video ?? this.videos[0];
     if (!targetVideo) return [];
 
@@ -260,8 +303,12 @@ export class LazyDataStore {
     if (!matchingFrames.length) return [];
 
     const rawOverride = options?.numFrames;
-    const override = Number.isFinite(rawOverride) && (rawOverride as number) > 0 ? Math.floor(rawOverride as number) : 0;
-    const effectiveLength = override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
+    const override =
+      Number.isFinite(rawOverride) && (rawOverride as number) > 0
+        ? Math.floor(rawOverride as number)
+        : 0;
+    const effectiveLength =
+      override > 0 ? override : (targetVideo.shape?.[0] ?? 0);
     if (effectiveLength > 0) {
       maxFrameIdx = Math.max(maxFrameIdx, effectiveLength - 1);
     }
@@ -272,8 +319,10 @@ export class LazyDataStore {
     // Allocate NaN-filled output
     const output: number[][][][] = Array.from({ length: maxFrameIdx + 1 }, () =>
       Array.from({ length: trackCount }, () =>
-        Array.from({ length: nodeCount }, () => Array.from({ length: channelCount }, () => Number.NaN))
-      )
+        Array.from({ length: nodeCount }, () =>
+          Array.from({ length: channelCount }, () => Number.NaN),
+        ),
+      ),
     );
 
     // Instance column data
@@ -304,7 +353,8 @@ export class LazyDataStore {
       for (let instIdx = iStart; instIdx < iEnd; instIdx++) {
         const isPredicted = Number(instTypes[instIdx]) === 1;
         const trackId = Number(instTracks[instIdx]);
-        const trackIndex = trackId >= 0 && this.tracks.length ? trackId : localIdx;
+        const trackIndex =
+          trackId >= 0 && this.tracks.length ? trackId : localIdx;
         localIdx++;
 
         const trackSlot = frameSlot[trackIndex];
@@ -351,7 +401,12 @@ export class LazyDataStore {
     return frames;
   }
 
-  private slicePoints(data: Record<string, any[]>, start: number, end: number, predicted = false): number[][] {
+  private slicePoints(
+    data: Record<string, any[]>,
+    start: number,
+    end: number,
+    predicted = false,
+  ): number[][] {
     const xs = data.x ?? [];
     const ys = data.y ?? [];
     const visible = data.visible ?? [];

--- a/src/model/mask.ts
+++ b/src/model/mask.ts
@@ -1,7 +1,11 @@
 import type { Track, Instance } from "./instance.js";
 import { ROI, _registerMaskFactory } from "./roi.js";
 import type { Geometry } from "./roi.js";
-import { type BoundingBox, UserBoundingBox, PredictedBoundingBox } from "./bbox.js";
+import {
+  type BoundingBox,
+  UserBoundingBox,
+  PredictedBoundingBox,
+} from "./bbox.js";
 
 export function encodeRle(
   mask: Uint8Array,
@@ -116,7 +120,9 @@ export class SegmentationMask {
     }
     const scale = options.scale ?? [1, 1];
     if (scale[0] <= 0 || scale[1] <= 0) {
-      throw new Error(`Scale must be positive, got [${scale[0]}, ${scale[1]}].`);
+      throw new Error(
+        `Scale must be positive, got [${scale[0]}, ${scale[1]}].`,
+      );
     }
     this.rleCounts = options.rleCounts;
     this.height = options.height;
@@ -135,7 +141,10 @@ export class SegmentationMask {
     mask: Uint8Array | boolean[][],
     height: number,
     width: number,
-    options?: Omit<SegmentationMaskOptions, "rleCounts" | "height" | "width"> & { stride?: number },
+    options?: Omit<
+      SegmentationMaskOptions,
+      "rleCounts" | "height" | "width"
+    > & { stride?: number },
   ): UserSegmentationMask {
     let flat: Uint8Array;
     if (mask instanceof Uint8Array) {
@@ -232,7 +241,13 @@ export class SegmentationMask {
    */
   resampled(targetHeight: number, targetWidth: number): SegmentationMask {
     const srcData = this.data;
-    const resized = resizeNearest(srcData, this.height, this.width, targetHeight, targetWidth);
+    const resized = resizeNearest(
+      srcData,
+      this.height,
+      this.width,
+      targetHeight,
+      targetWidth,
+    );
     const rleCounts = encodeRle(resized, targetHeight, targetWidth);
 
     const baseOpts: SegmentationMaskOptions = {
@@ -269,7 +284,8 @@ export class SegmentationMask {
 
     return new UserSegmentationMask({
       ...baseOpts,
-      fromPredicted: this instanceof UserSegmentationMask ? this.fromPredicted : null,
+      fromPredicted:
+        this instanceof UserSegmentationMask ? this.fromPredicted : null,
     });
   }
 
@@ -354,7 +370,8 @@ export class SegmentationMask {
     }
 
     return ROI.fromPolygon(
-      (geometry as { type: "Polygon"; coordinates: number[][][] }).coordinates[0],
+      (geometry as { type: "Polygon"; coordinates: number[][][] })
+        .coordinates[0],
       {
         name: this.name,
         category: this.category,
@@ -466,10 +483,20 @@ export class PredictedSegmentationMask extends SegmentationMask {
 
 // Register mask factory for ROI.toMask() to use
 _registerMaskFactory(
-  (mask: Uint8Array, height: number, width: number, options: Record<string, unknown>) => {
-    return SegmentationMask.fromArray(mask, height, width, options as Omit<
-      SegmentationMaskOptions,
-      "rleCounts" | "height" | "width"
-    >);
+  (
+    mask: Uint8Array,
+    height: number,
+    width: number,
+    options: Record<string, unknown>,
+  ) => {
+    return SegmentationMask.fromArray(
+      mask,
+      height,
+      width,
+      options as Omit<
+        SegmentationMaskOptions,
+        "rleCounts" | "height" | "width"
+      >,
+    );
   },
 );

--- a/src/model/matching.ts
+++ b/src/model/matching.ts
@@ -581,10 +581,7 @@ export function _getEffectiveShape(
  * (missing metadata). Compares ONLY (frames, height, width) — channels
  * (index 3) are EXCLUDED.
  */
-export function shapesCompatible(
-  video1: Video,
-  video2: Video,
-): boolean | null {
+export function shapesCompatible(video1: Video, video2: Video): boolean | null {
   const shape1 = _getEffectiveShape(video1);
   const shape2 = _getEffectiveShape(video2);
 
@@ -1088,10 +1085,7 @@ export function _getEmbeddedFrameIndices(video: Video): number[] | null {
   if (backend == null) {
     return null;
   }
-  if (
-    "embedded_frame_inds" in backend &&
-    backend.embedded_frame_inds != null
-  ) {
+  if ("embedded_frame_inds" in backend && backend.embedded_frame_inds != null) {
     return [...backend.embedded_frame_inds];
   }
   if ("frame_map" in backend && backend.frame_map) {
@@ -1150,7 +1144,11 @@ export function _toGrayscaleFloat(frame: VideoFrame): {
   data: Float32Array;
 } {
   // Only ImageData carries width/height + per-channel pixel data.
-  const img = frame as { width?: number; height?: number; data?: ArrayLike<number> };
+  const img = frame as {
+    width?: number;
+    height?: number;
+    data?: ArrayLike<number>;
+  };
   if (
     typeof img.width === "number" &&
     typeof img.height === "number" &&
@@ -1271,9 +1269,7 @@ export class SkeletonMatcher {
     options: { requireSameOrder?: boolean; minOverlap?: number } = {},
   ) {
     this.method =
-      typeof method === "string"
-        ? toSkeletonMatchMethod(method)
-        : method;
+      typeof method === "string" ? toSkeletonMatchMethod(method) : method;
     this.requireSameOrder = options.requireSameOrder ?? false;
     this.minOverlap = options.minOverlap ?? 0.5;
   }
@@ -1329,9 +1325,7 @@ export class InstanceMatcher {
     options: { threshold?: number } = {},
   ) {
     this.method =
-      typeof method === "string"
-        ? toInstanceMatchMethod(method)
-        : method;
+      typeof method === "string" ? toInstanceMatchMethod(method) : method;
     this.threshold = options.threshold ?? 5.0;
   }
 

--- a/src/model/roi.ts
+++ b/src/model/roi.ts
@@ -57,9 +57,7 @@ export class ROI {
 
   constructor(options: ROIOptions) {
     if (new.target === ROI) {
-      throw new TypeError(
-        "ROI is abstract. Use UserROI or PredictedROI.",
-      );
+      throw new TypeError("ROI is abstract. Use UserROI or PredictedROI.");
     }
     this.geometry = options.geometry;
     this.name = options.name ?? "";
@@ -174,26 +172,30 @@ export class ROI {
       copyFields.score = (this as any).score;
     }
     if (this.geometry.type === "MultiPolygon") {
-      return this.geometry.coordinates.map((coords) =>
-        new Ctor({
-          geometry: { type: "Polygon", coordinates: coords },
-          ...copyFields,
-        })
+      return this.geometry.coordinates.map(
+        (coords) =>
+          new Ctor({
+            geometry: { type: "Polygon", coordinates: coords },
+            ...copyFields,
+          }),
       );
     }
     if (this.geometry.type === "GeometryCollection") {
-      return this.geometry.geometries.map((geom) =>
-        new Ctor({
-          geometry: geom,
-          ...copyFields,
-        })
+      return this.geometry.geometries.map(
+        (geom) =>
+          new Ctor({
+            geometry: geom,
+            ...copyFields,
+          }),
       );
     }
     // Single geometry, return copy
-    return [new Ctor({
-      geometry: this.geometry,
-      ...copyFields,
-    })];
+    return [
+      new Ctor({
+        geometry: this.geometry,
+        ...copyFields,
+      }),
+    ];
   }
 
   toGeoJSON(): {
@@ -276,7 +278,10 @@ export class ROI {
   /** @deprecated Use `centroidXy` instead. */
   get centroid(): { x: number; y: number } {
     if (this.geometry.type === "Point") {
-      return { x: this.geometry.coordinates[0], y: this.geometry.coordinates[1] };
+      return {
+        x: this.geometry.coordinates[0],
+        y: this.geometry.coordinates[1],
+      };
     }
     const b = this.bounds;
     return { x: (b.minX + b.maxX) / 2, y: (b.minY + b.maxY) / 2 };
@@ -361,7 +366,11 @@ export function rasterizeGeometry(
 
   if (geometry.type === "MultiPolygon") {
     for (const poly of geometry.coordinates) {
-      const polyMask = rasterizeGeometry({ type: "Polygon", coordinates: poly }, height, width);
+      const polyMask = rasterizeGeometry(
+        { type: "Polygon", coordinates: poly },
+        height,
+        width,
+      );
       for (let i = 0; i < mask.length; i++) {
         if (polyMask[i]) mask[i] = 1;
       }
@@ -555,7 +564,10 @@ export function decodeWkb(bytes: Uint8Array): Geometry {
   return decodeWkbInternal(bytes).geometry;
 }
 
-function decodeWkbInternal(bytes: Uint8Array): { geometry: Geometry; bytesRead: number } {
+function decodeWkbInternal(bytes: Uint8Array): {
+  geometry: Geometry;
+  bytesRead: number;
+} {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const byteOrder = view.getUint8(0);
   const le = byteOrder === 1;
@@ -569,7 +581,10 @@ function decodeWkbInternal(bytes: Uint8Array): { geometry: Geometry; bytesRead: 
 
   if (wkbType === 3) {
     const { rings, bytesRead } = decodeWkbPolygon(view, 5, le);
-    return { geometry: { type: "Polygon", coordinates: rings }, bytesRead: 5 + bytesRead };
+    return {
+      geometry: { type: "Polygon", coordinates: rings },
+      bytesRead: 5 + bytesRead,
+    };
   }
 
   if (wkbType === 6) {
@@ -583,7 +598,10 @@ function decodeWkbInternal(bytes: Uint8Array): { geometry: Geometry; bytesRead: 
       polygons.push(rings);
       offset += bytesRead;
     }
-    return { geometry: { type: "MultiPolygon", coordinates: polygons }, bytesRead: offset };
+    return {
+      geometry: { type: "MultiPolygon", coordinates: polygons },
+      bytesRead: offset,
+    };
   }
 
   if (wkbType === 2) {
@@ -597,7 +615,10 @@ function decodeWkbInternal(bytes: Uint8Array): { geometry: Geometry; bytesRead: 
       coords.push([x, y]);
       offset += 16;
     }
-    return { geometry: { type: "LineString", coordinates: coords }, bytesRead: offset };
+    return {
+      geometry: { type: "LineString", coordinates: coords },
+      bytesRead: offset,
+    };
   }
 
   if (wkbType === 4) {
@@ -613,7 +634,10 @@ function decodeWkbInternal(bytes: Uint8Array): { geometry: Geometry; bytesRead: 
       coords.push([x, y]);
       offset += 16;
     }
-    return { geometry: { type: "MultiPoint", coordinates: coords }, bytesRead: offset };
+    return {
+      geometry: { type: "MultiPoint", coordinates: coords },
+      bytesRead: offset,
+    };
   }
 
   if (wkbType === 7) {
@@ -622,12 +646,19 @@ function decodeWkbInternal(bytes: Uint8Array): { geometry: Geometry; bytesRead: 
     const geometries: Geometry[] = [];
     let offset = 9;
     for (let i = 0; i < numGeometries; i++) {
-      const subBytes = new Uint8Array(bytes.buffer, bytes.byteOffset + offset, bytes.byteLength - offset);
+      const subBytes = new Uint8Array(
+        bytes.buffer,
+        bytes.byteOffset + offset,
+        bytes.byteLength - offset,
+      );
       const { geometry: geom, bytesRead } = decodeWkbInternal(subBytes);
       geometries.push(geom);
       offset += bytesRead;
     }
-    return { geometry: { type: "GeometryCollection", geometries }, bytesRead: offset };
+    return {
+      geometry: { type: "GeometryCollection", geometries },
+      bytesRead: offset,
+    };
   }
 
   throw new Error(`Unsupported WKB type: ${wkbType}`);

--- a/src/model/skeleton.ts
+++ b/src/model/skeleton.ts
@@ -85,10 +85,12 @@ export class Skeleton {
           symmetries?: Array<Symmetry | [NodeOrIndex, NodeOrIndex]>;
           name?: string;
         }
-      | Array<Node | string>
+      | Array<Node | string>,
   ) {
     const resolved = Array.isArray(options) ? { nodes: options } : options;
-    this.nodes = resolved.nodes.map((node) => (typeof node === "string" ? new Node(node) : node));
+    this.nodes = resolved.nodes.map((node) =>
+      typeof node === "string" ? new Node(node) : node,
+    );
     this.edges = [];
     this.symmetries = [];
     this.name = resolved.name;
@@ -96,11 +98,13 @@ export class Skeleton {
     this.nodeToIndex = new Map();
     this.rebuildCache();
     if (resolved.edges) {
-      this.edges = resolved.edges.map((edge) => (edge instanceof Edge ? edge : this.edgeFrom(edge)));
+      this.edges = resolved.edges.map((edge) =>
+        edge instanceof Edge ? edge : this.edgeFrom(edge),
+      );
     }
     if (resolved.symmetries) {
       this.symmetries = resolved.symmetries.map((symmetry) =>
-        symmetry instanceof Symmetry ? symmetry : this.symmetryFrom(symmetry)
+        symmetry instanceof Symmetry ? symmetry : this.symmetryFrom(symmetry),
       );
     }
   }
@@ -135,7 +139,10 @@ export class Skeleton {
   }
 
   get edgeIndices(): Array<[number, number]> {
-    return this.edges.map((edge) => [this.index(edge.source), this.index(edge.destination)]);
+    return this.edges.map((edge) => [
+      this.index(edge.source),
+      this.index(edge.destination),
+    ]);
   }
 
   get symmetryNames(): Array<[string, string]> {
@@ -182,10 +189,14 @@ export class Skeleton {
 
     // 4. Edge set equality: directed (source.name, destination.name) pairs.
     const selfEdgeSet = new Set(
-      this.edges.map((edge) => edgeKey(edge.source.name, edge.destination.name))
+      this.edges.map((edge) =>
+        edgeKey(edge.source.name, edge.destination.name),
+      ),
     );
     const otherEdgeSet = new Set(
-      other.edges.map((edge) => edgeKey(edge.source.name, edge.destination.name))
+      other.edges.map((edge) =>
+        edgeKey(edge.source.name, edge.destination.name),
+      ),
     );
     if (!setsEqual(selfEdgeSet, otherEdgeSet)) return false;
 
@@ -232,7 +243,8 @@ export class Skeleton {
     const nUnion = sizeSelf + sizeOther - nCommon;
 
     const jaccard = nUnion > 0 ? nCommon / nUnion : 0;
-    const dice = sizeSelf + sizeOther > 0 ? (2 * nCommon) / (sizeSelf + sizeOther) : 0;
+    const dice =
+      sizeSelf + sizeOther > 0 ? (2 * nCommon) / (sizeSelf + sizeOther) : 0;
 
     return { nCommon, nSelfOnly, nOtherOnly, jaccard, dice };
   }

--- a/src/model/suggestions.ts
+++ b/src/model/suggestions.ts
@@ -6,10 +6,19 @@ export class SuggestionFrame {
   group: string;
   metadata: Record<string, unknown>;
 
-  constructor(options: { video: Video; frameIdx: number; group?: string; metadata?: Record<string, unknown> }) {
+  constructor(options: {
+    video: Video;
+    frameIdx: number;
+    group?: string;
+    metadata?: Record<string, unknown>;
+  }) {
     this.video = options.video;
     this.frameIdx = options.frameIdx;
-    this.group = options.group ?? (options.metadata?.group != null ? String(options.metadata.group) : "default");
+    this.group =
+      options.group ??
+      (options.metadata?.group != null
+        ? String(options.metadata.group)
+        : "default");
     this.metadata = options.metadata ?? {};
   }
 }

--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -62,7 +62,7 @@ export interface CropOptions {
  */
 export function resolveCropRect(
   crop?: CropRect | null,
-  opts: CropOptions = {}
+  opts: CropOptions = {},
 ): CropRect {
   const { bbox, roi, center, size, margin = 0 } = opts;
 
@@ -70,7 +70,7 @@ export function resolveCropRect(
   if ((center == null) !== (size == null)) {
     throw new Error(
       "center and size must be provided together for a centered window; " +
-        `got center=${JSON.stringify(center)}, size=${JSON.stringify(size)}.`
+        `got center=${JSON.stringify(center)}, size=${JSON.stringify(size)}.`,
     );
   }
   const hasCenterSize = center != null && size != null;
@@ -83,7 +83,7 @@ export function resolveCropRect(
     throw new Error(
       "Exactly one of {crop, bbox, roi, (center, size)} must be provided " +
         `to specify a crop region, got ${nSpecs}. For a centered window, ` +
-        "pass both center and size."
+        "pass both center and size.",
     );
   }
 
@@ -122,7 +122,7 @@ export function resolveCropRect(
   if (x2 < x1 || y2 < y1) {
     throw new Error(
       `Inverted crop rect: x2 (${x2}) < x1 (${x1}) or y2 (${y2}) < y1 (${y1}). ` +
-        "Crop bounds must satisfy x2 >= x1 and y2 >= y1."
+        "Crop bounds must satisfy x2 >= x1 and y2 >= y1.",
     );
   }
   return [x1, y1, x2, y2];
@@ -200,7 +200,14 @@ export class Video {
   }
 
   get shape(): [number, number, number, number] | null {
-    return this._shape ?? this.backend?.shape ?? (this.backendMetadata.shape as [number, number, number, number] | undefined) ?? null;
+    return (
+      this._shape ??
+      this.backend?.shape ??
+      (this.backendMetadata.shape as
+        | [number, number, number, number]
+        | undefined) ??
+      null
+    );
   }
 
   set shape(value: [number, number, number, number] | null) {
@@ -208,7 +215,12 @@ export class Video {
   }
 
   get fps(): number | null {
-    return this._fps ?? this.backend?.fps ?? (this.backendMetadata.fps as number | undefined) ?? null;
+    return (
+      this._fps ??
+      this.backend?.fps ??
+      (this.backendMetadata.fps as number | undefined) ??
+      null
+    );
   }
 
   set fps(value: number | null) {
@@ -258,7 +270,7 @@ export class Video {
     if (this.backend == null) {
       throw new Error(
         "Cannot crop a video with no open backend. Provide a backend (the JS " +
-          "port has no filesystem auto-open) before cropping."
+          "port has no filesystem auto-open) before cropping.",
       );
     }
     const fill: Fill = opts.fill ?? 0;
@@ -320,13 +332,13 @@ export class Video {
   static fromCrop(
     video: Video | string,
     crop?: CropRect | null,
-    opts: CropOptions = {}
+    opts: CropOptions = {},
   ): Video {
     if (typeof video === "string") {
       throw new Error(
         "Video.fromCrop does not support opening a path string in the JS port " +
           "(there is no filesystem auto-open). Construct a Video with a backend " +
-          "first, then call Video.fromCrop(video, ...) or video.crop(...)."
+          "first, then call Video.fromCrop(video, ...) or video.crop(...).",
       );
     }
     return video.crop(crop, opts);
@@ -387,7 +399,7 @@ export class Video {
   toCropCoords<T extends FlatPoints>(points: T): T;
   toCropCoords(points: PointPairs): [number, number][];
   toCropCoords(
-    points: FlatPoints | PointPairs
+    points: FlatPoints | PointPairs,
   ): FlatPoints | [number, number][] {
     const crop = this._cropTuple();
     if (crop === null) {
@@ -406,7 +418,7 @@ export class Video {
   toSourceCoords<T extends FlatPoints>(points: T): T;
   toSourceCoords(points: PointPairs): [number, number][];
   toSourceCoords(
-    points: FlatPoints | PointPairs
+    points: FlatPoints | PointPairs,
   ): FlatPoints | [number, number][] {
     const crop = this._cropTuple();
     if (crop === null) {
@@ -535,11 +547,17 @@ export class Video {
     // present (real key-presence check, not truthiness).
     const selfShape =
       this.backend === null && hasOwn(this.backendMetadata, "shape")
-        ? (this.backendMetadata.shape as [number, number, number, number] | null | undefined)
+        ? (this.backendMetadata.shape as
+            | [number, number, number, number]
+            | null
+            | undefined)
         : this.shape;
     const otherShape =
       other.backend === null && hasOwn(other.backendMetadata, "shape")
-        ? (other.backendMetadata.shape as [number, number, number, number] | null | undefined)
+        ? (other.backendMetadata.shape as
+            | [number, number, number, number]
+            | null
+            | undefined)
         : other.shape;
 
     if (selfShape == null || otherShape == null) {
@@ -630,7 +648,7 @@ export class Video {
 
     // Keep only this video's images whose basename is not a duplicate.
     const deduplicatedPaths = (this.filename as string[]).filter(
-      (f) => !otherBasenames.has(basename(f))
+      (f) => !otherBasenames.has(basename(f)),
     );
 
     if (deduplicatedPaths.length === 0) {
@@ -703,7 +721,7 @@ export class Video {
  */
 function makeImageSequenceVideo(
   paths: string[],
-  grayscale: boolean | null
+  grayscale: boolean | null,
 ): Video {
   const backendMetadata: Record<string, unknown> = {};
   if (grayscale != null) {
@@ -724,12 +742,12 @@ function makeImageSequenceVideo(
  * passthrough (Python `points.copy()`).
  */
 function copyPoints(
-  points: FlatPoints | PointPairs
+  points: FlatPoints | PointPairs,
 ): FlatPoints | [number, number][] {
   if (Array.isArray(points)) {
     if (points.length > 0 && Array.isArray(points[0])) {
       return (points as unknown as PointPairs).map(
-        ([x, y]) => [x, y] as [number, number]
+        ([x, y]) => [x, y] as [number, number],
       );
     }
     return (points as number[]).slice();
@@ -769,7 +787,7 @@ function arraysEqual(a: string[], b: string[]): boolean {
 /** Component-wise equality of two (possibly null) 4-tuple shapes. */
 function shapeTupleEqual(
   a: [number, number, number, number] | null,
-  b: [number, number, number, number] | null
+  b: [number, number, number, number] | null,
 ): boolean {
   if (a === null || b === null) return a === b;
   if (a.length !== b.length) return false;

--- a/src/rendering/colors.ts
+++ b/src/rendering/colors.ts
@@ -262,7 +262,7 @@ export function rgbToCSS(rgb: RGB, alpha: number = 1): string {
 export function determineColorScheme(
   scheme: ColorScheme,
   hasTracks: boolean,
-  isSingleImage: boolean
+  isSingleImage: boolean,
 ): ColorScheme {
   if (scheme !== "auto") {
     return scheme;

--- a/src/rendering/context.ts
+++ b/src/rendering/context.ts
@@ -22,7 +22,7 @@ export class RenderContext {
     /** Current scale factor */
     public readonly scale: number = 1.0,
     /** Offset for cropped views [x, y] */
-    public readonly offset: [number, number] = [0, 0]
+    public readonly offset: [number, number] = [0, 0],
   ) {}
 
   /**
@@ -60,7 +60,7 @@ export class InstanceContext {
     /** Current scale factor */
     public readonly scale: number = 1.0,
     /** Offset for cropped views */
-    public readonly offset: [number, number] = [0, 0]
+    public readonly offset: [number, number] = [0, 0],
   ) {}
 
   /**

--- a/src/rendering/overlays.ts
+++ b/src/rendering/overlays.ts
@@ -203,10 +203,10 @@ export function drawLabelImage(
   const labH = labels.height;
   const labW = labels.width;
   // Prefer explicit opts, then the object's own transform, else identity.
-  const scale: [number, number] =
-    opts?.scale ?? (labels as LabelImage).scale ?? [1, 1];
-  const offset: [number, number] =
-    opts?.offset ?? (labels as LabelImage).offset ?? [0, 0];
+  const scale: [number, number] = opts?.scale ??
+    (labels as LabelImage).scale ?? [1, 1];
+  const offset: [number, number] = opts?.offset ??
+    (labels as LabelImage).offset ?? [0, 0];
 
   // Unique non-background labels and max id.
   let maxId = 0;
@@ -442,7 +442,12 @@ function configureStroke(
 export function drawBboxes(
   image: ImageData,
   bboxes: BoundingBox[],
-  opts?: { color?: RGB; colors?: RGB[]; lineWidth?: number; fillAlpha?: number },
+  opts?: {
+    color?: RGB;
+    colors?: RGB[];
+    lineWidth?: number;
+    fillAlpha?: number;
+  },
 ): ImageData {
   if (bboxes.length === 0) return image;
 
@@ -500,7 +505,12 @@ export function drawBboxes(
 export function drawRois(
   image: ImageData,
   rois: ROI[],
-  opts?: { color?: RGB; colors?: RGB[]; lineWidth?: number; fillAlpha?: number },
+  opts?: {
+    color?: RGB;
+    colors?: RGB[];
+    lineWidth?: number;
+    fillAlpha?: number;
+  },
 ): ImageData {
   if (rois.length === 0) return image;
 
@@ -557,7 +567,13 @@ function drawGeometry(
     case "Point": {
       const radius = Math.max(lineWidth, 2);
       ctx.beginPath();
-      ctx.arc(geometry.coordinates[0], geometry.coordinates[1], radius, 0, Math.PI * 2);
+      ctx.arc(
+        geometry.coordinates[0],
+        geometry.coordinates[1],
+        radius,
+        0,
+        Math.PI * 2,
+      );
       ctx.fillStyle = rgbToCSS(rgb);
       ctx.fill();
       break;
@@ -601,7 +617,10 @@ function drawGeometry(
  * cut holes out of the exterior. Port of `_polygon_to_path` (overlays.py
  * L583-620).
  */
-function polygonToPath(ctx: CanvasRenderingContext2D, rings: number[][][]): void {
+function polygonToPath(
+  ctx: CanvasRenderingContext2D,
+  rings: number[][][],
+): void {
   ctx.beginPath();
   for (const ring of rings) {
     if (ring.length === 0) continue;

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -90,7 +90,7 @@ interface SourceData {
  */
 export async function renderImage(
   source: Labels | LabeledFrame | (Instance | PredictedInstance)[],
-  options: RenderOptions = {}
+  options: RenderOptions = {},
 ): Promise<ImageData> {
   // Merge with defaults
   const opts = { ...DEFAULT_OPTIONS, ...options };
@@ -111,9 +111,7 @@ export async function renderImage(
     !hasNonInstanceAnnotations(source) &&
     !trailsPossible
   ) {
-    throw new Error(
-      "No instances to render and no background image provided"
-    );
+    throw new Error("No instances to render and no background image provided");
   }
 
   // Determine frame dimensions
@@ -122,7 +120,7 @@ export async function renderImage(
 
   if (!width || !height) {
     throw new Error(
-      "Cannot determine frame size. Provide image, width/height options, or ensure source has frame data."
+      "Cannot determine frame size. Provide image, width/height options, or ensure source has frame data.",
     );
   }
 
@@ -222,7 +220,7 @@ export async function renderImage(
     nodeNames.length,
     opts.palette,
     tracks,
-    trackIndexMap
+    trackIndexMap,
   );
 
   // Create render context for callbacks
@@ -235,7 +233,7 @@ export async function renderImage(
     edgeInds,
     nodeNames,
     opts.scale,
-    [0, 0]
+    [0, 0],
   );
 
   // Pre-render callback
@@ -251,7 +249,7 @@ export async function renderImage(
     const framesByIdx = resolveTrailFrames(
       labelsFrame,
       frameIdx,
-      options.trailFrames
+      options.trailFrames,
     );
     // The current frame may be empty, so fall back to a skeleton from the trail
     // context for resolving node-name targets.
@@ -263,13 +261,13 @@ export async function renderImage(
       const trailTracks =
         "labeledFrames" in labelsFrame
           ? labelsFrame.tracks
-          : options.trailTracks ?? collectTracks(framesByIdx.values());
+          : (options.trailTracks ?? collectTracks(framesByIdx.values()));
       const trailHasTracks = trailTracks.length > 0;
       const trailTrackIndexMap = new Map(trailTracks.map((t, i) => [t, i]));
       const nColors = nTrailPaletteColors(
         trailHasTracks,
         trailTracks.length,
-        framesByIdx.values()
+        framesByIdx.values(),
       );
       const trailPalette = getPalette(opts.palette as PaletteName, nColors);
       const trailTargets = resolveTrailNode(opts.trailNode, trailSkeleton);
@@ -300,7 +298,7 @@ export async function renderImage(
         drawTrails(
           ctx as unknown as CanvasRenderingContext2D,
           trails,
-          trailDrawOpts
+          trailDrawOpts,
         );
       }
     }
@@ -338,7 +336,7 @@ export async function renderImage(
         // Edge color: use node color for 'node' scheme, else instance color
         const edgeColor: RGB =
           colorScheme === "node"
-            ? colors.nodeColors?.[dstIdx] ?? instanceColor
+            ? (colors.nodeColors?.[dstIdx] ?? instanceColor)
             : instanceColor;
 
         ctx.strokeStyle = rgbToCSS(edgeColor, opts.alpha);
@@ -366,7 +364,7 @@ export async function renderImage(
 
         const nodeColor: RGB =
           colorScheme === "node"
-            ? colors.nodeColors?.[nodeIdx] ?? instanceColor
+            ? (colors.nodeColors?.[nodeIdx] ?? instanceColor)
             : instanceColor;
 
         drawMarker(
@@ -374,7 +372,7 @@ export async function renderImage(
           x * opts.scale,
           y * opts.scale,
           scaledMarkerSize,
-          rgbToCSS(nodeColor, opts.alpha)
+          rgbToCSS(nodeColor, opts.alpha),
         );
       }
     }
@@ -394,7 +392,7 @@ export async function renderImage(
         instance.track?.name ?? null,
         "score" in instance ? (instance as PredictedInstance).score : null,
         opts.scale,
-        [0, 0]
+        [0, 0],
       );
       opts.perInstanceCallback(instCtx);
     }
@@ -407,7 +405,12 @@ export async function renderImage(
 
   // Return ImageData
   // Cast to standard ImageData for compatibility
-  return ctx.getImageData(0, 0, scaledWidth, scaledHeight) as unknown as ImageData;
+  return ctx.getImageData(
+    0,
+    0,
+    scaledWidth,
+    scaledHeight,
+  ) as unknown as ImageData;
 }
 
 /**
@@ -421,7 +424,7 @@ export async function renderImage(
  * extend when that lands.
  */
 function hasNonInstanceAnnotations(
-  source: Labels | LabeledFrame | (Instance | PredictedInstance)[]
+  source: Labels | LabeledFrame | (Instance | PredictedInstance)[],
 ): boolean {
   if (Array.isArray(source)) return false;
   const lf: LabeledFrame | undefined =
@@ -452,7 +455,7 @@ function hasNonInstanceAnnotations(
 function resolveTrailFrames(
   source: Labels | LabeledFrame,
   frameIdx: number,
-  trailFrames?: LabeledFrame[] | Map<number, LabeledFrame>
+  trailFrames?: LabeledFrame[] | Map<number, LabeledFrame>,
 ): Map<number, LabeledFrame> | null {
   if ("labeledFrames" in source) {
     const rendered = source.labeledFrames[0];
@@ -474,7 +477,7 @@ function resolveTrailFrames(
 
 /** First instance skeleton found across the trail context frames, or `null`. */
 function firstSkeletonIn(
-  framesByIdx: Map<number, LabeledFrame> | null
+  framesByIdx: Map<number, LabeledFrame> | null,
 ): Skeleton | null {
   if (!framesByIdx) return null;
   for (const lf of framesByIdx.values()) {
@@ -488,7 +491,7 @@ function firstSkeletonIn(
  */
 function extractSourceData(
   source: Labels | LabeledFrame | (Instance | PredictedInstance)[],
-  options: RenderOptions
+  options: RenderOptions,
 ): SourceData {
   // Case 1: Array of Instances
   if (Array.isArray(source)) {
@@ -517,7 +520,11 @@ function extractSourceData(
   }
 
   // Case 2: LabeledFrame
-  if ("instances" in source && "frameIdx" in source && !("labeledFrames" in source)) {
+  if (
+    "instances" in source &&
+    "frameIdx" in source &&
+    !("labeledFrames" in source)
+  ) {
     const frame = source as LabeledFrame;
     const skeleton =
       frame.instances.length > 0 ? frame.instances[0].skeleton : null;
@@ -577,9 +584,7 @@ function extractSourceData(
   const firstFrame = labels.labeledFrames[0];
   const skeleton =
     labels.skeletons?.[0] ??
-    (firstFrame.instances.length > 0
-      ? firstFrame.instances[0].skeleton
-      : null);
+    (firstFrame.instances.length > 0 ? firstFrame.instances[0].skeleton : null);
 
   // Try to get video dimensions
   let frameSize: [number, number] = [options.width ?? 0, options.height ?? 0];
@@ -627,14 +632,14 @@ function buildColorMap(
   nNodes: number,
   paletteName: string,
   tracks: Track[],
-  trackIndexMap: Map<Track, number>
+  trackIndexMap: Map<Track, number>,
 ): { instanceColors?: RGB[]; nodeColors?: RGB[] } {
   switch (scheme) {
     case "instance":
       return {
         instanceColors: getPalette(
           paletteName as PaletteName,
-          Math.max(1, instances.length)
+          Math.max(1, instances.length),
         ),
       };
 
@@ -668,7 +673,7 @@ function buildColorMap(
       return {
         instanceColors: getPalette(
           paletteName as PaletteName,
-          Math.max(1, instances.length)
+          Math.max(1, instances.length),
         ),
       };
   }
@@ -693,7 +698,7 @@ export async function toPNG(imageData: ImageData): Promise<Buffer> {
  */
 export async function toJPEG(
   imageData: ImageData,
-  quality: number = 0.9
+  quality: number = 0.9,
 ): Promise<Buffer> {
   const { Canvas } = await import("skia-canvas");
   const canvas = new Canvas(imageData.width, imageData.height);
@@ -708,7 +713,7 @@ export async function toJPEG(
  */
 export async function toDataURL(
   imageData: ImageData,
-  format: "png" | "jpeg" = "png"
+  format: "png" | "jpeg" = "png",
 ): Promise<string> {
   const { Canvas } = await import("skia-canvas");
   const canvas = new Canvas(imageData.width, imageData.height);
@@ -726,7 +731,7 @@ export async function toDataURL(
  */
 export async function saveImage(
   imageData: ImageData,
-  path: string
+  path: string,
 ): Promise<void> {
   const { Canvas } = await import("skia-canvas");
   const canvas = new Canvas(imageData.width, imageData.height);

--- a/src/rendering/shapes.ts
+++ b/src/rendering/shapes.ts
@@ -10,7 +10,7 @@ type DrawMarkerFn = (
   size: number,
   fillColor: string,
   edgeColor?: string,
-  edgeWidth?: number
+  edgeWidth?: number,
 ) => void;
 
 /**
@@ -23,7 +23,7 @@ export function drawCircle(
   size: number,
   fillColor: string,
   edgeColor?: string,
-  edgeWidth: number = 1
+  edgeWidth: number = 1,
 ): void {
   ctx.beginPath();
   ctx.arc(x, y, size, 0, Math.PI * 2);
@@ -48,7 +48,7 @@ export function drawSquare(
   size: number,
   fillColor: string,
   edgeColor?: string,
-  edgeWidth: number = 1
+  edgeWidth: number = 1,
 ): void {
   const half = size;
   ctx.fillStyle = fillColor;
@@ -71,7 +71,7 @@ export function drawDiamond(
   size: number,
   fillColor: string,
   edgeColor?: string,
-  edgeWidth: number = 1
+  edgeWidth: number = 1,
 ): void {
   ctx.beginPath();
   ctx.moveTo(x, y - size); // Top
@@ -100,7 +100,7 @@ export function drawTriangle(
   size: number,
   fillColor: string,
   edgeColor?: string,
-  edgeWidth: number = 1
+  edgeWidth: number = 1,
 ): void {
   const h = size * 0.866; // Height factor for equilateral triangle
 
@@ -130,7 +130,7 @@ export function drawCross(
   size: number,
   fillColor: string,
   _edgeColor?: string,
-  edgeWidth: number = 2
+  edgeWidth: number = 2,
 ): void {
   ctx.strokeStyle = fillColor;
   ctx.lineWidth = edgeWidth;
@@ -207,7 +207,7 @@ export interface DrawTrailsOptions {
 export function drawTrails(
   ctx: CanvasRenderingContext2D,
   trails: Array<Array<[number, number] | number[]>>,
-  options: DrawTrailsOptions = {}
+  options: DrawTrailsOptions = {},
 ): void {
   if (trails.length === 0) return;
 
@@ -224,7 +224,7 @@ export function drawTrails(
   if (colors !== undefined && colors.length !== trails.length) {
     throw new Error(
       `colors has length ${colors.length} but there are ${trails.length} ` +
-        "trails; they must be the same length."
+        "trails; they must be the same length.",
     );
   }
 

--- a/src/rendering/trails.ts
+++ b/src/rendering/trails.ts
@@ -36,7 +36,7 @@ export type Trail = Array<[number, number]>;
  */
 export function resolveTrailNode(
   trailNode: string | string[],
-  skeleton: Skeleton
+  skeleton: Skeleton,
 ): TrailTarget[] {
   const names = typeof trailNode === "string" ? [trailNode] : [...trailNode];
 
@@ -49,8 +49,8 @@ export function resolveTrailNode(
     } catch {
       throw new Error(
         `Unknown trailNode ${JSON.stringify(name)}; skeleton nodes: ${JSON.stringify(
-          skeleton.nodeNames
-        )}`
+          skeleton.nodeNames,
+        )}`,
       );
     }
   });
@@ -73,7 +73,7 @@ export function resolveTrailNode(
 export function nTrailPaletteColors(
   hasTracks: boolean,
   nTracks: number,
-  frames: Iterable<LabeledFrame>
+  frames: Iterable<LabeledFrame>,
 ): number {
   if (hasTracks) {
     return Math.max(nTracks, 1);
@@ -221,7 +221,7 @@ export function computeTrails(opts: {
         if (!entry) {
           const arr: Trail = Array.from(
             { length: nPoints },
-            () => [NaN, NaN] as [number, number]
+            () => [NaN, NaN] as [number, number],
           );
           entry = { arr, keyIdx };
           trailData.set(dkey, entry);

--- a/src/rendering/video.ts
+++ b/src/rendering/video.ts
@@ -37,14 +37,14 @@ export async function checkFfmpeg(): Promise<boolean> {
 export async function renderVideo(
   source: Labels | LabeledFrame[],
   outputPath: string,
-  options: VideoOptions = {}
+  options: VideoOptions = {},
 ): Promise<void> {
   // Check ffmpeg availability
   const hasFfmpeg = await checkFfmpeg();
   if (!hasFfmpeg) {
     throw new Error(
       "ffmpeg not found. Please install ffmpeg and ensure it is in your PATH.\n" +
-        "Installation: https://ffmpeg.org/download.html"
+        "Installation: https://ffmpeg.org/download.html",
     );
   }
 
@@ -110,7 +110,10 @@ export async function renderVideo(
   // Build the per-frame render options. Overlay is resolved per frame (static
   // value, position-indexed list, frame-index-keyed Map, or callable) and
   // passed through as the single-frame `overlay` that renderImage understands.
-  const optsForFrame = (frame: LabeledFrame, position: number): RenderOptions => {
+  const optsForFrame = (
+    frame: LabeledFrame,
+    position: number,
+  ): RenderOptions => {
     // Strip the video-level (per-frame) `overlay` so the spread does not leak a
     // `VideoOverlay` into the single-frame `RenderOptions`; it is replaced by
     // the resolved single-frame overlay below.
@@ -129,7 +132,10 @@ export async function renderVideo(
   };
 
   // Get frame dimensions from first frame
-  const firstImage = await renderImage(selectedFrames[0], optsForFrame(selectedFrames[0], 0));
+  const firstImage = await renderImage(
+    selectedFrames[0],
+    optsForFrame(selectedFrames[0], 0),
+  );
   const width = firstImage.width;
   const height = firstImage.height;
 
@@ -204,7 +210,7 @@ export async function renderVideo(
     // Handle backpressure
     if (!canWrite) {
       await new Promise<void>((resolve) =>
-        ffmpeg.stdin?.once("drain", resolve)
+        ffmpeg.stdin?.once("drain", resolve),
       );
     }
 

--- a/src/transform/frame.ts
+++ b/src/transform/frame.ts
@@ -58,7 +58,12 @@ function isImageBitmap(value: unknown): boolean {
   }
   // Fallback duck-type: an ImageBitmap exposes width/height + close() but no
   // readable `data` buffer.
-  const v = value as { width?: unknown; height?: unknown; close?: unknown; data?: unknown };
+  const v = value as {
+    width?: unknown;
+    height?: unknown;
+    close?: unknown;
+    data?: unknown;
+  };
   return (
     v != null &&
     typeof v.width === "number" &&
@@ -101,7 +106,7 @@ function resolveFill(fill: Fill, channels: number): number[] {
     // Pad/truncate to the channel count (extra channels reuse the last value).
     const out = new Array<number>(channels);
     for (let c = 0; c < channels; c++) {
-      out[c] = c < fill.length ? fill[c] : fill[fill.length - 1] ?? 0;
+      out[c] = c < fill.length ? fill[c] : (fill[fill.length - 1] ?? 0);
     }
     return out;
   }
@@ -117,7 +122,7 @@ function resolveFill(fill: Fill, channels: number): number[] {
 function asImageData(
   data: Uint8ClampedArray<ArrayBuffer>,
   width: number,
-  height: number
+  height: number,
 ): ImageData {
   if (
     typeof globalThis !== "undefined" &&
@@ -144,18 +149,26 @@ function asImageData(
  * @returns For an `ImageData` input, an `ImageData`-shaped RGBA result; for a
  *   {@link RawFrame} input, a {@link RawFrame} with the same channel count.
  */
-export function cropFrame(frame: ImageData, crop: CropRect, fill?: Fill): ImageData;
-export function cropFrame(frame: RawFrame, crop: CropRect, fill?: Fill): RawFrame;
+export function cropFrame(
+  frame: ImageData,
+  crop: CropRect,
+  fill?: Fill,
+): ImageData;
+export function cropFrame(
+  frame: RawFrame,
+  crop: CropRect,
+  fill?: Fill,
+): RawFrame;
 export function cropFrame(
   frame: FrameLike,
   crop: CropRect,
-  fill: Fill = 0
+  fill: Fill = 0,
 ): ImageData | RawFrame {
   if (isImageBitmap(frame)) {
     throw new Error(
       "cropFrame cannot crop a raw ImageBitmap: its pixels are not synchronously " +
         "readable. Rasterize it to an ImageData (e.g. via OffscreenCanvas or " +
-        "skia-canvas) before cropping. This is handled by CropVideoBackend.getFrame."
+        "skia-canvas) before cropping. This is handled by CropVideoBackend.getFrame.",
     );
   }
 

--- a/src/transform/points.ts
+++ b/src/transform/points.ts
@@ -34,7 +34,11 @@ export type PointPairs = ReadonlyArray<readonly [number, number]>;
  * not present in this layout — the buffer is assumed to be pure interleaved
  * `(..., 2)` data.
  */
-function offsetFlat<T extends FlatPoints>(points: T, dx: number, dy: number): T {
+function offsetFlat<T extends FlatPoints>(
+  points: T,
+  dx: number,
+  dy: number,
+): T {
   if (Array.isArray(points)) {
     const out = points.slice() as number[];
     for (let i = 0; i + 1 < out.length; i += 2) {
@@ -54,7 +58,11 @@ function offsetFlat<T extends FlatPoints>(points: T, dx: number, dy: number): T 
 }
 
 /** Offset an array of `[x, y]` pairs by `(dx, dy)`, returning a fresh array. */
-function offsetPairs(points: PointPairs, dx: number, dy: number): [number, number][] {
+function offsetPairs(
+  points: PointPairs,
+  dx: number,
+  dy: number,
+): [number, number][] {
   return points.map(([x, y]) => [x + dx, y + dy] as [number, number]);
 }
 
@@ -72,10 +80,13 @@ function offsetPairs(points: PointPairs, dx: number, dy: number): [number, numbe
  * @returns Crop-local coordinates (a copy; input unmutated).
  */
 export function cropPoints<T extends FlatPoints>(points: T, crop: CropRect): T;
-export function cropPoints(points: PointPairs, crop: CropRect): [number, number][];
+export function cropPoints(
+  points: PointPairs,
+  crop: CropRect,
+): [number, number][];
 export function cropPoints(
   points: FlatPoints | PointPairs,
-  crop: CropRect
+  crop: CropRect,
 ): FlatPoints | [number, number][] {
   const [x1, y1] = crop;
   if (isPairs(points)) {
@@ -94,11 +105,17 @@ export function cropPoints(
  * @param crop Crop region `[x1, y1, x2, y2]` (x2/y2 exclusive).
  * @returns Source-frame coordinates (a copy; input unmutated).
  */
-export function uncropPoints<T extends FlatPoints>(points: T, crop: CropRect): T;
-export function uncropPoints(points: PointPairs, crop: CropRect): [number, number][];
+export function uncropPoints<T extends FlatPoints>(
+  points: T,
+  crop: CropRect,
+): T;
+export function uncropPoints(
+  points: PointPairs,
+  crop: CropRect,
+): [number, number][];
 export function uncropPoints(
   points: FlatPoints | PointPairs,
-  crop: CropRect
+  crop: CropRect,
 ): FlatPoints | [number, number][] {
   const [x1, y1] = crop;
   if (isPairs(points)) {

--- a/src/video/crop-backend.ts
+++ b/src/video/crop-backend.ts
@@ -80,7 +80,7 @@ function isImageBitmap(value: unknown): boolean {
 
 /** Detect an `ImageData`-shaped object (RGBA buffer with width/height). */
 function isImageDataLike(
-  value: unknown
+  value: unknown,
 ): value is { data: Uint8ClampedArray; width: number; height: number } {
   const v = value as {
     data?: unknown;
@@ -150,7 +150,7 @@ export class CropVideoBackend implements VideoBackend {
     inner: VideoBackend,
     crop: CropRect,
     fill: Fill,
-    ownsInner: boolean
+    ownsInner: boolean,
   ) {
     this.inner = inner;
     this.crop = [
@@ -277,7 +277,9 @@ export class CropVideoBackend implements VideoBackend {
     // Raw bytes (Uint8Array or ArrayBuffer) from a Node backend: either
     // undecoded encoded frames or raw interleaved pixel data.
     const bytes =
-      frame instanceof ArrayBuffer ? new Uint8Array(frame) : (frame as Uint8Array);
+      frame instanceof ArrayBuffer
+        ? new Uint8Array(frame)
+        : (frame as Uint8Array);
     if (isEncodedBytes(bytes)) {
       return decodeEncoded(bytes);
     }
@@ -287,7 +289,7 @@ export class CropVideoBackend implements VideoBackend {
       throw new Error(
         "CropVideoBackend.getFrame received raw pixel bytes but the inner " +
           "backend has no resolved shape to interpret them. Provide a shape on " +
-          "the inner backend, or use a backend that returns decoded frames."
+          "the inner backend, or use a backend that returns decoded frames.",
       );
     }
     const [, height, width, channels] = innerShape;
@@ -317,7 +319,7 @@ export class CropVideoBackend implements VideoBackend {
   toCropCoords<T extends FlatPoints>(points: T): T;
   toCropCoords(points: PointPairs): [number, number][];
   toCropCoords(
-    points: FlatPoints | PointPairs
+    points: FlatPoints | PointPairs,
   ): FlatPoints | [number, number][] {
     return cropPoints(points as FlatPoints, this.crop);
   }
@@ -331,7 +333,7 @@ export class CropVideoBackend implements VideoBackend {
   toSourceCoords<T extends FlatPoints>(points: T): T;
   toSourceCoords(points: PointPairs): [number, number][];
   toSourceCoords(
-    points: FlatPoints | PointPairs
+    points: FlatPoints | PointPairs,
   ): FlatPoints | [number, number][] {
     return uncropPoints(points as FlatPoints, this.crop);
   }

--- a/src/video/embedded-frame.ts
+++ b/src/video/embedded-frame.ts
@@ -28,7 +28,9 @@
 export type Hdf5Slice = Array<[number, number] | []>;
 
 // PNG magic bytes: 0x89 P N G \r \n 0x1A \n
-export const PNG_MAGIC = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+export const PNG_MAGIC = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
 
 // JPEG magic bytes: 0xFF 0xD8 0xFF
 export const JPEG_MAGIC = new Uint8Array([0xff, 0xd8, 0xff]);
@@ -50,7 +52,11 @@ export function magicFor(format: string): Uint8Array {
  * This deliberately avoids `buffer.subarray(pos)` (which allocates a throwaway
  * view at every byte position — the ~30× self-inflicted cost in the old scan).
  */
-export function matchesMagicAt(buffer: Uint8Array, pos: number, magic: Uint8Array): boolean {
+export function matchesMagicAt(
+  buffer: Uint8Array,
+  pos: number,
+  magic: Uint8Array,
+): boolean {
   if (pos + magic.length > buffer.length) return false;
   for (let k = 0; k < magic.length; k++) {
     if (buffer[pos + k] !== magic[k]) return false;
@@ -60,7 +66,10 @@ export function matchesMagicAt(buffer: Uint8Array, pos: number, magic: Uint8Arra
 
 /** Whether the buffer starts with a PNG or JPEG signature. */
 export function startsWithImageMagic(buffer: Uint8Array): boolean {
-  return matchesMagicAt(buffer, 0, PNG_MAGIC) || matchesMagicAt(buffer, 0, JPEG_MAGIC);
+  return (
+    matchesMagicAt(buffer, 0, PNG_MAGIC) ||
+    matchesMagicAt(buffer, 0, JPEG_MAGIC)
+  );
 }
 
 /**
@@ -74,7 +83,7 @@ export function startsWithImageMagic(buffer: Uint8Array): boolean {
 export function findEncodedFrameOffsets(
   buffer: Uint8Array,
   format: string,
-  expectedFrameCount: number
+  expectedFrameCount: number,
 ): number[] {
   const magic = magicFor(format);
   const m0 = magic[0];
@@ -138,7 +147,10 @@ export type EmbeddedLayout = "padded" | "vlen" | "concat" | "ambiguous1d";
  * otherwise it is `concat` (bytes). When the frame count is unknown the 1D case
  * is `ambiguous1d` and must be resolved by reading the value.
  */
-export function classifyLayout(shape: number[], frameCount: number): EmbeddedLayout {
+export function classifyLayout(
+  shape: number[],
+  frameCount: number,
+): EmbeddedLayout {
   if (shape.length >= 2) return "padded";
   if (shape.length === 1) {
     if (frameCount > 0) return shape[0] === frameCount ? "vlen" : "concat";
@@ -150,7 +162,7 @@ export function classifyLayout(shape: number[], frameCount: number): EmbeddedLay
 /** Build a hyperslab slice selecting only row `index` along the first dim. */
 export function rowSlice(shape: number[], index: number): Hdf5Slice {
   return shape.map(
-    (dim, d) => (d === 0 ? [index, index + 1] : [0, dim]) as [number, number]
+    (dim, d) => (d === 0 ? [index, index + 1] : [0, dim]) as [number, number],
   );
 }
 
@@ -170,7 +182,10 @@ export function asUint8Array(value: unknown): Uint8Array | null {
   if (Array.isArray(value)) {
     return Uint8Array.from(value as number[]);
   }
-  if (typeof value === "object" && "buffer" in (value as Record<string, unknown>)) {
+  if (
+    typeof value === "object" &&
+    "buffer" in (value as Record<string, unknown>)
+  ) {
     return new Uint8Array((value as { buffer: ArrayBuffer }).buffer);
   }
   return null;
@@ -225,7 +240,7 @@ export interface H5wasmModule {
     count: bigint[],
     offset: bigint[],
     strides: bigint[],
-    dataPtr: bigint
+    dataPtr: bigint,
   ): unknown;
   /** HDF5 datatype class enum; `H5T_VLEN.value` is the vlen class id. */
   H5T_class_t?: { H5T_VLEN: { value: number } };
@@ -261,9 +276,14 @@ export interface H5wasmVlenDataset {
 export function readVlenElementManual(
   Module: H5wasmModule | null | undefined,
   dataset: H5wasmVlenDataset,
-  index: number
+  index: number,
 ): Uint8Array | null {
-  if (!Module || !Module._malloc || !Module.HEAPU8 || !Module.get_dataset_data) {
+  if (
+    !Module ||
+    !Module._malloc ||
+    !Module.HEAPU8 ||
+    !Module.get_dataset_data
+  ) {
     return null;
   }
   const md = dataset.metadata;
@@ -273,7 +293,8 @@ export function readVlenElementManual(
   // of misreading. `metadata.vlen` is often false even for genuine vlen
   // datasets, so the datatype-class check carries the detection.
   const vlenClass = Module.H5T_class_t?.H5T_VLEN.value;
-  const isVlen = md?.vlen === true || (vlenClass != null && md?.type === vlenClass);
+  const isVlen =
+    md?.vlen === true || (vlenClass != null && md?.type === vlenClass);
   if (!isVlen || md?.size !== 8) return null;
 
   const dataPtr = Module._malloc(md.size);
@@ -286,7 +307,7 @@ export function readVlenElementManual(
       [1n],
       [BigInt(index)],
       [1n],
-      BigInt(dataPtr)
+      BigInt(dataPtr),
     );
     // `HEAPU32` is not exported by h5wasm; build a u32 view over `HEAPU8.buffer`.
     // Rebuild it every call — wasm heap growth can detach the prior ArrayBuffer.
@@ -310,7 +331,7 @@ export function readVlenElementManual(
  */
 export async function readEmbeddedFrameBytes(
   reader: EmbeddedFrameReader,
-  index: number
+  index: number,
 ): Promise<Uint8Array | null> {
   if (index < 0) return null;
   const meta = await reader.getMeta();
@@ -350,7 +371,11 @@ export async function readEmbeddedFrameBytes(
   }
 
   // 1D concatenated with known sizes: exact byte-range slice.
-  if (layout === "concat" && reader.frameSizes && reader.frameSizes.length > index) {
+  if (
+    layout === "concat" &&
+    reader.frameSizes &&
+    reader.frameSizes.length > index
+  ) {
     reader.legacy.offsets ??= computeOffsetsFromSizes(reader.frameSizes);
     const offsets = reader.legacy.offsets;
     const start = offsets[index];
@@ -371,7 +396,11 @@ export async function readEmbeddedFrameBytes(
       if (!buf) return null;
       reader.legacy.whole = buf;
       if (encoded && startsWithImageMagic(buf)) {
-        reader.legacy.offsets = findEncodedFrameOffsets(buf, reader.format, reader.frameCount);
+        reader.legacy.offsets = findEncodedFrameOffsets(
+          buf,
+          reader.format,
+          reader.frameCount,
+        );
       }
     }
   }

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -62,7 +62,7 @@ export class UnsupportedVideoFormatError extends Error {
     super(
       `Unsupported video format ".${extension}". AVI and MPEG program streams ` +
         `cannot be decoded in the browser or desktop app. Transcode to MP4 (H.264) ` +
-        `first, e.g. \`ffmpeg -i input.${extension} -c:v libx264 output.mp4\`.`
+        `first, e.g. \`ffmpeg -i input.${extension} -c:v libx264 output.mp4\`.`,
     );
     this.name = "UnsupportedVideoFormatError";
     this.extension = extension;
@@ -84,7 +84,7 @@ export async function createVideoBackend(
     shape?: [number, number, number, number];
     fps?: number;
     backend?: VideoBackendType;
-  }
+  },
 ): Promise<VideoBackend> {
   // Image-sequence video (Python `ImageVideo`): `source` is a LIST of image
   // paths, one image per frame. Route to ImageVideoBackend before the single-
@@ -96,9 +96,7 @@ export async function createVideoBackend(
     });
   }
   const isBlob = typeof Blob !== "undefined" && source instanceof Blob;
-  const filename = isBlob
-    ? (source as File).name ?? ""
-    : (source as string);
+  const filename = isBlob ? ((source as File).name ?? "") : (source as string);
   const normalized = filename.split("?")[0]?.toLowerCase() ?? "";
   const ext = normalized.split(".").pop() ?? "";
 
@@ -130,19 +128,24 @@ export async function createVideoBackend(
   // at the top of this function via Array.isArray. This must come before the
   // MediaVideo fallback, which would otherwise try (and fail) to play a .jpg.
   if (IMAGE_EXTENSIONS.includes(ext)) {
-    return ImageVideoBackend.create({ filename: [filename], shape: options?.shape });
+    return ImageVideoBackend.create({
+      filename: [filename],
+      shape: options?.shape,
+    });
   }
 
   // User-specified backend override
   if (options?.backend === "mediabunny") {
-    if (isBlob) return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
+    if (isBlob)
+      return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
     return MediaBunnyVideoBackend.fromUrl(filename);
   }
   if (options?.backend === "mp4box") {
     return new Mp4BoxVideoBackend(source);
   }
   if (options?.backend === "media") {
-    if (isBlob) return new MediaVideoBackend(URL.createObjectURL(source as Blob));
+    if (isBlob)
+      return new MediaVideoBackend(URL.createObjectURL(source as Blob));
     return new MediaVideoBackend(filename);
   }
 
@@ -166,7 +169,8 @@ export async function createVideoBackend(
 
   // Non-MP4 video formats: use MediaBunny
   if (supportsWebCodecs && MEDIABUNNY_EXTENSIONS.includes(ext)) {
-    if (isBlob) return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
+    if (isBlob)
+      return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
     return MediaBunnyVideoBackend.fromUrl(filename);
   }
 

--- a/src/video/hdf5-video.ts
+++ b/src/video/hdf5-video.ts
@@ -11,7 +11,8 @@ import {
   readVlenElementManual,
 } from "./embedded-frame.js";
 
-const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+const isBrowser =
+  typeof window !== "undefined" && typeof document !== "undefined";
 
 /**
  * Video backend for embedded images in HDF5 files (synchronous h5wasm).
@@ -54,7 +55,9 @@ export class Hdf5VideoBackend implements VideoBackend {
     // Build O(1) lookup map from frame numbers
     const frameNumbers = options.frameNumbers ?? [];
     this.frameNumbers = frameNumbers;
-    this.frameNumberToIndex = new Map(frameNumbers.map((num, idx) => [num, idx]));
+    this.frameNumberToIndex = new Map(
+      frameNumbers.map((num, idx) => [num, idx]),
+    );
     this.format = options.format ?? "png";
     this.channelOrder = options.channelOrder ?? "RGB";
     this.shape = options.shape;
@@ -67,16 +70,24 @@ export class Hdf5VideoBackend implements VideoBackend {
     const dataset = this.file.get(this.datasetPath);
     if (!dataset) return null;
     // Use O(1) Map lookup; if no frame numbers provided, use frameIndex directly
-    const index = this.frameNumberToIndex.size > 0
-      ? this.frameNumberToIndex.get(frameIndex)
-      : frameIndex;
+    const index =
+      this.frameNumberToIndex.size > 0
+        ? this.frameNumberToIndex.get(frameIndex)
+        : frameIndex;
     if (index === undefined) return null;
 
-    const rawBytes = await readEmbeddedFrameBytes(this.buildReader(dataset), index);
+    const rawBytes = await readEmbeddedFrameBytes(
+      this.buildReader(dataset),
+      index,
+    );
     if (!rawBytes || rawBytes.length === 0) return null;
 
     if (isEncodedFormat(this.format)) {
-      const decoded = await decodeImageBytes(rawBytes, this.format, this.channelOrder);
+      const decoded = await decodeImageBytes(
+        rawBytes,
+        this.format,
+        this.channelOrder,
+      );
       return decoded ?? rawBytes;
     }
 
@@ -91,7 +102,10 @@ export class Hdf5VideoBackend implements VideoBackend {
       format: this.format,
       frameSizes: this.frameSizes,
       legacy: this.legacy,
-      getMeta: async () => ({ shape: dataset.shape ?? [], dtype: dataset.dtype }),
+      getMeta: async () => ({
+        shape: dataset.shape ?? [],
+        dtype: dataset.dtype,
+      }),
       readSlice: async (slice?: Hdf5Slice): Promise<SliceReadResult> => {
         const value = slice ? dataset.slice(slice) : dataset.value;
         return { value, shape: dataset.shape ?? [] };
@@ -112,7 +126,7 @@ export class Hdf5VideoBackend implements VideoBackend {
 async function decodeImageBytes(
   bytes: Uint8Array,
   format: string,
-  channelOrder: string
+  channelOrder: string,
 ): Promise<VideoFrame | null> {
   if (!isBrowser || typeof createImageBitmap === "undefined") return null;
   const mime = format.toLowerCase() === "png" ? "image/png" : "image/jpeg";
@@ -151,7 +165,7 @@ async function decodeImageBytes(
 function decodeRawFrame(
   bytes: Uint8Array,
   shape: [number, number, number, number] | undefined,
-  channelOrder: string
+  channelOrder: string,
 ): VideoFrame | null {
   if (!isBrowser || !shape) return null;
   const [, height, width, channels] = shape;
@@ -168,7 +182,7 @@ function decodeRawFrame(
     const r = bytes[base + (useBgr ? 2 : 0)] ?? 0;
     const g = bytes[base + 1] ?? 0;
     const b = bytes[base + (useBgr ? 0 : 2)] ?? 0;
-    const a = channels === 4 ? bytes[base + 3] ?? 255 : 255;
+    const a = channels === 4 ? (bytes[base + 3] ?? 255) : 255;
     const out = i * 4;
     rgba[out] = r;
     rgba[out + 1] = g;

--- a/src/video/image-decode.ts
+++ b/src/video/image-decode.ts
@@ -41,7 +41,7 @@ export async function rasterizeBitmap(bitmap: ImageBitmap): Promise<ImageData> {
       "Rasterizing a frame returned as an ImageBitmap requires an image " +
         "rasterizer (a browser with OffscreenCanvas, or the optional " +
         "`skia-canvas` package on Node). " +
-        `Original error: ${(err as Error).message}`
+        `Original error: ${(err as Error).message}`,
     );
   }
 }
@@ -84,7 +84,7 @@ export async function decodeEncoded(bytes: Uint8Array): Promise<ImageData> {
     throw new Error(
       "Decoding undecoded JPEG/PNG image bytes requires an image decoder " +
         "(a browser, or the optional `skia-canvas` package on Node). " +
-        `Original error: ${(err as Error).message}`
+        `Original error: ${(err as Error).message}`,
     );
   }
 }

--- a/src/video/image-source.ts
+++ b/src/video/image-source.ts
@@ -20,7 +20,9 @@ export function setImageBytesReader(reader: ImageBytesReader | null): void {
 }
 
 /** Register the DEFAULT reader (called by the Node-only `node-image-reader`). */
-export function setDefaultImageBytesReader(reader: ImageBytesReader | null): void {
+export function setDefaultImageBytesReader(
+  reader: ImageBytesReader | null,
+): void {
   _default = reader;
 }
 

--- a/src/video/image-video.ts
+++ b/src/video/image-video.ts
@@ -50,7 +50,7 @@ export function computePrefetchWindow(
   last: number | null,
   length: number,
   ahead: number,
-  behind: number
+  behind: number,
 ): number[] {
   const dir = last === null || current >= last ? 1 : -1;
   const out: number[] = [];
@@ -106,13 +106,16 @@ export class ImageVideoBackend implements VideoBackend {
       prefetchConcurrency: number;
       prefetchAhead: number;
       prefetchBehind: number;
-    }
+    },
   ) {
     this.filename = filename;
     this.reader = reader;
     this.shape = shape;
     this.bytesCache = new LruCache(cfg.bytesCacheBytes, (b) => b.byteLength);
-    this.decodedCache = new LruCache(cfg.decodedCacheBytes, (f) => f.data.byteLength);
+    this.decodedCache = new LruCache(
+      cfg.decodedCacheBytes,
+      (f) => f.data.byteLength,
+    );
     this.prefetchConcurrency = cfg.prefetchConcurrency;
     this.prefetchAhead = cfg.prefetchAhead;
     this.prefetchBehind = cfg.prefetchBehind;
@@ -129,7 +132,7 @@ export class ImageVideoBackend implements VideoBackend {
       throw new Error(
         "ImageVideoBackend requires an image-bytes reader, but none is " +
           "injected. On desktop/Node a default is registered; in the browser " +
-          "supply one via setImageBytesReader()."
+          "supply one via setImageBytesReader().",
       );
     }
     const frames = opts.filename.length;
@@ -156,10 +159,11 @@ export class ImageVideoBackend implements VideoBackend {
       {
         bytesCacheBytes: opts.bytesCacheBytes ?? DEFAULT_BYTES_CACHE,
         decodedCacheBytes: opts.decodedCacheBytes ?? DEFAULT_DECODED_CACHE,
-        prefetchConcurrency: opts.prefetchConcurrency ?? DEFAULT_PREFETCH_CONCURRENCY,
+        prefetchConcurrency:
+          opts.prefetchConcurrency ?? DEFAULT_PREFETCH_CONCURRENCY,
         prefetchAhead: opts.prefetchAhead ?? DEFAULT_PREFETCH_AHEAD,
         prefetchBehind: opts.prefetchBehind ?? DEFAULT_PREFETCH_BEHIND,
-      }
+      },
     );
     // Seed the cache with frame 0 (decoded up front when no shape was given).
     if (seedBytes) be.bytesCache.set(0, seedBytes);
@@ -211,7 +215,7 @@ export class ImageVideoBackend implements VideoBackend {
   prefetch(indices: number[]): Promise<void> {
     const gen = ++this.prefetchGen;
     const queue = [...new Set(indices)].filter(
-      (i) => i >= 0 && i < this.filename.length && !this.bytesCache.has(i)
+      (i) => i >= 0 && i < this.filename.length && !this.bytesCache.has(i),
     );
     let next = 0;
     const worker = async (): Promise<void> => {
@@ -227,7 +231,7 @@ export class ImageVideoBackend implements VideoBackend {
     };
     const n = Math.min(this.prefetchConcurrency, queue.length);
     return Promise.all(Array.from({ length: n }, () => worker())).then(
-      () => undefined
+      () => undefined,
     );
   }
 
@@ -238,7 +242,7 @@ export class ImageVideoBackend implements VideoBackend {
       this.lastIndex,
       this.filename.length,
       this.prefetchAhead,
-      this.prefetchBehind
+      this.prefetchBehind,
     );
     this.lastIndex = frameIndex;
     this.lastPrefetch = this.prefetch(window);

--- a/src/video/lru-cache.ts
+++ b/src/video/lru-cache.ts
@@ -18,7 +18,7 @@ export class LruCache<K, V> {
    */
   constructor(
     private readonly maxBytes: number,
-    private readonly sizeOf: (value: V) => number
+    private readonly sizeOf: (value: V) => number,
   ) {}
 
   get size(): number {

--- a/src/video/media-video.ts
+++ b/src/video/media-video.ts
@@ -28,10 +28,16 @@ export class MediaVideoBackend implements VideoBackend {
         if (!this.video || !this.canvas) return;
         this.canvas.width = this.video.videoWidth;
         this.canvas.height = this.video.videoHeight;
-        this.fps = this.video.duration ? this.video.videoHeight ? undefined : undefined : undefined;
+        this.fps = this.video.duration
+          ? this.video.videoHeight
+            ? undefined
+            : undefined
+          : undefined;
         resolve();
       });
-      this.video?.addEventListener("error", () => reject(new Error("Failed to load video")));
+      this.video?.addEventListener("error", () =>
+        reject(new Error("Failed to load video")),
+      );
     });
   }
 
@@ -39,7 +45,8 @@ export class MediaVideoBackend implements VideoBackend {
     if (!this.video || !this.ctx || !this.canvas) return null;
     await this.ready;
     const duration = this.video.duration;
-    const frameCount = Math.floor(duration * (this.video?.playbackRate || 1) * 30) || 1;
+    const frameCount =
+      Math.floor(duration * (this.video?.playbackRate || 1) * 30) || 1;
     const fps = duration ? frameCount / duration : 30;
     const targetTime = frameIndex / fps;
 

--- a/src/video/mediabunny-video.ts
+++ b/src/video/mediabunny-video.ts
@@ -43,7 +43,7 @@ export class MediaBunnyVideoBackend implements VideoBackend {
 
   static async fromUrl(
     url: string,
-    options?: MediaBunnyOptions
+    options?: MediaBunnyOptions,
   ): Promise<MediaBunnyVideoBackend> {
     const backend = new MediaBunnyVideoBackend(url, options);
     backend.input = new Input({
@@ -57,7 +57,7 @@ export class MediaBunnyVideoBackend implements VideoBackend {
   static async fromBlob(
     blob: Blob,
     filename: string,
-    options?: MediaBunnyOptions
+    options?: MediaBunnyOptions,
   ): Promise<MediaBunnyVideoBackend> {
     const backend = new MediaBunnyVideoBackend(filename, options);
     backend.input = new Input({
@@ -92,7 +92,7 @@ export class MediaBunnyVideoBackend implements VideoBackend {
       this._frameTimes = [];
       this.sink = null;
       throw new Error(
-        `Failed to build frame time index: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to build frame time index: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
@@ -137,7 +137,9 @@ export class MediaBunnyVideoBackend implements VideoBackend {
     return this.decodeSingleFrame(frameIndex);
   }
 
-  private async decodeSingleFrame(frameIndex: number): Promise<VideoFrame | null> {
+  private async decodeSingleFrame(
+    frameIndex: number,
+  ): Promise<VideoFrame | null> {
     if (!this.sink) throw new Error("Backend not initialized");
 
     const timestamp = this._frameTimes[frameIndex];
@@ -180,7 +182,10 @@ export class MediaBunnyVideoBackend implements VideoBackend {
     }
   }
 
-  async getFrames(startIndex: number, endIndex: number): Promise<Map<number, ImageBitmap>> {
+  async getFrames(
+    startIndex: number,
+    endIndex: number,
+  ): Promise<Map<number, ImageBitmap>> {
     await this.prefetch(startIndex, endIndex);
 
     const result = new Map<number, ImageBitmap>();
@@ -193,7 +198,10 @@ export class MediaBunnyVideoBackend implements VideoBackend {
     return result;
   }
 
-  private async decodeRange(startIndex: number, endIndex: number): Promise<void> {
+  private async decodeRange(
+    startIndex: number,
+    endIndex: number,
+  ): Promise<void> {
     if (!this.sink) throw new Error("Backend not initialized");
 
     const sink = this.sink;

--- a/src/video/mp4box-video.ts
+++ b/src/video/mp4box-video.ts
@@ -1,7 +1,11 @@
 import { VideoBackend, VideoFrame } from "./backend.js";
 
-const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
-const hasWebCodecs = isBrowser && typeof window.VideoDecoder !== "undefined" && typeof window.EncodedVideoChunk !== "undefined";
+const isBrowser =
+  typeof window !== "undefined" && typeof document !== "undefined";
+const hasWebCodecs =
+  isBrowser &&
+  typeof window.VideoDecoder !== "undefined" &&
+  typeof window.EncodedVideoChunk !== "undefined";
 const MP4BOX_CDN = "https://unpkg.com/mp4box@0.5.4/dist/mp4box.all.min.js";
 
 async function loadMp4box(): Promise<any> {
@@ -66,14 +70,18 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   private decodeQueue: Promise<void>;
   private latestRequestedFrame: number | null;
 
-  constructor(source: string | File | Blob, options?: { cacheSize?: number; lookahead?: number }) {
+  constructor(
+    source: string | File | Blob,
+    options?: { cacheSize?: number; lookahead?: number },
+  ) {
     if (!hasWebCodecs) {
       throw new Error("Mp4BoxVideoBackend requires WebCodecs support.");
     }
     if (!isBrowser) {
       throw new Error("Mp4BoxVideoBackend requires a browser environment.");
     }
-    this.filename = source instanceof Blob ? (source as File).name ?? "" : source;
+    this.filename =
+      source instanceof Blob ? ((source as File).name ?? "") : source;
     this.dataset = null;
     this.samples = [];
     this.keyframeIndices = [];
@@ -97,7 +105,10 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     this.ready = this.init();
   }
 
-  async getFrame(frameIndex: number, signal?: AbortSignal): Promise<VideoFrame | null> {
+  async getFrame(
+    frameIndex: number,
+    signal?: AbortSignal,
+  ): Promise<VideoFrame | null> {
     await this.ready;
     if (frameIndex < 0 || frameIndex >= this.samples.length) return null;
 
@@ -117,7 +128,10 @@ export class Mp4BoxVideoBackend implements VideoBackend {
       if (signal?.aborted) return;
 
       const keyframe = this.findKeyframeBefore(frameIndex);
-      const end = Math.min(frameIndex + this.lookahead, this.samples.length - 1);
+      const end = Math.min(
+        frameIndex + this.lookahead,
+        this.samples.length - 1,
+      );
       await this.decodeRange(keyframe, end, frameIndex);
     });
     await this.decodeQueue;
@@ -178,7 +192,9 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     this.videoTrack = info.videoTracks[0];
     const trak = this.mp4boxFile.getTrackById(this.videoTrack.id);
     const description = this.getCodecDescription(trak);
-    const codec = this.videoTrack.codec.startsWith("vp08") ? "vp8" : this.videoTrack.codec;
+    const codec = this.videoTrack.codec.startsWith("vp08")
+      ? "vp8"
+      : this.videoTrack.codec;
     this.config = {
       codec,
       codedWidth: this.videoTrack.video.width,
@@ -231,7 +247,9 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   private async readChunk(offset: number, size: number): Promise<ArrayBuffer> {
     const end = Math.min(offset + size, this.fileSize);
     if (this.supportsRangeRequests) {
-      const response = await fetch(this.filename, { headers: { Range: `bytes=${offset}-${end - 1}` } });
+      const response = await fetch(this.filename, {
+        headers: { Range: `bytes=${offset}-${end - 1}` },
+      });
       return await response.arrayBuffer();
     }
     if (this.fileBlob) {
@@ -277,7 +295,9 @@ export class Mp4BoxVideoBackend implements VideoBackend {
 
   private getCodecDescription(trak: any): Uint8Array | undefined {
     const entries = trak?.mdia?.minf?.stbl?.stsd?.entries ?? [];
-    const dataStream = (globalThis as { DataStream?: any }).DataStream ?? this.mp4box?.DataStream;
+    const dataStream =
+      (globalThis as { DataStream?: any }).DataStream ??
+      this.mp4box?.DataStream;
     if (!dataStream) return undefined;
 
     for (const entry of entries) {
@@ -290,7 +310,9 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     return undefined;
   }
 
-  private async readSampleDataByDecodeOrder(samplesToFeed: Array<{ pi: number; sample: Sample }>): Promise<Map<number, Uint8Array>> {
+  private async readSampleDataByDecodeOrder(
+    samplesToFeed: Array<{ pi: number; sample: Sample }>,
+  ): Promise<Map<number, Uint8Array>> {
     const results = new Map<number, Uint8Array>();
     let i = 0;
 
@@ -302,7 +324,10 @@ export class Mp4BoxVideoBackend implements VideoBackend {
       while (regionEnd < samplesToFeed.length - 1) {
         const current = samplesToFeed[regionEnd];
         const next = samplesToFeed[regionEnd + 1];
-        if (next.sample.offset === current.sample.offset + current.sample.size) {
+        if (
+          next.sample.offset ===
+          current.sample.offset + current.sample.size
+        ) {
           regionEnd += 1;
           regionBytes += next.sample.size;
         } else {
@@ -316,7 +341,10 @@ export class Mp4BoxVideoBackend implements VideoBackend {
 
       for (let j = i; j <= regionEnd; j += 1) {
         const { sample } = samplesToFeed[j];
-        results.set(sample.decodeIndex, bufferView.slice(bufferOffset, bufferOffset + sample.size));
+        results.set(
+          sample.decodeIndex,
+          bufferView.slice(bufferOffset, bufferOffset + sample.size),
+        );
         bufferOffset += sample.size;
       }
 
@@ -326,7 +354,11 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     return results;
   }
 
-  private async decodeRange(start: number, end: number, target: number): Promise<void> {
+  private async decodeRange(
+    start: number,
+    end: number,
+    target: number,
+  ): Promise<void> {
     if (!this.config) throw new Error("Decoder not configured");
 
     if (this.decoder) {
@@ -347,7 +379,10 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     const toFeed: Array<{ pi: number; sample: Sample }> = [];
     for (let i = 0; i < this.samples.length; i += 1) {
       const sample = this.samples[i];
-      if (sample.decodeIndex >= minDecodeIndex && sample.decodeIndex <= maxDecodeIndex) {
+      if (
+        sample.decodeIndex >= minDecodeIndex &&
+        sample.decodeIndex <= maxDecodeIndex
+      ) {
         toFeed.push({ pi: i, sample });
       }
     }
@@ -392,7 +427,11 @@ export class Mp4BoxVideoBackend implements VideoBackend {
           if (decodedCount >= toFeed.length) resolveComplete();
         };
 
-        if (frameIndex !== undefined && frameIndex >= cacheStart && frameIndex <= cacheEnd) {
+        if (
+          frameIndex !== undefined &&
+          frameIndex >= cacheStart &&
+          frameIndex <= cacheEnd
+        ) {
           createImageBitmap(frame)
             .then((bitmap) => {
               this.addToCache(frameIndex as number, bitmap);
@@ -426,7 +465,7 @@ export class Mp4BoxVideoBackend implements VideoBackend {
             timestamp: sample.timestamp,
             duration: sample.duration,
             data,
-          })
+          }),
         );
       }
       if (i + BATCH_SIZE < toFeed.length) {

--- a/src/video/seq-video.ts
+++ b/src/video/seq-video.ts
@@ -30,7 +30,13 @@ const IMAGE_FORMAT_CODES: Record<number, string> = {
   2: "png", // Color PNG compressed
 };
 
-const COMPRESSED_CODECS = new Set(["monojpg", "jpg", "jbrgb", "monopng", "png"]);
+const COMPRESSED_CODECS = new Set([
+  "monojpg",
+  "jpg",
+  "jbrgb",
+  "monopng",
+  "png",
+]);
 const BAYER_CODECS = new Set(["brgb8", "jbrgb"]);
 
 const HEADER_SIZE = 1024;
@@ -81,7 +87,7 @@ let fileByteSourceFactory: FileByteSourceFactory | null = null;
 
 /** Register the Node `node:fs`-backed byte source factory (see `seq-node.ts`). */
 export function setSeqFileByteSourceFactory(
-  factory: FileByteSourceFactory | null
+  factory: FileByteSourceFactory | null,
 ): void {
   fileByteSourceFactory = factory;
 }
@@ -90,7 +96,7 @@ function createFileByteSource(path: string): ByteSource {
   if (!fileByteSourceFactory) {
     throw new Error(
       "Reading .seq files from a path requires the Node entry point " +
-        "(`@talmolab/sleap-io.js`). In the browser, pass a File/Blob instead."
+        "(`@talmolab/sleap-io.js`). In the browser, pass a File/Blob instead.",
     );
   }
   return fileByteSourceFactory(path);
@@ -120,7 +126,9 @@ export class SeqHeader {
 
   /** Human-readable codec name (e.g. `"monoraw"`). */
   get codecName(): string {
-    return IMAGE_FORMAT_CODES[this.imageFormat] ?? `unknown(${this.imageFormat})`;
+    return (
+      IMAGE_FORMAT_CODES[this.imageFormat] ?? `unknown(${this.imageFormat})`
+    );
   }
 
   /** Whether frames use variable-length compression (JPEG/PNG). */
@@ -148,7 +156,7 @@ export class SeqHeader {
     if (magic !== MAGIC) {
       throw new Error(
         `Invalid .seq magic: 0x${magic.toString(16).toUpperCase()} ` +
-          `(expected 0x${MAGIC.toString(16).toUpperCase()})`
+          `(expected 0x${MAGIC.toString(16).toUpperCase()})`,
       );
     }
 
@@ -232,7 +240,7 @@ export class SeqIndex {
    */
   static async buildCompressed(
     source: ByteSource,
-    header: SeqHeader
+    header: SeqHeader,
   ): Promise<SeqIndex> {
     const fileSize = await source.size();
     const nMax = header.numFrames > 0 ? header.numFrames : 10_000_000;
@@ -268,7 +276,7 @@ export class SeqIndex {
           const candSize = new DataView(
             probe.buffer,
             probe.byteOffset,
-            6
+            6,
           ).getUint32(0, true);
           const m0 = probe[4];
           const m1 = probe[5];
@@ -291,10 +299,11 @@ export class SeqIndex {
       // (size + magic) and require all 6 to be present, matching Python's scan.
       const check = await source.read(nextOffset, 6);
       if (check.length < 6) break;
-      const checkSize = new DataView(check.buffer, check.byteOffset, 6).getUint32(
-        0,
-        true
-      );
+      const checkSize = new DataView(
+        check.buffer,
+        check.byteOffset,
+        6,
+      ).getUint32(0, true);
       if (checkSize === 0 || checkSize > fileSize) break;
 
       offsets.push(nextOffset);
@@ -308,30 +317,38 @@ export class SeqIndex {
 // Image decoding helpers
 // =============================================================================
 
-const hasGlobalImageData = typeof globalThis !== "undefined" &&
+const hasGlobalImageData =
+  typeof globalThis !== "undefined" &&
   typeof (globalThis as { ImageData?: unknown }).ImageData !== "undefined";
 
 /** Construct an `ImageData` from RGBA bytes, in browser or Node (skia-canvas). */
 async function makeImageData(
   rgba: Uint8ClampedArray<ArrayBuffer>,
   width: number,
-  height: number
+  height: number,
 ): Promise<ImageData> {
   if (hasGlobalImageData) {
     return new ImageData(rgba, width, height);
   }
   try {
     const sc = await import("skia-canvas");
-    return new (sc as unknown as {
-      ImageData: new (
-        d: Uint8ClampedArray<ArrayBuffer>,
-        w: number,
-        h: number
-      ) => ImageData;
-    }).ImageData(rgba, width, height);
+    return new (
+      sc as unknown as {
+        ImageData: new (
+          d: Uint8ClampedArray<ArrayBuffer>,
+          w: number,
+          h: number,
+        ) => ImageData;
+      }
+    ).ImageData(rgba, width, height);
   } catch {
     // Last-resort duck-typed frame: consumers only read width/height/data.
-    return { data: rgba, width, height, colorSpace: "srgb" } as unknown as ImageData;
+    return {
+      data: rgba,
+      width,
+      height,
+      colorSpace: "srgb",
+    } as unknown as ImageData;
   }
 }
 
@@ -357,10 +374,13 @@ async function decodeEncoded(bytes: Uint8Array): Promise<ImageData> {
     const src =
       typeof Buffer !== "undefined" ? Buffer.from(bytes) : (bytes as unknown);
     const img = await (
-      sc as unknown as { loadImage: (b: unknown) => Promise<{ width: number; height: number }> }
+      sc as unknown as {
+        loadImage: (b: unknown) => Promise<{ width: number; height: number }>;
+      }
     ).loadImage(src);
-    const Canvas = (sc as unknown as { Canvas: new (w: number, h: number) => unknown })
-      .Canvas;
+    const Canvas = (
+      sc as unknown as { Canvas: new (w: number, h: number) => unknown }
+    ).Canvas;
     const canvas = new Canvas(img.width, img.height) as {
       getContext: (t: string) => {
         drawImage: (i: unknown, x: number, y: number) => void;
@@ -374,7 +394,7 @@ async function decodeEncoded(bytes: Uint8Array): Promise<ImageData> {
     throw new Error(
       "Decoding JPEG/PNG frames in .seq files requires an image decoder " +
         "(a browser, or the optional `skia-canvas` package on Node). " +
-        `Original error: ${(err as Error).message}`
+        `Original error: ${(err as Error).message}`,
     );
   }
 }
@@ -407,7 +427,7 @@ export class SeqVideoBackend implements VideoBackend {
     source: ByteSource,
     header: SeqHeader,
     index: SeqIndex,
-    fps: number | undefined
+    fps: number | undefined,
   ) {
     this.filename = filename;
     this.source = source;
@@ -421,7 +441,9 @@ export class SeqVideoBackend implements VideoBackend {
   /** Open a `.seq` file from a path (Node) or a `File`/`Blob` (browser). */
   static async create(source: string | File | Blob): Promise<SeqVideoBackend> {
     const isBlob = typeof Blob !== "undefined" && source instanceof Blob;
-    const filename = isBlob ? ((source as File).name ?? "") : (source as string);
+    const filename = isBlob
+      ? ((source as File).name ?? "")
+      : (source as string);
     const byteSource = isBlob
       ? new BlobByteSource(source as Blob)
       : createFileByteSource(source as string);
@@ -431,14 +453,14 @@ export class SeqVideoBackend implements VideoBackend {
       if (BAYER_CODECS.has(header.codecName)) {
         throw new Error(
           `Bayer codec '${header.codecName}' is not supported in .seq files. ` +
-            "Convert the file to a standard format first."
+            "Convert the file to a standard format first.",
         );
       }
       const index = header.isCompressed
         ? await SeqIndex.buildCompressed(byteSource, header)
         : SeqIndex.buildUncompressed(header);
       const fps = await computeFps(byteSource, header, index, (i, h) =>
-        readTimestamp(byteSource, h, index, i)
+        readTimestamp(byteSource, h, index, i),
       );
       return new SeqVideoBackend(filename, byteSource, header, index, fps);
     } catch (err) {
@@ -462,7 +484,12 @@ export class SeqVideoBackend implements VideoBackend {
     if (idx < 0) idx = this.index.numFrames + idx;
     if (idx < 0 || idx >= this.index.numFrames) return null;
 
-    const data = await readFrameData(this.source, this.headerData, this.index, idx);
+    const data = await readFrameData(
+      this.source,
+      this.headerData,
+      this.index,
+      idx,
+    );
     return decodeFrame(this.headerData, data);
   }
 
@@ -473,7 +500,9 @@ export class SeqVideoBackend implements VideoBackend {
   async getTimestamps(): Promise<number[]> {
     const out: number[] = [];
     for (let i = 0; i < this.index.numFrames; i++) {
-      out.push(await readTimestamp(this.source, this.headerData, this.index, i));
+      out.push(
+        await readTimestamp(this.source, this.headerData, this.index, i),
+      );
     }
     return out;
   }
@@ -484,7 +513,7 @@ export class SeqVideoBackend implements VideoBackend {
     if (idx < 0) idx = this.index.numFrames + idx;
     if (idx < 0 || idx >= this.index.numFrames) {
       throw new Error(
-        `Frame ${frameIndex} out of range [0, ${this.index.numFrames})`
+        `Frame ${frameIndex} out of range [0, ${this.index.numFrames})`,
       );
     }
     return readTimestamp(this.source, this.headerData, this.index, idx);
@@ -514,10 +543,13 @@ export class SeqVideoBackend implements VideoBackend {
 /** Read the compressed frame's leading 4-byte size field (includes itself). */
 async function readCompressedFrameSize(
   source: ByteSource,
-  offset: number
+  offset: number,
 ): Promise<number> {
   const sizeBytes = await source.read(offset, 4);
-  return new DataView(sizeBytes.buffer, sizeBytes.byteOffset, 4).getUint32(0, true);
+  return new DataView(sizeBytes.buffer, sizeBytes.byteOffset, 4).getUint32(
+    0,
+    true,
+  );
 }
 
 /** Read the raw (possibly compressed) bytes of a frame. */
@@ -525,7 +557,7 @@ async function readFrameData(
   source: ByteSource,
   header: SeqHeader,
   index: SeqIndex,
-  frameIdx: number
+  frameIdx: number,
 ): Promise<Uint8Array> {
   const offset = index.frameOffset(frameIdx);
   if (header.isCompressed) {
@@ -540,7 +572,7 @@ async function readTimestamp(
   source: ByteSource,
   header: SeqHeader,
   index: SeqIndex,
-  frameIdx: number
+  frameIdx: number,
 ): Promise<number> {
   // The timestamp directly follows the image data. Its position is nominal in
   // both cases (matching Python's value for well-formed files) — no need to read
@@ -565,7 +597,10 @@ async function readTimestamp(
 }
 
 /** Decode raw frame bytes into an RGBA `ImageData`. */
-async function decodeFrame(header: SeqHeader, data: Uint8Array): Promise<ImageData> {
+async function decodeFrame(
+  header: SeqHeader,
+  data: Uint8Array,
+): Promise<ImageData> {
   const codec = header.codecName;
   const h = header.height;
   const w = header.width;
@@ -617,7 +652,7 @@ async function computeFps(
   source: ByteSource,
   header: SeqHeader,
   index: SeqIndex,
-  read: (i: number, h: SeqHeader) => Promise<number>
+  read: (i: number, h: SeqHeader) => Promise<number>,
 ): Promise<number | undefined> {
   const fallback = header.fps >= 1.0 ? header.fps : undefined;
   try {

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -10,7 +10,8 @@ import {
   readEmbeddedFrameBytes,
 } from "./embedded-frame.js";
 
-const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+const isBrowser =
+  typeof window !== "undefined" && typeof document !== "undefined";
 
 /**
  * Video backend for embedded images in HDF5 files accessed via streaming.
@@ -58,7 +59,9 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     // Build O(1) lookup map from frame numbers
     const frameNumbers = options.frameNumbers ?? [];
     this.frameNumbers = frameNumbers;
-    this.frameNumberToIndex = new Map(frameNumbers.map((num, idx) => [num, idx]));
+    this.frameNumberToIndex = new Map(
+      frameNumbers.map((num, idx) => [num, idx]),
+    );
     this.format = options.format ?? "png";
     this.channelOrder = options.channelOrder ?? "RGB";
     this.frameSizes = options.frameSizes;
@@ -70,9 +73,10 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
 
   async getFrame(frameIndex: number): Promise<VideoFrame | null> {
     // Use O(1) Map lookup; if no frame numbers provided, use frameIndex directly
-    const index = this.frameNumberToIndex.size > 0
-      ? this.frameNumberToIndex.get(frameIndex)
-      : frameIndex;
+    const index =
+      this.frameNumberToIndex.size > 0
+        ? this.frameNumberToIndex.get(frameIndex)
+        : frameIndex;
     if (index === undefined) return null;
 
     let rawBytes: Uint8Array | null;
@@ -84,7 +88,11 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     if (!rawBytes || rawBytes.length === 0) return null;
 
     if (isEncodedFormat(this.format)) {
-      const decoded = await decodeImageBytes(rawBytes, this.format, this.channelOrder);
+      const decoded = await decodeImageBytes(
+        rawBytes,
+        this.format,
+        this.channelOrder,
+      );
       return decoded ?? rawBytes;
     }
 
@@ -100,7 +108,11 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
       if (!rawBytes || rawBytes.length === 0) return;
 
       if (isEncodedFormat(this.format)) {
-        const decoded = await decodeImageBytes(rawBytes, this.format, this.channelOrder);
+        const decoded = await decodeImageBytes(
+          rawBytes,
+          this.format,
+          this.channelOrder,
+        );
         if (decoded && "width" in decoded && "height" in decoded) {
           // Use source frame count if available, otherwise infer from max frame number
           let fc = sourceFrameCount ?? 0;
@@ -118,7 +130,9 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
           this.shape = [fc, decoded.height, decoded.width, channels];
         }
       }
-    } catch { /* probe failed, shape stays undefined */ }
+    } catch {
+      /* probe failed, shape stays undefined */
+    }
   }
 
   /** Build a single-frame reader bound to the streaming worker file. */
@@ -164,7 +178,7 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
 async function decodeImageBytes(
   bytes: Uint8Array,
   format: string,
-  channelOrder: string
+  channelOrder: string,
 ): Promise<VideoFrame | null> {
   if (!isBrowser || typeof createImageBitmap === "undefined") return null;
   const mime = format.toLowerCase() === "png" ? "image/png" : "image/jpeg";
@@ -203,7 +217,7 @@ async function decodeImageBytes(
 function decodeRawFrame(
   bytes: Uint8Array,
   shape: [number, number, number, number] | undefined,
-  channelOrder: string
+  channelOrder: string,
 ): VideoFrame | null {
   if (!isBrowser || !shape) return null;
   const [, height, width, channels] = shape;
@@ -220,7 +234,7 @@ function decodeRawFrame(
     const r = bytes[base + (useBgr ? 2 : 0)] ?? 0;
     const g = bytes[base + 1] ?? 0;
     const b = bytes[base + (useBgr ? 0 : 2)] ?? 0;
-    const a = channels === 4 ? bytes[base + 3] ?? 255 : 255;
+    const a = channels === 4 ? (bytes[base + 3] ?? 255) : 255;
     const out = i * 4;
     rgba[out] = r;
     rgba[out + 1] = g;

--- a/tests/bbox.test.ts
+++ b/tests/bbox.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, expect } from "./bun-test";
-import { BoundingBox, UserBoundingBox, PredictedBoundingBox } from "../src/model/bbox.js";
+import {
+  BoundingBox,
+  UserBoundingBox,
+  PredictedBoundingBox,
+} from "../src/model/bbox.js";
 import "../src/model/mask.js"; // Ensure mask factory is registered
 
 describe("BoundingBox", () => {
   it("is abstract — cannot be instantiated directly", () => {
-    expect(() => new (BoundingBox as any)({ x1: 0, y1: 10, x2: 100, y2: 90 })).toThrow(TypeError);
+    expect(
+      () => new (BoundingBox as any)({ x1: 0, y1: 10, x2: 100, y2: 90 }),
+    ).toThrow(TypeError);
   });
 
   it("constructs with defaults", () => {
@@ -58,7 +64,10 @@ describe("BoundingBox", () => {
 
   it("corners handles rotation", () => {
     const bb = new UserBoundingBox({
-      x1: -1, y1: -1, x2: 1, y2: 1,
+      x1: -1,
+      y1: -1,
+      x2: 1,
+      y2: 1,
       angle: Math.PI / 4, // 45 degrees
     });
     expect(bb.isRotated).toBe(true);
@@ -120,7 +129,11 @@ describe("BoundingBox", () => {
 describe("PredictedBoundingBox", () => {
   it("has score and isPredicted", () => {
     const bb = new PredictedBoundingBox({
-      x1: 0, y1: 10, x2: 100, y2: 90, score: 0.95,
+      x1: 0,
+      y1: 10,
+      x2: 100,
+      y2: 90,
+      score: 0.95,
     });
     expect(bb.score).toBe(0.95);
     expect(bb.isPredicted).toBe(true);

--- a/tests/browser-bundle.test.ts
+++ b/tests/browser-bundle.test.ts
@@ -81,7 +81,10 @@ describe("Browser bundle isolation (issue #70)", () => {
 
       for (const pattern of NODE_ONLY_PATTERNS) {
         const match = content.match(pattern);
-        expect(match, `${fileName} contains Node-only import: ${match?.[0]}`).toBeNull();
+        expect(
+          match,
+          `${fileName} contains Node-only import: ${match?.[0]}`,
+        ).toBeNull();
       }
     }
   });

--- a/tests/bun-test.ts
+++ b/tests/bun-test.ts
@@ -53,8 +53,7 @@ const stubbedGlobals = new Map<string, PropertyDescriptor | undefined>();
 /** Minimal `vi` shim covering the vitest APIs used in this repo. */
 export const vi = {
   /** vitest `vi.fn` -> bun `mock`. */
-  fn: (impl?: (...args: never[]) => unknown) =>
-    mock(impl ?? (() => undefined)),
+  fn: (impl?: (...args: never[]) => unknown) => mock(impl ?? (() => undefined)),
 
   /** vitest `vi.spyOn` -> bun `spyOn`. */
   spyOn,

--- a/tests/centroid.test.ts
+++ b/tests/centroid.test.ts
@@ -34,7 +34,9 @@ describe("Centroid", () => {
   it("constructs UserCentroid with all options", () => {
     const track = new Track("track1");
     const c = new UserCentroid({
-      x: 100, y: 200, z: 1.5,
+      x: 100,
+      y: 200,
+      z: 1.5,
       track,
       trackingScore: 0.8,
       category: "cell",
@@ -90,7 +92,13 @@ describe("Centroid", () => {
 
   it("toInstance creates PredictedInstance from PredictedCentroid", () => {
     const track = new Track("t");
-    const c = new PredictedCentroid({ x: 50, y: 60, score: 0.9, track, trackingScore: 0.5 });
+    const c = new PredictedCentroid({
+      x: 50,
+      y: 60,
+      score: 0.9,
+      track,
+      trackingScore: 0.5,
+    });
     const inst = c.toInstance();
     expect(inst).toBeInstanceOf(PredictedInstance);
     expect((inst as PredictedInstance).score).toBe(0.9);
@@ -181,7 +189,9 @@ describe("Centroid", () => {
   it("fromInstance throws with no visible points", () => {
     const skel = new Skeleton(["a"]);
     const inst = new Instance({
-      points: [{ xy: [Number.NaN, Number.NaN], visible: false, complete: false }],
+      points: [
+        { xy: [Number.NaN, Number.NaN], visible: false, complete: false },
+      ],
       skeleton: skel,
     });
     expect(() => Centroid.fromInstance(inst)).toThrow(/No visible points/);
@@ -193,7 +203,9 @@ describe("Centroid", () => {
       points: [{ xy: [10, 20], visible: true, complete: true }],
       skeleton: skel,
     });
-    expect(() => Centroid.fromInstance(inst, { method: "invalid" })).toThrow(/Unknown method/);
+    expect(() => Centroid.fromInstance(inst, { method: "invalid" })).toThrow(
+      /Unknown method/,
+    );
   });
 });
 
@@ -213,7 +225,9 @@ describe("Instance.centroidXy", () => {
   it("returns null when no points visible", () => {
     const skel = new Skeleton(["a"]);
     const inst = new Instance({
-      points: [{ xy: [Number.NaN, Number.NaN], visible: false, complete: false }],
+      points: [
+        { xy: [Number.NaN, Number.NaN], visible: false, complete: false },
+      ],
       skeleton: skel,
     });
     expect(inst.centroidXy).toBeNull();
@@ -248,7 +262,9 @@ describe("Labels.getCentroids", () => {
     const lf1v1 = new LabeledFrame({ video: v1, frameIdx: 1 });
     lf1v1.centroids.push(new UserCentroid({ x: 3, y: 4 }));
     const lf0v2 = new LabeledFrame({ video: v2, frameIdx: 0 });
-    lf0v2.centroids.push(new PredictedCentroid({ x: 5, y: 6, score: 0.9, track: t1 }));
+    lf0v2.centroids.push(
+      new PredictedCentroid({ x: 5, y: 6, score: 0.9, track: t1 }),
+    );
 
     const labels = new Labels({
       labeledFrames: [lf0v1, lf1v1, lf0v2],

--- a/tests/codecs/dictionary.test.ts
+++ b/tests/codecs/dictionary.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from "../bun-test";
 import { loadSlp } from "../../src/io/main.js";
 import { toDict, fromDict } from "../../src/codecs/dictionary.js";
-import { Instance, PredictedInstance, Track } from "../../src/model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+} from "../../src/model/instance.js";
 import { LabeledFrame } from "../../src/model/labeled-frame.js";
 import { Labels } from "../../src/model/labels.js";
 import { Skeleton } from "../../src/model/skeleton.js";
@@ -13,7 +17,9 @@ import path from "node:path";
 const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 
 async function loadFixture(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+  });
 }
 
 describe("dictionary codec", () => {
@@ -56,7 +62,9 @@ describe("dictionary codec", () => {
       expect(frame.video_idx).toBe(0);
     });
 
-    const nonEmptyCount = labels.labeledFrames.filter((lf) => lf.instances.length > 0).length;
+    const nonEmptyCount = labels.labeledFrames.filter(
+      (lf) => lf.instances.length > 0,
+    ).length;
     const skipped = toDict(labels, { skipEmptyFrames: true });
     expect(skipped.labeled_frames.length).toBe(nonEmptyCount);
   });
@@ -86,8 +94,15 @@ describe("dictionary codec", () => {
       score: 0.8,
     });
 
-    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [instance1, instance2] });
-    const labels = new Labels({ labeledFrames: [lf], tracks: [track1, track2] });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instance1, instance2],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      tracks: [track1, track2],
+    });
 
     const data = toDict(labels);
     expect(data.tracks.length).toBe(2);
@@ -110,7 +125,11 @@ describe("dictionary codec", () => {
       ],
       skeleton,
     });
-    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [instance] })] });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [instance] }),
+      ],
+    });
     labels.provenance = { source: "test", metadata: { key: "value" } };
 
     const data = toDict(labels);
@@ -132,7 +151,12 @@ describe("dictionary codec", () => {
     const skeleton = new Skeleton({ nodes: ["node1"] });
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("animal1");
-    const instance = PredictedInstance.fromNumpy({ pointsData: [[1, 2]], skeleton, track, score: 0.95 });
+    const instance = PredictedInstance.fromNumpy({
+      pointsData: [[1, 2]],
+      skeleton,
+      track,
+      score: 0.95,
+    });
     const lf = new LabeledFrame({ video, frameIdx: 0, instances: [instance] });
     const labels = new Labels({ labeledFrames: [lf], tracks: [track] });
     labels.suggestions = [new SuggestionFrame({ video, frameIdx: 10 })];
@@ -156,7 +180,9 @@ describe("dictionary codec", () => {
     const labels = fromDict(data);
     expect(labels.labeledFrames.length).toBe(0);
 
-    expect(() => fromDict({ skeletons: [] } as any)).toThrow(/Missing required key/);
+    expect(() => fromDict({ skeletons: [] } as any)).toThrow(
+      /Missing required key/,
+    );
   });
 
   it("serializes tracking_score and from_predicted flag", () => {
@@ -164,13 +190,29 @@ describe("dictionary codec", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("animal1");
 
-    const predicted = PredictedInstance.fromNumpy({ pointsData: [[5, 6]], skeleton, track, score: 0.9 });
-    const user = Instance.fromNumpy({ pointsData: [[1, 2]], skeleton, track, fromPredicted: predicted });
+    const predicted = PredictedInstance.fromNumpy({
+      pointsData: [[5, 6]],
+      skeleton,
+      track,
+      score: 0.9,
+    });
+    const user = Instance.fromNumpy({
+      pointsData: [[1, 2]],
+      skeleton,
+      track,
+      fromPredicted: predicted,
+    });
     user.trackingScore = 0.85;
 
-    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [predicted, user] })] });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [predicted, user] }),
+      ],
+    });
     const data = toDict(labels);
-    const userDict = data.labeled_frames[0].instances.find((inst) => inst.type === "instance") as any;
+    const userDict = data.labeled_frames[0].instances.find(
+      (inst) => inst.type === "instance",
+    ) as any;
     expect(userDict.has_from_predicted).toBe(true);
     expect(userDict.tracking_score).toBeCloseTo(0.85);
   });
@@ -179,11 +221,18 @@ describe("dictionary codec", () => {
     const skeleton = new Skeleton({ nodes: ["node1"] });
     const video = new Video({
       filename: "test.mp4",
-      backend: { constructor: { name: "MediaVideo" }, shape: [1, 384, 384, 1] } as any,
+      backend: {
+        constructor: { name: "MediaVideo" },
+        shape: [1, 384, 384, 1],
+      } as any,
     });
 
     const instance = Instance.fromNumpy({ pointsData: [[1, 2]], skeleton });
-    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [instance] })] });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [instance] }),
+      ],
+    });
     const data = toDict(labels);
 
     const videoDict = data.videos[0];
@@ -202,11 +251,34 @@ describe("dictionary codec", () => {
   it("preserves negative frames in round-trip", () => {
     const skeleton = new Skeleton({ nodes: ["node1", "node2"] });
     const video = new Video({ filename: "test.mp4" });
-    const instance = Instance.fromNumpy({ pointsData: [[1, 2], [3, 4]], skeleton });
-    const normalFrame = new LabeledFrame({ video, frameIdx: 0, instances: [instance] });
-    const negativeFrame = new LabeledFrame({ video, frameIdx: 5, isNegative: true });
-    const negativeWithInst = new LabeledFrame({ video, frameIdx: 10, instances: [instance], isNegative: true });
-    const labels = new Labels({ labeledFrames: [normalFrame, negativeFrame, negativeWithInst], videos: [video], skeletons: [skeleton] });
+    const instance = Instance.fromNumpy({
+      pointsData: [
+        [1, 2],
+        [3, 4],
+      ],
+      skeleton,
+    });
+    const normalFrame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instance],
+    });
+    const negativeFrame = new LabeledFrame({
+      video,
+      frameIdx: 5,
+      isNegative: true,
+    });
+    const negativeWithInst = new LabeledFrame({
+      video,
+      frameIdx: 10,
+      instances: [instance],
+      isNegative: true,
+    });
+    const labels = new Labels({
+      labeledFrames: [normalFrame, negativeFrame, negativeWithInst],
+      videos: [video],
+      skeletons: [skeleton],
+    });
 
     const dict = toDict(labels);
     expect(dict.labeled_frames[0].is_negative).toBeUndefined();
@@ -223,10 +295,22 @@ describe("dictionary codec", () => {
     const skeleton = new Skeleton({ nodes: ["node1"] });
     const video = new Video({ filename: "test.mp4" });
     const instance = Instance.fromNumpy({ pointsData: [[1, 2]], skeleton });
-    const normalFrame = new LabeledFrame({ video, frameIdx: 0, instances: [instance] });
+    const normalFrame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instance],
+    });
     const emptyFrame = new LabeledFrame({ video, frameIdx: 1 }); // empty, not negative
-    const negativeFrame = new LabeledFrame({ video, frameIdx: 2, isNegative: true }); // empty but negative
-    const labels = new Labels({ labeledFrames: [normalFrame, emptyFrame, negativeFrame], videos: [video], skeletons: [skeleton] });
+    const negativeFrame = new LabeledFrame({
+      video,
+      frameIdx: 2,
+      isNegative: true,
+    }); // empty but negative
+    const labels = new Labels({
+      labeledFrames: [normalFrame, emptyFrame, negativeFrame],
+      videos: [video],
+      skeletons: [skeleton],
+    });
 
     const dict = toDict(labels, { skipEmptyFrames: true });
     // emptyFrame should be dropped, but negativeFrame should be kept

--- a/tests/codecs/frame-count.test.ts
+++ b/tests/codecs/frame-count.test.ts
@@ -32,9 +32,9 @@ describe("resolveSourceFrameCount", () => {
 
   it("derives max(frame_numbers)+1 when neither attr nor json count exists (PyQt pkg.slp)", () => {
     // mice_hc video0: frame_numbers up to 12167 -> seekbar extent 12168.
-    expect(
-      resolveSourceFrameCount({ frameNumbers: [214, 705, 12167] }),
-    ).toBe(12168);
+    expect(resolveSourceFrameCount({ frameNumbers: [214, 705, 12167] })).toBe(
+      12168,
+    );
   });
 
   it("returns undefined when nothing is available", () => {

--- a/tests/codecs/numpy.test.ts
+++ b/tests/codecs/numpy.test.ts
@@ -12,7 +12,9 @@ import path from "node:path";
 const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 
 async function loadFixture(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+  });
 }
 
 function buildSparseLabels(options: {
@@ -25,9 +27,21 @@ function buildSparseLabels(options: {
   const frame = new LabeledFrame({
     video,
     frameIdx: options.labeledFrameIdx,
-    instances: [Instance.fromArray([[1, 2], [3, 4]], skeleton)],
+    instances: [
+      Instance.fromArray(
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        skeleton,
+      ),
+    ],
   });
-  return new Labels({ labeledFrames: [frame], videos: [video], skeletons: [skeleton] });
+  return new Labels({
+    labeledFrames: [frame],
+    videos: [video],
+    skeletons: [skeleton],
+  });
 }
 
 describe("numpy codec", () => {
@@ -96,8 +110,8 @@ describe("numpy codec", () => {
   it("matches Labels.fromNumpy", () => {
     const arr = Array.from({ length: 2 }, () =>
       Array.from({ length: 2 }, () =>
-        Array.from({ length: 3 }, () => [Math.random(), Math.random()])
-      )
+        Array.from({ length: 3 }, () => [Math.random(), Math.random()]),
+      ),
     );
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton(["a", "b", "c"]);
@@ -123,7 +137,12 @@ describe("numpy codec", () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton(["node1", "node2"]);
 
-    const labels = fromNumpy(arr, { video, skeleton, trackNames: ["mouse1", "mouse2"], firstFrame: 10 });
+    const labels = fromNumpy(arr, {
+      video,
+      skeleton,
+      trackNames: ["mouse1", "mouse2"],
+      firstFrame: 10,
+    });
     expect(labels.tracks[0].name).toBe("mouse1");
     expect(labels.labeledFrames[0].frameIdx).toBe(10);
   });
@@ -132,14 +151,21 @@ describe("numpy codec", () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton(["node1"]);
 
-    expect(() => fromNumpy([] as any, { video, skeleton })).toThrow(/4 dimensions/);
+    expect(() => fromNumpy([] as any, { video, skeleton })).toThrow(
+      /4 dimensions/,
+    );
     expect(() => fromNumpy([[[[0, 0]]]] as any, { skeleton })).toThrow(/video/);
     expect(() => fromNumpy([[[[0, 0]]]] as any, { video })).toThrow(/skeleton/);
-    expect(() => fromNumpy([[[[0, 0]]]] as any, { video, videos: [video], skeleton })).toThrow(/both/);
+    expect(() =>
+      fromNumpy([[[[0, 0]]]] as any, { video, videos: [video], skeleton }),
+    ).toThrow(/both/);
   });
 
   it("sizes output to video.shape[0] when known and labels are sparse", () => {
-    const labels = buildSparseLabels({ shape: [10, 1, 1, 1], labeledFrameIdx: 3 });
+    const labels = buildSparseLabels({
+      shape: [10, 1, 1, 1],
+      labeledFrameIdx: 3,
+    });
     const arr = labels.numpy();
     expect(arr.length).toBe(10);
     expect(arr[3][0][0]).toEqual([1, 2]);
@@ -160,7 +186,10 @@ describe("numpy codec", () => {
   });
 
   it("numFrames overrides video.shape[0] when both provided", () => {
-    const labels = buildSparseLabels({ shape: [5, 1, 1, 1], labeledFrameIdx: 1 });
+    const labels = buildSparseLabels({
+      shape: [5, 1, 1, 1],
+      labeledFrameIdx: 1,
+    });
     const arr = labels.numpy({ numFrames: 12 });
     expect(arr.length).toBe(12);
   });
@@ -175,7 +204,10 @@ describe("numpy codec", () => {
   });
 
   it("ignores numFrames <= 0", () => {
-    const labels = buildSparseLabels({ shape: [6, 1, 1, 1], labeledFrameIdx: 1 });
+    const labels = buildSparseLabels({
+      shape: [6, 1, 1, 1],
+      labeledFrameIdx: 1,
+    });
     const arr = labels.numpy({ numFrames: 0 });
     expect(arr.length).toBe(6);
   });
@@ -184,7 +216,9 @@ describe("numpy codec", () => {
     const labels = buildSparseLabels({ shape: null, labeledFrameIdx: 2 });
     expect(labels.numpy({ numFrames: 9.7 }).length).toBe(9);
     expect(labels.numpy({ numFrames: Number.NaN }).length).toBe(3);
-    expect(labels.numpy({ numFrames: Number.POSITIVE_INFINITY }).length).toBe(3);
+    expect(labels.numpy({ numFrames: Number.POSITIVE_INFINITY }).length).toBe(
+      3,
+    );
     expect(labels.numpy({ numFrames: -2.5 }).length).toBe(3);
   });
 

--- a/tests/codecs/skeleton-edgeless-nodes.test.ts
+++ b/tests/codecs/skeleton-edgeless-nodes.test.ts
@@ -255,9 +255,7 @@ function symNamePairs(sk: Skeleton): Array<[string, string]> {
     .sort((a, b) => (a.join("\0") < b.join("\0") ? -1 : 1));
 }
 
-function sortPairs(
-  pairs: Array<[string, string]>
-): Array<[string, string]> {
+function sortPairs(pairs: Array<[string, string]>): Array<[string, string]> {
   return [...pairs].sort((a, b) => (a.join("\0") < b.join("\0") ? -1 : 1));
 }
 
@@ -358,13 +356,13 @@ describe("edge-less skeletons: SLP encoder guard (nodes listed, not link-derived
 
     const tmp = join(
       tmpdir(),
-      `edgeless-guard-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`
+      `edgeless-guard-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`,
     );
     writeFileSync(tmp, bytes);
     try {
       const file = new H5File(tmp, "r");
       const meta = JSON.parse(
-        file.get("metadata").attrs.json.value as string
+        file.get("metadata").attrs.json.value as string,
       ) as {
         skeletons: Array<{ nodes: Array<{ id: number }>; links: unknown[] }>;
         nodes: Array<{ name: string }>;
@@ -377,7 +375,10 @@ describe("edge-less skeletons: SLP encoder guard (nodes listed, not link-derived
       // Only ONE link exists (A-B); the node count must exceed link-reachable
       // nodes, proving the encoder did not derive the list from links.
       const linkReachable = new Set<number>();
-      for (const link of skel.links as Array<{ source: number; target: number }>) {
+      for (const link of skel.links as Array<{
+        source: number;
+        target: number;
+      }>) {
         linkReachable.add(link.source);
         linkReachable.add(link.target);
       }
@@ -408,14 +409,16 @@ describe("edge-less skeletons: SLP encoder guard (nodes listed, not link-derived
     const bytes = await saveSlpToBytes(labelsForSkeleton(sk));
     const tmp = join(
       tmpdir(),
-      `edgeless-symguard-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`
+      `edgeless-symguard-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`,
     );
     writeFileSync(tmp, bytes);
     try {
       const file = new H5File(tmp, "r");
       const meta = JSON.parse(
-        file.get("metadata").attrs.json.value as string
-      ) as { skeletons: Array<{ nodes: Array<{ id: number }>; links: unknown[] }> };
+        file.get("metadata").attrs.json.value as string,
+      ) as {
+        skeletons: Array<{ nodes: Array<{ id: number }>; links: unknown[] }>;
+      };
       file.close();
       const skel = meta.skeletons[0];
       expect(skel.nodes.map((n) => n.id)).toEqual([0, 1, 2]);
@@ -436,7 +439,7 @@ describe("edge-less skeletons: readSkeletonJson (Python jsonpickle golden bytes)
   for (const c of JSONPICKLE_CASES) {
     it(`decodes Python encode_skeleton bytes for ${c.key} (no decode-to-empty)`, () => {
       const sk = readSkeletonJson(
-        PY_JSONPICKLE[c.key as keyof typeof PY_JSONPICKLE]
+        PY_JSONPICKLE[c.key as keyof typeof PY_JSONPICKLE],
       );
       const expectedNames = c.jsonpickleNames ?? c.names;
       // Node SET + count must match (the #148 bug was decode-to-empty).
@@ -504,7 +507,7 @@ describe("edge-less skeletons: training-config skeleton extraction", () => {
       expect(skeletons.length).toBe(1);
       expect(skeletons[0].nodes.length).toBe(c.names.length);
       expect(new Set(skeletons[0].nodeNames)).toEqual(
-        new Set(c.jsonpickleNames ?? c.names)
+        new Set(c.jsonpickleNames ?? c.names),
       );
       expect(skeletons[0].edges.length).toBe(c.edgePairs.length);
       expect(skeletons[0].symmetries.length).toBe(c.symPairs.length);
@@ -532,7 +535,7 @@ function pythonRunner(): { cmd: string; args: string[] } | null {
     execFileSync(
       "uv",
       ["run", "--with", "sleap-io", "python", "-c", "import sleap_io"],
-      { stdio: "pipe", timeout: 120_000 }
+      { stdio: "pipe", timeout: 120_000 },
     );
     return { cmd: "uv", args: ["run", "--with", "sleap-io", "python"] };
   } catch {
@@ -542,11 +545,11 @@ function pythonRunner(): { cmd: string; args: string[] } | null {
 
 function runPython(
   runner: { cmd: string; args: string[] },
-  script: string
+  script: string,
 ): string {
   const pyPath = join(
     tmpdir(),
-    `edgeless-py-${Date.now()}-${Math.random().toString(16).slice(2)}.py`
+    `edgeless-py-${Date.now()}-${Math.random().toString(16).slice(2)}.py`,
   );
   try {
     writeFileSync(pyPath, script);
@@ -582,7 +585,7 @@ describePy("edge-less skeletons: Python <-> JS SLP cross-compat", () => {
           tmpdir(),
           `edgeless-js-${c.key}-${Date.now()}-${Math.random()
             .toString(16)
-            .slice(2)}.slp`
+            .slice(2)}.slp`,
         );
         writeFileSync(slpPath, bytes);
         tmpFiles.push(slpPath);
@@ -613,7 +616,7 @@ print("OK: Python read all JS-written edge-less skeletons")
 `;
       const out = runPython(r, script);
       expect(out).toContain(
-        "OK: Python read all JS-written edge-less skeletons"
+        "OK: Python read all JS-written edge-less skeletons",
       );
     } finally {
       for (const f of tmpFiles) {

--- a/tests/codecs/skeleton-yaml.test.ts
+++ b/tests/codecs/skeleton-yaml.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "../bun-test";
-import { decodeYamlSkeleton, encodeYamlSkeleton } from "../../src/codecs/skeleton-yaml.js";
+import {
+  decodeYamlSkeleton,
+  encodeYamlSkeleton,
+} from "../../src/codecs/skeleton-yaml.js";
 import { Skeleton } from "../../src/model/skeleton.js";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -49,7 +52,7 @@ describe("skeleton YAML codec", () => {
     expect(skeletons).toHaveLength(1);
     const skeleton = skeletons[0];
     expect(skeleton.name).toBe(
-      "M:/talmo/data/leap_datasets/BermanFlies/2018-05-03_cluster-sampled.k=10,n=150.labels.mat"
+      "M:/talmo/data/leap_datasets/BermanFlies/2018-05-03_cluster-sampled.k=10,n=150.labels.mat",
     );
     expect(skeleton.nodeNames).toHaveLength(32);
     expect(skeleton.edges.length).toBeGreaterThan(0);

--- a/tests/codecs/slp-crop-streaming-decode.test.ts
+++ b/tests/codecs/slp-crop-streaming-decode.test.ts
@@ -50,7 +50,10 @@ describe("readVideoCropsStreaming — h5wasm payload forms", () => {
   });
 
   it("returns an empty map when /video_crops is absent", async () => {
-    const file: any = { keys: () => [], getDatasetValue: async () => ({ value: null }) };
+    const file: any = {
+      keys: () => [],
+      getDatasetValue: async () => ({ value: null }),
+    };
     const map = await readVideoCropsStreaming(file);
     expect(map.size).toBe(0);
   });

--- a/tests/codecs/slp-crop-streaming.test.ts
+++ b/tests/codecs/slp-crop-streaming.test.ts
@@ -31,7 +31,11 @@ const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 const FIXTURE = path.join(fixtureRoot, "slp", "cropped_format_2_3.pkg.slp");
 
 /** Grayscale value of the RGBA pixel (x,y) in an ImageData-shaped frame. */
-function gray(frame: { data: ArrayLike<number>; width: number }, x: number, y: number): number {
+function gray(
+  frame: { data: ArrayLike<number>; width: number },
+  x: number,
+  y: number,
+): number {
   return frame.data[(y * frame.width + x) * 4];
 }
 
@@ -79,7 +83,9 @@ describe("STREAMING PARITY — virtual crop", () => {
     expect(sv._cropTuple()).toEqual(ev._cropTuple());
     expect(sv._cropFill()).toEqual(ev._cropFill());
     expect(sv.shape).toEqual(ev.shape);
-    expect(sv.backendMetadata.source_shape).toEqual(ev.backendMetadata.source_shape);
+    expect(sv.backendMetadata.source_shape).toEqual(
+      ev.backendMetadata.source_shape,
+    );
     expect(sv.backend instanceof CropVideoBackend).toBe(true);
 
     // Identical cropped frame (256x192, same pixels as the eager path).

--- a/tests/codecs/slp-crop.test.ts
+++ b/tests/codecs/slp-crop.test.ts
@@ -39,7 +39,11 @@ const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 const FIXTURE = path.join(fixtureRoot, "slp", "cropped_format_2_3.pkg.slp");
 
 /** Grayscale value of the RGBA pixel (x,y) in an ImageData-shaped frame. */
-function gray(frame: { data: ArrayLike<number>; width: number }, x: number, y: number): number {
+function gray(
+  frame: { data: ArrayLike<number>; width: number },
+  x: number,
+  y: number,
+): number {
   return frame.data[(y * frame.width + x) * 4];
 }
 
@@ -62,9 +66,7 @@ function makeBackend(
 }
 
 /** Read the file-level metadata/datasets from saved SLP bytes via h5wasm/node. */
-async function inspectSlp(
-  bytes: Uint8Array,
-): Promise<{
+async function inspectSlp(bytes: Uint8Array): Promise<{
   keys: string[];
   formatId: number;
   videoCrops: unknown;
@@ -77,8 +79,9 @@ async function inspectSlp(
   const file = new H5File(memPath, "r");
   try {
     const keys = file.keys() as string[];
-    const fmtAttr = (file.get("metadata") as { attrs: Record<string, { value?: number }> })
-      .attrs["format_id"];
+    const fmtAttr = (
+      file.get("metadata") as { attrs: Record<string, { value?: number }> }
+    ).attrs["format_id"];
     const formatId = Number(fmtAttr?.value ?? fmtAttr);
     let videoCrops: unknown;
     let videoCropsShape: number[] | undefined;
@@ -137,8 +140,9 @@ describe("PYTHON -> JS: committed format-2.3 cropped fixture", () => {
     const module = await ready;
     const file = new H5File(FIXTURE, "r");
     try {
-      const fmt = (file.get("metadata") as { attrs: Record<string, { value?: number }> })
-        .attrs["format_id"];
+      const fmt = (
+        file.get("metadata") as { attrs: Record<string, { value?: number }> }
+      ).attrs["format_id"];
       expect(Number(fmt?.value ?? fmt)).toBe(2.3);
       expect((file.keys() as string[]).includes("video_crops")).toBe(true);
     } finally {
@@ -155,9 +159,23 @@ describe("FORMAT_ID + /video_crops byte-stability", () => {
       backend: makeBackend(640, 480, "/data/big.mp4"),
     });
     const cropped = src.crop([100, 50, 300, 250], { fill: 7 });
-    const inst = Instance.fromArray([[10, 20], [30, 40]], skel);
-    const lf = new LabeledFrame({ video: cropped, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ skeletons: [skel], videos: [cropped], labeledFrames: [lf] });
+    const inst = Instance.fromArray(
+      [
+        [10, 20],
+        [30, 40],
+      ],
+      skel,
+    );
+    const lf = new LabeledFrame({
+      video: cropped,
+      frameIdx: 0,
+      instances: [inst],
+    });
+    const labels = new Labels({
+      skeletons: [skel],
+      videos: [cropped],
+      labeledFrames: [lf],
+    });
 
     const bytes = await saveSlpToBytes(labels);
     const info = await inspectSlp(bytes);
@@ -182,7 +200,11 @@ describe("FORMAT_ID + /video_crops byte-stability", () => {
     });
     const inst = Instance.fromArray([[1, 2]], skel);
     const lf = new LabeledFrame({ video: v, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ skeletons: [skel], videos: [v], labeledFrames: [lf] });
+    const labels = new Labels({
+      skeletons: [skel],
+      videos: [v],
+      labeledFrames: [lf],
+    });
 
     const bytes = await saveSlpToBytes(labels);
     const info = await inspectSlp(bytes);
@@ -192,11 +214,17 @@ describe("FORMAT_ID + /video_crops byte-stability", () => {
     const entry = info.videosJson[0];
     expect(entry).not.toHaveProperty("crop");
     expect(entry).not.toHaveProperty("crop_fill");
-    expect((entry.backend as Record<string, unknown>)).not.toHaveProperty("crop");
-    expect((entry.backend as Record<string, unknown>)).not.toHaveProperty("crop_fill");
-    expect((entry.backend as Record<string, unknown>)).not.toHaveProperty("source_shape");
+    expect(entry.backend as Record<string, unknown>).not.toHaveProperty("crop");
+    expect(entry.backend as Record<string, unknown>).not.toHaveProperty(
+      "crop_fill",
+    );
+    expect(entry.backend as Record<string, unknown>).not.toHaveProperty(
+      "source_shape",
+    );
     // videos_json still describes the full (uncropped) shape.
-    expect((entry.backend as Record<string, unknown>).shape).toEqual([1, 480, 640, 1]);
+    expect((entry.backend as Record<string, unknown>).shape).toEqual([
+      1, 480, 640, 1,
+    ]);
   });
 });
 
@@ -209,8 +237,16 @@ describe("videos_json UNCROPPED INVARIANT", () => {
     });
     const cropped = src.crop([100, 50, 300, 250], { fill: 7 });
     const inst = Instance.fromArray([[5, 5]], skel);
-    const lf = new LabeledFrame({ video: cropped, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ skeletons: [skel], videos: [cropped], labeledFrames: [lf] });
+    const lf = new LabeledFrame({
+      video: cropped,
+      frameIdx: 0,
+      instances: [inst],
+    });
+    const labels = new Labels({
+      skeletons: [skel],
+      videos: [cropped],
+      labeledFrames: [lf],
+    });
 
     const bytes = await saveSlpToBytes(labels);
     const info = await inspectSlp(bytes);
@@ -223,7 +259,9 @@ describe("videos_json UNCROPPED INVARIANT", () => {
     expect(backend).not.toHaveProperty("source_shape");
 
     // Reload: the crop is re-applied from /video_crops only.
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     const rv = reloaded.videos[0];
     expect(rv._cropTuple()).toEqual([100, 50, 300, 250]);
     expect(rv._cropFill()).toBe(7);
@@ -241,12 +279,22 @@ describe("JS -> JS round-trip preserves the crop", () => {
     });
     const cropped = src.crop([16, 32, 144, 160], { fill: 42 });
     const inst = Instance.fromArray([[1, 1]], skel);
-    const lf = new LabeledFrame({ video: cropped, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ skeletons: [skel], videos: [cropped], labeledFrames: [lf] });
+    const lf = new LabeledFrame({
+      video: cropped,
+      frameIdx: 0,
+      instances: [inst],
+    });
+    const labels = new Labels({
+      skeletons: [skel],
+      videos: [cropped],
+      labeledFrames: [lf],
+    });
 
     const bytes = await saveSlpToBytes(labels);
 
-    const reClosed = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reClosed = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     const vc = reClosed.videos[0];
     expect(vc._cropTuple()).toEqual([16, 32, 144, 160]);
     expect(vc._cropFill()).toBe(42);
@@ -260,8 +308,16 @@ describe("nested crop-of-crop write throws", () => {
     const skel = new Skeleton({ name: "s", nodes: ["a"] });
     const inner = makeBackend(640, 480, "/data/big.mp4");
     // Different fills -> wrap NESTS (no flatten), so inner stays a crop wrapper.
-    const c1 = CropVideoBackend.wrap({ inner, crop: [100, 50, 300, 250], fill: 0 });
-    const c2 = CropVideoBackend.wrap({ inner: c1, crop: [10, 10, 50, 50], fill: 9 });
+    const c1 = CropVideoBackend.wrap({
+      inner,
+      crop: [100, 50, 300, 250],
+      fill: 0,
+    });
+    const c2 = CropVideoBackend.wrap({
+      inner: c1,
+      crop: [10, 10, 50, 50],
+      fill: 9,
+    });
     expect(c2.inner instanceof CropVideoBackend).toBe(true); // genuinely nested
 
     const v = new Video({ filename: "/data/big.mp4", backend: c2 });
@@ -272,7 +328,11 @@ describe("nested crop-of-crop write throws", () => {
     };
     const inst = Instance.fromArray([[1, 1]], skel);
     const lf = new LabeledFrame({ video: v, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ skeletons: [skel], videos: [v], labeledFrames: [lf] });
+    const labels = new Labels({
+      skeletons: [skel],
+      videos: [v],
+      labeledFrames: [lf],
+    });
 
     await expect(saveSlpToBytes(labels)).rejects.toThrow(/nested crop-of-crop/);
   });

--- a/tests/embed.test.ts
+++ b/tests/embed.test.ts
@@ -2,14 +2,23 @@ import { describe, it, expect } from "./bun-test";
 import { loadSlp } from "../src/io/main.js";
 import { saveSlpToBytes } from "../src/codecs/slp/write.js";
 import { readSlp } from "../src/codecs/slp/read.js";
-import { Labels, LabeledFrame, Video, Skeleton, Instance, SuggestionFrame } from "../src/index.js";
+import {
+  Labels,
+  LabeledFrame,
+  Video,
+  Skeleton,
+  Instance,
+  SuggestionFrame,
+} from "../src/index.js";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 
 async function loadFixture(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+  });
 }
 
 describe("Frame Embedding", () => {
@@ -27,7 +36,9 @@ describe("Frame Embedding", () => {
     const bytes = await saveSlpToBytes(labels);
     expect(bytes.length).toBeGreaterThan(0);
 
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     expect(reloaded.labeledFrames.length).toBe(labels.labeledFrames.length);
   });
 
@@ -35,7 +46,7 @@ describe("Frame Embedding", () => {
     // Load a package file that has embedded video frames
     const labels = await loadSlp(
       path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"),
-      { openVideos: true }
+      { openVideos: true },
     );
 
     // Verify the video has embedded images
@@ -58,7 +69,9 @@ describe("Frame Embedding", () => {
     expect(reloaded.videos[0].hasEmbeddedImages).toBe(true);
 
     // Verify we can read a frame from the re-embedded video
-    const frame = await reloaded.videos[0].getFrame(labels.labeledFrames[0].frameIdx);
+    const frame = await reloaded.videos[0].getFrame(
+      labels.labeledFrames[0].frameIdx,
+    );
     expect(frame).not.toBeNull();
 
     // Cleanup
@@ -68,17 +81,21 @@ describe("Frame Embedding", () => {
   it("embed='user' only embeds frames with user instances", async () => {
     const labels = await loadSlp(
       path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"),
-      { openVideos: true }
+      { openVideos: true },
     );
 
     // Count frames with user instances
-    const userFrameCount = labels.labeledFrames.filter((f) => f.hasUserInstances).length;
+    const userFrameCount = labels.labeledFrames.filter(
+      (f) => f.hasUserInstances,
+    ).length;
     expect(userFrameCount).toBeGreaterThan(0);
 
     const bytes = await saveSlpToBytes(labels, { embed: "user" });
     expect(bytes.length).toBeGreaterThan(0);
 
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: true });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: true,
+    });
     expect(reloaded.videos[0].hasEmbeddedImages).toBe(true);
   });
 
@@ -87,7 +104,9 @@ describe("Frame Embedding", () => {
     const bytes = await saveSlpToBytes(labels, { embed: "source" });
     expect(bytes.length).toBeGreaterThan(0);
 
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     expect(reloaded.videos[0].hasEmbeddedImages).toBe(false);
   });
 
@@ -95,13 +114,22 @@ describe("Frame Embedding", () => {
     // Create a labels with a non-embedded video that has a backend returning bytes
     const video = new Video({ filename: "original_video.mp4" });
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
+    const inst = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ labeledFrames: [frame], videos: [video], skeletons: [skeleton] });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
+    });
 
     // Without a backend, no frames will be embedded, but the code path should work
     const bytes = await saveSlpToBytes(labels, { embed: true });
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     // Since no backend was available, video should not be embedded
     expect(reloaded.videos[0].hasEmbeddedImages).toBe(false);
   });
@@ -109,7 +137,7 @@ describe("Frame Embedding", () => {
   it("writes frame_sizes dataset and reads frames correctly", async () => {
     const labels = await loadSlp(
       path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"),
-      { openVideos: true }
+      { openVideos: true },
     );
 
     const fs = await import("node:fs");
@@ -125,7 +153,9 @@ describe("Frame Embedding", () => {
     const { file } = await openH5File(tmpFile);
     const frameSizesDs = file.get("video0/frame_sizes");
     expect(frameSizesDs).not.toBeNull();
-    const frameSizes = Array.from(frameSizesDs.value).map((v: any) => Number(v));
+    const frameSizes = Array.from(frameSizesDs.value).map((v: any) =>
+      Number(v),
+    );
     expect(frameSizes.length).toBeGreaterThan(0);
     expect(frameSizes.every((s: number) => s > 0)).toBe(true);
 
@@ -137,7 +167,9 @@ describe("Frame Embedding", () => {
 
     // Read back and verify frames are accessible
     const reloaded = await readSlp(tmpFile, { openVideos: true });
-    const frame = await reloaded.videos[0].getFrame(reloaded.labeledFrames[0].frameIdx);
+    const frame = await reloaded.videos[0].getFrame(
+      reloaded.labeledFrames[0].frameIdx,
+    );
     expect(frame).not.toBeNull();
 
     fs.rmSync(tmpDir, { recursive: true });
@@ -146,11 +178,13 @@ describe("Frame Embedding", () => {
   it("re-embedded pkg.slp preserves frame data", async () => {
     const labels = await loadSlp(
       path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"),
-      { openVideos: true }
+      { openVideos: true },
     );
 
     // Read a frame before embedding
-    const originalFrame = await labels.videos[0].getFrame(labels.labeledFrames[0].frameIdx);
+    const originalFrame = await labels.videos[0].getFrame(
+      labels.labeledFrames[0].frameIdx,
+    );
     expect(originalFrame).not.toBeNull();
 
     // Re-embed and verify metadata

--- a/tests/feature-gaps.test.ts
+++ b/tests/feature-gaps.test.ts
@@ -12,20 +12,36 @@ import path from "node:path";
 const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 
 async function loadFixture(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+  });
 }
 
 async function loadFixtureLazy(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false, lazy: true });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+    lazy: true,
+  });
 }
 
 describe("Unit 1: Source Video Restoration Mode", () => {
   it("embed='source' restores sourceVideo paths", async () => {
     const sourceVideo = new Video({ filename: "original.mp4" });
-    const embeddedVideo = new Video({ filename: ".", embedded: true, sourceVideo });
+    const embeddedVideo = new Video({
+      filename: ".",
+      embedded: true,
+      sourceVideo,
+    });
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
-    const frame = new LabeledFrame({ video: embeddedVideo, frameIdx: 0, instances: [inst] });
+    const inst = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
+    const frame = new LabeledFrame({
+      video: embeddedVideo,
+      frameIdx: 0,
+      instances: [inst],
+    });
     const labels = new Labels({
       labeledFrames: [frame],
       videos: [embeddedVideo],
@@ -33,7 +49,9 @@ describe("Unit 1: Source Video Restoration Mode", () => {
     });
 
     const bytes = await saveSlpToBytes(labels, { embed: "source" });
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(reloaded.videos[0].filename).toBe("original.mp4");
     expect(reloaded.videos[0].hasEmbeddedImages).toBe(false);
@@ -51,7 +69,9 @@ describe("Unit 1: Source Video Restoration Mode", () => {
     });
 
     const bytes = await saveSlpToBytes(labels, { embed: "source" });
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(reloaded.videos[0].filename).toBe("video.mp4");
   });
@@ -59,7 +79,9 @@ describe("Unit 1: Source Video Restoration Mode", () => {
   it("embed='source' does not embed frame data", async () => {
     const labels = await loadFixture("minimal_instance.slp");
     const bytes = await saveSlpToBytes(labels, { embed: "source" });
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(reloaded.videos[0].hasEmbeddedImages).toBe(false);
     expect(reloaded.labeledFrames.length).toBe(labels.labeledFrames.length);
@@ -67,13 +89,25 @@ describe("Unit 1: Source Video Restoration Mode", () => {
 
   it("embed='source' with multiple videos restores only those with sourceVideo", async () => {
     const sourceVideo = new Video({ filename: "original.mp4" });
-    const embeddedVideo = new Video({ filename: ".", embedded: true, sourceVideo });
+    const embeddedVideo = new Video({
+      filename: ".",
+      embedded: true,
+      sourceVideo,
+    });
     const plainVideo = new Video({ filename: "other.mp4" });
     const skeleton = new Skeleton({ nodes: ["X"] });
     const inst1 = new Instance({ points: { X: [5, 5] }, skeleton });
     const inst2 = new Instance({ points: { X: [15, 25] }, skeleton });
-    const frame1 = new LabeledFrame({ video: embeddedVideo, frameIdx: 0, instances: [inst1] });
-    const frame2 = new LabeledFrame({ video: plainVideo, frameIdx: 0, instances: [inst2] });
+    const frame1 = new LabeledFrame({
+      video: embeddedVideo,
+      frameIdx: 0,
+      instances: [inst1],
+    });
+    const frame2 = new LabeledFrame({
+      video: plainVideo,
+      frameIdx: 0,
+      instances: [inst2],
+    });
     const labels = new Labels({
       labeledFrames: [frame1, frame2],
       videos: [embeddedVideo, plainVideo],
@@ -81,7 +115,9 @@ describe("Unit 1: Source Video Restoration Mode", () => {
     });
 
     const bytes = await saveSlpToBytes(labels, { embed: "source" });
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(reloaded.videos[0].filename).toBe("original.mp4");
     expect(reloaded.videos[1].filename).toBe("other.mp4");
@@ -114,9 +150,13 @@ describe("Unit 2: Format 1.2 tracking_score Handling", () => {
     });
 
     const bytes = await saveSlpToBytes(labels);
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
-    expect(reloaded.labeledFrames[0].instances[0].trackingScore).toBeCloseTo(0.75);
+    expect(reloaded.labeledFrames[0].instances[0].trackingScore).toBeCloseTo(
+      0.75,
+    );
   });
 
   it("tracking_score defaults to 0 for PredictedInstance", async () => {
@@ -135,7 +175,9 @@ describe("Unit 2: Format 1.2 tracking_score Handling", () => {
     });
 
     const bytes = await saveSlpToBytes(labels);
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(reloaded.labeledFrames[0].instances[0].trackingScore).toBe(0);
   });
@@ -261,8 +303,23 @@ describe("Unit 3: Lazy toNumpy() Fast Path", () => {
   it("lazy toNumpy() on empty store returns empty", async () => {
     const { LazyDataStore } = await import("../src/model/lazy.js");
     const store = new LazyDataStore({
-      framesData: { frame_id: [], video: [], frame_idx: [], instance_id_start: [], instance_id_end: [] },
-      instancesData: { instance_type: [], skeleton: [], track: [], point_id_start: [], point_id_end: [], score: [], tracking_score: [], from_predicted: [] },
+      framesData: {
+        frame_id: [],
+        video: [],
+        frame_idx: [],
+        instance_id_start: [],
+        instance_id_end: [],
+      },
+      instancesData: {
+        instance_type: [],
+        skeleton: [],
+        track: [],
+        point_id_start: [],
+        point_id_end: [],
+        score: [],
+        tracking_score: [],
+        from_predicted: [],
+      },
       pointsData: { x: [], y: [], visible: [], complete: [] },
       predPointsData: { x: [], y: [], visible: [], complete: [], score: [] },
       skeletons: [new Skeleton({ nodes: ["A"] })],

--- a/tests/geojson.test.ts
+++ b/tests/geojson.test.ts
@@ -1,11 +1,25 @@
 import { describe, it, expect } from "./bun-test";
-import { roisToGeoJSON, roisFromGeoJSON, writeGeoJSON, readGeoJSON } from "../src/io/geojson.js";
+import {
+  roisToGeoJSON,
+  roisFromGeoJSON,
+  writeGeoJSON,
+  readGeoJSON,
+} from "../src/io/geojson.js";
 import { ROI } from "../src/model/roi.js";
 
 describe("GeoJSON I/O", () => {
   it("round-trips ROIs through GeoJSON", () => {
     const rois = [
-      ROI.fromPolygon([[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]], { name: "test", category: "region" }),
+      ROI.fromPolygon(
+        [
+          [0, 0],
+          [10, 0],
+          [10, 10],
+          [0, 10],
+          [0, 0],
+        ],
+        { name: "test", category: "region" },
+      ),
       ROI.fromBbox(5, 5, 20, 20, { name: "box" }),
     ];
     const json = writeGeoJSON(rois);
@@ -33,8 +47,24 @@ describe("GeoJSON I/O", () => {
     const fc = {
       type: "FeatureCollection" as const,
       features: [
-        { type: "Feature" as const, geometry: { type: "Point" as const, coordinates: [1, 2] } },
-        { type: "Feature" as const, geometry: { type: "Polygon" as const, coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] } },
+        {
+          type: "Feature" as const,
+          geometry: { type: "Point" as const, coordinates: [1, 2] },
+        },
+        {
+          type: "Feature" as const,
+          geometry: {
+            type: "Polygon" as const,
+            coordinates: [
+              [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 0],
+              ],
+            ],
+          },
+        },
       ],
     };
     const rois = roisFromGeoJSON(fc);
@@ -44,9 +74,7 @@ describe("GeoJSON I/O", () => {
   });
 
   it("roisToGeoJSON creates valid FeatureCollection", () => {
-    const rois = [
-      ROI.fromBbox(0, 0, 10, 10, { name: "a", category: "cat1" }),
-    ];
+    const rois = [ROI.fromBbox(0, 0, 10, 10, { name: "a", category: "cat1" })];
     const fc = roisToGeoJSON(rois);
     expect(fc.type).toBe("FeatureCollection");
     expect(fc.features).toHaveLength(1);

--- a/tests/h5-attrs-and-cleanup.test.ts
+++ b/tests/h5-attrs-and-cleanup.test.ts
@@ -39,7 +39,9 @@ describe("attrToString", () => {
   });
 
   it("unwraps { value: Uint8Array }", () => {
-    expect(attrToString({ value: new TextEncoder().encode("jpg") })).toBe("jpg");
+    expect(attrToString({ value: new TextEncoder().encode("jpg") })).toBe(
+      "jpg",
+    );
   });
 
   it("trims trailing nulls and whitespace from fixed-width HDF5 strings", () => {
@@ -96,17 +98,30 @@ describe("read.ts honors `frames` HDF5 attribute on embedded video dataset", () 
   // because write.ts only emits shape from `video.backend?.shape`, not
   // `backendMetadata.shape`, so we'd have no way to inject the JSON shape via
   // the public API.
-  async function buildFixture(opts: { jsonFrameCount: number; framesAttr: number | null }) {
+  async function buildFixture(opts: {
+    jsonFrameCount: number;
+    framesAttr: number | null;
+  }) {
     const h5 = await import("h5wasm");
     await h5.ready;
     const FS = h5.FS;
-    const memPath = "/test-fixture-" + Date.now() + "-" + Math.random().toString(36).slice(2) + ".slp";
+    const memPath =
+      "/test-fixture-" +
+      Date.now() +
+      "-" +
+      Math.random().toString(36).slice(2) +
+      ".slp";
     FS.writeFile(memPath, new Uint8Array(0));
     const f = new h5.File(memPath, "w");
 
-    const meta = f.create_group("metadata") as { create_attribute: (n: string, v: unknown, s?: null, t?: string) => void };
+    const meta = f.create_group("metadata") as {
+      create_attribute: (n: string, v: unknown, s?: null, t?: string) => void;
+    };
     meta.create_attribute("format_id", 1.5);
-    meta.create_attribute("json", JSON.stringify({ skeletons: [], provenance: {} }));
+    meta.create_attribute(
+      "json",
+      JSON.stringify({ skeletons: [], provenance: {} }),
+    );
 
     f.create_dataset({
       name: "videos_json",
@@ -131,14 +146,29 @@ describe("read.ts honors `frames` HDF5 attribute on embedded video dataset", () 
         create_attribute: (n: string, v: number, s: null, t: string) => void;
       };
     };
-    const vd = v0.create_dataset({ name: "video", data: new Uint8Array([0x89]), shape: [1], dtype: "<B" });
+    const vd = v0.create_dataset({
+      name: "video",
+      data: new Uint8Array([0x89]),
+      shape: [1],
+      dtype: "<B",
+    });
     if (opts.framesAttr !== null) {
       vd.create_attribute("frames", opts.framesAttr, null, "<i8");
     }
-    v0.create_dataset({ name: "frame_numbers", data: new Uint32Array([0]), shape: [1], dtype: "<i4" });
+    v0.create_dataset({
+      name: "frame_numbers",
+      data: new Uint32Array([0]),
+      shape: [1],
+      dtype: "<i4",
+    });
 
     f.create_dataset({ name: "tracks_json", data: [], shape: [0], dtype: "S" });
-    f.create_dataset({ name: "suggestions_json", data: [], shape: [0], dtype: "S" });
+    f.create_dataset({
+      name: "suggestions_json",
+      data: [],
+      shape: [0],
+      dtype: "S",
+    });
     f.close();
 
     const out = FS.readFile(memPath);
@@ -150,7 +180,8 @@ describe("read.ts honors `frames` HDF5 attribute on embedded video dataset", () 
     const buf = await buildFixture({ jsonFrameCount: 50, framesAttr: 14100 });
     const labels = await readSlp(buf, { openVideos: false });
     expect(labels.videos.length).toBe(1);
-    const shape = (labels.videos[0].backendMetadata as { shape?: number[] })?.shape;
+    const shape = (labels.videos[0].backendMetadata as { shape?: number[] })
+      ?.shape;
     expect(shape).toBeDefined();
     expect(shape?.[0]).toBe(14100);
     expect(shape?.slice(1)).toEqual([100, 100, 1]);
@@ -160,7 +191,8 @@ describe("read.ts honors `frames` HDF5 attribute on embedded video dataset", () 
     const buf = await buildFixture({ jsonFrameCount: 50, framesAttr: null });
     const labels = await readSlp(buf, { openVideos: false });
     expect(labels.videos.length).toBe(1);
-    const shape = (labels.videos[0].backendMetadata as { shape?: number[] })?.shape;
+    const shape = (labels.videos[0].backendMetadata as { shape?: number[] })
+      ?.shape;
     expect(shape).toBeDefined();
     expect(shape?.[0]).toBe(50);
   });
@@ -177,7 +209,9 @@ describe("MEMFS cleanup algorithm (mirrors h5-worker.ts closeFile)", () => {
     const FS = h5.FS;
 
     const before = new Set(FS.readdir("/"));
-    const data = new Uint8Array(fs.readFileSync(path.join(fixtureRoot, "slp", "minimal_instance.slp")));
+    const data = new Uint8Array(
+      fs.readFileSync(path.join(fixtureRoot, "slp", "minimal_instance.slp")),
+    );
 
     for (let i = 0; i < 10; i++) {
       // open

--- a/tests/h5-provider.test.ts
+++ b/tests/h5-provider.test.ts
@@ -30,7 +30,11 @@ describe("h5 provider pattern", () => {
   });
 
   it("openH5File opens an SLP file by path (Node provider)", async () => {
-    const fixturePath = join(fixturesDir, "slp", "centered_pair_predictions.slp");
+    const fixturePath = join(
+      fixturesDir,
+      "slp",
+      "centered_pair_predictions.slp",
+    );
     if (!existsSync(fixturePath)) return; // skip if fixture missing
 
     const { file, close } = await openH5File(fixturePath);
@@ -43,7 +47,11 @@ describe("h5 provider pattern", () => {
   });
 
   it("openH5File opens an SLP file from bytes (Node provider)", async () => {
-    const fixturePath = join(fixturesDir, "slp", "centered_pair_predictions.slp");
+    const fixturePath = join(
+      fixturesDir,
+      "slp",
+      "centered_pair_predictions.slp",
+    );
     if (!existsSync(fixturePath)) return;
 
     const bytes = readFileSync(fixturePath);
@@ -57,7 +65,11 @@ describe("h5 provider pattern", () => {
   });
 
   it("openH5File opens from ArrayBuffer (Node provider)", async () => {
-    const fixturePath = join(fixturesDir, "slp", "centered_pair_predictions.slp");
+    const fixturePath = join(
+      fixturesDir,
+      "slp",
+      "centered_pair_predictions.slp",
+    );
     if (!existsSync(fixturePath)) return;
 
     const bytes = readFileSync(fixturePath);

--- a/tests/io/analysis-h5.test.ts
+++ b/tests/io/analysis-h5.test.ts
@@ -671,9 +671,7 @@ describe("Analysis HDF5 write", () => {
         expect(
           rootAttrString(file as never, "video_backend_metadata"),
         ).toBeDefined();
-        expect(
-          rootAttrString(file as never, "sleap_io_version"),
-        ).toBeDefined();
+        expect(rootAttrString(file as never, "sleap_io_version")).toBeDefined();
       } finally {
         close();
       }
@@ -887,7 +885,9 @@ describe("Analysis HDF5 read + round-trip", () => {
     try {
       const out = path.join(tmp, "custom_videoobj.analysis.h5");
       await writeAnalysisH5(simpleLabels(), out);
-      const custom = new Video({ filename: path.join(tmp, "custom_video.mp4") });
+      const custom = new Video({
+        filename: path.join(tmp, "custom_video.mp4"),
+      });
       const loaded = await loadAnalysisH5(out, { video: custom });
       expect(loaded.videos[0].filename).toBe(custom.filename);
     } finally {
@@ -1151,9 +1151,9 @@ describe("Analysis HDF5 edge cases", () => {
         const { file, close } = await openH5File(out);
         try {
           expect(shapeOf(file.get("tracks") as never)).toEqual(expectedShape);
-          expect(
-            stringArray((file.get("track_names") as never).value),
-          ).toEqual(["track_0", "track_1"]);
+          expect(stringArray((file.get("track_names") as never).value)).toEqual(
+            ["track_0", "track_1"],
+          );
         } finally {
           close();
         }
@@ -1421,9 +1421,7 @@ describe("Analysis HDF5 differential parity with Python fixtures", () => {
           for (let n = 0; n < ei.points.length; n++) {
             const ep = ei.points[n];
             for (let c = 0; c < ep.length; c++) {
-              expect(
-                allclose(got[n][c], parseMaybeNaN(ep[c])),
-              ).toBe(true);
+              expect(allclose(got[n][c], parseMaybeNaN(ep[c]))).toBe(true);
             }
           }
 

--- a/tests/io/jabs.test.ts
+++ b/tests/io/jabs.test.ts
@@ -43,7 +43,9 @@ describe("JABS default skeleton", () => {
     expect(sk.nodes.length).toBe(12);
     expect(sk.edges.length).toBe(11);
     expect(sk.symmetries.length).toBe(3);
-    expect(sk.nodes.map((n) => n.name)).toEqual([...JABS_DEFAULT_KEYPOINT_NAMES]);
+    expect(sk.nodes.map((n) => n.name)).toEqual([
+      ...JABS_DEFAULT_KEYPOINT_NAMES,
+    ]);
   });
 
   it("makeJabsDefaultSkeleton returns a fresh equivalent skeleton", () => {
@@ -228,7 +230,9 @@ describe("predictionToInstance", () => {
   it("throws when the skeleton size does not match the keypoints", () => {
     const data = Array.from({ length: 5 }, () => [0, 0]);
     const conf = new Array(5).fill(1);
-    expect(() => predictionToInstance(data, conf, JABS_DEFAULT_SKELETON)).toThrow();
+    expect(() =>
+      predictionToInstance(data, conf, JABS_DEFAULT_SKELETON),
+    ).toThrow();
   });
 });
 
@@ -257,7 +261,9 @@ describe("staticObjectToRoi", () => {
     expect(roi.category).toBe("anchor");
     expect(roi.source).toBe("jabs");
     expect(roi.geometry.type).toBe("Point");
-    expect((roi.geometry as { coordinates: number[] }).coordinates).toEqual([100, 200]);
+    expect((roi.geometry as { coordinates: number[] }).coordinates).toEqual([
+      100, 200,
+    ]);
     expect(roi.video).toBe(video);
   });
 
@@ -275,6 +281,8 @@ describe("staticObjectToRoi", () => {
     );
     expect(roi.category).toBe("arena");
     expect(roi.geometry.type).toBe("MultiPoint");
-    expect((roi.geometry as { coordinates: number[][] }).coordinates.length).toBe(4);
+    expect(
+      (roi.geometry as { coordinates: number[][] }).coordinates.length,
+    ).toBe(4);
   });
 });

--- a/tests/io/label-images.test.ts
+++ b/tests/io/label-images.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "../bun-test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { loadLabelImages, inferAxes, inferLabelIdsFromPages } from "../../src/io/label-images";
+import {
+  loadLabelImages,
+  inferAxes,
+  inferLabelIdsFromPages,
+} from "../../src/io/label-images";
 import "../../src/io/label-images-node"; // register node:fs reader
 import { Track } from "../../src/model/instance";
 
@@ -48,7 +52,8 @@ function makeTiff(pages: PageSpec[]): Uint8Array {
       if (cursor % 2 !== 0) cursor += 1;
     }
     const bytesPerSample = p.bitsPerSample / 8;
-    const stripBytes = p.width * p.height * (p.samplesPerPixel ?? 1) * bytesPerSample;
+    const stripBytes =
+      p.width * p.height * (p.samplesPerPixel ?? 1) * bytesPerSample;
     const stripOffset = cursor;
     cursor += stripBytes;
     if (cursor % 2 !== 0) cursor += 1;
@@ -67,21 +72,46 @@ function makeTiff(pages: PageSpec[]): Uint8Array {
     const L = layout[i];
     const p = L.p;
     const nextIFD = i + 1 < layout.length ? layout[i + 1].ifdOffset : 0;
-    const entries: { tag: number; type: number; count: number; value: number }[] = [];
+    const entries: {
+      tag: number;
+      type: number;
+      count: number;
+      value: number;
+    }[] = [];
     entries.push({ tag: 256, type: TYPE_SHORT, count: 1, value: p.width });
     entries.push({ tag: 257, type: TYPE_SHORT, count: 1, value: p.height });
-    entries.push({ tag: 258, type: TYPE_SHORT, count: 1, value: p.bitsPerSample });
+    entries.push({
+      tag: 258,
+      type: TYPE_SHORT,
+      count: 1,
+      value: p.bitsPerSample,
+    });
     entries.push({ tag: 259, type: TYPE_SHORT, count: 1, value: 1 }); // no compression
     entries.push({ tag: 262, type: TYPE_SHORT, count: 1, value: 1 }); // BlackIsZero
     if (p.description !== undefined) {
-      entries.push({ tag: 270, type: TYPE_ASCII, count: L.descBytes, value: L.descOffset });
+      entries.push({
+        tag: 270,
+        type: TYPE_ASCII,
+        count: L.descBytes,
+        value: L.descOffset,
+      });
     }
     entries.push({ tag: 273, type: TYPE_LONG, count: 1, value: L.stripOffset });
-    entries.push({ tag: 277, type: TYPE_SHORT, count: 1, value: p.samplesPerPixel ?? 1 });
+    entries.push({
+      tag: 277,
+      type: TYPE_SHORT,
+      count: 1,
+      value: p.samplesPerPixel ?? 1,
+    });
     entries.push({ tag: 278, type: TYPE_SHORT, count: 1, value: p.height });
     entries.push({ tag: 279, type: TYPE_LONG, count: 1, value: L.stripBytes });
     if (p.sampleFormat !== undefined) {
-      entries.push({ tag: 339, type: TYPE_SHORT, count: 1, value: p.sampleFormat });
+      entries.push({
+        tag: 339,
+        type: TYPE_SHORT,
+        count: 1,
+        value: p.sampleFormat,
+      });
     }
     entries.sort((a, b) => a.tag - b.tag);
 
@@ -108,11 +138,14 @@ function makeTiff(pages: PageSpec[]): Uint8Array {
       buf[L.descOffset + enc.length] = 0;
     }
     if (p.bitsPerSample === 8) {
-      for (let k = 0; k < p.pixels.length; k++) buf[L.stripOffset + k] = p.pixels[k] & 0xff;
+      for (let k = 0; k < p.pixels.length; k++)
+        buf[L.stripOffset + k] = p.pixels[k] & 0xff;
     } else if (p.bitsPerSample === 16) {
-      for (let k = 0; k < p.pixels.length; k++) dv.setUint16(L.stripOffset + k * 2, p.pixels[k] & 0xffff, LE);
+      for (let k = 0; k < p.pixels.length; k++)
+        dv.setUint16(L.stripOffset + k * 2, p.pixels[k] & 0xffff, LE);
     } else {
-      for (let k = 0; k < p.pixels.length; k++) dv.setUint32(L.stripOffset + k * 4, p.pixels[k] >>> 0, LE);
+      for (let k = 0; k < p.pixels.length; k++)
+        dv.setUint32(L.stripOffset + k * 4, p.pixels[k] >>> 0, LE);
     }
   }
   return buf;
@@ -127,7 +160,8 @@ function page(rows: number[][], opts?: Partial<PageSpec>): PageSpec {
   return { width, height, bitsPerSample: 8, pixels, ...opts };
 }
 
-const blobOf = (bytes: Uint8Array): Blob => new Blob([bytes.buffer as ArrayBuffer]);
+const blobOf = (bytes: Uint8Array): Blob =>
+  new Blob([bytes.buffer as ArrayBuffer]);
 
 // ---------------------------------------------------------------------------
 // Pure helpers
@@ -141,24 +175,31 @@ describe("inferAxes", () => {
     expect(inferAxes(undefined, 3)).toBe("unknown");
   });
   it("ImageJ multi-channel single-frame is CYX", () => {
-    expect(inferAxes("ImageJ=1.53\nimages=3\nchannels=3\nslices=1\nframes=1\n", 3)).toBe("CYX");
+    expect(
+      inferAxes("ImageJ=1.53\nimages=3\nchannels=3\nslices=1\nframes=1\n", 3),
+    ).toBe("CYX");
   });
   it("ImageJ z/time stack is TYX", () => {
     expect(inferAxes("ImageJ=1.53\nimages=3\nslices=3\n", 3)).toBe("TYX");
     expect(inferAxes("ImageJ=1.53\nimages=4\nframes=4\n", 4)).toBe("TYX");
   });
   it("ImageJ channels+frames is TCYX", () => {
-    expect(inferAxes("ImageJ=1.53\nimages=4\nchannels=2\nframes=2\n", 4)).toBe("TCYX");
+    expect(inferAxes("ImageJ=1.53\nimages=4\nchannels=2\nframes=2\n", 4)).toBe(
+      "TCYX",
+    );
   });
   it("OME SizeC>1 single timepoint is CYX", () => {
-    const ome = '<?xml version="1.0"?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"><Image><Pixels SizeC="3" SizeT="1" SizeZ="1" SizeX="4" SizeY="4" DimensionOrder="XYCZT"/></Image></OME>';
+    const ome =
+      '<?xml version="1.0"?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"><Image><Pixels SizeC="3" SizeT="1" SizeZ="1" SizeX="4" SizeY="4" DimensionOrder="XYCZT"/></Image></OME>';
     expect(inferAxes(ome, 3)).toBe("CYX");
   });
 });
 
 describe("inferLabelIdsFromPages", () => {
   it("preserves distinct single-class page IDs", () => {
-    expect(inferLabelIdsFromPages([[[5, 0]], [[0, 17]], [[99, 0]]])).toEqual([5, 17, 99]);
+    expect(inferLabelIdsFromPages([[[5, 0]], [[0, 17]], [[99, 0]]])).toEqual([
+      5, 17, 99,
+    ]);
   });
   it("returns null for colliding IDs (purely binary)", () => {
     expect(inferLabelIdsFromPages([[[1, 0]], [[0, 1]]])).toBeNull();
@@ -174,7 +215,12 @@ describe("inferLabelIdsFromPages", () => {
 
 describe("loadLabelImages — time mode", () => {
   it("reads a single page as one label image", async () => {
-    const tiff = makeTiff([page([[0, 1], [2, 0]])]);
+    const tiff = makeTiff([
+      page([
+        [0, 1],
+        [2, 0],
+      ]),
+    ]);
     const lis = await loadLabelImages(blobOf(tiff));
     expect(lis).toHaveLength(1);
     expect(lis[0].height).toBe(2);
@@ -185,9 +231,18 @@ describe("loadLabelImages — time mode", () => {
   it("preserves per-page integer values across a multi-page time stack", async () => {
     // Each page has 2+ distinct labels -> not a class stack -> time, no warning.
     const tiff = makeTiff([
-      page([[0, 1], [2, 0]]),
-      page([[3, 0], [0, 4]]),
-      page([[5, 6], [0, 0]]),
+      page([
+        [0, 1],
+        [2, 0],
+      ]),
+      page([
+        [3, 0],
+        [0, 4],
+      ]),
+      page([
+        [5, 6],
+        [0, 0],
+      ]),
     ]);
     const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time" });
     expect(lis).toHaveLength(3);
@@ -197,37 +252,75 @@ describe("loadLabelImages — time mode", () => {
   });
 
   it("uint16 values survive intact", async () => {
-    const tiff = makeTiff([page([[0, 60000], [300, 0]], { bitsPerSample: 16 })]);
+    const tiff = makeTiff([
+      page(
+        [
+          [0, 60000],
+          [300, 0],
+        ],
+        { bitsPerSample: 16 },
+      ),
+    ]);
     const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time" });
     expect(lis[0].labelIds).toEqual([300, 60000]);
   });
 
   it("createTracks:false yields no tracks; true auto-creates shared tracks", async () => {
-    const tiff = makeTiff([page([[0, 1], [2, 0]]), page([[1, 0], [0, 2]])]);
+    const tiff = makeTiff([
+      page([
+        [0, 1],
+        [2, 0],
+      ]),
+      page([
+        [1, 0],
+        [0, 2],
+      ]),
+    ]);
     const trackless = await loadLabelImages(blobOf(tiff), { pagesAs: "time" });
     expect(trackless[0].tracks).toEqual([]);
 
-    const tracked = await loadLabelImages(blobOf(tiff), { pagesAs: "time", createTracks: true });
+    const tracked = await loadLabelImages(blobOf(tiff), {
+      pagesAs: "time",
+      createTracks: true,
+    });
     expect(tracked[0].tracks).toHaveLength(2);
     // Shared Track objects across frames (same label IDs).
-    expect(tracked[0].objects.get(1)!.track).toBe(tracked[1].objects.get(1)!.track);
+    expect(tracked[0].objects.get(1)!.track).toBe(
+      tracked[1].objects.get(1)!.track,
+    );
   });
 
   it("applies categories by label ID (Map) in time mode", async () => {
-    const tiff = makeTiff([page([[0, 1], [2, 0]])]);
+    const tiff = makeTiff([
+      page([
+        [0, 1],
+        [2, 0],
+      ]),
+    ]);
     const lis = await loadLabelImages(blobOf(tiff), {
       pagesAs: "time",
-      categories: new Map([[1, "cell"], [2, "nucleus"]]),
+      categories: new Map([
+        [1, "cell"],
+        [2, "nucleus"],
+      ]),
     });
     expect(lis[0].objects.get(1)!.category).toBe("cell");
     expect(lis[0].objects.get(2)!.category).toBe("nucleus");
   });
 
   it("honors explicit tracks (positional)", async () => {
-    const tiff = makeTiff([page([[0, 1], [2, 0]])]);
+    const tiff = makeTiff([
+      page([
+        [0, 1],
+        [2, 0],
+      ]),
+    ]);
     const a = new Track("A");
     const b = new Track("B");
-    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time", tracks: [a, b] });
+    const lis = await loadLabelImages(blobOf(tiff), {
+      pagesAs: "time",
+      tracks: [a, b],
+    });
     expect(lis[0].objects.get(1)!.track).toBe(a);
     expect(lis[0].objects.get(2)!.track).toBe(b);
   });
@@ -240,9 +333,18 @@ describe("loadLabelImages — time mode", () => {
 describe("loadLabelImages — classes mode", () => {
   it("composites single-class pages and preserves distinct COCO IDs", async () => {
     const tiff = makeTiff([
-      page([[5, 0], [0, 0]]),
-      page([[0, 17], [0, 0]]),
-      page([[0, 0], [99, 0]]),
+      page([
+        [5, 0],
+        [0, 0],
+      ]),
+      page([
+        [0, 17],
+        [0, 0],
+      ]),
+      page([
+        [0, 0],
+        [99, 0],
+      ]),
     ]);
     const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "classes" });
     expect(lis).toHaveLength(1);
@@ -251,9 +353,18 @@ describe("loadLabelImages — classes mode", () => {
 
   it("renumbers positionally 1..N for purely-binary pages", async () => {
     const tiff = makeTiff([
-      page([[1, 0], [0, 0]]),
-      page([[0, 1], [0, 0]]),
-      page([[0, 0], [1, 0]]),
+      page([
+        [1, 0],
+        [0, 0],
+      ]),
+      page([
+        [0, 1],
+        [0, 0],
+      ]),
+      page([
+        [0, 0],
+        [1, 0],
+      ]),
     ]);
     const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "classes" });
     expect(lis[0].labelIds).toEqual([1, 2, 3]);
@@ -276,7 +387,8 @@ describe("loadLabelImages — classes mode", () => {
 
 describe("loadLabelImages — auto detection", () => {
   it("ImageJ CYX metadata routes to classes (1 image)", async () => {
-    const desc = "ImageJ=1.53\nimages=3\nchannels=3\nslices=1\nframes=1\nhyperstack=true\n";
+    const desc =
+      "ImageJ=1.53\nimages=3\nchannels=3\nslices=1\nframes=1\nhyperstack=true\n";
     // Distinct pixel positions per class so composited IDs don't overlap.
     const tiff = makeTiff([
       page([[5, 0, 0]], { description: desc }),
@@ -300,8 +412,12 @@ describe("loadLabelImages — auto detection", () => {
   });
 
   it("OME CYX metadata routes to classes", async () => {
-    const ome = '<?xml version="1.0"?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"><Image><Pixels SizeC="2" SizeT="1" SizeZ="1"/></Image></OME>';
-    const tiff = makeTiff([page([[7, 0]], { description: ome }), page([[0, 8]])]);
+    const ome =
+      '<?xml version="1.0"?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"><Image><Pixels SizeC="2" SizeT="1" SizeZ="1"/></Image></OME>';
+    const tiff = makeTiff([
+      page([[7, 0]], { description: ome }),
+      page([[0, 8]]),
+    ]);
     const lis = await loadLabelImages(blobOf(tiff));
     expect(lis).toHaveLength(1);
     expect(lis[0].labelIds).toEqual([7, 8]);
@@ -324,12 +440,18 @@ describe("loadLabelImages — auto detection", () => {
     const orig = console.warn;
     console.warn = (...args: unknown[]) => warnings.push(String(args[0]));
     try {
-      const lis = await loadLabelImages(blobOf(tiff), { source: "ambiguous-uniq.tif" });
+      const lis = await loadLabelImages(blobOf(tiff), {
+        source: "ambiguous-uniq.tif",
+      });
       expect(lis).toHaveLength(3); // routed to time
     } finally {
       console.warn = orig;
     }
-    expect(warnings.some((w) => /multi-page TIFF/.test(w) && /pagesAs: 'classes'/.test(w))).toBe(true);
+    expect(
+      warnings.some(
+        (w) => /multi-page TIFF/.test(w) && /pagesAs: 'classes'/.test(w),
+      ),
+    ).toBe(true);
   });
 });
 
@@ -345,40 +467,62 @@ describe("loadLabelImages — frames, errors, paths", () => {
       page([[5, 6]]),
       page([[7, 8]]),
     ]);
-    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time", frames: [0, 2] });
+    const lis = await loadLabelImages(blobOf(tiff), {
+      pagesAs: "time",
+      frames: [0, 2],
+    });
     expect(lis).toHaveLength(2);
     expect(lis[0].labelIds).toEqual([1, 2]);
     expect(lis[1].labelIds).toEqual([5, 6]);
   });
 
   it("throws a clear error for 32-bit integer TIFFs", async () => {
-    const tiff = makeTiff([page([[1, 2], [3, 4]], { bitsPerSample: 32, sampleFormat: 1 })]);
-    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "time" })).rejects.toThrow(
-      /8- and 16-bit unsigned/
-    );
+    const tiff = makeTiff([
+      page(
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        { bitsPerSample: 32, sampleFormat: 1 },
+      ),
+    ]);
+    await expect(
+      loadLabelImages(blobOf(tiff), { pagesAs: "time" }),
+    ).rejects.toThrow(/8- and 16-bit unsigned/);
   });
 
   it("rejects floating-point TIFFs (not silently truncated)", async () => {
-    const tiff = makeTiff([page([[1, 2], [3, 4]], { bitsPerSample: 32, sampleFormat: 3 })]);
-    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "time" })).rejects.toThrow(
-      /Floating-point/
-    );
+    const tiff = makeTiff([
+      page(
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        { bitsPerSample: 32, sampleFormat: 3 },
+      ),
+    ]);
+    await expect(
+      loadLabelImages(blobOf(tiff), { pagesAs: "time" }),
+    ).rejects.toThrow(/Floating-point/);
   });
 
   it("rejects multi-channel (RGB) TIFFs", async () => {
     const tiff = makeTiff([
       { width: 2, height: 1, bitsPerSample: 8, samplesPerPixel: 3, pixels: [] },
     ]);
-    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "time" })).rejects.toThrow(
-      /single-channel/
-    );
+    await expect(
+      loadLabelImages(blobOf(tiff), { pagesAs: "time" }),
+    ).rejects.toThrow(/single-channel/);
   });
 
   it("assigns class-mode categories from a Map (positional 1..N keys)", async () => {
     const tiff = makeTiff([page([[7, 0]]), page([[0, 8]])]);
     const lis = await loadLabelImages(blobOf(tiff), {
       pagesAs: "classes",
-      categories: new Map([[1, "cell"], [2, "debris"]]),
+      categories: new Map([
+        [1, "cell"],
+        [2, "debris"],
+      ]),
     });
     // Categories key by positional post-composite IDs 1..N, even though the
     // preserved label IDs are 7 and 8.
@@ -388,7 +532,10 @@ describe("loadLabelImages — frames, errors, paths", () => {
 
   it("ignores out-of-range frame indices", async () => {
     const tiff = makeTiff([page([[1, 2]]), page([[3, 4]]), page([[5, 6]])]);
-    const lis = await loadLabelImages(blobOf(tiff), { pagesAs: "time", frames: [0, 5, 2] });
+    const lis = await loadLabelImages(blobOf(tiff), {
+      pagesAs: "time",
+      frames: [0, 5, 2],
+    });
     expect(lis).toHaveLength(2); // 5 is out of range -> dropped
     expect(lis[0].labelIds).toEqual([1, 2]);
     expect(lis[1].labelIds).toEqual([5, 6]);
@@ -400,7 +547,10 @@ describe("loadLabelImages — frames, errors, paths", () => {
     fs.writeFileSync(path.join(dir, "01.tif"), makeTiff([page([[0, 2]])]));
     fs.writeFileSync(path.join(dir, "02.tif"), makeTiff([page([[3, 0]])]));
     try {
-      const lis = await loadLabelImages(dir, { pagesAs: "time", frames: [0, 2] });
+      const lis = await loadLabelImages(dir, {
+        pagesAs: "time",
+        frames: [0, 2],
+      });
       expect(lis).toHaveLength(2);
       expect(lis[0].labelIds).toEqual([1]);
       expect(lis[1].labelIds).toEqual([3]);
@@ -421,13 +571,22 @@ describe("loadLabelImages — frames, errors, paths", () => {
   it("throws on an invalid pagesAs value", async () => {
     const tiff = makeTiff([page([[1, 0]])]);
     // @ts-expect-error testing runtime validation
-    await expect(loadLabelImages(blobOf(tiff), { pagesAs: "bogus" })).rejects.toThrow(
-      "pagesAs must be"
-    );
+    await expect(
+      loadLabelImages(blobOf(tiff), { pagesAs: "bogus" }),
+    ).rejects.toThrow("pagesAs must be");
   });
 
   it("reads a .tif from a path (node:fs reader)", async () => {
-    const tiff = makeTiff([page([[10, 0], [0, 20]]), page([[0, 30], [40, 0]])]);
+    const tiff = makeTiff([
+      page([
+        [10, 0],
+        [0, 20],
+      ]),
+      page([
+        [0, 30],
+        [40, 0],
+      ]),
+    ]);
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "li-test-"));
     const file = path.join(dir, "labels.tif");
     fs.writeFileSync(file, tiff);

--- a/tests/io/ultralytics.test.ts
+++ b/tests/io/ultralytics.test.ts
@@ -84,7 +84,12 @@ afterEach(() => {
 });
 
 /** Write a tiny valid PNG of the given size into `dir` and return its path. */
-function writeTestPng(dir: string, name: string, width: number, height: number): string {
+function writeTestPng(
+  dir: string,
+  name: string,
+  width: number,
+  height: number,
+): string {
   const rgba = new Uint8Array(width * height * 4).fill(0);
   const png = encodePng(rgba, width, height);
   const p = path.join(dir, name);
@@ -122,8 +127,12 @@ describe("data.yaml + skeleton", () => {
 
 describe("detectLineFormat", () => {
   it("auto-detects per-line formats", () => {
-    expect(detectLineFormat(["0", "0.5", "0.5", "0.2", "0.3"])).toBe("detection");
-    expect(detectLineFormat(["0", "0.5", "0.5", "0.2", "0.3", "0.9"])).toBe("detection_conf");
+    expect(detectLineFormat(["0", "0.5", "0.5", "0.2", "0.3"])).toBe(
+      "detection",
+    );
+    expect(detectLineFormat(["0", "0.5", "0.5", "0.2", "0.3", "0.9"])).toBe(
+      "detection_conf",
+    );
     expect(detectLineFormat(Array(8).fill("0"))).toBe("pose"); // 5 + 3*1
     expect(detectLineFormat(Array(11).fill("0"))).toBe("pose"); // 5 + 3*2
     expect(detectLineFormat(Array(9).fill("0"))).toBe("segmentation"); // 4 polygon pts
@@ -137,8 +146,17 @@ describe("detectLineFormat", () => {
 
 describe("parseLabelFile (pose)", () => {
   it("parses a single-instance label file", () => {
-    const labelFile = path.join(ultralyticsDataset, "train", "labels", "image_001.txt");
-    const { instances, rois, bboxes } = parseLabelFile(labelFile, ultralyticsSkeleton(), [480, 640]);
+    const labelFile = path.join(
+      ultralyticsDataset,
+      "train",
+      "labels",
+      "image_001.txt",
+    );
+    const { instances, rois, bboxes } = parseLabelFile(
+      labelFile,
+      ultralyticsSkeleton(),
+      [480, 640],
+    );
     expect(instances.length).toBe(1);
     expect(rois.length).toBe(0);
     expect(bboxes.length).toBe(0);
@@ -156,8 +174,17 @@ describe("parseLabelFile (pose)", () => {
   });
 
   it("parses a multi-instance label file", () => {
-    const labelFile = path.join(ultralyticsDataset, "train", "labels", "image_002.txt");
-    const { instances, rois } = parseLabelFile(labelFile, ultralyticsSkeleton(), [480, 640]);
+    const labelFile = path.join(
+      ultralyticsDataset,
+      "train",
+      "labels",
+      "image_002.txt",
+    );
+    const { instances, rois } = parseLabelFile(
+      labelFile,
+      ultralyticsSkeleton(),
+      [480, 640],
+    );
     expect(instances.length).toBe(2);
     expect(rois.length).toBe(0);
     for (const instance of instances) {
@@ -168,7 +195,11 @@ describe("parseLabelFile (pose)", () => {
   it("handles empty label files", () => {
     const labelFile = path.join(tmp, "empty.txt");
     fs.writeFileSync(labelFile, "");
-    const { instances, rois, bboxes } = parseLabelFile(labelFile, ultralyticsSkeleton(), [480, 640]);
+    const { instances, rois, bboxes } = parseLabelFile(
+      labelFile,
+      ultralyticsSkeleton(),
+      [480, 640],
+    );
     expect(instances.length).toBe(0);
     expect(rois.length).toBe(0);
     expect(bboxes.length).toBe(0);
@@ -177,13 +208,21 @@ describe("parseLabelFile (pose)", () => {
   it("skips malformed lines without crashing", () => {
     const labelFile = path.join(tmp, "malformed.txt");
     fs.writeFileSync(labelFile, "invalid line\n0 0.5\n");
-    const { instances, rois } = parseLabelFile(labelFile, ultralyticsSkeleton(), [480, 640]);
+    const { instances, rois } = parseLabelFile(
+      labelFile,
+      ultralyticsSkeleton(),
+      [480, 640],
+    );
     expect(instances.length).toBe(0);
     expect(rois.length).toBe(0);
   });
 
   it("rejects instances when keypoint count mismatches skeleton", () => {
-    const skeleton = new Skeleton([new Node("a"), new Node("b"), new Node("c")]);
+    const skeleton = new Skeleton([
+      new Node("a"),
+      new Node("b"),
+      new Node("c"),
+    ]);
     const labelFile = path.join(tmp, "mismatch.txt");
     fs.writeFileSync(labelFile, "0 0.5 0.5 0.2 0.4 0.1 0.1 2 0.2 0.2 2\n"); // only 2 keypoints
     const { instances } = parseLabelFile(labelFile, skeleton, [100, 100]);
@@ -193,7 +232,11 @@ describe("parseLabelFile (pose)", () => {
   it("warns and skips on non-numeric class id", () => {
     const labelFile = path.join(tmp, "invalid_data.txt");
     fs.writeFileSync(labelFile, "not_a_number 0.5 0.5 0.2 0.2\n");
-    const { instances } = parseLabelFile(labelFile, ultralyticsSkeleton(), [480, 640]);
+    const { instances } = parseLabelFile(
+      labelFile,
+      ultralyticsSkeleton(),
+      [480, 640],
+    );
     expect(instances.length).toBe(0);
   });
 
@@ -231,7 +274,10 @@ describe("readLabels", () => {
     expect(labels.labeledFrames.length).toBe(2);
     expect(labels.skeletons.length).toBe(1);
     expect(labels.skeletons[0].nodes.length).toBe(5);
-    const total = labels.labeledFrames.reduce((s, f) => s + f.instances.length, 0);
+    const total = labels.labeledFrames.reduce(
+      (s, f) => s + f.instances.length,
+      0,
+    );
     expect(total).toBe(3); // 1 + 2
   });
 
@@ -239,12 +285,18 @@ describe("readLabels", () => {
     const labels = readLabels(ultralyticsDataset, { split: "val" });
     expect(labels.labeledFrames.length).toBe(1);
     expect(labels.skeletons.length).toBe(1);
-    const total = labels.labeledFrames.reduce((s, f) => s + f.instances.length, 0);
+    const total = labels.labeledFrames.reduce(
+      (s, f) => s + f.instances.length,
+      0,
+    );
     expect(total).toBe(1);
   });
 
   it("uses a custom skeleton when provided", () => {
-    const nodes = Array.from({ length: 5 }, (_, i) => new Node(`custom_node_${i}`));
+    const nodes = Array.from(
+      { length: 5 },
+      (_, i) => new Node(`custom_node_${i}`),
+    );
     const custom = new Skeleton({ nodes, name: "custom" });
     const labels = readLabels(ultralyticsDataset, { skeleton: custom });
     expect(labels.skeletons[0]).toBe(custom);
@@ -267,7 +319,9 @@ describe("readLabels", () => {
   });
 
   it("throws when data.yaml is missing", () => {
-    expect(() => readLabels(path.join(tmp, "nonexistent"))).toThrow(/data\.yaml not found/);
+    expect(() => readLabels(path.join(tmp, "nonexistent"))).toThrow(
+      /data\.yaml not found/,
+    );
   });
 
   it("throws when images directory is missing", () => {
@@ -275,7 +329,9 @@ describe("readLabels", () => {
       path.join(tmp, "data.yaml"),
       "kpt_shape: [1, 3]\ntrain: train/images\n",
     );
-    expect(() => readLabels(tmp, { split: "train" })).toThrow(/Images directory not found/);
+    expect(() => readLabels(tmp, { split: "train" })).toThrow(
+      /Images directory not found/,
+    );
   });
 
   it("throws when labels directory is missing", () => {
@@ -284,7 +340,9 @@ describe("readLabels", () => {
       "kpt_shape: [2, 3]\ntrain: train/images\nnode_names: [a, b]\n",
     );
     fs.mkdirSync(path.join(tmp, "train", "images"), { recursive: true });
-    expect(() => readLabels(tmp, { split: "train" })).toThrow(/Labels directory not found/);
+    expect(() => readLabels(tmp, { split: "train" })).toThrow(
+      /Labels directory not found/,
+    );
   });
 
   it("reads image dimensions from the file header (denormalization)", () => {
@@ -328,7 +386,11 @@ describe("writeLabelFile (pose)", () => {
   });
 
   it("writes an empty file when no points are visible", () => {
-    const skeleton = new Skeleton([new Node("a"), new Node("b"), new Node("c")]);
+    const skeleton = new Skeleton([
+      new Node("a"),
+      new Node("b"),
+      new Node("c"),
+    ]);
     const pointsData = [
       [NaN, NaN, 0],
       [NaN, NaN, 0],
@@ -346,7 +408,11 @@ describe("writeLabelFile (pose)", () => {
   });
 
   it("skips instances whose point count mismatches the skeleton", () => {
-    const skeleton = new Skeleton([new Node("a"), new Node("b"), new Node("c")]);
+    const skeleton = new Skeleton([
+      new Node("a"),
+      new Node("b"),
+      new Node("c"),
+    ]);
     const instance = Instance.fromNumpy({
       pointsData: [
         [10, 20, 1],
@@ -368,7 +434,10 @@ describe("writeLabelFile (pose)", () => {
 describe("writeLabels (pose) round trips", () => {
   it("writes a single split with images + labels", async () => {
     // Three frames backed by real on-disk images (so the copy path runs).
-    const skeleton = new Skeleton([new Node("head"), new Node("tail")], [new Edge(new Node("head"), new Node("tail"))]);
+    const skeleton = new Skeleton(
+      [new Node("head"), new Node("tail")],
+      [new Edge(new Node("head"), new Node("tail"))],
+    );
     const frames: LabeledFrame[] = [];
     for (let i = 0; i < 3; i++) {
       const imgPath = writeTestPng(tmp, `src_${i}.png`, 64, 48);
@@ -402,7 +471,9 @@ describe("writeLabels (pose) round trips", () => {
 
     const images = fs.readdirSync(path.join(outDir, "train", "images")).sort();
     expect(images).toEqual(["0000000.png", "0000001.png", "0000002.png"]);
-    const labelFiles = fs.readdirSync(path.join(outDir, "train", "labels")).sort();
+    const labelFiles = fs
+      .readdirSync(path.join(outDir, "train", "labels"))
+      .sort();
     expect(labelFiles).toEqual(["0000000.txt", "0000001.txt", "0000002.txt"]);
   });
 
@@ -412,19 +483,27 @@ describe("writeLabels (pose) round trips", () => {
     await writeLabels(original, outDir, { splitRatios: { train: 1.0 } });
     const reloaded = readLabels(outDir, { split: "train" });
     expect(reloaded.labeledFrames.length).toBe(original.labeledFrames.length);
-    expect(reloaded.skeletons[0].nodes.length).toBe(original.skeletons[0].nodes.length);
+    expect(reloaded.skeletons[0].nodes.length).toBe(
+      original.skeletons[0].nodes.length,
+    );
   });
 
   it("saveUltralytics is a convenience wrapper", async () => {
     const skeleton = new Skeleton([new Node("p")]);
     const imgPath = writeTestPng(tmp, "single.png", 32, 32);
-    const instance = Instance.fromNumpy({ pointsData: [[10, 10, 1]], skeleton });
+    const instance = Instance.fromNumpy({
+      pointsData: [[10, 10, 1]],
+      skeleton,
+    });
     const frame = new LabeledFrame({
       video: new Video({ filename: imgPath, openBackend: false }),
       frameIdx: 0,
       instances: [instance],
     });
-    const labels = new Labels({ labeledFrames: [frame], skeletons: [skeleton] });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      skeletons: [skeleton],
+    });
     const outDir = path.join(tmp, "save_ultralytics");
     await saveUltralytics(labels, outDir);
     expect(fs.existsSync(path.join(outDir, "data.yaml"))).toBe(true);
@@ -435,7 +514,9 @@ describe("writeLabels (pose) round trips", () => {
     const skeleton = new Skeleton([new Node("node")]);
     const labels = new Labels({ labeledFrames: [], skeletons: [skeleton] });
     await expect(
-      writeLabels(labels, path.join(tmp, "bad"), { splitRatios: { train: 0.5, val: 0.6 } }),
+      writeLabels(labels, path.join(tmp, "bad"), {
+        splitRatios: { train: 0.5, val: 0.6 },
+      }),
     ).rejects.toThrow(/Split ratios must sum to 1\.0/);
   });
 
@@ -451,7 +532,10 @@ describe("writeLabels (pose) round trips", () => {
     const frames: LabeledFrame[] = [];
     for (let i = 0; i < 10; i++) {
       const imgPath = writeTestPng(tmp, `tw_${i}.png`, 16, 16);
-      const instance = Instance.fromNumpy({ pointsData: [[i, i, 1]], skeleton });
+      const instance = Instance.fromNumpy({
+        pointsData: [[i, i, 1]],
+        skeleton,
+      });
       frames.push(
         new LabeledFrame({
           video: new Video({ filename: imgPath, openBackend: false }),
@@ -583,9 +667,14 @@ describe("detection format", () => {
   it("normalizes/denormalizes detection coordinates correctly", () => {
     const labelFile = path.join(tmp, "det.txt");
     fs.writeFileSync(labelFile, "0 0.5 0.5 0.4 0.6\n");
-    const { instances, rois, bboxes } = parseLabelFile(labelFile, new Skeleton([]), [100, 200], {
-      classNames: new Map([[0, "obj"]]),
-    });
+    const { instances, rois, bboxes } = parseLabelFile(
+      labelFile,
+      new Skeleton([]),
+      [100, 200],
+      {
+        classNames: new Map([[0, "obj"]]),
+      },
+    );
     expect(instances.length).toBe(0);
     expect(rois.length).toBe(0);
     expect(bboxes.length).toBe(1);
@@ -609,10 +698,25 @@ describe("detection format", () => {
   it("writes UserBoundingBox (5 values) and PredictedBoundingBox (6 values)", () => {
     const bboxes = [
       new UserBoundingBox({ x1: 60, y1: 20, x2: 140, y2: 80, category: "cat" }),
-      new PredictedBoundingBox({ x1: 30, y1: 10, x2: 70, y2: 40, category: "dog", score: 0.9 }),
+      new PredictedBoundingBox({
+        x1: 30,
+        y1: 10,
+        x2: 70,
+        y2: 40,
+        category: "dog",
+        score: 0.9,
+      }),
     ];
     const labelPath = path.join(tmp, "bbox.txt");
-    writeBboxLabelFile(labelPath, bboxes, [100, 200], new Map([["cat", 0], ["dog", 1]]));
+    writeBboxLabelFile(
+      labelPath,
+      bboxes,
+      [100, 200],
+      new Map([
+        ["cat", 0],
+        ["dog", 1],
+      ]),
+    );
     const lines = fs.readFileSync(labelPath, "utf-8").trim().split("\n");
     expect(lines.length).toBe(2);
 
@@ -628,9 +732,17 @@ describe("detection format", () => {
     expect(Number(parts1[5])).toBeCloseTo(0.9, 4);
 
     // Round-trip.
-    const { bboxes: readBack } = parseLabelFile(labelPath, new Skeleton([]), [100, 200], {
-      classNames: new Map([[0, "cat"], [1, "dog"]]),
-    });
+    const { bboxes: readBack } = parseLabelFile(
+      labelPath,
+      new Skeleton([]),
+      [100, 200],
+      {
+        classNames: new Map([
+          [0, "cat"],
+          [1, "dog"],
+        ]),
+      },
+    );
     expect(readBack.length).toBe(2);
     expect(readBack[0]).toBeInstanceOf(UserBoundingBox);
     expect(readBack[0].category).toBe("cat");
@@ -647,9 +759,14 @@ describe("segmentation format", () => {
   it("parses + writes a segmentation polygon round-trip", () => {
     const labelFile = path.join(tmp, "seg.txt");
     fs.writeFileSync(labelFile, "0 0.1 0.1 0.9 0.2 0.8 0.9 0.2 0.8\n");
-    const { instances, rois, bboxes } = parseLabelFile(labelFile, new Skeleton([]), [100, 200], {
-      classNames: new Map([[0, "animal"]]),
-    });
+    const { instances, rois, bboxes } = parseLabelFile(
+      labelFile,
+      new Skeleton([]),
+      [100, 200],
+      {
+        classNames: new Map([[0, "animal"]]),
+      },
+    );
     expect(instances.length).toBe(0);
     expect(rois.length).toBe(1);
     expect(bboxes.length).toBe(0);
@@ -659,16 +776,22 @@ describe("segmentation format", () => {
     expect(roi.category).toBe("animal");
     expect(roi.area).toBeGreaterThan(0);
 
-    const coords = (roi.geometry as { coordinates: number[][][] }).coordinates[0];
+    const coords = (roi.geometry as { coordinates: number[][][] })
+      .coordinates[0];
     expect(coords.length).toBe(5); // 4 vertices + closing point
     expect(coords[0][0]).toBeCloseTo(0.1 * 200, 4);
     expect(coords[0][1]).toBeCloseTo(0.1 * 100, 4);
 
     const labelOut = path.join(tmp, "seg_out.txt");
     writeRoiLabelFile(labelOut, rois, [100, 200], new Map([["animal", 0]]));
-    const { rois: rois2, bboxes: bboxes2 } = parseLabelFile(labelOut, new Skeleton([]), [100, 200], {
-      classNames: new Map([[0, "animal"]]),
-    });
+    const { rois: rois2, bboxes: bboxes2 } = parseLabelFile(
+      labelOut,
+      new Skeleton([]),
+      [100, 200],
+      {
+        classNames: new Map([[0, "animal"]]),
+      },
+    );
     expect(rois2.length).toBe(1);
     expect(bboxes2.length).toBe(0);
     expect(rois2[0].isBbox).toBe(false);
@@ -676,26 +799,29 @@ describe("segmentation format", () => {
   });
 
   it("explodes MultiPolygon ROIs into separate lines", () => {
-    const multi = UserROI.fromMultiPolygon([
+    const multi = UserROI.fromMultiPolygon(
       [
         [
-          [0, 0],
-          [50, 0],
-          [50, 50],
-          [0, 50],
-          [0, 0],
+          [
+            [0, 0],
+            [50, 0],
+            [50, 50],
+            [0, 50],
+            [0, 0],
+          ],
         ],
-      ],
-      [
         [
-          [60, 60],
-          [100, 60],
-          [100, 100],
-          [60, 100],
-          [60, 60],
+          [
+            [60, 60],
+            [100, 60],
+            [100, 100],
+            [60, 100],
+            [60, 60],
+          ],
         ],
       ],
-    ], { category: "obj" });
+      { category: "obj" },
+    );
     const labelPath = path.join(tmp, "multi.txt");
     writeRoiLabelFile(labelPath, [multi], [200, 200], new Map([["obj", 0]]));
     const lines = fs.readFileSync(labelPath, "utf-8").trim().split("\n");
@@ -745,10 +871,18 @@ describe("segmentation format", () => {
       verbose: false,
     });
 
-    expect(fs.readdirSync(path.join(datasetPath, "train", "images")).length).toBe(8);
-    expect(fs.readdirSync(path.join(datasetPath, "val", "images")).length).toBe(2);
-    expect(fs.readdirSync(path.join(datasetPath, "train", "labels")).length).toBe(8);
-    expect(fs.readdirSync(path.join(datasetPath, "val", "labels")).length).toBe(2);
+    expect(
+      fs.readdirSync(path.join(datasetPath, "train", "images")).length,
+    ).toBe(8);
+    expect(fs.readdirSync(path.join(datasetPath, "val", "images")).length).toBe(
+      2,
+    );
+    expect(
+      fs.readdirSync(path.join(datasetPath, "train", "labels")).length,
+    ).toBe(8);
+    expect(fs.readdirSync(path.join(datasetPath, "val", "labels")).length).toBe(
+      2,
+    );
   });
 });
 
@@ -789,7 +923,12 @@ describe("readLabelsSet", () => {
       fs.mkdirSync(imagesDir, { recursive: true });
       fs.mkdirSync(labelsDir, { recursive: true });
       for (let i = 0; i < 2; i++) {
-        writeTestPng(imagesDir, `img_${String(i).padStart(3, "0")}.png`, 10, 10);
+        writeTestPng(
+          imagesDir,
+          `img_${String(i).padStart(3, "0")}.png`,
+          10,
+          10,
+        );
         fs.writeFileSync(
           path.join(labelsDir, `img_${String(i).padStart(3, "0")}.txt`),
           "0 0.5 0.5 0.4 0.4 0.4 0.4 2 0.5 0.5 2 0.6 0.6 2\n",
@@ -826,7 +965,11 @@ describe("readLabelsSet", () => {
   it("uses a custom skeleton", () => {
     const datasetPath = path.join(tmp, "yolo");
     createDataset(datasetPath, ["train"]);
-    const skeleton = new Skeleton([new Node("head"), new Node("body"), new Node("tail")]);
+    const skeleton = new Skeleton([
+      new Node("head"),
+      new Node("body"),
+      new Node("tail"),
+    ]);
     const set = readLabelsSet(datasetPath, { skeleton });
     expect(set.get("train")!.skeletons[0].nodes[0].name).toBe("head");
     expect(set.get("train")!.skeletons[0].nodes[2].name).toBe("tail");
@@ -835,7 +978,9 @@ describe("readLabelsSet", () => {
   it("ignores missing splits", () => {
     const datasetPath = path.join(tmp, "yolo");
     createDataset(datasetPath, ["train"]);
-    const set = readLabelsSet(datasetPath, { splits: ["train", "val", "test"] });
+    const set = readLabelsSet(datasetPath, {
+      splits: ["train", "val", "test"],
+    });
     expect(set.size).toBe(1);
     expect(set.get("train")).toBeDefined();
   });
@@ -864,7 +1009,10 @@ describe("createSplitsFromLabels", () => {
   function dummyLabels(n: number): Labels {
     const skeleton = new Skeleton([new Node("a")]);
     const frames = Array.from({ length: n }, (_, i) => {
-      const instance = Instance.fromNumpy({ pointsData: [[i, i, 1]], skeleton });
+      const instance = Instance.fromNumpy({
+        pointsData: [[i, i, 1]],
+        skeleton,
+      });
       return new LabeledFrame({
         video: new Video({ filename: `f_${i}.mp4`, openBackend: false }),
         frameIdx: i,
@@ -875,13 +1023,20 @@ describe("createSplitsFromLabels", () => {
   }
 
   it("creates two-way splits with correct counts", () => {
-    const splits = createSplitsFromLabels(dummyLabels(10), { train: 0.8, val: 0.2 });
+    const splits = createSplitsFromLabels(dummyLabels(10), {
+      train: 0.8,
+      val: 0.2,
+    });
     expect(splits.train.labeledFrames.length).toBe(8);
     expect(splits.val.labeledFrames.length).toBe(2);
   });
 
   it("creates three-way splits with correct counts", () => {
-    const splits = createSplitsFromLabels(dummyLabels(10), { train: 0.6, val: 0.2, test: 0.2 });
+    const splits = createSplitsFromLabels(dummyLabels(10), {
+      train: 0.6,
+      val: 0.2,
+      test: 0.2,
+    });
     expect(splits.train.labeledFrames.length).toBe(6);
     expect(splits.val.labeledFrames.length).toBe(2);
     expect(splits.test.labeledFrames.length).toBe(2);
@@ -916,7 +1071,9 @@ describe("encodePng", () => {
   it("produces a valid PNG signature + probeable dimensions", () => {
     const png = encodePng(new Uint8Array(4 * 4 * 4).fill(255), 4, 4);
     // PNG signature.
-    expect(Array.from(png.slice(0, 8))).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(Array.from(png.slice(0, 8))).toEqual([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
     const p = path.join(tmp, "enc.png");
     fs.writeFileSync(p, png);
     expect(probeImageSize(p)).toEqual([4, 4]);
@@ -960,15 +1117,24 @@ describe("Python-parity edge cases", () => {
     const ds = path.join(tmp, "exts");
     fs.mkdirSync(path.join(ds, "train", "images"), { recursive: true });
     fs.mkdirSync(path.join(ds, "train", "labels"), { recursive: true });
-    fs.writeFileSync(path.join(ds, "data.yaml"), "kpt_shape: [1, 3]\ntrain: train/images\nnames: [animal]\n");
+    fs.writeFileSync(
+      path.join(ds, "data.yaml"),
+      "kpt_shape: [1, 3]\ntrain: train/images\nnames: [animal]\n",
+    );
     writeTestPng(path.join(ds, "train", "images"), "a.png", 10, 10);
     // A GIF header (10x10) that the reader must ignore.
     fs.writeFileSync(
       path.join(ds, "train", "images", "b.gif"),
       Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 10, 0, 10, 0]),
     );
-    fs.writeFileSync(path.join(ds, "train", "labels", "a.txt"), "0 0.5 0.5 0.2 0.2 0.5 0.5 2\n");
-    fs.writeFileSync(path.join(ds, "train", "labels", "b.txt"), "0 0.5 0.5 0.2 0.2 0.5 0.5 2\n");
+    fs.writeFileSync(
+      path.join(ds, "train", "labels", "a.txt"),
+      "0 0.5 0.5 0.2 0.2 0.5 0.5 2\n",
+    );
+    fs.writeFileSync(
+      path.join(ds, "train", "labels", "b.txt"),
+      "0 0.5 0.5 0.2 0.2 0.5 0.5 2\n",
+    );
     const labels = readLabels(ds, { split: "train" });
     expect(labels.labeledFrames.length).toBe(1); // only a.png
   });
@@ -983,7 +1149,11 @@ describe("Python-parity edge cases", () => {
     }
     const labels = new Labels({ labeledFrames: lfs });
     const ds = path.join(tmp, "bankers");
-    await writeLabels(labels, ds, { splitRatios: { train: 0.5, val: 0.5 }, task: "segment", verbose: false });
+    await writeLabels(labels, ds, {
+      splitRatios: { train: 0.5, val: 0.5 },
+      task: "segment",
+      verbose: false,
+    });
     // boundary train = roundHalfToEven(0.5*5 = 2.5) = 2; val gets the remaining 3.
     expect(fs.readdirSync(path.join(ds, "train", "images")).length).toBe(2);
     expect(fs.readdirSync(path.join(ds, "val", "images")).length).toBe(3);
@@ -998,9 +1168,14 @@ describe("Python-parity edge cases", () => {
       frameIdx: 0,
       instances: [instance],
     });
-    const labels = new Labels({ labeledFrames: [frame], skeletons: [skeleton] });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      skeletons: [skeleton],
+    });
     // 0.999999 is within ~1e-5 of 1.0 → accepted (was rejected by the old 1e-8 tolerance).
-    await writeLabels(labels, path.join(tmp, "tol"), { splitRatios: { train: 0.999999 } });
+    await writeLabels(labels, path.join(tmp, "tol"), {
+      splitRatios: { train: 0.999999 },
+    });
     expect(fs.existsSync(path.join(tmp, "tol", "data.yaml"))).toBe(true);
   });
 
@@ -1018,12 +1193,18 @@ describe("Python-parity edge cases", () => {
     const good0 = mk("g0.png");
     // Middle frame: a non-existent, non-image source → skipped on write.
     const bad = new LabeledFrame({
-      video: new Video({ filename: path.join(tmp, "missing.mp4"), openBackend: false }),
+      video: new Video({
+        filename: path.join(tmp, "missing.mp4"),
+        openBackend: false,
+      }),
       frameIdx: 7,
       instances: [Instance.fromNumpy({ pointsData: [[5, 5, 1]], skeleton })],
     });
     const good2 = mk("g2.png");
-    const labels = new Labels({ labeledFrames: [good0, bad, good2], skeletons: [skeleton] });
+    const labels = new Labels({
+      labeledFrames: [good0, bad, good2],
+      skeletons: [skeleton],
+    });
     const ds = path.join(tmp, "gap");
     await writeLabels(labels, ds, { splitRatios: { train: 1.0 } });
     const images = fs.readdirSync(path.join(ds, "train", "images")).sort();

--- a/tests/label-image-slp.test.ts
+++ b/tests/label-image-slp.test.ts
@@ -24,17 +24,27 @@ describe("LabelImage SLP I/O", () => {
 
     const data = new Int32Array(10 * 10);
     // Object 1: top-left corner
-    data[0] = 1; data[1] = 1; data[10] = 1;
+    data[0] = 1;
+    data[1] = 1;
+    data[10] = 1;
     // Object 2: bottom-right area
-    data[98] = 2; data[99] = 2; data[89] = 2;
+    data[98] = 2;
+    data[99] = 2;
+    data[89] = 2;
 
     const li = new UserLabelImage({
       data,
       height: 10,
       width: 10,
       objects: new Map<number, LabelImageObjectInfo>([
-        [1, { track: track1, category: "neuron", name: "cell_A", instance: null }],
-        [2, { track: track2, category: "glia", name: "cell_B", instance: null }],
+        [
+          1,
+          { track: track1, category: "neuron", name: "cell_A", instance: null },
+        ],
+        [
+          2,
+          { track: track2, category: "glia", name: "cell_B", instance: null },
+        ],
       ]),
       source: "cellpose",
     });
@@ -157,7 +167,10 @@ describe("LabelImage SLP I/O", () => {
     const inst2 = new Instance({ points: { a: [1, 2] }, skeleton });
     const frame2 = new LabeledFrame({ video, frameIdx: 0, instances: [inst2] });
     const bb = new UserBoundingBox({
-      x1: 0, y1: 10, x2: 100, y2: 90,
+      x1: 0,
+      y1: 10,
+      x2: 100,
+      y2: 90,
     });
     frame2.bboxes.push(bb);
 
@@ -190,7 +203,15 @@ describe("LabelImage SLP I/O", () => {
         height: 8,
         width: 8,
         objects: new Map<number, LabelImageObjectInfo>([
-          [1, { track, category: "cell", name: `frame_${frameIdx}`, instance: null }],
+          [
+            1,
+            {
+              track,
+              category: "cell",
+              name: `frame_${frameIdx}`,
+              instance: null,
+            },
+          ],
         ]),
         source: "auto",
       });
@@ -249,37 +270,43 @@ describe("LabelImage SLP I/O", () => {
     };
 
     const lf0 = new LabeledFrame({ video, frameIdx: 0 });
-    lf0.labelImages.push(new UserLabelImage({
-      data: makeData(),
-      height: 4,
-      width: 4,
-      objects: new Map<number, LabelImageObjectInfo>([
-        [1, { track: trackA, category: "neuron", name: "", instance: null }],
-      ]),
-      source: "model",
-    }));
+    lf0.labelImages.push(
+      new UserLabelImage({
+        data: makeData(),
+        height: 4,
+        width: 4,
+        objects: new Map<number, LabelImageObjectInfo>([
+          [1, { track: trackA, category: "neuron", name: "", instance: null }],
+        ]),
+        source: "model",
+      }),
+    );
 
     const lf5 = new LabeledFrame({ video, frameIdx: 5 });
-    lf5.labelImages.push(new UserLabelImage({
-      data: makeData(),
-      height: 4,
-      width: 4,
-      objects: new Map<number, LabelImageObjectInfo>([
-        [1, { track: trackB, category: "glia", name: "", instance: null }],
-      ]),
-      source: "model",
-    }));
+    lf5.labelImages.push(
+      new UserLabelImage({
+        data: makeData(),
+        height: 4,
+        width: 4,
+        objects: new Map<number, LabelImageObjectInfo>([
+          [1, { track: trackB, category: "glia", name: "", instance: null }],
+        ]),
+        source: "model",
+      }),
+    );
 
     const lf10 = new LabeledFrame({ video, frameIdx: 10 });
-    lf10.labelImages.push(new UserLabelImage({
-      data: makeData(),
-      height: 4,
-      width: 4,
-      objects: new Map<number, LabelImageObjectInfo>([
-        [1, { track: trackA, category: "neuron", name: "", instance: null }],
-      ]),
-      source: "model",
-    }));
+    lf10.labelImages.push(
+      new UserLabelImage({
+        data: makeData(),
+        height: 4,
+        width: 4,
+        objects: new Map<number, LabelImageObjectInfo>([
+          [1, { track: trackA, category: "neuron", name: "", instance: null }],
+        ]),
+        source: "model",
+      }),
+    );
 
     const labels = new Labels({
       labeledFrames: [lf0, lf5, lf10],
@@ -366,7 +393,11 @@ describe("LabelImage SLP I/O", () => {
       points: { a: [10, 20], b: [30, 40] },
       skeleton,
     });
-    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [instance] });
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instance],
+    });
 
     const data = new Int32Array(5 * 5);
     data[0] = 1;
@@ -430,7 +461,9 @@ describe("LabelImage SLP I/O", () => {
     });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlpLazy(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlpLazy(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     // labelImages should be loaded eagerly even in lazy mode
     expect(loaded.labelImages).toHaveLength(1);
@@ -484,7 +517,9 @@ describe("LabelImage SLP I/O", () => {
     // Load, hold only the inner LabelImage, then drop the Labels reference.
     let labelImage: LabelImage | null;
     {
-      const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+      const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+        openVideos: false,
+      });
       labelImage = loaded.labelImages[0];
     }
     // `loaded` is now out of scope; only `labelImage` keeps the data alive.

--- a/tests/label-image.test.ts
+++ b/tests/label-image.test.ts
@@ -7,7 +7,10 @@ import {
   normalizeLabelIds,
 } from "../src/model/label-image.js";
 import { Track } from "../src/model/instance.js";
-import { SegmentationMask, PredictedSegmentationMask } from "../src/model/mask.js";
+import {
+  SegmentationMask,
+  PredictedSegmentationMask,
+} from "../src/model/mask.js";
 import { UserBoundingBox, PredictedBoundingBox } from "../src/model/bbox.js";
 import { Video } from "../src/model/video.js";
 
@@ -199,14 +202,10 @@ describe("LabelImage", () => {
       const li = new UserLabelImage({ data, height, width });
 
       const mask1 = li.getObjectMask(1);
-      expect(mask1).toEqual(
-        new Uint8Array([0, 1, 0, 0, 1, 0, 0, 0, 0]),
-      );
+      expect(mask1).toEqual(new Uint8Array([0, 1, 0, 0, 1, 0, 0, 0, 0]));
 
       const mask2 = li.getObjectMask(2);
-      expect(mask2).toEqual(
-        new Uint8Array([0, 0, 0, 1, 0, 1, 0, 0, 0]),
-      );
+      expect(mask2).toEqual(new Uint8Array([0, 0, 0, 1, 0, 1, 0, 0, 0]));
     });
 
     it("returns all zeros for non-existent label ID", () => {
@@ -575,9 +574,7 @@ describe("LabelImage", () => {
       expect(li.nObjects).toBe(1);
       expect(li.labelIds).toEqual([1]);
       expect(li.tracks).toEqual([track]);
-      expect(li.getObjectMask(1)).toEqual(
-        new Uint8Array([0, 1, 1, 0]),
-      );
+      expect(li.getObjectMask(1)).toEqual(new Uint8Array([0, 1, 1, 0]));
     });
 
     it("sparse IDs (3, 7, 15) sort correctly", () => {
@@ -605,22 +602,35 @@ describe("LabelImage", () => {
 describe("LabelImage abstract base and subclasses", () => {
   it("LabelImage cannot be instantiated directly", () => {
     const data = new Int32Array(4);
-    expect(() => new (LabelImage as any)({ data, height: 2, width: 2 })).toThrow(TypeError);
+    expect(
+      () => new (LabelImage as any)({ data, height: 2, width: 2 }),
+    ).toThrow(TypeError);
   });
 
   it("UserLabelImage isPredicted is false", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 2]]);
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 2],
+    ]);
     const li = new UserLabelImage({ data, height, width });
     expect(li.isPredicted).toBe(false);
     expect(li).toBeInstanceOf(UserLabelImage);
   });
 
   it("PredictedLabelImage has score, scoreMap, isPredicted", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 2]]);
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 2],
+    ]);
     const sm = new Float32Array(4).fill(0.5);
     const li = new PredictedLabelImage({
-      data, height, width, score: 0.88, scoreMap: sm,
-      scoreMapScale: [2, 2], scoreMapOffset: [1, 1],
+      data,
+      height,
+      width,
+      score: 0.88,
+      scoreMap: sm,
+      scoreMapScale: [2, 2],
+      scoreMapOffset: [1, 1],
     });
     expect(li.isPredicted).toBe(true);
     expect(li.score).toBe(0.88);
@@ -640,8 +650,14 @@ describe("LabelImage abstract base and subclasses", () => {
 
 describe("LabelImage.fromStack", () => {
   it("creates label images from 2D array stack", () => {
-    const frame1 = [[1, 0], [0, 2]];
-    const frame2 = [[0, 1], [2, 0]];
+    const frame1 = [
+      [1, 0],
+      [0, 2],
+    ];
+    const frame2 = [
+      [0, 1],
+      [2, 0],
+    ];
     const result = LabelImage.fromStack({ data: [frame1, frame2] });
     expect(result).toHaveLength(2);
     expect(result[0].height).toBe(2);
@@ -653,9 +669,18 @@ describe("LabelImage.fromStack", () => {
   });
 
   it("createTracks auto-creates shared Track objects", () => {
-    const frame1 = [[1, 0], [0, 2]];
-    const frame2 = [[0, 1], [2, 0]];
-    const result = LabelImage.fromStack({ data: [frame1, frame2], createTracks: true });
+    const frame1 = [
+      [1, 0],
+      [0, 2],
+    ];
+    const frame2 = [
+      [0, 1],
+      [2, 0],
+    ];
+    const result = LabelImage.fromStack({
+      data: [frame1, frame2],
+      createTracks: true,
+    });
     // Both frames should share the same Track references
     const tracks1 = result[0].tracks;
     const tracks2 = result[1].tracks;
@@ -666,16 +691,28 @@ describe("LabelImage.fromStack", () => {
   });
 
   it("accepts custom categories as Map", () => {
-    const frame = [[1, 2], [0, 0]];
-    const cats = new Map<number, string>([[1, "cell"], [2, "nucleus"]]);
+    const frame = [
+      [1, 2],
+      [0, 0],
+    ];
+    const cats = new Map<number, string>([
+      [1, "cell"],
+      [2, "nucleus"],
+    ]);
     const result = LabelImage.fromStack({ data: [frame], categories: cats });
     expect(result[0].objects.get(1)?.category).toBe("cell");
     expect(result[0].objects.get(2)?.category).toBe("nucleus");
   });
 
   it("accepts custom categories as Array (1-indexed)", () => {
-    const frame = [[1, 2], [0, 0]];
-    const result = LabelImage.fromStack({ data: [frame], categories: ["cell", "nucleus"] });
+    const frame = [
+      [1, 2],
+      [0, 0],
+    ];
+    const result = LabelImage.fromStack({
+      data: [frame],
+      categories: ["cell", "nucleus"],
+    });
     expect(result[0].objects.get(1)?.category).toBe("cell");
     expect(result[0].objects.get(2)?.category).toBe("nucleus");
   });
@@ -708,14 +745,26 @@ describe("LabelImage scale/offset", () => {
   });
 
   it("imageExtent accounts for scale", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 1]]);
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 1],
+    ]);
     const li = new UserLabelImage({ data, height, width, scale: [2, 2] });
     expect(li.imageExtent).toEqual({ height: 1, width: 1 });
   });
 
   it("resampled returns identity scale/offset", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 2]]);
-    const li = new UserLabelImage({ data, height, width, scale: [2, 2], offset: [5, 5] });
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 2],
+    ]);
+    const li = new UserLabelImage({
+      data,
+      height,
+      width,
+      scale: [2, 2],
+      offset: [5, 5],
+    });
     const resampled = li.resampled(1, 1);
     expect(resampled.scale).toEqual([1, 1]);
     expect(resampled.offset).toEqual([0, 0]);
@@ -725,9 +774,18 @@ describe("LabelImage scale/offset", () => {
   });
 
   it("resampled preserves PredictedLabelImage", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 2]]);
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 2],
+    ]);
     const sm = new Float32Array(4).fill(0.5);
-    const li = new PredictedLabelImage({ data, height, width, score: 0.9, scoreMap: sm });
+    const li = new PredictedLabelImage({
+      data,
+      height,
+      width,
+      score: 0.9,
+      scoreMap: sm,
+    });
     const resampled = li.resampled(1, 1);
     expect(resampled).toBeInstanceOf(PredictedLabelImage);
     const pli = resampled as PredictedLabelImage;
@@ -737,14 +795,27 @@ describe("LabelImage scale/offset", () => {
   });
 
   it("fromMasks validates consistent scale/offset", () => {
-    const m1 = SegmentationMask.fromArray(new Uint8Array([1, 0, 0, 0]), 2, 2, { scale: [2, 2] });
-    const m2 = SegmentationMask.fromArray(new Uint8Array([0, 1, 0, 0]), 2, 2, { scale: [3, 3] });
+    const m1 = SegmentationMask.fromArray(new Uint8Array([1, 0, 0, 0]), 2, 2, {
+      scale: [2, 2],
+    });
+    const m2 = SegmentationMask.fromArray(new Uint8Array([0, 1, 0, 0]), 2, 2, {
+      scale: [3, 3],
+    });
     expect(() => LabelImage.fromMasks([m1, m2])).toThrow("same scale");
   });
 
   it("toMasks propagates scale/offset", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 2]]);
-    const li = new UserLabelImage({ data, height, width, scale: [2, 2], offset: [5, 5] });
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 2],
+    ]);
+    const li = new UserLabelImage({
+      data,
+      height,
+      width,
+      scale: [2, 2],
+      offset: [5, 5],
+    });
     const masks = li.toMasks();
     for (const mask of masks) {
       expect(mask.scale).toEqual([2, 2]);
@@ -753,7 +824,10 @@ describe("LabelImage scale/offset", () => {
   });
 
   it("toMasks creates PredictedSegmentationMask from PredictedLabelImage", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 2]]);
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 2],
+    ]);
     const li = new PredictedLabelImage({ data, height, width, score: 0.9 });
     const masks = li.toMasks();
     expect(masks).toHaveLength(2);
@@ -765,12 +839,21 @@ describe("LabelImage scale/offset", () => {
   });
 
   it("toMasks uses per-object score when available", () => {
-    const { data, height, width } = makeLabelData([[1, 0], [0, 2]]);
+    const { data, height, width } = makeLabelData([
+      [1, 0],
+      [0, 2],
+    ]);
     const objects = new Map<number, LabelImageObjectInfo>([
       [1, { track: null, category: "", name: "", instance: null, score: 0.7 }],
       [2, { track: null, category: "", name: "", instance: null, score: 0.3 }],
     ]);
-    const li = new PredictedLabelImage({ data, height, width, objects, score: 0.5 });
+    const li = new PredictedLabelImage({
+      data,
+      height,
+      width,
+      objects,
+      score: 0.5,
+    });
     const masks = li.toMasks();
     expect((masks[0] as PredictedSegmentationMask).score).toBe(0.7);
     expect((masks[1] as PredictedSegmentationMask).score).toBe(0.3);
@@ -778,7 +861,9 @@ describe("LabelImage scale/offset", () => {
 
   it("scale must be positive", () => {
     const { data, height, width } = makeLabelData([[0]]);
-    expect(() => new UserLabelImage({ data, height, width, scale: [-1, 1] })).toThrow("Scale must be positive");
+    expect(
+      () => new UserLabelImage({ data, height, width, scale: [-1, 1] }),
+    ).toThrow("Scale must be positive");
   });
 });
 
@@ -994,9 +1079,9 @@ describe("LabelImage.fromBinaryMasks", () => {
   });
 
   it("throws on empty mask list", () => {
-    expect(() =>
-      LabelImage.fromBinaryMasks([] as number[][][]),
-    ).toThrow("empty mask list");
+    expect(() => LabelImage.fromBinaryMasks([] as number[][][])).toThrow(
+      "empty mask list",
+    );
   });
 
   it("throws on mismatched mask dimensions", () => {
@@ -1405,7 +1490,9 @@ describe("LabelImage.toBboxes", () => {
       data,
       height: 10,
       width: 10,
-      objects: new Map([[1, { track: null, category: "", name: "", instance: null }]]),
+      objects: new Map([
+        [1, { track: null, category: "", name: "", instance: null }],
+      ]),
     });
     const bboxes = li.toBboxes();
     expect(bboxes).toHaveLength(1);
@@ -1479,15 +1566,23 @@ describe("LabelImage.toBboxes", () => {
       height: 5,
       width: 5,
       objects: new Map([
-        [1, { track: null, category: "", name: "", instance: null, score: 0.9 }],
-        [2, { track: null, category: "", name: "", instance: null, score: 0.8 }],
+        [
+          1,
+          { track: null, category: "", name: "", instance: null, score: 0.9 },
+        ],
+        [
+          2,
+          { track: null, category: "", name: "", instance: null, score: 0.8 },
+        ],
       ]),
       score: 0.5,
     });
     const bboxes = li.toBboxes();
     expect(bboxes).toHaveLength(2);
     expect(bboxes.every((bb) => bb instanceof PredictedBoundingBox)).toBe(true);
-    const scores = new Set(bboxes.map((bb) => (bb as PredictedBoundingBox).score));
+    const scores = new Set(
+      bboxes.map((bb) => (bb as PredictedBoundingBox).score),
+    );
     expect(scores).toEqual(new Set([0.9, 0.8]));
   });
 
@@ -1501,7 +1596,10 @@ describe("LabelImage.toBboxes", () => {
       height: 2,
       width: 2,
       objects: new Map([
-        [1, { track: null, category: "", name: "", instance: null, score: null }],
+        [
+          1,
+          { track: null, category: "", name: "", instance: null, score: null },
+        ],
       ]),
       score: 0.75,
     });
@@ -1527,7 +1625,9 @@ describe("LabelImage.toBboxes", () => {
       data,
       height: 10,
       width: 10,
-      objects: new Map([[1, { track: null, category: "", name: "", instance: null }]]),
+      objects: new Map([
+        [1, { track: null, category: "", name: "", instance: null }],
+      ]),
       scale: [0.5, 0.5],
       offset: [10, 20],
     });

--- a/tests/labels-rois-masks.test.ts
+++ b/tests/labels-rois-masks.test.ts
@@ -17,7 +17,12 @@ describe("Labels ROI and Mask integration", () => {
     const video = new Video({ filename: "test.mp4" });
     const roi = ROI.fromBbox(10, 20, 100, 200, { video });
     const mask = SegmentationMask.fromArray(new Uint8Array(16), 4, 4);
-    const lf = new LabeledFrame({ video, frameIdx: 0, rois: [roi], masks: [mask] });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      rois: [roi],
+      masks: [mask],
+    });
     const labels = new Labels({ labeledFrames: [lf], videos: [video] });
     expect(labels.rois).toHaveLength(1);
     expect(labels.masks).toHaveLength(1);
@@ -149,11 +154,19 @@ describe("Labels ROI and Mask integration", () => {
     const roi1 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "animal" });
     const roi2 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "arena" });
     const roi3 = ROI.fromBbox(0, 0, 10, 10, { video: v1, category: "animal" });
-    const lf0 = new LabeledFrame({ video: v1, frameIdx: 0, rois: [roi1, roi2] });
+    const lf0 = new LabeledFrame({
+      video: v1,
+      frameIdx: 0,
+      rois: [roi1, roi2],
+    });
     const lf5 = new LabeledFrame({ video: v1, frameIdx: 5, rois: [roi3] });
     const labels = new Labels({ labeledFrames: [lf0, lf5] });
 
-    const result = labels.getRois({ video: v1, category: "animal", frameIdx: 0 });
+    const result = labels.getRois({
+      video: v1,
+      category: "animal",
+      frameIdx: 0,
+    });
     expect(result).toEqual([roi1]);
   });
 
@@ -171,8 +184,12 @@ describe("Labels ROI and Mask integration", () => {
 
   it("getMasks filters by category", () => {
     const v = new Video({ filename: "test.mp4" });
-    const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { category: "bg" });
-    const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, { category: "fg" });
+    const m1 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, {
+      category: "bg",
+    });
+    const m2 = SegmentationMask.fromArray(new Uint8Array(4), 2, 2, {
+      category: "fg",
+    });
     const lf = new LabeledFrame({ video: v, frameIdx: 0, masks: [m1, m2] });
     const labels = new Labels({ labeledFrames: [lf] });
 
@@ -207,7 +224,13 @@ describe("Labels ROI and Mask integration", () => {
 describe("getBboxes", () => {
   it("returns all bboxes without filters", () => {
     const bb1 = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
-    const bb2 = new PredictedBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35, score: 0.9 });
+    const bb2 = new PredictedBoundingBox({
+      x1: 0,
+      y1: 5,
+      x2: 40,
+      y2: 35,
+      score: 0.9,
+    });
     const v = new Video({ filename: "test.mp4" });
     const lf = new LabeledFrame({ video: v, frameIdx: 0, bboxes: [bb1, bb2] });
     const labels = new Labels({ labeledFrames: [lf] });
@@ -228,7 +251,13 @@ describe("getBboxes", () => {
 
   it("filters by predicted", () => {
     const bb1 = new UserBoundingBox({ x1: 0, y1: 10, x2: 100, y2: 90 });
-    const bb2 = new PredictedBoundingBox({ x1: 0, y1: 5, x2: 40, y2: 35, score: 0.9 });
+    const bb2 = new PredictedBoundingBox({
+      x1: 0,
+      y1: 5,
+      x2: 40,
+      y2: 35,
+      score: 0.9,
+    });
     const v = new Video({ filename: "test.mp4" });
     const lf = new LabeledFrame({ video: v, frameIdx: 0, bboxes: [bb1, bb2] });
     const labels = new Labels({ labeledFrames: [lf] });

--- a/tests/labels-set.test.ts
+++ b/tests/labels-set.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "./bun-test";
-import { LabelsSet, Labels, Video, Skeleton, LabeledFrame, Instance } from "../src/index.js";
+import {
+  LabelsSet,
+  Labels,
+  Video,
+  Skeleton,
+  LabeledFrame,
+  Instance,
+} from "../src/index.js";
 import { loadSlpSet, saveSlpSet, loadSlp, saveSlp } from "../src/io/main.js";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -89,9 +96,16 @@ describe("saveSlpSet", () => {
   it("saves multiple SLP files", async () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
+    const inst = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ labeledFrames: [frame], videos: [video], skeletons: [skeleton] });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
+    });
 
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sleap-test-"));
     const file1 = path.join(tmpDir, "train.slp");

--- a/tests/lazy-write.test.ts
+++ b/tests/lazy-write.test.ts
@@ -40,8 +40,16 @@ describe("lazy SLP write fast path", () => {
     const video = new Video({ filename: "v.mp4" });
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
     const track = new Track("t1");
-    const inst1 = new Instance({ points: { A: [1, 2], B: [3, 4] }, skeleton, track });
-    const inst2 = new Instance({ points: { A: [5, 6], B: [7, 8] }, skeleton, track });
+    const inst1 = new Instance({
+      points: { A: [1, 2], B: [3, 4] },
+      skeleton,
+      track,
+    });
+    const inst2 = new Instance({
+      points: { A: [5, 6], B: [7, 8] },
+      skeleton,
+      track,
+    });
     const lf0 = new LabeledFrame({ video, frameIdx: 0, instances: [inst1] });
     const lf1 = new LabeledFrame({ video, frameIdx: 1, instances: [inst2] });
     const labels = new Labels({ labeledFrames: [lf0, lf1] });
@@ -103,7 +111,13 @@ describe("lazy SLP write fast path", () => {
     const video = new Video({ filename: "v.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const inst = new Instance({ points: { A: [0, 0] }, skeleton });
-    const b1 = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, category: "obj" });
+    const b1 = new UserBoundingBox({
+      x1: 0,
+      y1: 0,
+      x2: 10,
+      y2: 10,
+      category: "obj",
+    });
     const b2 = new PredictedBoundingBox({
       x1: 5,
       y1: 5,
@@ -121,7 +135,9 @@ describe("lazy SLP write fast path", () => {
 
     const loaded = await lazyRoundTrip(labels);
     expect(loaded.labeledFrames[0].bboxes).toHaveLength(2);
-    expect(loaded.labeledFrames[0].bboxes.find((b) => b.category === "obj")).toBeDefined();
+    expect(
+      loaded.labeledFrames[0].bboxes.find((b) => b.category === "obj"),
+    ).toBeDefined();
   });
 
   it("preserves frame-bound masks", async () => {
@@ -184,8 +200,14 @@ describe("lazy SLP write fast path", () => {
     const v2 = new Video({ filename: "v2.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const inst = new Instance({ points: { A: [0, 0] }, skeleton });
-    const frameRoi = UserROI.fromBbox(0, 0, 50, 50, { video: v1, category: "frame-roi" });
-    const staticRoi = UserROI.fromBbox(0, 0, 100, 100, { video: v2, category: "arena" });
+    const frameRoi = UserROI.fromBbox(0, 0, 50, 50, {
+      video: v1,
+      category: "frame-roi",
+    });
+    const staticRoi = UserROI.fromBbox(0, 0, 100, 100, {
+      video: v2,
+      category: "arena",
+    });
     const lf = new LabeledFrame({
       video: v1,
       frameIdx: 0,

--- a/tests/lazy.test.ts
+++ b/tests/lazy.test.ts
@@ -8,11 +8,16 @@ import path from "node:path";
 const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 
 async function loadFixture(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+  });
 }
 
 async function loadFixtureLazy(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false, lazy: true });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+    lazy: true,
+  });
 }
 
 describe("Lazy Loading", () => {
@@ -250,7 +255,7 @@ describe("LazyDataStore.toNumpy numFrames", () => {
     const maxLabeledFrame = Math.max(
       ...eager.labeledFrames
         .filter((f) => f.video.matchesPath(targetVideo, true))
-        .map((f) => f.frameIdx)
+        .map((f) => f.frameIdx),
     );
     return { lazy, eager, maxLabeledFrame };
   }

--- a/tests/lite.test.ts
+++ b/tests/lite.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "./bun-test";
-import { loadSlpMetadata, validateSlpBuffer, isHdf5Buffer } from "../src/lite.js";
+import {
+  loadSlpMetadata,
+  validateSlpBuffer,
+  isHdf5Buffer,
+} from "../src/lite.js";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -33,7 +37,9 @@ describe("loadSlpMetadata", () => {
   });
 
   it("reads provenance metadata", async () => {
-    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const buffer = loadFixtureBuffer(
+      "predictions_1.2.7_provenance_and_tracking.slp",
+    );
     const metadata = await loadSlpMetadata(buffer);
 
     expect(metadata.provenance).toBeDefined();
@@ -41,7 +47,9 @@ describe("loadSlpMetadata", () => {
   });
 
   it("extracts track information", async () => {
-    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const buffer = loadFixtureBuffer(
+      "predictions_1.2.7_provenance_and_tracking.slp",
+    );
     const metadata = await loadSlpMetadata(buffer);
 
     expect(metadata.tracks.length).toBeGreaterThan(0);
@@ -73,7 +81,9 @@ describe("loadSlpMetadata", () => {
   });
 
   it("counts points and predicted points separately", async () => {
-    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const buffer = loadFixtureBuffer(
+      "predictions_1.2.7_provenance_and_tracking.slp",
+    );
     const metadata = await loadSlpMetadata(buffer);
 
     // This file has predictions, so should have predicted points
@@ -102,7 +112,9 @@ describe("loadSlpMetadata", () => {
 
   it("throws on file missing required datasets", async () => {
     // HDF5 magic number but not a valid SLP
-    const hdf5Header = new Uint8Array([0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const hdf5Header = new Uint8Array([
+      0x89, 0x48, 0x44, 0x46, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
 
     // This will throw because jsfive can't parse a truncated HDF5
     await expect(loadSlpMetadata(hdf5Header)).rejects.toThrow();
@@ -156,11 +168,17 @@ describe("lite vs full comparison", () => {
 
     // Compare skeletons
     expect(liteMetadata.skeletons.length).toBe(fullLabels.skeletons.length);
-    expect(liteMetadata.skeletons[0].nodeNames).toEqual(fullLabels.skeletons[0].nodeNames);
-    expect(liteMetadata.skeletons[0].edgeIndices).toEqual(fullLabels.skeletons[0].edgeIndices);
+    expect(liteMetadata.skeletons[0].nodeNames).toEqual(
+      fullLabels.skeletons[0].nodeNames,
+    );
+    expect(liteMetadata.skeletons[0].edgeIndices).toEqual(
+      fullLabels.skeletons[0].edgeIndices,
+    );
 
     // Compare counts
-    expect(liteMetadata.counts.labeledFrames).toBe(fullLabels.labeledFrames.length);
+    expect(liteMetadata.counts.labeledFrames).toBe(
+      fullLabels.labeledFrames.length,
+    );
     expect(liteMetadata.videos.length).toBe(fullLabels.videos.length);
     expect(liteMetadata.tracks.length).toBe(fullLabels.tracks.length);
   });
@@ -168,12 +186,20 @@ describe("lite vs full comparison", () => {
   it("extracts same provenance as full loadSlp", async () => {
     const { loadSlp } = await import("../src/io/main.js");
 
-    const buffer = loadFixtureBuffer("predictions_1.2.7_provenance_and_tracking.slp");
+    const buffer = loadFixtureBuffer(
+      "predictions_1.2.7_provenance_and_tracking.slp",
+    );
     const liteMetadata = await loadSlpMetadata(buffer);
 
-    const fullPath = path.join(fixtureRoot, "slp", "predictions_1.2.7_provenance_and_tracking.slp");
+    const fullPath = path.join(
+      fixtureRoot,
+      "slp",
+      "predictions_1.2.7_provenance_and_tracking.slp",
+    );
     const fullLabels = await loadSlp(fullPath, { openVideos: false });
 
-    expect(liteMetadata.provenance?.sleap_version).toBe(fullLabels.provenance.sleap_version);
+    expect(liteMetadata.provenance?.sleap_version).toBe(
+      fullLabels.provenance.sleap_version,
+    );
   });
 });

--- a/tests/mask.test.ts
+++ b/tests/mask.test.ts
@@ -12,7 +12,11 @@ import { Track, Instance } from "../src/model/instance.js";
 import { Skeleton } from "../src/model/skeleton.js";
 import { Video } from "../src/model/video.js";
 
-function makeMask2D(height: number, width: number, fill?: (r: number, c: number) => boolean): Uint8Array {
+function makeMask2D(
+  height: number,
+  width: number,
+  fill?: (r: number, c: number) => boolean,
+): Uint8Array {
   const flat = new Uint8Array(height * width);
   if (fill) {
     for (let r = 0; r < height; r++) {
@@ -46,7 +50,11 @@ describe("encodeRle / decodeRle", () => {
   });
 
   it("roundtrip", () => {
-    const mask = makeMask2D(10, 10, (r, c) => r >= 2 && r < 5 && c >= 3 && c < 7);
+    const mask = makeMask2D(
+      10,
+      10,
+      (r, c) => r >= 2 && r < 5 && c >= 3 && c < 7,
+    );
     // Also set one isolated pixel
     mask[7 * 10 + 1] = 1;
 
@@ -89,7 +97,11 @@ describe("SegmentationMask", () => {
   });
 
   it("fromArray with metadata", () => {
-    const data = makeMask2D(10, 15, (r, c) => r >= 2 && r < 5 && c >= 3 && c < 8);
+    const data = makeMask2D(
+      10,
+      15,
+      (r, c) => r >= 2 && r < 5 && c >= 3 && c < 8,
+    );
     const mask = SegmentationMask.fromArray(data, 10, 15, { name: "test" });
     expect(mask.height).toBe(10);
     expect(mask.width).toBe(15);
@@ -97,7 +109,11 @@ describe("SegmentationMask", () => {
   });
 
   it("data roundtrip", () => {
-    const original = makeMask2D(10, 10, (r, c) => r >= 3 && r < 7 && c >= 2 && c < 8);
+    const original = makeMask2D(
+      10,
+      10,
+      (r, c) => r >= 3 && r < 7 && c >= 2 && c < 8,
+    );
     const mask = SegmentationMask.fromArray(original, 10, 10);
     const decoded = mask.data;
     expect(decoded).toEqual(original);
@@ -105,13 +121,21 @@ describe("SegmentationMask", () => {
 
   it("area", () => {
     // 3 rows * 4 cols = 12 pixels
-    const data = makeMask2D(10, 10, (r, c) => r >= 2 && r < 5 && c >= 3 && c < 7);
+    const data = makeMask2D(
+      10,
+      10,
+      (r, c) => r >= 2 && r < 5 && c >= 3 && c < 7,
+    );
     const mask = SegmentationMask.fromArray(data, 10, 10);
     expect(mask.area).toBe(12);
   });
 
   it("bbox", () => {
-    const data = makeMask2D(20, 20, (r, c) => r >= 5 && r < 10 && c >= 3 && c < 8);
+    const data = makeMask2D(
+      20,
+      20,
+      (r, c) => r >= 5 && r < 10 && c >= 3 && c < 8,
+    );
     const mask = SegmentationMask.fromArray(data, 20, 20);
     const bb = mask.bbox;
     expect(bb.x).toBe(3);
@@ -173,7 +197,11 @@ describe("SegmentationMask", () => {
   });
 
   it("toPolygon creates an ROI", () => {
-    const data = makeMask2D(20, 20, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const data = makeMask2D(
+      20,
+      20,
+      (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15,
+    );
     const mask = SegmentationMask.fromArray(data, 20, 20, {
       name: "test_mask",
       category: "cat",
@@ -195,7 +223,10 @@ describe("SegmentationMask", () => {
 describe("Abstract base and subclasses", () => {
   it("SegmentationMask cannot be instantiated directly", () => {
     const rle = encodeRle(new Uint8Array(25), 5, 5);
-    expect(() => new (SegmentationMask as any)({ rleCounts: rle, height: 5, width: 5 })).toThrow(TypeError);
+    expect(
+      () =>
+        new (SegmentationMask as any)({ rleCounts: rle, height: 5, width: 5 }),
+    ).toThrow(TypeError);
   });
 
   it("UserSegmentationMask is not predicted", () => {
@@ -205,9 +236,16 @@ describe("Abstract base and subclasses", () => {
   });
 
   it("PredictedSegmentationMask has score and isPredicted", () => {
-    const rle = encodeRle(makeMask2D(5, 5, () => true), 5, 5);
+    const rle = encodeRle(
+      makeMask2D(5, 5, () => true),
+      5,
+      5,
+    );
     const mask = new PredictedSegmentationMask({
-      rleCounts: rle, height: 5, width: 5, score: 0.85,
+      rleCounts: rle,
+      height: 5,
+      width: 5,
+      score: 0.85,
     });
     expect(mask.isPredicted).toBe(true);
     expect(mask.score).toBe(0.85);
@@ -217,11 +255,20 @@ describe("Abstract base and subclasses", () => {
   });
 
   it("PredictedSegmentationMask stores scoreMap", () => {
-    const rle = encodeRle(makeMask2D(3, 4, () => true), 3, 4);
+    const rle = encodeRle(
+      makeMask2D(3, 4, () => true),
+      3,
+      4,
+    );
     const sm = new Float32Array(12).fill(0.5);
     const mask = new PredictedSegmentationMask({
-      rleCounts: rle, height: 3, width: 4, score: 0.9,
-      scoreMap: sm, scoreMapScale: [2, 2], scoreMapOffset: [1, 1],
+      rleCounts: rle,
+      height: 3,
+      width: 4,
+      score: 0.9,
+      scoreMap: sm,
+      scoreMapScale: [2, 2],
+      scoreMapOffset: [1, 1],
     });
     expect(mask.scoreMap).toBe(sm);
     expect(mask.scoreMapScale).toEqual([2, 2]);
@@ -316,7 +363,13 @@ describe("PredictedSegmentationMask.toUser", () => {
 
   it("preserves the instance reference", () => {
     const skeleton = new Skeleton(["A", "B"]);
-    const instance = Instance.fromArray([[0, 0], [1, 1]], skeleton);
+    const instance = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+      ],
+      skeleton,
+    );
     const pred = makePred(() => true, { instance });
     const user = pred.toUser();
     expect(user.instance).toBe(instance);
@@ -402,9 +455,14 @@ describe("Scale/offset spatial metadata", () => {
 
   it("bbox applies scale and offset", () => {
     // 5x5 mask with pixels at rows 1-3, cols 1-3
-    const data = makeMask2D(5, 5, (r, c) => r >= 1 && r <= 3 && c >= 1 && c <= 3);
+    const data = makeMask2D(
+      5,
+      5,
+      (r, c) => r >= 1 && r <= 3 && c >= 1 && c <= 3,
+    );
     const mask = SegmentationMask.fromArray(data, 5, 5, {
-      scale: [2, 2], offset: [10, 20],
+      scale: [2, 2],
+      offset: [10, 20],
     });
     const bb = mask.bbox;
     // mask-space: x=1, y=1, w=3, h=3
@@ -424,21 +482,25 @@ describe("Scale/offset spatial metadata", () => {
 
   it("explicit scale takes precedence over stride", () => {
     const mask = SegmentationMask.fromArray(makeMask2D(10, 10), 10, 10, {
-      stride: 4, scale: [3, 3],
+      stride: 4,
+      scale: [3, 3],
     });
     expect(mask.scale).toEqual([3, 3]);
   });
 
   it("scale must be positive", () => {
-    expect(() => SegmentationMask.fromArray(makeMask2D(5, 5), 5, 5, {
-      scale: [0, 1],
-    })).toThrow("Scale must be positive");
+    expect(() =>
+      SegmentationMask.fromArray(makeMask2D(5, 5), 5, 5, {
+        scale: [0, 1],
+      }),
+    ).toThrow("Scale must be positive");
   });
 
   it("resampled returns identity scale/offset", () => {
     const data = makeMask2D(10, 10, (r, c) => r < 5 && c < 5);
     const mask = SegmentationMask.fromArray(data, 10, 10, {
-      scale: [2, 2], offset: [5, 5],
+      scale: [2, 2],
+      offset: [5, 5],
     });
     const resampled = mask.resampled(5, 5);
     expect(resampled.height).toBe(5);
@@ -449,10 +511,18 @@ describe("Scale/offset spatial metadata", () => {
   });
 
   it("resampled preserves PredictedSegmentationMask", () => {
-    const rle = encodeRle(makeMask2D(4, 4, () => true), 4, 4);
+    const rle = encodeRle(
+      makeMask2D(4, 4, () => true),
+      4,
+      4,
+    );
     const sm = new Float32Array(16).fill(0.7);
     const mask = new PredictedSegmentationMask({
-      rleCounts: rle, height: 4, width: 4, score: 0.9, scoreMap: sm,
+      rleCounts: rle,
+      height: 4,
+      width: 4,
+      score: 0.9,
+      scoreMap: sm,
     });
     const resampled = mask.resampled(2, 2);
     expect(resampled).toBeInstanceOf(PredictedSegmentationMask);
@@ -463,9 +533,16 @@ describe("Scale/offset spatial metadata", () => {
   });
 
   it("resampled preserves fromPredicted on a linked user mask", () => {
-    const rle = encodeRle(makeMask2D(4, 4, () => true), 4, 4);
+    const rle = encodeRle(
+      makeMask2D(4, 4, () => true),
+      4,
+      4,
+    );
     const pred = new PredictedSegmentationMask({
-      rleCounts: rle, height: 4, width: 4, score: 0.9,
+      rleCounts: rle,
+      height: 4,
+      width: 4,
+      score: 0.9,
     });
     const user = pred.toUser(); // links fromPredicted to pred
     const resampled = user.resampled(2, 2);
@@ -476,8 +553,16 @@ describe("Scale/offset spatial metadata", () => {
   });
 
   it("resampled leaves fromPredicted null on an unlinked user mask", () => {
-    const rle = encodeRle(makeMask2D(4, 4, () => true), 4, 4);
-    const user = new UserSegmentationMask({ rleCounts: rle, height: 4, width: 4 });
+    const rle = encodeRle(
+      makeMask2D(4, 4, () => true),
+      4,
+      4,
+    );
+    const user = new UserSegmentationMask({
+      rleCounts: rle,
+      height: 4,
+      width: 4,
+    });
     expect(user.fromPredicted).toBeNull();
     const resampled = user.resampled(2, 2);
     expect(resampled).toBeInstanceOf(UserSegmentationMask);
@@ -499,7 +584,9 @@ describe("resizeNearest", () => {
   });
 
   it("downscales Int32Array", () => {
-    const src = new Int32Array([1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4]); // 4x4
+    const src = new Int32Array([
+      1, 1, 2, 2, 1, 1, 2, 2, 3, 3, 4, 4, 3, 3, 4, 4,
+    ]); // 4x4
     const dst = resizeNearest(src, 4, 4, 2, 2);
     expect(dst).toBeInstanceOf(Int32Array);
     expect(dst.length).toBe(4);
@@ -532,7 +619,11 @@ describe("SegmentationMask.toBbox", () => {
 
   it("propagates metadata", () => {
     const track = new Track("t1");
-    const mask = makeMask2D(10, 10, (r, c) => r >= 2 && r < 5 && c >= 1 && c < 4);
+    const mask = makeMask2D(
+      10,
+      10,
+      (r, c) => r >= 2 && r < 5 && c >= 1 && c < 4,
+    );
     const sm = SegmentationMask.fromArray(mask, 10, 10, {
       track,
       category: "cell",
@@ -560,7 +651,11 @@ describe("SegmentationMask.toBbox", () => {
   });
 
   it("respects scale", () => {
-    const mask = makeMask2D(10, 10, (r, c) => r >= 2 && r < 4 && c >= 3 && c < 6);
+    const mask = makeMask2D(
+      10,
+      10,
+      (r, c) => r >= 2 && r < 4 && c >= 3 && c < 6,
+    );
     const sm = SegmentationMask.fromArray(mask, 10, 10, {
       scale: [0.5, 0.5],
     });
@@ -570,7 +665,11 @@ describe("SegmentationMask.toBbox", () => {
   });
 
   it("respects offset", () => {
-    const mask = makeMask2D(10, 10, (r, c) => r >= 2 && r < 4 && c >= 3 && c < 6);
+    const mask = makeMask2D(
+      10,
+      10,
+      (r, c) => r >= 2 && r < 4 && c >= 3 && c < 6,
+    );
     const sm = SegmentationMask.fromArray(mask, 10, 10, {
       offset: [10, 20],
     });

--- a/tests/model/camera-3d.test.ts
+++ b/tests/model/camera-3d.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "../bun-test";
-import { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } from "../../src/model/camera.js";
+import {
+  Camera,
+  CameraGroup,
+  InstanceGroup,
+  FrameGroup,
+  RecordingSession,
+} from "../../src/model/camera.js";
 import { Identity } from "../../src/model/identity.js";
 import { Instance3D, PredictedInstance3D } from "../../src/model/instance3d.js";
 import { Instance } from "../../src/model/instance.js";
@@ -25,33 +31,62 @@ describe("InstanceGroup with identity and instance3d", () => {
   });
 
   it("accepts Instance3D in constructor", () => {
-    const inst3d = new Instance3D({ points: [[1, 2, 3], [4, 5, 6]], skeleton });
-    const group = new InstanceGroup({ instanceByCamera: new Map(), instance3d: inst3d });
+    const inst3d = new Instance3D({
+      points: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      skeleton,
+    });
+    const group = new InstanceGroup({
+      instanceByCamera: new Map(),
+      instance3d: inst3d,
+    });
     expect(group.instance3d).toBe(inst3d);
-    expect(group.points).toEqual([[1, 2, 3], [4, 5, 6]]);
+    expect(group.points).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
   });
 
   it("points getter delegates to instance3d when present", () => {
-    const inst3d = new Instance3D({ points: [[10, 20, 30]], skeleton: new Skeleton({ nodes: ["A"] }) });
-    const group = new InstanceGroup({ instanceByCamera: new Map(), instance3d: inst3d });
+    const inst3d = new Instance3D({
+      points: [[10, 20, 30]],
+      skeleton: new Skeleton({ nodes: ["A"] }),
+    });
+    const group = new InstanceGroup({
+      instanceByCamera: new Map(),
+      instance3d: inst3d,
+    });
     expect(group.points).toEqual([[10, 20, 30]]);
   });
 
   it("points getter returns raw points when no instance3d", () => {
-    const group = new InstanceGroup({ instanceByCamera: new Map(), points: [[1, 2, 3]] });
+    const group = new InstanceGroup({
+      instanceByCamera: new Map(),
+      points: [[1, 2, 3]],
+    });
     expect(group.points).toEqual([[1, 2, 3]]);
     expect(group.instance3d).toBeUndefined();
   });
 
   it("accepts PredictedInstance3D", () => {
     const inst3d = new PredictedInstance3D({
-      points: [[1, 2, 3], [4, 5, 6]],
+      points: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
       skeleton,
       score: 0.9,
       pointScores: [0.95, 0.85],
     });
-    const group = new InstanceGroup({ instanceByCamera: new Map(), instance3d: inst3d });
+    const group = new InstanceGroup({
+      instanceByCamera: new Map(),
+      instance3d: inst3d,
+    });
     expect(group.instance3d).toBeInstanceOf(PredictedInstance3D);
-    expect((group.instance3d as PredictedInstance3D).pointScores).toEqual([0.95, 0.85]);
+    expect((group.instance3d as PredictedInstance3D).pointScores).toEqual([
+      0.95, 0.85,
+    ]);
   });
 });

--- a/tests/model/instance-matching.test.ts
+++ b/tests/model/instance-matching.test.ts
@@ -34,9 +34,27 @@ describe("InstanceMatcher", () => {
   // test_spatial_match (96-113)
   it("spatial match: near within threshold, far outside", () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const inst1 = Instance.fromArray([[10, 10], [20, 20]], skeleton);
-    const inst2 = Instance.fromArray([[11, 11], [21, 21]], skeleton); // close
-    const inst3 = Instance.fromArray([[50, 50], [60, 60]], skeleton); // far
+    const inst1 = Instance.fromArray(
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      skeleton,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [11, 11],
+        [21, 21],
+      ],
+      skeleton,
+    ); // close
+    const inst3 = Instance.fromArray(
+      [
+        [50, 50],
+        [60, 60],
+      ],
+      skeleton,
+    ); // far
 
     const matcher = new InstanceMatcher(InstanceMatchMethod.SPATIAL, {
       threshold: 5.0,
@@ -52,17 +70,26 @@ describe("InstanceMatcher", () => {
     const track2 = new Track("track2");
 
     const inst1 = new Instance({
-      points: [[10, 10], [20, 20]],
+      points: [
+        [10, 10],
+        [20, 20],
+      ],
       skeleton,
       track: track1,
     });
     const inst2 = new Instance({
-      points: [[50, 50], [60, 60]],
+      points: [
+        [50, 50],
+        [60, 60],
+      ],
       skeleton,
       track: track1,
     });
     const inst3 = new Instance({
-      points: [[10, 10], [20, 20]],
+      points: [
+        [10, 10],
+        [20, 20],
+      ],
       skeleton,
       track: track2,
     });
@@ -76,15 +103,30 @@ describe("InstanceMatcher", () => {
   it("iou match: overlapping boxes true, disjoint false at threshold 0.1", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2", "p3", "p4"] });
     const inst1 = Instance.fromArray(
-      [[0, 0], [10, 0], [10, 10], [0, 10]],
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
       skeleton,
     ); // box (0,0)-(10,10)
     const inst2 = Instance.fromArray(
-      [[5, 5], [15, 5], [15, 15], [5, 15]],
+      [
+        [5, 5],
+        [15, 5],
+        [15, 15],
+        [5, 15],
+      ],
       skeleton,
     ); // box (5,5)-(15,15)
     const inst3 = Instance.fromArray(
-      [[20, 20], [30, 20], [30, 30], [20, 30]],
+      [
+        [20, 20],
+        [30, 20],
+        [30, 30],
+        [20, 30],
+      ],
       skeleton,
     ); // box (20,20)-(30,30)
 
@@ -99,12 +141,36 @@ describe("InstanceMatcher", () => {
   it("find_matches returns [i, j, score] triples for within-threshold pairs only", () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
     const instances1 = [
-      Instance.fromArray([[10, 10], [20, 20]], skeleton),
-      Instance.fromArray([[30, 30], [40, 40]], skeleton),
+      Instance.fromArray(
+        [
+          [10, 10],
+          [20, 20],
+        ],
+        skeleton,
+      ),
+      Instance.fromArray(
+        [
+          [30, 30],
+          [40, 40],
+        ],
+        skeleton,
+      ),
     ];
     const instances2 = [
-      Instance.fromArray([[11, 11], [21, 21]], skeleton),
-      Instance.fromArray([[50, 50], [60, 60]], skeleton),
+      Instance.fromArray(
+        [
+          [11, 11],
+          [21, 21],
+        ],
+        skeleton,
+      ),
+      Instance.fromArray(
+        [
+          [50, 50],
+          [60, 60],
+        ],
+        skeleton,
+      ),
     ];
 
     const matcher = new InstanceMatcher(InstanceMatchMethod.SPATIAL, {
@@ -128,19 +194,39 @@ describe("InstanceMatcher edge cases", () => {
   it("iou with overlap: score 25/175 (0.14..0.15), no-overlap len 0, identical 1.0", () => {
     const skeleton = new Skeleton({ nodes: ["tl", "tr", "br", "bl"] });
     const inst1 = Instance.fromArray(
-      [[0, 0], [10, 0], [10, 10], [0, 10]],
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
       skeleton,
     ); // box (0,0)-(10,10)
     const inst2 = Instance.fromArray(
-      [[5, 5], [15, 5], [15, 15], [5, 15]],
+      [
+        [5, 5],
+        [15, 5],
+        [15, 15],
+        [5, 15],
+      ],
       skeleton,
     ); // box (5,5)-(15,15)
     const inst3 = Instance.fromArray(
-      [[20, 20], [30, 20], [30, 30], [20, 30]],
+      [
+        [20, 20],
+        [30, 20],
+        [30, 30],
+        [20, 30],
+      ],
       skeleton,
     ); // box (20,20)-(30,30), no overlap
     const inst4 = Instance.fromArray(
-      [[0, 0], [10, 0], [10, 10], [0, 10]],
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
       skeleton,
     ); // identical to inst1
 
@@ -169,9 +255,27 @@ describe("InstanceMatcher edge cases", () => {
   // test_instance_matcher_iou_edge_cases (541-570)
   it("iou NaN edge cases: degenerate bbox handled; no valid bbox → no match", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2"] });
-    const inst1 = Instance.fromArray([[10, 10], [NaN_, NaN_]], skeleton); // one valid point
-    const inst2 = Instance.fromArray([[11, 11], [21, 21]], skeleton);
-    const inst3 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton); // all NaN, no bbox
+    const inst1 = Instance.fromArray(
+      [
+        [10, 10],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    ); // one valid point
+    const inst2 = Instance.fromArray(
+      [
+        [11, 11],
+        [21, 21],
+      ],
+      skeleton,
+    );
+    const inst3 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    ); // all NaN, no bbox
 
     const matcher = new InstanceMatcher(InstanceMatchMethod.IOU, {
       threshold: 0.0,
@@ -194,9 +298,23 @@ describe("InstanceMatcher edge cases", () => {
   it("spatial disjoint valid nodes → no match (no common valid node)", () => {
     const skel = new Skeleton({ nodes: ["head", "thorax", "abdomen"] });
     // Valid head, thorax; abdomen NaN.
-    const inst1 = Instance.fromArray([[1, 2], [3, 4], [NaN_, NaN_]], skel);
+    const inst1 = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+        [NaN_, NaN_],
+      ],
+      skel,
+    );
     // NaN head, thorax; valid abdomen only.
-    const inst2 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_], [5, 6]], skel);
+    const inst2 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+        [5, 6],
+      ],
+      skel,
+    );
 
     const matcher = new InstanceMatcher(InstanceMatchMethod.SPATIAL, {
       threshold: 10.0,
@@ -210,8 +328,20 @@ describe("InstanceMatcher edge cases", () => {
   // test_instance_matcher_iou_no_bounding_box (647-664)
   it("iou with one all-NaN (no bbox) → no match", () => {
     const skel = new Skeleton({ nodes: ["head", "thorax"] });
-    const inst1 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skel); // no bbox
-    const inst2 = Instance.fromArray([[1, 2], [3, 4]], skel);
+    const inst1 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skel,
+    ); // no bbox
+    const inst2 = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      skel,
+    );
 
     const matcher = new InstanceMatcher(InstanceMatchMethod.IOU, {
       threshold: 0.5,
@@ -225,8 +355,20 @@ describe("InstanceMatcher edge cases", () => {
   // test_instance_matcher_iou_no_intersection (666-681)
   it("iou no intersection → no match at threshold 0.1", () => {
     const skel = new Skeleton({ nodes: ["head", "thorax"] });
-    const inst1 = Instance.fromArray([[0, 0], [1, 1]], skel); // box (0,0)-(1,1)
-    const inst2 = Instance.fromArray([[10, 10], [11, 11]], skel); // box (10,10)-(11,11)
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+      ],
+      skel,
+    ); // box (0,0)-(1,1)
+    const inst2 = Instance.fromArray(
+      [
+        [10, 10],
+        [11, 11],
+      ],
+      skel,
+    ); // box (10,10)-(11,11)
 
     const matcher = new InstanceMatcher(InstanceMatchMethod.IOU, {
       threshold: 0.1,
@@ -240,8 +382,20 @@ describe("InstanceMatcher edge cases", () => {
   // test_find_matches_spatial_matching_edge_cases (755-774)
   it("find_matches identity: score 1.0 even with no spatial overlap (disjoint valid points)", () => {
     const skel = new Skeleton({ nodes: ["head", "thorax"] });
-    const inst1 = Instance.fromArray([[1, 2], [NaN_, NaN_]], skel);
-    const inst2 = Instance.fromArray([[NaN_, NaN_], [3, 4]], skel);
+    const inst1 = Instance.fromArray(
+      [
+        [1, 2],
+        [NaN_, NaN_],
+      ],
+      skel,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [3, 4],
+      ],
+      skel,
+    );
 
     // Shared track for identity matching.
     const sharedTrack = new Track("track1");
@@ -258,8 +412,20 @@ describe("InstanceMatcher edge cases", () => {
   // test_find_matches_iou_matching_edge_cases (776-810)
   it("find_matches identity (iou setup): valid bboxes no intersection but identity → score 1.0", () => {
     const skel = new Skeleton({ nodes: ["head", "thorax"] });
-    const inst3 = Instance.fromArray([[0, 0], [1, 1]], skel);
-    const inst4 = Instance.fromArray([[10, 10], [11, 11]], skel);
+    const inst3 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+      ],
+      skel,
+    );
+    const inst4 = Instance.fromArray(
+      [
+        [10, 10],
+        [11, 11],
+      ],
+      skel,
+    );
 
     const sharedTrack2 = new Track("track2");
     inst3.track = sharedTrack2;
@@ -275,8 +441,20 @@ describe("InstanceMatcher edge cases", () => {
   // test_instance_matcher_find_matches_all_nan_spatial (812-834)
   it("find_matches SPATIAL both all-NaN (no track) → len 1, score 0.0", () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const inst1 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton);
-    const inst2 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton);
+    const inst1 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    );
 
     const matcher = new InstanceMatcher(InstanceMatchMethod.SPATIAL, {
       threshold: 10.0,
@@ -290,8 +468,20 @@ describe("InstanceMatcher edge cases", () => {
   // test_instance_matcher_find_matches_iou_no_intersection (836-858)
   it("find_matches IOU ignores track: shared track + IoU 0 → len 0", () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const inst1 = Instance.fromArray([[0, 0], [10, 10]], skeleton); // box (0,0)-(10,10)
-    const inst2 = Instance.fromArray([[20, 20], [30, 30]], skeleton); // box (20,20)-(30,30)
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [10, 10],
+      ],
+      skeleton,
+    ); // box (0,0)-(10,10)
+    const inst2 = Instance.fromArray(
+      [
+        [20, 20],
+        [30, 30],
+      ],
+      skeleton,
+    ); // box (20,20)-(30,30)
 
     const sharedTrack = new Track("track1");
     inst1.track = sharedTrack;
@@ -308,8 +498,20 @@ describe("InstanceMatcher edge cases", () => {
   // test_instance_matcher_find_matches_iou_null_bbox (860-884)
   it("find_matches IOU null bbox (one all-NaN) + shared track → len 0", () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const inst1 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton); // no bbox
-    const inst2 = Instance.fromArray([[10, 10], [20, 20]], skeleton);
+    const inst1 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    ); // no bbox
+    const inst2 = Instance.fromArray(
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      skeleton,
+    );
 
     const sharedTrack = new Track("track1");
     inst1.track = sharedTrack;
@@ -328,8 +530,20 @@ describe("InstanceMatcher edge cases", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2"] });
 
     // Case 1: both all-NaN, shared track.
-    const inst1NoBbox = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton);
-    const inst2NoBbox = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton);
+    const inst1NoBbox = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    );
+    const inst2NoBbox = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    );
     const track = new Track("track1");
     inst1NoBbox.track = track;
     inst2NoBbox.track = track;
@@ -340,13 +554,31 @@ describe("InstanceMatcher edge cases", () => {
     expect(matcher.findMatches([inst1NoBbox], [inst2NoBbox]).length).toBe(0);
 
     // Case 2: one has bbox, other doesn't.
-    const instWithBbox = Instance.fromArray([[10, 10], [20, 20]], skeleton);
+    const instWithBbox = Instance.fromArray(
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      skeleton,
+    );
     instWithBbox.track = track;
     expect(matcher.findMatches([inst1NoBbox], [instWithBbox]).length).toBe(0);
 
     // Case 3: bboxes don't intersect.
-    const inst3 = Instance.fromArray([[0, 0], [5, 5]], skeleton);
-    const inst4 = Instance.fromArray([[10, 10], [15, 15]], skeleton);
+    const inst3 = Instance.fromArray(
+      [
+        [0, 0],
+        [5, 5],
+      ],
+      skeleton,
+    );
+    const inst4 = Instance.fromArray(
+      [
+        [10, 10],
+        [15, 15],
+      ],
+      skeleton,
+    );
     const track2 = new Track("track2");
     inst3.track = track2;
     inst4.track = track2;
@@ -371,11 +603,21 @@ describe("InstanceMatcher edge cases", () => {
 
     // Case 1: bounding boxes don't intersect → score 0.0.
     const inst1 = Instance.fromArray(
-      [[0, 0], [2, 0], [2, 2], [0, 2]],
+      [
+        [0, 0],
+        [2, 0],
+        [2, 2],
+        [0, 2],
+      ],
       skeleton,
     );
     const inst2 = Instance.fromArray(
-      [[10, 10], [12, 10], [12, 12], [10, 12]],
+      [
+        [10, 10],
+        [12, 10],
+        [12, 12],
+        [10, 12],
+      ],
       skeleton,
     );
     let matches = matcher.findMatches([inst1], [inst2]);
@@ -384,11 +626,21 @@ describe("InstanceMatcher edge cases", () => {
 
     // Case 2: one instance has no valid bounding box → score 0.0.
     const inst3 = Instance.fromArray(
-      [[NaN_, NaN_], [NaN_, NaN_], [NaN_, NaN_], [NaN_, NaN_]],
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
       skeleton,
     );
     const inst4 = Instance.fromArray(
-      [[5, 5], [7, 5], [7, 7], [5, 7]],
+      [
+        [5, 5],
+        [7, 5],
+        [7, 7],
+        [5, 7],
+      ],
       skeleton,
     );
     matches = matcher.findMatches([inst3], [inst4]);
@@ -397,7 +649,12 @@ describe("InstanceMatcher edge cases", () => {
 
     // Case 3: both instances have no valid bounding box → score 0.0.
     const inst5 = Instance.fromArray(
-      [[NaN_, NaN_], [NaN_, NaN_], [NaN_, NaN_], [NaN_, NaN_]],
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
       skeleton,
     );
     matches = matcher.findMatches([inst3], [inst5]);
@@ -415,9 +672,27 @@ describe("InstanceMatcher edge cases", () => {
 describe("Instance.samePoseAs", () => {
   it("near poses within tolerance → true; far → false", () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const inst1 = Instance.fromArray([[10, 10], [20, 20]], skeleton);
-    const inst2 = Instance.fromArray([[11, 11], [21, 21]], skeleton);
-    const inst3 = Instance.fromArray([[50, 50], [60, 60]], skeleton);
+    const inst1 = Instance.fromArray(
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      skeleton,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [11, 11],
+        [21, 21],
+      ],
+      skeleton,
+    );
+    const inst3 = Instance.fromArray(
+      [
+        [50, 50],
+        [60, 60],
+      ],
+      skeleton,
+    );
 
     expect(inst1.samePoseAs(inst2, 5.0)).toBe(true);
     expect(inst1.samePoseAs(inst3, 5.0)).toBe(false);
@@ -425,8 +700,22 @@ describe("Instance.samePoseAs", () => {
 
   it("disjoint valid nodes → false (no common visible node within tolerance)", () => {
     const skel = new Skeleton({ nodes: ["head", "thorax", "abdomen"] });
-    const inst1 = Instance.fromArray([[1, 2], [3, 4], [NaN_, NaN_]], skel);
-    const inst2 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_], [5, 6]], skel);
+    const inst1 = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+        [NaN_, NaN_],
+      ],
+      skel,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+        [5, 6],
+      ],
+      skel,
+    );
     // NaN masks differ (head/thorax valid vs abdomen valid) → false.
     expect(inst1.samePoseAs(inst2, 10.0)).toBe(false);
   });
@@ -434,8 +723,20 @@ describe("Instance.samePoseAs", () => {
   it("skeleton mismatch short-circuits to false before point compare", () => {
     const skelA = new Skeleton({ nodes: ["head", "tail"] });
     const skelB = new Skeleton({ nodes: ["head", "wing"] });
-    const inst1 = Instance.fromArray([[1, 2], [3, 4]], skelA);
-    const inst2 = Instance.fromArray([[1, 2], [3, 4]], skelB);
+    const inst1 = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      skelA,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      skelB,
+    );
     expect(inst1.samePoseAs(inst2, 5.0)).toBe(false);
   });
 });
@@ -446,10 +747,37 @@ describe("Instance.sameIdentityAs", () => {
     const track1 = new Track("track1");
     const track2 = new Track("track2");
 
-    const inst1 = new Instance({ points: [[10, 10], [20, 20]], skeleton, track: track1 });
-    const inst2 = new Instance({ points: [[50, 50], [60, 60]], skeleton, track: track1 });
-    const inst3 = new Instance({ points: [[10, 10], [20, 20]], skeleton, track: track2 });
-    const instNoTrack = Instance.fromArray([[10, 10], [20, 20]], skeleton);
+    const inst1 = new Instance({
+      points: [
+        [10, 10],
+        [20, 20],
+      ],
+      skeleton,
+      track: track1,
+    });
+    const inst2 = new Instance({
+      points: [
+        [50, 50],
+        [60, 60],
+      ],
+      skeleton,
+      track: track1,
+    });
+    const inst3 = new Instance({
+      points: [
+        [10, 10],
+        [20, 20],
+      ],
+      skeleton,
+      track: track2,
+    });
+    const instNoTrack = Instance.fromArray(
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      skeleton,
+    );
 
     expect(inst1.sameIdentityAs(inst2)).toBe(true); // same object
     expect(inst1.sameIdentityAs(inst3)).toBe(false); // different object
@@ -461,8 +789,22 @@ describe("Instance.sameIdentityAs", () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
     const trackA = new Track("same");
     const trackB = new Track("same");
-    const inst1 = new Instance({ points: [[1, 2], [3, 4]], skeleton, track: trackA });
-    const inst2 = new Instance({ points: [[1, 2], [3, 4]], skeleton, track: trackB });
+    const inst1 = new Instance({
+      points: [
+        [1, 2],
+        [3, 4],
+      ],
+      skeleton,
+      track: trackA,
+    });
+    const inst2 = new Instance({
+      points: [
+        [1, 2],
+        [3, 4],
+      ],
+      skeleton,
+      track: trackB,
+    });
     expect(inst1.sameIdentityAs(inst2)).toBe(false);
   });
 });
@@ -470,9 +812,33 @@ describe("Instance.sameIdentityAs", () => {
 describe("Instance.overlapsWith", () => {
   it("overlapping boxes pass at low threshold; disjoint fail", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2", "p3", "p4"] });
-    const inst1 = Instance.fromArray([[0, 0], [10, 0], [10, 10], [0, 10]], skeleton);
-    const inst2 = Instance.fromArray([[5, 5], [15, 5], [15, 15], [5, 15]], skeleton);
-    const inst3 = Instance.fromArray([[20, 20], [30, 20], [30, 30], [20, 30]], skeleton);
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
+      skeleton,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [5, 5],
+        [15, 5],
+        [15, 15],
+        [5, 15],
+      ],
+      skeleton,
+    );
+    const inst3 = Instance.fromArray(
+      [
+        [20, 20],
+        [30, 20],
+        [30, 30],
+        [20, 30],
+      ],
+      skeleton,
+    );
 
     // IoU ≈ 0.1428: passes threshold 0.1, fails default 0.5.
     expect(inst1.overlapsWith(inst2, 0.1)).toBe(true);
@@ -482,16 +848,40 @@ describe("Instance.overlapsWith", () => {
 
   it("touching boxes (shared edge) count as NO overlap", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2"] });
-    const inst1 = Instance.fromArray([[0, 0], [10, 10]], skeleton); // box (0,0)-(10,10)
-    const inst2 = Instance.fromArray([[10, 0], [20, 10]], skeleton); // box (10,0)-(20,10)
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [10, 10],
+      ],
+      skeleton,
+    ); // box (0,0)-(10,10)
+    const inst2 = Instance.fromArray(
+      [
+        [10, 0],
+        [20, 10],
+      ],
+      skeleton,
+    ); // box (10,0)-(20,10)
     // Boxes share the x=10 edge → strict-< IoU is 0 → no overlap at any positive threshold.
     expect(inst1.overlapsWith(inst2, 0.0)).toBe(false);
   });
 
   it("no bounding box (all-NaN) → no overlap", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2"] });
-    const inst1 = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton);
-    const inst2 = Instance.fromArray([[0, 0], [10, 10]], skeleton);
+    const inst1 = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [0, 0],
+        [10, 10],
+      ],
+      skeleton,
+    );
     expect(inst1.overlapsWith(inst2, 0.0)).toBe(false);
   });
 });
@@ -500,7 +890,12 @@ describe("Instance.boundingBox", () => {
   it("computed over visible points as [[minX,minY],[maxX,maxY]]", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2", "p3", "p4"] });
     const inst = Instance.fromArray(
-      [[2, 3], [10, 1], [7, 12], [4, 6]],
+      [
+        [2, 3],
+        [10, 1],
+        [7, 12],
+        [4, 6],
+      ],
       skeleton,
     );
     expect(inst.boundingBox()).toEqual([
@@ -511,7 +906,14 @@ describe("Instance.boundingBox", () => {
 
   it("ignores NaN (invisible) points when computing extents", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2", "p3"] });
-    const inst = Instance.fromArray([[5, 5], [NaN_, NaN_], [15, 20]], skeleton);
+    const inst = Instance.fromArray(
+      [
+        [5, 5],
+        [NaN_, NaN_],
+        [15, 20],
+      ],
+      skeleton,
+    );
     expect(inst.boundingBox()).toEqual([
       [5, 5],
       [15, 20],
@@ -520,7 +922,13 @@ describe("Instance.boundingBox", () => {
 
   it("returns null when no points are visible (all NaN)", () => {
     const skeleton = new Skeleton({ nodes: ["p1", "p2"] });
-    const inst = Instance.fromArray([[NaN_, NaN_], [NaN_, NaN_]], skeleton);
+    const inst = Instance.fromArray(
+      [
+        [NaN_, NaN_],
+        [NaN_, NaN_],
+      ],
+      skeleton,
+    );
     expect(inst.boundingBox()).toBeNull();
   });
 });

--- a/tests/model/instance.test.ts
+++ b/tests/model/instance.test.ts
@@ -16,12 +16,22 @@ describe("Point", () => {
   });
 
   it("can be created with optional score", () => {
-    const point: Point = { xy: [10, 20], visible: true, complete: false, score: 0.95 };
+    const point: Point = {
+      xy: [10, 20],
+      visible: true,
+      complete: false,
+      score: 0.95,
+    };
     expect(point.score).toBe(0.95);
   });
 
   it("PredictedPoint requires score", () => {
-    const point: PredictedPoint = { xy: [10, 20], visible: true, complete: false, score: 0.8 };
+    const point: PredictedPoint = {
+      xy: [10, 20],
+      visible: true,
+      complete: false,
+      score: 0.8,
+    };
     expect(point.score).toBe(0.8);
   });
 });
@@ -30,9 +40,12 @@ describe("PredictedInstance.numpy with scores", () => {
   it("includes point scores when scores option is true", () => {
     const skeleton = new Skeleton({ nodes: ["a", "b"] });
     const inst = PredictedInstance.fromArray(
-      [[1, 2, 0.9], [3, 4, 0.8]],
+      [
+        [1, 2, 0.9],
+        [3, 4, 0.8],
+      ],
       skeleton,
-      0.95
+      0.95,
     );
     const result = inst.numpy({ scores: true, invisibleAsNaN: false });
     expect(result[0][2]).toBe(0.9);

--- a/tests/model/instance3d.test.ts
+++ b/tests/model/instance3d.test.ts
@@ -2,11 +2,21 @@ import { describe, it, expect } from "../bun-test";
 import { Instance3D, PredictedInstance3D } from "../../src/model/instance3d.js";
 import { Skeleton } from "../../src/model/skeleton.js";
 
-const skeleton = new Skeleton({ nodes: ["nose", "ear", "tail"], edges: [["nose", "ear"], ["ear", "tail"]] });
+const skeleton = new Skeleton({
+  nodes: ["nose", "ear", "tail"],
+  edges: [
+    ["nose", "ear"],
+    ["ear", "tail"],
+  ],
+});
 
 describe("Instance3D", () => {
   it("creates with 3D points", () => {
-    const pts = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    const pts = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
     const inst = new Instance3D({ points: pts, skeleton });
     expect(inst.points).toEqual(pts);
     expect(inst.skeleton).toBe(skeleton);
@@ -15,19 +25,31 @@ describe("Instance3D", () => {
   });
 
   it("nVisible counts non-NaN points", () => {
-    const pts = [[1, 2, 3], [NaN, NaN, NaN], [7, 8, 9]];
+    const pts = [
+      [1, 2, 3],
+      [NaN, NaN, NaN],
+      [7, 8, 9],
+    ];
     const inst = new Instance3D({ points: pts, skeleton });
     expect(inst.nVisible).toBe(2);
   });
 
   it("isEmpty is true when all NaN", () => {
-    const pts = [[NaN, NaN, NaN], [NaN, NaN, NaN], [NaN, NaN, NaN]];
+    const pts = [
+      [NaN, NaN, NaN],
+      [NaN, NaN, NaN],
+      [NaN, NaN, NaN],
+    ];
     const inst = new Instance3D({ points: pts, skeleton });
     expect(inst.isEmpty).toBe(true);
   });
 
   it("isEmpty is false when any point is valid", () => {
-    const pts = [[NaN, NaN, NaN], [1, 2, 3], [NaN, NaN, NaN]];
+    const pts = [
+      [NaN, NaN, NaN],
+      [1, 2, 3],
+      [NaN, NaN, NaN],
+    ];
     const inst = new Instance3D({ points: pts, skeleton });
     expect(inst.isEmpty).toBe(false);
   });
@@ -39,7 +61,11 @@ describe("Instance3D", () => {
   });
 
   it("creates with optional score", () => {
-    const pts = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    const pts = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
     const inst = new Instance3D({ points: pts, skeleton, score: 0.95 });
     expect(inst.score).toBe(0.95);
   });
@@ -47,9 +73,18 @@ describe("Instance3D", () => {
 
 describe("PredictedInstance3D", () => {
   it("extends Instance3D with pointScores", () => {
-    const pts = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    const pts = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
     const scores = [0.9, 0.8, 0.7];
-    const inst = new PredictedInstance3D({ points: pts, skeleton, score: 0.85, pointScores: scores });
+    const inst = new PredictedInstance3D({
+      points: pts,
+      skeleton,
+      score: 0.85,
+      pointScores: scores,
+    });
     expect(inst.points).toEqual(pts);
     expect(inst.score).toBe(0.85);
     expect(inst.pointScores).toEqual(scores);
@@ -57,7 +92,11 @@ describe("PredictedInstance3D", () => {
   });
 
   it("pointScores defaults to undefined", () => {
-    const pts = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+    const pts = [
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ];
     const inst = new PredictedInstance3D({ points: pts, skeleton });
     expect(inst.pointScores).toBeUndefined();
   });

--- a/tests/model/labeled-frame-merge.test.ts
+++ b/tests/model/labeled-frame-merge.test.ts
@@ -59,7 +59,9 @@ describe("LabeledFrame.merge", () => {
     );
     const frame2 = new LabeledFrame({ video, frameIdx: 0, instances: [inst2] });
 
-    const [merged, conflicts] = frame1.merge(frame2, { frame: "keep_original" });
+    const [merged, conflicts] = frame1.merge(frame2, {
+      frame: "keep_original",
+    });
 
     expect(merged.length).toBe(1);
     expect(merged[0]).toBe(inst1);
@@ -121,7 +123,9 @@ describe("LabeledFrame.merge", () => {
     inst2.track = new Track("track1");
     const frame2 = new LabeledFrame({ video, frameIdx: 0, instances: [inst2] });
 
-    const [merged, conflicts] = frame1.merge(frame2, { frame: "update_tracks" });
+    const [merged, conflicts] = frame1.merge(frame2, {
+      frame: "update_tracks",
+    });
 
     expect(merged.length).toBe(1);
     expect(merged.includes(inst1)).toBe(true);
@@ -390,7 +394,9 @@ describe("LabeledFrame.unusedPredictedMasks", () => {
     return encodeRle(flat, 5, 5);
   }
 
-  function makePred(offset: [number, number] = [0, 0]): PredictedSegmentationMask {
+  function makePred(
+    offset: [number, number] = [0, 0],
+  ): PredictedSegmentationMask {
     return new PredictedSegmentationMask({
       rleCounts: rle3x3(),
       height: 5,
@@ -467,7 +473,9 @@ describe("LabeledFrame.mergeAnnotations link-first mask merge (auto)", () => {
     return encodeRle(flat, 5, 5);
   }
 
-  function makePred(offset: [number, number] = [0, 0]): PredictedSegmentationMask {
+  function makePred(
+    offset: [number, number] = [0, 0],
+  ): PredictedSegmentationMask {
     return new PredictedSegmentationMask({
       rleCounts: rle3x3(),
       height: 5,

--- a/tests/model/labels-clean.test.ts
+++ b/tests/model/labels-clean.test.ts
@@ -23,7 +23,11 @@
  *   pruning by reference identity.
  */
 import { describe, it, expect } from "../bun-test";
-import { Instance, PredictedInstance, Track } from "../../src/model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+} from "../../src/model/instance.js";
 import { Skeleton } from "../../src/model/skeleton.js";
 import { Video } from "../../src/model/video.js";
 import { LabeledFrame } from "../../src/model/labeled-frame.js";
@@ -65,14 +69,17 @@ describe("Labels.clean", () => {
     const maskData: boolean[][] = Array.from({ length: 10 }, () =>
       new Array(10).fill(false),
     );
-    for (let r = 2; r < 8; r++) for (let cc = 2; cc < 8; cc++) maskData[r][cc] = true;
+    for (let r = 2; r < 8; r++)
+      for (let cc = 2; cc < 8; cc++) maskData[r][cc] = true;
     const m = UserSegmentationMask.fromArray(maskData, 10, 10);
     const roi = UserROI.fromBbox(0, 0, 10, 10, { video });
     const li = new UserLabelImage({
       data: Int32Array.from([0, 1]),
       height: 1,
       width: 2,
-      objects: new Map([[1, { track: null, category: "cell", name: "", instance: null }]]),
+      objects: new Map([
+        [1, { track: null, category: "cell", name: "", instance: null }],
+      ]),
     });
 
     const lf0 = new LabeledFrame({ video, frameIdx: 0, centroids: [c] });

--- a/tests/model/labels-copy.test.ts
+++ b/tests/model/labels-copy.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "../bun-test";
 import { Labels } from "../../src/model/labels.js";
 import { LabeledFrame } from "../../src/model/labeled-frame.js";
 import { Video } from "../../src/model/video.js";
-import { Instance, PredictedInstance, Track } from "../../src/model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+} from "../../src/model/instance.js";
 import { Skeleton, Node, Edge } from "../../src/model/skeleton.js";
 import { SuggestionFrame } from "../../src/model/suggestions.js";
 import { UserROI } from "../../src/model/roi.js";
@@ -18,14 +22,34 @@ const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 function makeLabels(): Labels {
   const nodeA = new Node("a");
   const nodeB = new Node("b");
-  const skeleton = new Skeleton({ nodes: [nodeA, nodeB], edges: [new Edge(nodeA, nodeB)] });
+  const skeleton = new Skeleton({
+    nodes: [nodeA, nodeB],
+    edges: [new Edge(nodeA, nodeB)],
+  });
   const video = new Video({ filename: "test.mp4" });
   const track = new Track("t1");
-  const instance = Instance.fromArray([[10, 20], [30, 40]], skeleton);
+  const instance = Instance.fromArray(
+    [
+      [10, 20],
+      [30, 40],
+    ],
+    skeleton,
+  );
   instance.track = track;
-  const predicted = PredictedInstance.fromArray([[11, 21], [31, 41]], skeleton, 0.95);
+  const predicted = PredictedInstance.fromArray(
+    [
+      [11, 21],
+      [31, 41],
+    ],
+    skeleton,
+    0.95,
+  );
   predicted.track = track;
-  const frame = new LabeledFrame({ video, frameIdx: 0, instances: [instance, predicted] });
+  const frame = new LabeledFrame({
+    video,
+    frameIdx: 0,
+    instances: [instance, predicted],
+  });
   const suggestion = new SuggestionFrame({ video, frameIdx: 5 });
   const roi = new UserROI({
     geometry: { type: "Point", coordinates: [1, 2] },
@@ -180,10 +204,10 @@ describe("Labels.copy (eager)", () => {
 
 describe("Labels.copy (lazy)", () => {
   it("creates an independent lazy copy", async () => {
-    const labels = await loadSlp(
-      path.join(fixtureRoot, "slp", "typical.slp"),
-      { openVideos: false, lazy: true },
-    );
+    const labels = await loadSlp(path.join(fixtureRoot, "slp", "typical.slp"), {
+      openVideos: false,
+      lazy: true,
+    });
     expect(labels.isLazy).toBe(true);
 
     const copy = labels.copy();
@@ -201,10 +225,10 @@ describe("Labels.copy (lazy)", () => {
   });
 
   it("lazy copy materializes independently", async () => {
-    const labels = await loadSlp(
-      path.join(fixtureRoot, "slp", "typical.slp"),
-      { openVideos: false, lazy: true },
-    );
+    const labels = await loadSlp(path.join(fixtureRoot, "slp", "typical.slp"), {
+      openVideos: false,
+      lazy: true,
+    });
     const copy = labels.copy();
 
     // Materialize the copy
@@ -217,10 +241,10 @@ describe("Labels.copy (lazy)", () => {
   });
 
   it("lazy copy has consistent skeleton/track refs after materialize", async () => {
-    const labels = await loadSlp(
-      path.join(fixtureRoot, "slp", "typical.slp"),
-      { openVideos: false, lazy: true },
-    );
+    const labels = await loadSlp(path.join(fixtureRoot, "slp", "typical.slp"), {
+      openVideos: false,
+      lazy: true,
+    });
     const copy = labels.copy();
     copy.materialize();
 
@@ -252,7 +276,13 @@ describe("Labels.copy + replaceVideos integration", () => {
     });
     const instance = Instance.fromArray([[5, 10]], skeleton);
     instance.track = track;
-    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [instance], centroids: [centroid], labelImages: [li] });
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instance],
+      centroids: [centroid],
+      labelImages: [li],
+    });
 
     const labels = new Labels({
       labeledFrames: [frame],

--- a/tests/model/labels-dedup-skeletons.test.ts
+++ b/tests/model/labels-dedup-skeletons.test.ts
@@ -28,8 +28,20 @@ describe("Labels.dedupSkeletons", () => {
     const sA = skel(["head", "thorax"], "A");
     const sB = skel(["head", "thorax"], "B");
     const video = new Video({ filename: "v.mp4" });
-    const instA = Instance.fromArray([[1, 2], [3, 4]], sA);
-    const instB = Instance.fromArray([[5, 6], [7, 8]], sB);
+    const instA = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      sA,
+    );
+    const instB = Instance.fromArray(
+      [
+        [5, 6],
+        [7, 8],
+      ],
+      sB,
+    );
     const frame = new LabeledFrame({
       video,
       frameIdx: 0,
@@ -60,8 +72,21 @@ describe("Labels.dedupSkeletons", () => {
     const c2 = skel(["m"], "c2");
     const video = new Video({ filename: "v.mp4" });
     const instances = [
-      Instance.fromArray([[1, 1], [2, 2]], a2),
-      Instance.fromArray([[3, 3], [4, 4], [5, 5]], b2),
+      Instance.fromArray(
+        [
+          [1, 1],
+          [2, 2],
+        ],
+        a2,
+      ),
+      Instance.fromArray(
+        [
+          [3, 3],
+          [4, 4],
+          [5, 5],
+        ],
+        b2,
+      ),
       Instance.fromArray([[6, 6]], c2),
     ];
     const frame = new LabeledFrame({ video, frameIdx: 0, instances });
@@ -114,7 +139,13 @@ describe("Labels.dedupSkeletons", () => {
   it("is a no-op on a copied Labels (clones are 1-per-equivalence-class)", () => {
     const s = skel(["head", "thorax"], "fly");
     const video = new Video({ filename: "v.mp4" });
-    const instance = Instance.fromArray([[1, 2], [3, 4]], s);
+    const instance = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      s,
+    );
     const frame = new LabeledFrame({
       video,
       frameIdx: 0,
@@ -135,7 +166,14 @@ describe("Labels.dedupSkeletons", () => {
     const sA = skel(["head", "thorax"], "A");
     const sB = skel(["head", "thorax"], "B");
     const video = new Video({ filename: "v.mp4" });
-    const pred = PredictedInstance.fromArray([[1, 2], [3, 4]], sB, 0.9);
+    const pred = PredictedInstance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      sB,
+      0.9,
+    );
     const frame = new LabeledFrame({
       video,
       frameIdx: 0,
@@ -158,8 +196,20 @@ describe("loadSlp does not auto-dedup skeletons (helper is opt-in)", () => {
     const sA = skel(["head", "thorax"], "A");
     const sB = skel(["head", "thorax"], "B");
     const video = new Video({ filename: "v.mp4" });
-    const instA = Instance.fromArray([[1, 2], [3, 4]], sA);
-    const instB = Instance.fromArray([[5, 6], [7, 8]], sB);
+    const instA = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      sA,
+    );
+    const instB = Instance.fromArray(
+      [
+        [5, 6],
+        [7, 8],
+      ],
+      sB,
+    );
     const frame = new LabeledFrame({
       video,
       frameIdx: 0,
@@ -189,8 +239,20 @@ describe("loadSlp does not auto-dedup skeletons (helper is opt-in)", () => {
     const sA = skel(["head", "thorax"], "A");
     const sB = skel(["head", "thorax"], "B");
     const video = new Video({ filename: "v.mp4" });
-    const instA = Instance.fromArray([[1, 2], [3, 4]], sA);
-    const instB = Instance.fromArray([[5, 6], [7, 8]], sB);
+    const instA = Instance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      sA,
+    );
+    const instB = Instance.fromArray(
+      [
+        [5, 6],
+        [7, 8],
+      ],
+      sB,
+    );
     const frame = new LabeledFrame({
       video,
       frameIdx: 0,

--- a/tests/model/labels-extract-split.test.ts
+++ b/tests/model/labels-extract-split.test.ts
@@ -48,9 +48,21 @@ describe("Labels.extract", () => {
     const skel = new Skeleton({ nodes: ["a", "b"] });
     const labels = new Labels({
       labeledFrames: [
-        new LabeledFrame({ video: video1, frameIdx: 0, instances: [zeros2x2(skel)] }),
-        new LabeledFrame({ video: video1, frameIdx: 1, instances: [zeros2x2(skel)] }),
-        new LabeledFrame({ video: video2, frameIdx: 0, instances: [zeros2x2(skel)] }),
+        new LabeledFrame({
+          video: video1,
+          frameIdx: 0,
+          instances: [zeros2x2(skel)],
+        }),
+        new LabeledFrame({
+          video: video1,
+          frameIdx: 1,
+          instances: [zeros2x2(skel)],
+        }),
+        new LabeledFrame({
+          video: video2,
+          frameIdx: 0,
+          instances: [zeros2x2(skel)],
+        }),
       ],
       suggestions: [
         new SuggestionFrame({ video: video1, frameIdx: 2 }),
@@ -156,7 +168,9 @@ describe("Labels.extract", () => {
     // Shared within the extracted subgraph (copied exactly once).
     expect(t0).toBe(t1);
     // Same shared video too.
-    expect(extracted.labeledFrames[0].video).toBe(extracted.labeledFrames[1].video);
+    expect(extracted.labeledFrames[0].video).toBe(
+      extracted.labeledFrames[1].video,
+    );
     expect(extracted.labeledFrames[0].video).not.toBe(video);
     // Source unchanged.
     expect(inst0.track).toBe(track);
@@ -320,7 +334,11 @@ describe("Labels.split", () => {
         }),
       );
     }
-    return new Labels({ labeledFrames: lfs, videos: [video], skeletons: [skel] });
+    return new Labels({
+      labeledFrames: lfs,
+      videos: [video],
+      skeletons: [skel],
+    });
   }
 
   it("fraction split n=0.6 -> 6 / 4", () => {
@@ -375,7 +393,12 @@ describe("Labels.split", () => {
       const inst = Instance.fromArray([[i, 0.0]], skeleton);
       const c = new UserCentroid({ x: i, y: 0.0 });
       lfs.push(
-        new LabeledFrame({ video, frameIdx: i, instances: [inst], centroids: [c] }),
+        new LabeledFrame({
+          video,
+          frameIdx: i,
+          instances: [inst],
+          centroids: [c],
+        }),
       );
     }
     const labels = new Labels({

--- a/tests/model/labels-index.test.ts
+++ b/tests/model/labels-index.test.ts
@@ -3,7 +3,11 @@ import { Labels } from "../../src/model/labels.js";
 import { LabeledFrame } from "../../src/model/labeled-frame.js";
 import { Video } from "../../src/model/video.js";
 import { Skeleton } from "../../src/model/skeleton.js";
-import { Instance, PredictedInstance, Track } from "../../src/model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+} from "../../src/model/instance.js";
 import { UserCentroid } from "../../src/model/centroid.js";
 import { UserBoundingBox } from "../../src/model/bbox.js";
 import { UserSegmentationMask } from "../../src/model/mask.js";
@@ -147,7 +151,13 @@ describe("Labels track index", () => {
         [1, { track, category: "cell", name: "", instance: null }],
       ]),
     });
-    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video, frameIdx: 0, labelImages: [li] })], videos: [video], tracks: [track] });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, labelImages: [li] }),
+      ],
+      videos: [video],
+      tracks: [track],
+    });
 
     const anns = labels.getTrackAnnotations(video, track);
     expect(anns).toHaveLength(1);
@@ -205,9 +215,15 @@ describe("Labels.find() fast path", () => {
 describe("get*() fast paths", () => {
   it("getCentroids uses O(1) frame lookup when video+frameIdx given", () => {
     const video = new Video({ filename: "test.mp4" });
-    const c0 = new UserCentroid({ x: 1, y: 2});
-    const c1 = new UserCentroid({ x: 3, y: 4});
-    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video: video, frameIdx: 0, centroids: [c0] }), new LabeledFrame({ video: video, frameIdx: 1, centroids: [c1] })], videos: [video] });
+    const c0 = new UserCentroid({ x: 1, y: 2 });
+    const c1 = new UserCentroid({ x: 3, y: 4 });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video: video, frameIdx: 0, centroids: [c0] }),
+        new LabeledFrame({ video: video, frameIdx: 1, centroids: [c1] }),
+      ],
+      videos: [video],
+    });
 
     // Fast path: both video and frameIdx
     let result = labels.getCentroids({ video, frameIdx: 0 });
@@ -250,7 +266,12 @@ describe("get*() fast paths", () => {
       video,
       frameIdx: 0,
     });
-    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video: video, frameIdx: 0, bboxes: [b1, b2] })], videos: [video] });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video: video, frameIdx: 0, bboxes: [b1, b2] }),
+      ],
+      videos: [video],
+    });
 
     // Fast path with video+frameIdx
     let result = labels.getBboxes({ video, frameIdx: 0 });
@@ -276,8 +297,14 @@ describe("get*() fast paths", () => {
     const mask = new UserSegmentationMask({
       rleCounts: new Uint32Array([16]),
       height: 4,
-      width: 4, });
-    const labels = new Labels({ labeledFrames: [new LabeledFrame({ video: video, frameIdx: 0, masks: [mask] })], videos: [video] });
+      width: 4,
+    });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video: video, frameIdx: 0, masks: [mask] }),
+      ],
+      videos: [video],
+    });
 
     let result = labels.getMasks({ video, frameIdx: 0 });
     expect(result).toHaveLength(1);
@@ -386,7 +413,11 @@ describe("Index invalidation", () => {
     const track = new Track("t1");
     const c0 = new UserCentroid({ x: 1, y: 2, track });
     const lf0 = new LabeledFrame({ video, frameIdx: 0, centroids: [c0] });
-    const labels = new Labels({ labeledFrames: [lf0], videos: [video], tracks: [track] });
+    const labels = new Labels({
+      labeledFrames: [lf0],
+      videos: [video],
+      tracks: [track],
+    });
 
     // Build track index
     let anns = labels.getTrackAnnotations(video, track);
@@ -407,22 +438,30 @@ const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 
 describe("Lazy guards", () => {
   it("getFrame throws on lazy Labels", async () => {
-    const lazy = await loadSlp(path.join(fixtureRoot, "slp", "centered_pair_predictions.slp"), {
-      openVideos: false,
-      lazy: true,
-    });
+    const lazy = await loadSlp(
+      path.join(fixtureRoot, "slp", "centered_pair_predictions.slp"),
+      {
+        openVideos: false,
+        lazy: true,
+      },
+    );
     const video = lazy.videos[0];
     expect(() => lazy.getFrame(video, 0)).toThrow("getFrame");
   });
 
   it("getTrackAnnotations throws on lazy Labels", async () => {
-    const lazy = await loadSlp(path.join(fixtureRoot, "slp", "centered_pair_predictions.slp"), {
-      openVideos: false,
-      lazy: true,
-    });
+    const lazy = await loadSlp(
+      path.join(fixtureRoot, "slp", "centered_pair_predictions.slp"),
+      {
+        openVideos: false,
+        lazy: true,
+      },
+    );
     const video = lazy.videos[0];
     const track = lazy.tracks[0];
-    expect(() => lazy.getTrackAnnotations(video, track)).toThrow("getTrackAnnotations");
+    expect(() => lazy.getTrackAnnotations(video, track)).toThrow(
+      "getTrackAnnotations",
+    );
   });
 });
 
@@ -432,7 +471,14 @@ describe("Labels.removePredictions()", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("t1");
 
-    const pred = PredictedInstance.fromArray([[1, 2], [3, 4]], skel, 0.9);
+    const pred = PredictedInstance.fromArray(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      skel,
+      0.9,
+    );
     pred.track = track;
     const lf = new LabeledFrame({ video, frameIdx: 0, instances: [pred] });
     const c = new UserCentroid({ x: 5, y: 6, track });

--- a/tests/model/labels-lookup-widening.test.ts
+++ b/tests/model/labels-lookup-widening.test.ts
@@ -41,7 +41,10 @@ function buildLabels() {
   const skeleton = new Skeleton({ nodes: ["A", "B"] });
   // Canonical video lives under a directory so a bare-basename query must use
   // the basename tier (not the strict path tier) to resolve.
-  const canonical = new Video({ filename: "path/to/clip.mp4", openBackend: false });
+  const canonical = new Video({
+    filename: "path/to/clip.mp4",
+    openBackend: false,
+  });
   const inst = Instance.fromArray(
     [
       [1, 2],
@@ -109,7 +112,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
     it("resolves a foreign filename that shares only the basename (relocated file)", () => {
       const { labels, lf } = buildLabels();
       // Different directory, same basename -> basename tier resolves.
-      const results = labels.find({ video: "/new/location/clip.mp4", frameIdx: 10 });
+      const results = labels.find({
+        video: "/new/location/clip.mp4",
+        frameIdx: 10,
+      });
       expect(results).toHaveLength(1);
       expect(results[0]).toBe(lf);
     });
@@ -172,7 +178,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
       const byString = labels.numpy({ video: "clip.mp4" });
       const byCanonical = labels.numpy({ video: canonical });
       const byForeign = labels.numpy({
-        video: new Video({ filename: canonical.filename as string, openBackend: false }),
+        video: new Video({
+          filename: canonical.filename as string,
+          openBackend: false,
+        }),
       });
 
       // One labeled frame at idx 10 -> 11 frames (shape[0]) since maxFrame == 10.
@@ -197,7 +206,9 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
       const byCanonical = labels.extract(canonical);
       expect(byString.labeledFrames).toHaveLength(1);
       expect(byCanonical.labeledFrames).toHaveLength(1);
-      expect(byString.labeledFrames.length).toBe(byCanonical.labeledFrames.length);
+      expect(byString.labeledFrames.length).toBe(
+        byCanonical.labeledFrames.length,
+      );
     });
 
     it("widens [video, idx] tuple selectors with a foreign Video / string", () => {
@@ -220,7 +231,9 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
       const { labels, canonical } = buildLabels();
       const byUrl = labels.extract(new URL("file:///x/clip.mp4"));
       const byCanonical = labels.extract(canonical);
-      expect(byUrl.labeledFrames).toHaveLength(byCanonical.labeledFrames.length);
+      expect(byUrl.labeledFrames).toHaveLength(
+        byCanonical.labeledFrames.length,
+      );
       expect(byUrl.labeledFrames).toHaveLength(1);
     });
   });
@@ -228,7 +241,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
   describe("get* family widening", () => {
     it("getCentroids({video: 'name'}) matches passing the canonical Video", () => {
       const skeleton = new Skeleton({ nodes: ["A", "B"] });
-      const video = new Video({ filename: "/data/vid.mp4", openBackend: false });
+      const video = new Video({
+        filename: "/data/vid.mp4",
+        openBackend: false,
+      });
       const inst = Instance.fromArray(
         [
           [1, 2],
@@ -249,10 +265,15 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
         skeletons: [skeleton],
       });
 
-      const foreign = new Video({ filename: "/data/vid.mp4", openBackend: false });
+      const foreign = new Video({
+        filename: "/data/vid.mp4",
+        openBackend: false,
+      });
       expect(labels.getCentroids({ video })).toEqual([centroid]);
       expect(labels.getCentroids({ video: foreign })).toEqual([centroid]);
-      expect(labels.getCentroids({ video: "/data/vid.mp4" })).toEqual([centroid]);
+      expect(labels.getCentroids({ video: "/data/vid.mp4" })).toEqual([
+        centroid,
+      ]);
       // Bare basename also resolves via the basename tier.
       expect(labels.getCentroids({ video: "vid.mp4" })).toEqual([centroid]);
     });
@@ -263,7 +284,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
       const lf = new LabeledFrame({ video, frameIdx: 0, rois: [roi] });
       const labels = new Labels({ labeledFrames: [lf], videos: [video] });
 
-      const foreign = new Video({ filename: "/data/v1.mp4", openBackend: false });
+      const foreign = new Video({
+        filename: "/data/v1.mp4",
+        openBackend: false,
+      });
       expect(labels.getRois({ video })).toEqual([roi]);
       expect(labels.getRois({ video: foreign })).toEqual([roi]);
       expect(labels.getRois({ video: "/data/v1.mp4" })).toEqual([roi]);
@@ -276,7 +300,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
       const lf = new LabeledFrame({ video, frameIdx: 0, masks: [mask] });
       const labels = new Labels({ labeledFrames: [lf], videos: [video] });
 
-      const foreign = new Video({ filename: "/data/m.mp4", openBackend: false });
+      const foreign = new Video({
+        filename: "/data/m.mp4",
+        openBackend: false,
+      });
       expect(labels.getMasks({ video })).toEqual([mask]);
       expect(labels.getMasks({ video: foreign })).toEqual([mask]);
       expect(labels.getMasks({ video: "/data/m.mp4" })).toEqual([mask]);
@@ -289,7 +316,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
       const lf = new LabeledFrame({ video, frameIdx: 0, bboxes: [bbox] });
       const labels = new Labels({ labeledFrames: [lf], videos: [video] });
 
-      const foreign = new Video({ filename: "/data/b.mp4", openBackend: false });
+      const foreign = new Video({
+        filename: "/data/b.mp4",
+        openBackend: false,
+      });
       expect(labels.getBboxes({ video })).toEqual([bbox]);
       expect(labels.getBboxes({ video: foreign })).toEqual([bbox]);
       expect(labels.getBboxes({ video: "/data/b.mp4" })).toEqual([bbox]);
@@ -306,7 +336,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
       const lf = new LabeledFrame({ video, frameIdx: 0, labelImages: [li] });
       const labels = new Labels({ labeledFrames: [lf], videos: [video] });
 
-      const foreign = new Video({ filename: "/data/li.mp4", openBackend: false });
+      const foreign = new Video({
+        filename: "/data/li.mp4",
+        openBackend: false,
+      });
       expect(labels.getLabelImages({ video })).toEqual([li]);
       expect(labels.getLabelImages({ video: foreign })).toEqual([li]);
       expect(labels.getLabelImages({ video: "/data/li.mp4" })).toEqual([li]);
@@ -314,7 +347,10 @@ describe("Labels lookup widening (#107 / Python PR #436)", () => {
     });
 
     it("get* widening returns empty for a non-matching string (no throw)", () => {
-      const video = new Video({ filename: "/data/vid.mp4", openBackend: false });
+      const video = new Video({
+        filename: "/data/vid.mp4",
+        openBackend: false,
+      });
       const roi = ROI.fromBbox(0, 0, 10, 10, { video });
       const lf = new LabeledFrame({ video, frameIdx: 0, rois: [roi] });
       const labels = new Labels({ labeledFrames: [lf], videos: [video] });

--- a/tests/model/labels-match.test.ts
+++ b/tests/model/labels-match.test.ts
@@ -97,11 +97,20 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_unmatched_videos (test_labels.py:4635-4653)
   it("stores null in the video map on no-match (and is side-effect free)", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt = new Video({ filename: "/data/video_a.mp4", openBackend: false });
-    const videoPred = new Video({ filename: "/data/video_b.mp4", openBackend: false });
+    const videoGt = new Video({
+      filename: "/data/video_a.mp4",
+      openBackend: false,
+    });
+    const videoPred = new Video({
+      filename: "/data/video_b.mp4",
+      openBackend: false,
+    });
 
     const gtLabels = new Labels({ videos: [videoGt], skeletons: [skeleton] });
-    const predLabels = new Labels({ videos: [videoPred], skeletons: [skeleton] });
+    const predLabels = new Labels({
+      videos: [videoPred],
+      skeletons: [skeleton],
+    });
 
     const result = await gtLabels.match(predLabels);
 
@@ -120,16 +129,31 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_multiple_videos (test_labels.py:4655-4681)
   it("matches multiple videos (2 match, 1 doesn't), preserving other order", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt1 = new Video({ filename: "/data/video1.mp4", openBackend: false });
-    const videoGt2 = new Video({ filename: "/data/video2.mp4", openBackend: false });
+    const videoGt1 = new Video({
+      filename: "/data/video1.mp4",
+      openBackend: false,
+    });
+    const videoGt2 = new Video({
+      filename: "/data/video2.mp4",
+      openBackend: false,
+    });
     const gtLabels = new Labels({
       videos: [videoGt1, videoGt2],
       skeletons: [skeleton],
     });
 
-    const videoPred1 = new Video({ filename: "/output/video1.mp4", openBackend: false });
-    const videoPred2 = new Video({ filename: "/output/video2.mp4", openBackend: false });
-    const videoPred3 = new Video({ filename: "/output/video3.mp4", openBackend: false });
+    const videoPred1 = new Video({
+      filename: "/output/video1.mp4",
+      openBackend: false,
+    });
+    const videoPred2 = new Video({
+      filename: "/output/video2.mp4",
+      openBackend: false,
+    });
+    const videoPred3 = new Video({
+      filename: "/output/video3.mp4",
+      openBackend: false,
+    });
     const predLabels = new Labels({
       videos: [videoPred1, videoPred2, videoPred3],
       skeletons: [skeleton],
@@ -148,7 +172,10 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_track_matching (test_labels.py:4683-4699)
   it("matches tracks by name (different object, same name)", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const video = new Video({ filename: "/data/video.mp4", openBackend: false });
+    const video = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
     const trackGt = new Track("animal_1");
     const trackPred = new Track("animal_1");
 
@@ -172,11 +199,20 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_string_method (test_labels.py:4701-4715)
   it("accepts string method arguments", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt = new Video({ filename: "/data/video.mp4", openBackend: false });
-    const videoPred = new Video({ filename: "/output/video.mp4", openBackend: false });
+    const videoGt = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
+    const videoPred = new Video({
+      filename: "/output/video.mp4",
+      openBackend: false,
+    });
 
     const gtLabels = new Labels({ videos: [videoGt], skeletons: [skeleton] });
-    const predLabels = new Labels({ videos: [videoPred], skeletons: [skeleton] });
+    const predLabels = new Labels({
+      videos: [videoPred],
+      skeletons: [skeleton],
+    });
 
     const result = await gtLabels.match(predLabels, {
       video: "basename",
@@ -193,15 +229,25 @@ describe("Labels.match (read-only)", () => {
     // gt is a subset of pred, so gt nodes must be a subset of pred nodes.
     const skeletonGt = new Skeleton({ nodes: ["head", "tail"] });
     const skeletonPred = new Skeleton({ nodes: ["head", "body", "tail"] });
-    const video = new Video({ filename: "/data/video.mp4", openBackend: false });
+    const video = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
 
     const gtLabels = new Labels({ videos: [video], skeletons: [skeletonGt] });
-    const predLabels = new Labels({ videos: [video], skeletons: [skeletonPred] });
+    const predLabels = new Labels({
+      videos: [video],
+      skeletons: [skeletonPred],
+    });
 
-    const resultStruct = await gtLabels.match(predLabels, { skeleton: "structure" });
+    const resultStruct = await gtLabels.match(predLabels, {
+      skeleton: "structure",
+    });
     expect(resultStruct.allSkeletonsMatched).toBe(false);
 
-    const resultSubset = await gtLabels.match(predLabels, { skeleton: "subset" });
+    const resultSubset = await gtLabels.match(predLabels, {
+      skeleton: "subset",
+    });
     expect(resultSubset.allSkeletonsMatched).toBe(true);
   });
 
@@ -223,14 +269,20 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_summary (test_labels.py:4753-4768)
   it("summary() reports matched counts and unmatched videos", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt = new Video({ filename: "/data/video.mp4", openBackend: false });
+    const videoGt = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
     const videoPred = new Video({
       filename: "/output/different.mp4",
       openBackend: false,
     });
 
     const gtLabels = new Labels({ videos: [videoGt], skeletons: [skeleton] });
-    const predLabels = new Labels({ videos: [videoPred], skeletons: [skeleton] });
+    const predLabels = new Labels({
+      videos: [videoPred],
+      skeletons: [skeleton],
+    });
 
     const result = await gtLabels.match(predLabels);
 
@@ -251,8 +303,14 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_with_matcher_objects (test_labels.py:4784-4819)
   it("accepts Matcher objects (not strings)", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt = new Video({ filename: "/data/video.mp4", openBackend: false });
-    const videoPred = new Video({ filename: "/output/video.mp4", openBackend: false });
+    const videoGt = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
+    const videoPred = new Video({
+      filename: "/output/video.mp4",
+      openBackend: false,
+    });
     const trackGt = new Track("animal_1");
     const trackPred = new Track("animal_1");
 
@@ -281,14 +339,21 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_summary_many_unmatched (test_labels.py:4821-4844)
   it("summary() truncates unmatched videos at 5 with '... and N more'", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt = new Video({ filename: "/data/video_gt.mp4", openBackend: false });
+    const videoGt = new Video({
+      filename: "/data/video_gt.mp4",
+      openBackend: false,
+    });
     const gtLabels = new Labels({ videos: [videoGt], skeletons: [skeleton] });
 
     const predVideos = Array.from(
       { length: 7 },
-      (_, i) => new Video({ filename: `/output/pred_${i}.mp4`, openBackend: false }),
+      (_, i) =>
+        new Video({ filename: `/output/pred_${i}.mp4`, openBackend: false }),
     );
-    const predLabels = new Labels({ videos: predVideos, skeletons: [skeleton] });
+    const predLabels = new Labels({
+      videos: predVideos,
+      skeletons: [skeleton],
+    });
 
     const result = await gtLabels.match(predLabels);
 
@@ -302,14 +367,20 @@ describe("Labels.match (read-only)", () => {
   // test_labels_match_summary_image_video (test_labels.py:4846-4878)
   it("summary() handles an ImageVideo (list filename)", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt = new Video({ filename: "/data/video.mp4", openBackend: false });
+    const videoGt = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
     const gtLabels = new Labels({ videos: [videoGt], skeletons: [skeleton] });
 
     const videoPred = new Video({
       filename: ["/output/frame001.png", "/output/frame002.png"],
       openBackend: false,
     });
-    const predLabels = new Labels({ videos: [videoPred], skeletons: [skeleton] });
+    const predLabels = new Labels({
+      videos: [videoPred],
+      skeletons: [skeleton],
+    });
 
     const result = await gtLabels.match(predLabels);
 
@@ -324,13 +395,22 @@ describe("Labels.match (read-only)", () => {
   // (shape is rejection-only). (ARCH §7.1; PY:test_matching.py:473-494.)
   it("AUTO video match is rejection-only on shape (same shape, diff basename -> null)", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const videoGt = new Video({ filename: "/data/video_a.mp4", openBackend: false });
+    const videoGt = new Video({
+      filename: "/data/video_a.mp4",
+      openBackend: false,
+    });
     videoGt.backendMetadata = { shape: [100, 480, 640, 3] };
-    const videoPred = new Video({ filename: "/data/video_b.mp4", openBackend: false });
+    const videoPred = new Video({
+      filename: "/data/video_b.mp4",
+      openBackend: false,
+    });
     videoPred.backendMetadata = { shape: [100, 480, 640, 3] };
 
     const gtLabels = new Labels({ videos: [videoGt], skeletons: [skeleton] });
-    const predLabels = new Labels({ videos: [videoPred], skeletons: [skeleton] });
+    const predLabels = new Labels({
+      videos: [videoPred],
+      skeletons: [skeleton],
+    });
 
     const result = await gtLabels.match(predLabels);
     expect(result.videoMap.get(videoPred)).toBe(null);
@@ -343,7 +423,10 @@ describe("Labels.match (read-only)", () => {
       filename: "/data/recordings/video.mp4",
       openBackend: false,
     });
-    const videoGt2 = new Video({ filename: "/data/other/video.mp4", openBackend: false });
+    const videoGt2 = new Video({
+      filename: "/data/other/video.mp4",
+      openBackend: false,
+    });
     const gtLabels = new Labels({
       videos: [videoGt2, videoGt1],
       skeletons: [skeleton],
@@ -353,7 +436,10 @@ describe("Labels.match (read-only)", () => {
       filename: "/data/recordings/video.mp4",
       openBackend: false,
     });
-    const predLabels = new Labels({ videos: [videoPred], skeletons: [skeleton] });
+    const predLabels = new Labels({
+      videos: [videoPred],
+      skeletons: [skeleton],
+    });
 
     const result = await gtLabels.match(predLabels);
     expect(result.videoMap.get(videoPred)).toBe(videoGt1);
@@ -363,10 +449,16 @@ describe("Labels.match (read-only)", () => {
 describe("Labels.matchVideo", () => {
   // test_match_video_foreign_instance (test_labels.py:343-354, programmatic)
   it("resolves a foreign Video with the same path to the canonical, and identity arg unchanged", async () => {
-    const canonical = new Video({ filename: "/data/video.mp4", openBackend: false });
+    const canonical = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
     const labels = new Labels({ videos: [canonical] });
 
-    const foreign = new Video({ filename: canonical.filename, openBackend: false });
+    const foreign = new Video({
+      filename: canonical.filename,
+      openBackend: false,
+    });
     expect(foreign).not.toBe(canonical);
     expect(await labels.matchVideo(foreign)).toBe(canonical);
 
@@ -376,14 +468,20 @@ describe("Labels.matchVideo", () => {
 
   // test_match_video_by_path (test_labels.py:357-363, programmatic)
   it("resolves a str filename to the canonical Video", async () => {
-    const canonical = new Video({ filename: "/data/video.mp4", openBackend: false });
+    const canonical = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
     const labels = new Labels({ videos: [canonical] });
     expect(await labels.matchVideo("/data/video.mp4")).toBe(canonical);
   });
 
   // test_match_video_no_match (test_labels.py:366-370, programmatic)
   it("returns null when no video matches", async () => {
-    const canonical = new Video({ filename: "/data/video.mp4", openBackend: false });
+    const canonical = new Video({
+      filename: "/data/video.mp4",
+      openBackend: false,
+    });
     const labels = new Labels({ videos: [canonical] });
     expect(await labels.matchVideo("not_in_project.mp4")).toBe(null);
     expect(
@@ -495,7 +593,9 @@ describe("Labels.matchVideo", () => {
     const labels = new Labels({
       videos: [new Video({ filename: "vid.mp4", openBackend: false })],
     });
-    await expect(labels.matchVideo("vid.mp4", "not_a_method")).rejects.toThrow();
+    await expect(
+      labels.matchVideo("vid.mp4", "not_a_method"),
+    ).rejects.toThrow();
   });
 
   // Method validation runs BEFORE the identity short-circuit: passing the
@@ -504,7 +604,9 @@ describe("Labels.matchVideo", () => {
   it("validates the method BEFORE the identity short-circuit", async () => {
     const canonical = new Video({ filename: "vid.mp4", openBackend: false });
     const labels = new Labels({ videos: [canonical] });
-    await expect(labels.matchVideo(canonical, "not_a_method")).rejects.toThrow();
+    await expect(
+      labels.matchVideo(canonical, "not_a_method"),
+    ).rejects.toThrow();
   });
 
   // test_match_video_image_sequence (test_labels.py:559-570)
@@ -513,7 +615,10 @@ describe("Labels.matchVideo", () => {
     const video = new Video({ filename: [...framePaths], openBackend: false });
     const labels = new Labels({ videos: [video] });
 
-    const foreign = new Video({ filename: [...framePaths], openBackend: false });
+    const foreign = new Video({
+      filename: [...framePaths],
+      openBackend: false,
+    });
     expect(await labels.matchVideo(foreign)).toBe(video);
 
     // A partially overlapping sequence is not an "auto" match.

--- a/tests/model/labels-merge-negative-flag.test.ts
+++ b/tests/model/labels-merge-negative-flag.test.ts
@@ -25,59 +25,137 @@ describe("Labels.merge preserves isNegative (issue #108 / PR #432)", () => {
     const sk = SK();
     const v = new Video({ filename: "v.mp4", openBackend: false });
     const base = new Labels();
-    base.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [user([[1, 1], [2, 2]], sk)] }));
+    base.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [
+          user(
+            [
+              [1, 1],
+              [2, 2],
+            ],
+            sk,
+          ),
+        ],
+      }),
+    );
 
     const other = new Labels();
-    other.append(new LabeledFrame({ video: v, frameIdx: 5, instances: [], isNegative: true }));
+    other.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 5,
+        instances: [],
+        isNegative: true,
+      }),
+    );
 
     const result = await base.merge(other);
 
     const appended = base.find({ video: v, frameIdx: 5 })[0];
     expect(appended.isNegative).toBe(true);
-    expect(result.conflicts.some((c) => c.conflictType === "negative_flag_conflict")).toBe(false);
+    expect(
+      result.conflicts.some((c) => c.conflictType === "negative_flag_conflict"),
+    ).toBe(false);
   });
 
   it("colliding: both sides negative, no user pose -> stays negative, no conflict", async () => {
     const sk = SK();
     const v = new Video({ filename: "v.mp4", openBackend: false });
     const base = new Labels();
-    base.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [], isNegative: true }));
+    base.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [],
+        isNegative: true,
+      }),
+    );
     const other = new Labels();
-    other.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [], isNegative: true }));
+    other.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [],
+        isNegative: true,
+      }),
+    );
 
     const result = await base.merge(other);
 
     expect(base.find({ video: v, frameIdx: 0 })[0].isNegative).toBe(true);
-    expect(result.conflicts.some((c) => c.conflictType === "negative_flag_conflict")).toBe(false);
+    expect(
+      result.conflicts.some((c) => c.conflictType === "negative_flag_conflict"),
+    ).toBe(false);
   });
 
   it("colliding: one side negative, no user pose -> stays negative, no conflict", async () => {
     const sk = SK();
     const v = new Video({ filename: "v.mp4", openBackend: false });
     const base = new Labels();
-    base.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [], isNegative: true }));
+    base.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [],
+        isNegative: true,
+      }),
+    );
     const other = new Labels();
-    other.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [], isNegative: false }));
+    other.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [],
+        isNegative: false,
+      }),
+    );
 
     const result = await base.merge(other);
 
     expect(base.find({ video: v, frameIdx: 0 })[0].isNegative).toBe(true);
-    expect(result.conflicts.some((c) => c.conflictType === "negative_flag_conflict")).toBe(false);
+    expect(
+      result.conflicts.some((c) => c.conflictType === "negative_flag_conflict"),
+    ).toBe(false);
   });
 
   it("colliding: negative base + incoming USER pose -> flag cleared + negative_flag_conflict emitted", async () => {
     const sk = SK();
     const v = new Video({ filename: "v.mp4", openBackend: false });
     const base = new Labels();
-    base.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [], isNegative: true }));
+    base.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [],
+        isNegative: true,
+      }),
+    );
     const other = new Labels();
-    other.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [user([[1, 1], [2, 2]], sk)] }));
+    other.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [
+          user(
+            [
+              [1, 1],
+              [2, 2],
+            ],
+            sk,
+          ),
+        ],
+      }),
+    );
 
     const result = await base.merge(other);
 
     const frame = base.find({ video: v, frameIdx: 0 })[0];
     expect(frame.isNegative).toBe(false); // user pose vetoes the flag
-    const conflict = result.conflicts.find((c) => c.conflictType === "negative_flag_conflict");
+    const conflict = result.conflicts.find(
+      (c) => c.conflictType === "negative_flag_conflict",
+    );
     expect(conflict).toBeDefined();
     expect(conflict!.originalData).toBe(true); // base was negative
     expect(conflict!.resolution).toBe("dropped_for_user_pose");
@@ -87,13 +165,36 @@ describe("Labels.merge preserves isNegative (issue #108 / PR #432)", () => {
     const sk = SK();
     const v = new Video({ filename: "v.mp4", openBackend: false });
     const base = new Labels();
-    base.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [], isNegative: true }));
+    base.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [],
+        isNegative: true,
+      }),
+    );
     const other = new Labels();
-    other.append(new LabeledFrame({ video: v, frameIdx: 0, instances: [pred([[1, 1], [2, 2]], sk)] }));
+    other.append(
+      new LabeledFrame({
+        video: v,
+        frameIdx: 0,
+        instances: [
+          pred(
+            [
+              [1, 1],
+              [2, 2],
+            ],
+            sk,
+          ),
+        ],
+      }),
+    );
 
     const result = await base.merge(other);
 
     expect(base.find({ video: v, frameIdx: 0 })[0].isNegative).toBe(true);
-    expect(result.conflicts.some((c) => c.conflictType === "negative_flag_conflict")).toBe(false);
+    expect(
+      result.conflicts.some((c) => c.conflictType === "negative_flag_conflict"),
+    ).toBe(false);
   });
 });

--- a/tests/model/labels-merge-video-auto.test.ts
+++ b/tests/model/labels-merge-video-auto.test.ts
@@ -62,7 +62,15 @@ describe("Labels.merge — AUTO video matching (GROUP B7-B11)", () => {
         video: predVideo,
         frameIdx: 0,
         instances: [
-          predInst([[100, 200], [150, 250], [200, 300]], skeleton, 0.95),
+          predInst(
+            [
+              [100, 200],
+              [150, 250],
+              [200, 300],
+            ],
+            skeleton,
+            0.95,
+          ),
         ],
       }),
     ];
@@ -92,7 +100,16 @@ describe("Labels.merge — AUTO video matching (GROUP B7-B11)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[100, 200], [150, 250]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [100, 200],
+              [150, 250],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -122,7 +139,16 @@ describe("Labels.merge — AUTO video matching (GROUP B7-B11)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[100, 200], [150, 250]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [100, 200],
+              [150, 250],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -150,7 +176,16 @@ describe("Labels.merge — AUTO video matching (GROUP B7-B11)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 5,
-        instances: [predInst([[50, 60], [70, 80]], skeleton, 0.85)],
+        instances: [
+          predInst(
+            [
+              [50, 60],
+              [70, 80],
+            ],
+            skeleton,
+            0.85,
+          ),
+        ],
       }),
     ];
 
@@ -171,14 +206,26 @@ describe("Labels.merge — AUTO video matching (GROUP B7-B11)", () => {
     const labels = new Labels({ skeletons: [skeleton] });
     labels.videos = [videoA];
 
-    const predVideo = makeVideo("/predictions/video_b.mp4", [200, 1920, 1080, 3]);
+    const predVideo = makeVideo(
+      "/predictions/video_b.mp4",
+      [200, 1920, 1080, 3],
+    );
     const predictions = new Labels({ skeletons: [skeleton] });
     predictions.videos = [predVideo];
     predictions.labeledFrames = [
       new LabeledFrame({
         video: predVideo,
         frameIdx: 10,
-        instances: [predInst([[100, 200], [300, 400]], skeleton, 0.95)],
+        instances: [
+          predInst(
+            [
+              [100, 200],
+              [300, 400],
+            ],
+            skeleton,
+            0.95,
+          ),
+        ],
       }),
     ];
 

--- a/tests/model/labels-merge.test.ts
+++ b/tests/model/labels-merge.test.ts
@@ -26,10 +26,18 @@ import path from "node:path";
 import fs from "node:fs";
 import { Labels } from "../../src/model/labels.js";
 import { LabeledFrame } from "../../src/model/labeled-frame.js";
-import { Instance, PredictedInstance, Track } from "../../src/model/instance.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+} from "../../src/model/instance.js";
 import { Skeleton } from "../../src/model/skeleton.js";
 import { Video } from "../../src/model/video.js";
-import { MergeResult, VideoMatcher, VideoMatchMethod } from "../../src/model/matching.js";
+import {
+  MergeResult,
+  VideoMatcher,
+  VideoMatchMethod,
+} from "../../src/model/matching.js";
 
 // --- helpers ----------------------------------------------------------------
 
@@ -48,7 +56,11 @@ function makeVideo(
   return v;
 }
 
-function userInst(points: number[][], skeleton: Skeleton, track?: Track): Instance {
+function userInst(
+  points: number[][],
+  skeleton: Skeleton,
+  track?: Track,
+): Instance {
   return new Instance({
     points: Instance.fromArray(points, skeleton).points,
     skeleton,
@@ -79,7 +91,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+          ),
+        ],
       }),
     );
 
@@ -88,7 +108,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 1,
-        instances: [userInst([[30, 30], [40, 40]], skeleton)],
+        instances: [
+          userInst(
+            [
+              [30, 30],
+              [40, 40],
+            ],
+            skeleton,
+          ),
+        ],
       }),
     );
 
@@ -111,7 +139,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+          ),
+        ],
       }),
     );
 
@@ -120,7 +156,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[11, 11], [21, 21]], skeleton)],
+        instances: [
+          userInst(
+            [
+              [11, 11],
+              [21, 21],
+            ],
+            skeleton,
+          ),
+        ],
       }),
     );
 
@@ -147,7 +191,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton1)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton1,
+          ),
+        ],
       }),
     );
 
@@ -156,7 +208,16 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 1,
-        instances: [userInst([[10, 10], [15, 15], [20, 20]], skeleton2)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [15, 15],
+              [20, 20],
+            ],
+            skeleton2,
+          ),
+        ],
       }),
     );
 
@@ -184,7 +245,16 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton, track1)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            track1,
+          ),
+        ],
       }),
     );
 
@@ -193,7 +263,16 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 1,
-        instances: [userInst([[30, 30], [40, 40]], skeleton, track2)],
+        instances: [
+          userInst(
+            [
+              [30, 30],
+              [40, 40],
+            ],
+            skeleton,
+            track2,
+          ),
+        ],
       }),
     );
 
@@ -217,7 +296,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton1)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton1,
+          ),
+        ],
       }),
     );
 
@@ -226,7 +313,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton2)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton2,
+          ),
+        ],
       }),
     );
 
@@ -249,7 +344,15 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+          ),
+        ],
       }),
     );
 
@@ -258,14 +361,24 @@ describe("Labels.merge — basics (GROUP B)", () => {
       new LabeledFrame({
         video,
         frameIdx: 1,
-        instances: [userInst([[30, 30], [40, 40]], skeleton)],
+        instances: [
+          userInst(
+            [
+              [30, 30],
+              [40, 40],
+            ],
+            skeleton,
+          ),
+        ],
       }),
     );
 
     await labels1.merge(labels2);
 
     expect("merge_history" in labels1.provenance).toBe(true);
-    const history = labels1.provenance.merge_history as Array<Record<string, unknown>>;
+    const history = labels1.provenance.merge_history as Array<
+      Record<string, unknown>
+    >;
     expect(history.length).toBe(1);
     const rec = history[0];
     expect("timestamp" in rec).toBe(true);
@@ -304,7 +417,16 @@ describe("Labels.merge — source_video awareness (GROUP C)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 10,
-        instances: [predInst([[50, 60], [70, 80]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [50, 60],
+              [70, 80],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -313,7 +435,8 @@ describe("Labels.merge — source_video awareness (GROUP C)", () => {
     expect(result.successful).toBeTruthy();
     expect(result.framesMerged).toBe(1);
     expect(baseLabels.videos.length).toBe(2); // no new video
-    const merged = baseLabels.labeledFrames[baseLabels.labeledFrames.length - 1];
+    const merged =
+      baseLabels.labeledFrames[baseLabels.labeledFrames.length - 1];
     expect(merged.video).toBe(videoB);
   });
 
@@ -329,14 +452,27 @@ describe("Labels.merge — source_video awareness (GROUP C)", () => {
 
     // source has no explicit shape in Python (only filename) — leave shape unset.
     const source = makeVideo("/data/recordings/experiment_002.mp4");
-    const predVideo = makeVideo("training_run_2024_12_15.pkg.slp", shape, source);
+    const predVideo = makeVideo(
+      "training_run_2024_12_15.pkg.slp",
+      shape,
+      source,
+    );
     const predictions = new Labels({ skeletons: [skeleton] });
     predictions.videos = [predVideo];
     predictions.labeledFrames = [
       new LabeledFrame({
         video: predVideo,
         frameIdx: 5,
-        instances: [predInst([[25, 35], [45, 55]], skeleton, 0.85)],
+        instances: [
+          predInst(
+            [
+              [25, 35],
+              [45, 55],
+            ],
+            skeleton,
+            0.85,
+          ),
+        ],
       }),
     ];
 
@@ -344,7 +480,8 @@ describe("Labels.merge — source_video awareness (GROUP C)", () => {
 
     expect(result.successful).toBeTruthy();
     expect(baseLabels.videos.length).toBe(2);
-    const merged = baseLabels.labeledFrames[baseLabels.labeledFrames.length - 1];
+    const merged =
+      baseLabels.labeledFrames[baseLabels.labeledFrames.length - 1];
     expect(merged.video).toBe(baseVideo2);
   });
 
@@ -359,7 +496,11 @@ describe("Labels.merge — source_video awareness (GROUP C)", () => {
     baseLabels.videos = [videoA, videoB];
 
     const intermediateSource = makeVideo("/data/video_b.mp4");
-    const intermediate = makeVideo("intermediate.pkg.slp", undefined, intermediateSource);
+    const intermediate = makeVideo(
+      "intermediate.pkg.slp",
+      undefined,
+      intermediateSource,
+    );
     const final = makeVideo("final.pkg.slp", shape, intermediate);
 
     const predictions = new Labels({ skeletons: [skeleton] });
@@ -368,7 +509,16 @@ describe("Labels.merge — source_video awareness (GROUP C)", () => {
       new LabeledFrame({
         video: final,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -376,7 +526,8 @@ describe("Labels.merge — source_video awareness (GROUP C)", () => {
 
     expect(result.successful).toBeTruthy();
     expect(baseLabels.videos.length).toBe(2);
-    const merged = baseLabels.labeledFrames[baseLabels.labeledFrames.length - 1];
+    const merged =
+      baseLabels.labeledFrames[baseLabels.labeledFrames.length - 1];
     expect(merged.video).toBe(videoB);
   });
 });
@@ -403,7 +554,16 @@ describe("Labels.merge — cross-platform paths (GROUP D)", () => {
       new LabeledFrame({
         video: linuxVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 20], [30, 40]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 20],
+              [30, 40],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -431,7 +591,16 @@ describe("Labels.merge — cross-platform paths (GROUP D)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 20], [30, 40]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 20],
+              [30, 40],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -453,7 +622,11 @@ describe("Labels.merge — ImageVideo (GROUP E)", () => {
   // E1 test_merge_imagevideo_basic (lines 972-1015)
   it("E1: identical image-path lists (copies) -> same video, pred frame added", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
-    const paths = ["/data/img_000.jpg", "/data/img_001.jpg", "/data/img_002.jpg"];
+    const paths = [
+      "/data/img_000.jpg",
+      "/data/img_001.jpg",
+      "/data/img_002.jpg",
+    ];
     const shape: [number, number, number, number] = [3, 480, 640, 3];
 
     const video1 = makeVideo([...paths], shape);
@@ -463,7 +636,15 @@ describe("Labels.merge — ImageVideo (GROUP E)", () => {
       new LabeledFrame({
         video: video1,
         frameIdx: 0,
-        instances: [userInst([[10, 10], [20, 20]], skeleton)],
+        instances: [
+          userInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+          ),
+        ],
       }),
     ];
 
@@ -474,7 +655,16 @@ describe("Labels.merge — ImageVideo (GROUP E)", () => {
       new LabeledFrame({
         video: video2,
         frameIdx: 1,
-        instances: [predInst([[30, 30], [40, 40]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [30, 30],
+              [40, 40],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -489,7 +679,10 @@ describe("Labels.merge — ImageVideo (GROUP E)", () => {
   it("E2: IMAGE_DEDUP remaps pred frame_idx 0 (img_002) onto base frame 2", async () => {
     const skeleton = new Skeleton({ nodes: ["head", "tail"] });
 
-    const basePaths = Array.from({ length: 5 }, (_, i) => `/data/img_${String(i).padStart(3, "0")}.jpg`);
+    const basePaths = Array.from(
+      { length: 5 },
+      (_, i) => `/data/img_${String(i).padStart(3, "0")}.jpg`,
+    );
     const baseVideo = makeVideo(basePaths, [5, 480, 640, 3]);
     const baseLabels = new Labels({ skeletons: [skeleton] });
     baseLabels.videos = [baseVideo];
@@ -508,7 +701,16 @@ describe("Labels.merge — ImageVideo (GROUP E)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[50, 50], [60, 60]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [50, 50],
+              [60, 60],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -536,14 +738,26 @@ describe("Labels.merge — shape rejection (GROUP F)", () => {
     const labels = new Labels({ skeletons: [skeleton] });
     labels.videos = [videoA];
 
-    const predVideo = makeVideo("/predictions/video_a.mp4", [100, 1080, 1920, 1]);
+    const predVideo = makeVideo(
+      "/predictions/video_a.mp4",
+      [100, 1080, 1920, 1],
+    );
     const predictions = new Labels({ skeletons: [skeleton] });
     predictions.videos = [predVideo];
     predictions.labeledFrames = [
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -568,7 +782,16 @@ describe("Labels.merge — shape rejection (GROUP F)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -593,7 +816,16 @@ describe("Labels.merge — shape rejection (GROUP F)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -620,7 +852,16 @@ describe("Labels.merge — shape rejection (GROUP F)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -652,7 +893,16 @@ describe("Labels.merge — leaf-path uniqueness (GROUP G)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -679,7 +929,16 @@ describe("Labels.merge — leaf-path uniqueness (GROUP G)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -706,7 +965,16 @@ describe("Labels.merge — leaf-path uniqueness (GROUP G)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -733,7 +1001,16 @@ describe("Labels.merge — leaf-path uniqueness (GROUP G)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -761,7 +1038,16 @@ describe("Labels.merge — leaf-path uniqueness (GROUP G)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -809,7 +1095,16 @@ describe("Labels.merge — samefile matching (GROUP H)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -845,7 +1140,16 @@ describe("Labels.merge — samefile matching (GROUP H)", () => {
         new LabeledFrame({
           video: predVideo,
           frameIdx: 0,
-          instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+          instances: [
+            predInst(
+              [
+                [10, 10],
+                [20, 20],
+              ],
+              skeleton,
+              0.9,
+            ),
+          ],
         }),
       ];
       result = await labels.merge(predictions);
@@ -881,7 +1185,16 @@ describe("Labels.merge — original_video OR-logic (GROUP J)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -909,7 +1222,16 @@ describe("Labels.merge — original_video OR-logic (GROUP J)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -938,7 +1260,16 @@ describe("Labels.merge — original_video OR-logic (GROUP J)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -966,7 +1297,16 @@ describe("Labels.merge — original_video OR-logic (GROUP J)", () => {
       new LabeledFrame({
         video: predVideo,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 
@@ -995,7 +1335,16 @@ describe("Labels.merge — original_video OR-logic (GROUP J)", () => {
       new LabeledFrame({
         video: final,
         frameIdx: 0,
-        instances: [predInst([[10, 10], [20, 20]], skeleton, 0.9)],
+        instances: [
+          predInst(
+            [
+              [10, 10],
+              [20, 20],
+            ],
+            skeleton,
+            0.9,
+          ),
+        ],
       }),
     ];
 

--- a/tests/model/labels-remove-video.test.ts
+++ b/tests/model/labels-remove-video.test.ts
@@ -84,7 +84,10 @@ describe("Labels.removeVideo / removeVideos", () => {
     const fa = new LabeledFrame({ video: a, frameIdx: 0 });
     const fb = new LabeledFrame({ video: b, frameIdx: 0 });
     const fc = new LabeledFrame({ video: c, frameIdx: 0 });
-    const labels = new Labels({ labeledFrames: [fa, fb, fc], videos: [a, b, c] });
+    const labels = new Labels({
+      labeledFrames: [fa, fb, fc],
+      videos: [a, b, c],
+    });
     labels.removeVideos([a, c]);
     expect(labels.videos).toEqual([b]);
     expect(labels.labeledFrames).toEqual([fb]);

--- a/tests/model/labels-replace-videos.test.ts
+++ b/tests/model/labels-replace-videos.test.ts
@@ -26,7 +26,10 @@ describe("Labels.replaceVideos", () => {
     const oldVideo = new Video({ filename: "old.mp4" });
     const newVideo = new Video({ filename: "new.mp4" });
     const suggestion = new SuggestionFrame({ video: oldVideo, frameIdx: 0 });
-    const labels = new Labels({ videos: [oldVideo], suggestions: [suggestion] });
+    const labels = new Labels({
+      videos: [oldVideo],
+      suggestions: [suggestion],
+    });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
 
@@ -56,7 +59,11 @@ describe("Labels.replaceVideos", () => {
       height: 4,
       width: 4,
     });
-    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, masks: [mask] });
+    const lf = new LabeledFrame({
+      video: oldVideo,
+      frameIdx: 0,
+      masks: [mask],
+    });
     const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
@@ -68,9 +75,16 @@ describe("Labels.replaceVideos", () => {
     const oldVideo = new Video({ filename: "old.mp4" });
     const newVideo = new Video({ filename: "new.mp4" });
     const bbox = new UserBoundingBox({
-      x1: 0, y1: 0, x2: 10, y2: 10,
+      x1: 0,
+      y1: 0,
+      x2: 10,
+      y2: 10,
     });
-    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, bboxes: [bbox] });
+    const lf = new LabeledFrame({
+      video: oldVideo,
+      frameIdx: 0,
+      bboxes: [bbox],
+    });
     const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
@@ -82,7 +96,11 @@ describe("Labels.replaceVideos", () => {
     const oldVideo = new Video({ filename: "old.mp4" });
     const newVideo = new Video({ filename: "new.mp4" });
     const centroid = new UserCentroid({ x: 1, y: 2 });
-    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, centroids: [centroid] });
+    const lf = new LabeledFrame({
+      video: oldVideo,
+      frameIdx: 0,
+      centroids: [centroid],
+    });
     const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
@@ -98,7 +116,11 @@ describe("Labels.replaceVideos", () => {
       height: 2,
       width: 2,
     });
-    const lf = new LabeledFrame({ video: oldVideo, frameIdx: 0, labelImages: [li] });
+    const lf = new LabeledFrame({
+      video: oldVideo,
+      frameIdx: 0,
+      labelImages: [li],
+    });
     const labels = new Labels({ labeledFrames: [lf], videos: [oldVideo] });
 
     labels.replaceVideos({ oldVideos: [oldVideo], newVideos: [newVideo] });
@@ -137,7 +159,10 @@ describe("Labels.replaceVideos", () => {
     const newA = new Video({ filename: "new_a.mp4" });
     const frameA = new LabeledFrame({ video: videoA, frameIdx: 0 });
     const frameB = new LabeledFrame({ video: videoB, frameIdx: 0 });
-    const labels = new Labels({ labeledFrames: [frameA, frameB], videos: [videoA, videoB] });
+    const labels = new Labels({
+      labeledFrames: [frameA, frameB],
+      videos: [videoA, videoB],
+    });
 
     labels.replaceVideos({ oldVideos: [videoA], newVideos: [newA] });
 

--- a/tests/model/matching-results.test.ts
+++ b/tests/model/matching-results.test.ts
@@ -336,9 +336,11 @@ describe("MatchResult.summary (merging.md doc A.3)", () => {
   it("'0/0 matched' is valid for an empty MatchResult", () => {
     const result = new MatchResult();
     expect(result.summary()).toBe(
-      ["Videos: 0/0 matched", "Skeletons: 0/0 matched", "Tracks: 0/0 matched"].join(
-        "\n",
-      ),
+      [
+        "Videos: 0/0 matched",
+        "Skeletons: 0/0 matched",
+        "Tracks: 0/0 matched",
+      ].join("\n"),
     );
   });
 

--- a/tests/model/video-crop-dedup.test.ts
+++ b/tests/model/video-crop-dedup.test.ts
@@ -23,7 +23,11 @@ import {
 afterEach(() => setFsResolver(null));
 
 /** A fake source backend (shared inner) with a known shape. */
-function makeBackend(filename: string, width = 384, height = 384): VideoBackend {
+function makeBackend(
+  filename: string,
+  width = 384,
+  height = 384,
+): VideoBackend {
   return {
     filename,
     shape: [1, height, width, 1],

--- a/tests/model/video-crop.test.ts
+++ b/tests/model/video-crop.test.ts
@@ -70,14 +70,16 @@ describe("resolveCropRect — Python parity for every spec form", () => {
   });
 
   it("roi bounds + margin expands symmetrically", () => {
-    const roi = { bounds: [2.2, 3.7, 8.1, 9.4] as [number, number, number, number] };
+    const roi = {
+      bounds: [2.2, 3.7, 8.1, 9.4] as [number, number, number, number],
+    };
     expect(resolveCropRect(null, { roi, margin: 2 })).toEqual([0, 1, 11, 12]);
   });
 
   it("throws on multiple specs", () => {
-    expect(() =>
-      resolveCropRect([0, 0, 1, 1], { bbox: [0, 0, 1, 1] }),
-    ).toThrow(/Exactly one/);
+    expect(() => resolveCropRect([0, 0, 1, 1], { bbox: [0, 0, 1, 1] })).toThrow(
+      /Exactly one/,
+    );
   });
 
   it("throws on zero specs", () => {
@@ -123,7 +125,9 @@ describe("Video.crop — basic facade", () => {
     expect(
       v.crop(null, { center: [50, 40], size: [10, 20] })._cropTuple(),
     ).toEqual([45, 30, 55, 50]);
-    const roi = { bounds: [2.2, 3.7, 8.1, 9.4] as [number, number, number, number] };
+    const roi = {
+      bounds: [2.2, 3.7, 8.1, 9.4] as [number, number, number, number],
+    };
     expect(v.crop(null, { roi, margin: 2 })._cropTuple()).toEqual([
       0, 1, 11, 12,
     ]);

--- a/tests/model/video-embedded-frame-indices.test.ts
+++ b/tests/model/video-embedded-frame-indices.test.ts
@@ -28,7 +28,10 @@ function backendWith(frameNumbers?: number[]): VideoBackend {
 
 describe("Video.embeddedFrameIndices", () => {
   it("returns sorted, de-duplicated frame numbers from an embedded backend", () => {
-    const video = new Video({ filename: "x", backend: backendWith([20, 10, 10, 30]) });
+    const video = new Video({
+      filename: "x",
+      backend: backendWith([20, 10, 10, 30]),
+    });
     expect(video.embeddedFrameIndices).toEqual([10, 20, 30]);
   });
 

--- a/tests/model/video-matching-helpers.test.ts
+++ b/tests/model/video-matching-helpers.test.ts
@@ -252,11 +252,20 @@ describe("VideoMatcher coverage gaps (GROUP 12)", () => {
       "/data/recordings/video.mp4",
       [100, 480, 640, 3],
     );
-    const otherCandidate = makeVideo("/data/other/video.mp4", [100, 480, 640, 3]);
-    const incoming = makeVideo("/data/recordings/video.mp4", [100, 480, 640, 3]);
+    const otherCandidate = makeVideo(
+      "/data/other/video.mp4",
+      [100, 480, 640, 3],
+    );
+    const incoming = makeVideo(
+      "/data/recordings/video.mp4",
+      [100, 480, 640, 3],
+    );
 
     const matcher = new VideoMatcher(VideoMatchMethod.AUTO);
-    const result = await matcher.findMatch(incoming, [otherCandidate, candidate]);
+    const result = await matcher.findMatch(incoming, [
+      otherCandidate,
+      candidate,
+    ]);
 
     expect(result).toBe(candidate); // identity, full-path wins over basename
   });
@@ -333,7 +342,10 @@ describe("VideoMatcher coverage gaps (GROUP 12)", () => {
   it("find_match candidate too short for depth is skipped; unique deep wins", async () => {
     const shallowCandidate = makeVideo("video.mp4", [100, 480, 640, 3]);
     const deepCandidate = makeVideo("/data/exp1/video.mp4", [100, 480, 640, 3]);
-    const deepCandidate2 = makeVideo("/data/exp2/video.mp4", [100, 480, 640, 3]);
+    const deepCandidate2 = makeVideo(
+      "/data/exp2/video.mp4",
+      [100, 480, 640, 3],
+    );
     const incoming = makeVideo("/other/exp1/video.mp4", [100, 480, 640, 3]);
 
     const matcher = new VideoMatcher(VideoMatchMethod.AUTO);

--- a/tests/model/video-pose-image-helpers.test.ts
+++ b/tests/model/video-pose-image-helpers.test.ts
@@ -401,8 +401,14 @@ describe("framesSimilarByImage (TestImageMatching._frames_similar_by_image)", ()
   // Videos with no backend raise on frame access -> caught -> false. In JS a
   // backend-less getFrame returns null, which the helper treats as false.
   it("frame access failure => false", async () => {
-    const video1 = new Video({ filename: "/nonexistent.mp4", openBackend: false });
-    const video2 = new Video({ filename: "/nonexistent.mp4", openBackend: false });
+    const video1 = new Video({
+      filename: "/nonexistent.mp4",
+      openBackend: false,
+    });
+    const video2 = new Video({
+      filename: "/nonexistent.mp4",
+      openBackend: false,
+    });
     expect(await _framesSimilarByImage(video1, video2, 0, 0.05)).toBe(false);
   });
 });
@@ -433,8 +439,16 @@ describe("helpers coverage (TestHelperFunctionsCoverage)", () => {
       skeleton,
     );
 
-    const lf1 = new LabeledFrame({ video: video1, frameIdx: 0, instances: [inst1] });
-    const lf2 = new LabeledFrame({ video: video2, frameIdx: 0, instances: [inst2] });
+    const lf1 = new LabeledFrame({
+      video: video1,
+      frameIdx: 0,
+      instances: [inst1],
+    });
+    const lf2 = new LabeledFrame({
+      video: video2,
+      frameIdx: 0,
+      instances: [inst2],
+    });
 
     const labels = new Labels({
       videos: [video1, video2],
@@ -460,7 +474,11 @@ describe("helpers coverage (TestHelperFunctionsCoverage)", () => {
       ],
       skeleton,
     );
-    const lf = new LabeledFrame({ video: video2, frameIdx: 0, instances: [inst] });
+    const lf = new LabeledFrame({
+      video: video2,
+      frameIdx: 0,
+      instances: [inst],
+    });
 
     const labels = new Labels({
       videos: [video1, video2],

--- a/tests/negative-frames.test.ts
+++ b/tests/negative-frames.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "./bun-test";
-import { LabeledFrame, Labels, Video, Skeleton, Instance } from "../src/index.js";
+import {
+  LabeledFrame,
+  Labels,
+  Video,
+  Skeleton,
+  Instance,
+} from "../src/index.js";
 import { saveSlpToBytes } from "../src/codecs/slp/write.js";
 import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
 
@@ -22,7 +28,11 @@ describe("Negative Frames", () => {
     const frame1 = new LabeledFrame({ video, frameIdx: 0, isNegative: false });
     const frame2 = new LabeledFrame({ video, frameIdx: 1, isNegative: true });
     const frame3 = new LabeledFrame({ video, frameIdx: 2, isNegative: true });
-    const labels = new Labels({ labeledFrames: [frame1, frame2, frame3], videos: [video], skeletons: [skeleton] });
+    const labels = new Labels({
+      labeledFrames: [frame1, frame2, frame3],
+      videos: [video],
+      skeletons: [skeleton],
+    });
     expect(labels.negativeFrames.length).toBe(2);
     expect(labels.negativeFrames[0].frameIdx).toBe(1);
     expect(labels.negativeFrames[1].frameIdx).toBe(2);
@@ -31,14 +41,28 @@ describe("Negative Frames", () => {
   it("round-trips negative frames through write and read", async () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
+    const inst = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
     const frame1 = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
     const frame2 = new LabeledFrame({ video, frameIdx: 5, isNegative: true });
-    const frame3 = new LabeledFrame({ video, frameIdx: 10, instances: [inst], isNegative: true });
-    const labels = new Labels({ labeledFrames: [frame1, frame2, frame3], videos: [video], skeletons: [skeleton] });
+    const frame3 = new LabeledFrame({
+      video,
+      frameIdx: 10,
+      instances: [inst],
+      isNegative: true,
+    });
+    const labels = new Labels({
+      labeledFrames: [frame1, frame2, frame3],
+      videos: [video],
+      skeletons: [skeleton],
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.labeledFrames.length).toBe(3);
     expect(loaded.labeledFrames[0].isNegative).toBe(false);
@@ -50,14 +74,28 @@ describe("Negative Frames", () => {
   it("preserves negative frames through lazy load cycle", async () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
+    const inst = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
     const frame1 = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
     const frame2 = new LabeledFrame({ video, frameIdx: 5, isNegative: true });
-    const frame3 = new LabeledFrame({ video, frameIdx: 10, instances: [inst], isNegative: true });
-    const labels = new Labels({ labeledFrames: [frame1, frame2, frame3], videos: [video], skeletons: [skeleton] });
+    const frame3 = new LabeledFrame({
+      video,
+      frameIdx: 10,
+      instances: [inst],
+      isNegative: true,
+    });
+    const labels = new Labels({
+      labeledFrames: [frame1, frame2, frame3],
+      videos: [video],
+      skeletons: [skeleton],
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlpLazy(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlpLazy(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.isLazy).toBe(true);
     loaded.materialize();
@@ -75,10 +113,17 @@ describe("Negative Frames", () => {
     // Set video shape: 100 frames, 384x384, 1 channel
     video.shape = [100, 384, 384, 1];
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
+    const inst = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
     // Only label frame 5 — video has 100 frames
     const frame = new LabeledFrame({ video, frameIdx: 5, instances: [inst] });
-    const labels = new Labels({ labeledFrames: [frame], videos: [video], skeletons: [skeleton] });
+    const labels = new Labels({
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
+    });
 
     const arr = labels.numpy();
     // Should span all 100 frames (indices 0..99), not just 0..5

--- a/tests/nested-annotations.test.ts
+++ b/tests/nested-annotations.test.ts
@@ -11,8 +11,14 @@ import { Video } from "../src/model/video.js";
 import { UserCentroid, PredictedCentroid } from "../src/model/centroid.js";
 import { UserBoundingBox, PredictedBoundingBox } from "../src/model/bbox.js";
 import { UserROI, PredictedROI } from "../src/model/roi.js";
-import { UserSegmentationMask, PredictedSegmentationMask } from "../src/model/mask.js";
-import { UserLabelImage, PredictedLabelImage } from "../src/model/label-image.js";
+import {
+  UserSegmentationMask,
+  PredictedSegmentationMask,
+} from "../src/model/mask.js";
+import {
+  UserLabelImage,
+  PredictedLabelImage,
+} from "../src/model/label-image.js";
 import type { LabelImageObjectInfo } from "../src/model/label-image.js";
 import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
 import { saveSlpToBytes } from "../src/codecs/slp/write.js";
@@ -30,10 +36,15 @@ async function roundTripLazy(labels: Labels): Promise<Labels> {
 describe("LabeledFrame annotation fields", () => {
   it("has centroids, bboxes, masks, labelImages, rois fields", () => {
     const video = new Video({ filename: "test.mp4" });
-    const c = new UserCentroid({ x: 1, y: 2});
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10});
+    const c = new UserCentroid({ x: 1, y: 2 });
+    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
 
-    const lf = new LabeledFrame({ video, frameIdx: 0, centroids: [c], bboxes: [b] });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [c],
+      bboxes: [b],
+    });
     expect(lf.centroids).toHaveLength(1);
     expect(lf.centroids[0]).toBe(c);
     expect(lf.bboxes).toHaveLength(1);
@@ -45,10 +56,16 @@ describe("LabeledFrame annotation fields", () => {
 
   it("removePredictions removes predicted annotations", () => {
     const video = new Video({ filename: "test.mp4" });
-    const cUser = new UserCentroid({ x: 1, y: 2});
+    const cUser = new UserCentroid({ x: 1, y: 2 });
     const cPred = new PredictedCentroid({ x: 3, y: 4, score: 0.9 });
-    const bUser = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10});
-    const bPred = new PredictedBoundingBox({ x1: 5, y1: 5, x2: 15, y2: 15, score: 0.8 });
+    const bUser = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
+    const bPred = new PredictedBoundingBox({
+      x1: 5,
+      y1: 5,
+      x2: 15,
+      y2: 15,
+      score: 0.8,
+    });
 
     const lf = new LabeledFrame({
       video,
@@ -66,11 +83,15 @@ describe("LabeledFrame annotation fields", () => {
 
   it("mergeAnnotations merges, deduplicates, and copies new items", () => {
     const video = new Video({ filename: "test.mp4" });
-    const shared = new UserCentroid({ x: 1, y: 2});
-    const unique = new UserCentroid({ x: 3, y: 4});
+    const shared = new UserCentroid({ x: 1, y: 2 });
+    const unique = new UserCentroid({ x: 3, y: 4 });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [shared] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [shared, unique] });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [shared, unique],
+    });
 
     lf1.mergeAnnotations(lf2);
 
@@ -91,7 +112,12 @@ describe("Labels annotation on LabeledFrames", () => {
     const c2 = new UserCentroid({ x: 3, y: 4 });
     const b1 = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
 
-    const lf0 = new LabeledFrame({ video, frameIdx: 0, centroids: [c1], bboxes: [b1] });
+    const lf0 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [c1],
+      bboxes: [b1],
+    });
     const lf1 = new LabeledFrame({ video, frameIdx: 1, centroids: [c2] });
 
     const labels = new Labels({ labeledFrames: [lf0, lf1], videos: [video] });
@@ -114,7 +140,12 @@ describe("Labels annotation on LabeledFrames", () => {
     const skeleton = new Skeleton({ nodes: ["A"] });
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const c = new UserCentroid({ x: 1, y: 2 });
-    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      centroids: [c],
+    });
 
     const labels = new Labels({ labeledFrames: [lf] });
 
@@ -133,7 +164,10 @@ describe("Labels annotation on LabeledFrames", () => {
     const lfV1 = new LabeledFrame({ video: v1, frameIdx: 0, centroids: [c1] });
     const lfV2 = new LabeledFrame({ video: v2, frameIdx: 0, centroids: [c2] });
 
-    const labels = new Labels({ labeledFrames: [lfV1, lfV2], videos: [v1, v2] });
+    const labels = new Labels({
+      labeledFrames: [lfV1, lfV2],
+      videos: [v1, v2],
+    });
 
     expect(labels.labeledFrames).toHaveLength(2);
     expect(lfV1.centroids[0]).toBe(c1);
@@ -237,7 +271,13 @@ describe("Labels track collection from annotations", () => {
   it("append collects annotation tracks", () => {
     const video = new Video({ filename: "test.mp4" });
     const tBbox = new Track("t_bbox");
-    const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, track: tBbox });
+    const b = new UserBoundingBox({
+      x1: 0,
+      y1: 0,
+      x2: 10,
+      y2: 10,
+      track: tBbox,
+    });
     const lf = new LabeledFrame({ video, frameIdx: 0, bboxes: [b] });
 
     const labels = new Labels({ videos: [video] });
@@ -269,7 +309,13 @@ describe("SLP round-trip with annotations", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
     const c = new UserCentroid({ x: 1, y: 2, track });
     const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
-    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c], bboxes: [b] });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      centroids: [c],
+      bboxes: [b],
+    });
 
     const labels = new Labels({ labeledFrames: [lf] });
 
@@ -290,17 +336,19 @@ describe("SLP round-trip with annotations", () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A"] });
     const track = new Track("t1");
-    const centroids = Array.from({ length: 5 }, (_, i) =>
-      new PredictedCentroid({
-        x: i,
-        y: i * 2,
-        track,
-        score: 0.9,
-      }),
+    const centroids = Array.from(
+      { length: 5 },
+      (_, i) =>
+        new PredictedCentroid({
+          x: i,
+          y: i * 2,
+          track,
+          score: 0.9,
+        }),
     );
 
-    const frames = centroids.map((c, i) =>
-      new LabeledFrame({ video, frameIdx: i, centroids: [c] })
+    const frames = centroids.map(
+      (c, i) => new LabeledFrame({ video, frameIdx: i, centroids: [c] }),
     );
     const labels = new Labels({
       labeledFrames: frames,
@@ -328,7 +376,13 @@ describe("Lazy read with annotations", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
     const c = new UserCentroid({ x: 1, y: 2, track });
     const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10 });
-    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c], bboxes: [b] });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      centroids: [c],
+      bboxes: [b],
+    });
 
     const labels = new Labels({ labeledFrames: [lf] });
 
@@ -377,7 +431,12 @@ describe("Lazy read with annotations", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton, track });
     const c = new UserCentroid({ x: 1, y: 2, track });
 
-    const lf0 = new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] });
+    const lf0 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      centroids: [c],
+    });
     const labels = new Labels({
       labeledFrames: [lf0],
     });
@@ -399,7 +458,15 @@ describe("Lazy read with annotations", () => {
     const b = new UserBoundingBox({ x1: 0, y1: 0, x2: 10, y2: 10, track });
 
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c], bboxes: [b] })],
+      labeledFrames: [
+        new LabeledFrame({
+          video,
+          frameIdx: 0,
+          instances: [inst],
+          centroids: [c],
+          bboxes: [b],
+        }),
+      ],
     });
 
     const lazy = await roundTripLazy(labels);
@@ -423,7 +490,14 @@ describe("Lazy read with annotations", () => {
     const c = new UserCentroid({ x: 1, y: 2, track });
 
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] })],
+      labeledFrames: [
+        new LabeledFrame({
+          video,
+          frameIdx: 0,
+          instances: [inst],
+          centroids: [c],
+        }),
+      ],
     });
 
     const lazy = await roundTripLazy(labels);
@@ -443,7 +517,12 @@ describe("Lazy read with annotations", () => {
       return new LabeledFrame({ video, frameIdx: i, centroids: [c] });
     });
 
-    const labels = new Labels({ labeledFrames: frames, videos: [video], skeletons: [skeleton], tracks: [track] });
+    const labels = new Labels({
+      labeledFrames: frames,
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [track],
+    });
     const lazy = await roundTripLazy(labels);
 
     // at(-1) should return the last supplementary frame
@@ -468,7 +547,14 @@ describe("Lazy read with annotations", () => {
     const c = new UserCentroid({ x: 1, y: 2, track });
 
     const labels = new Labels({
-      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [c] })],
+      labeledFrames: [
+        new LabeledFrame({
+          video,
+          frameIdx: 0,
+          instances: [inst],
+          centroids: [c],
+        }),
+      ],
     });
 
     // Write -> lazy read -> save lazy directly -> eager read.
@@ -476,7 +562,9 @@ describe("Lazy read with annotations", () => {
     const lazy = await roundTripLazy(labels);
     expect(lazy.isLazy).toBe(true);
     const bytes2 = await saveSlpToBytes(lazy);
-    const loaded = await readSlp(new Uint8Array(bytes2).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes2).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.centroids).toHaveLength(1);
     expect(loaded.centroids[0].x).toBe(1);
@@ -487,8 +575,8 @@ describe("Lazy read with annotations", () => {
 describe("mergeAnnotations strategies", () => {
   it("keep_original keeps self's annotations and discards other's", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfC = new UserCentroid({ x: 1, y: 2});
-    const otherC = new UserCentroid({ x: 3, y: 4});
+    const selfC = new UserCentroid({ x: 1, y: 2 });
+    const otherC = new UserCentroid({ x: 3, y: 4 });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
@@ -501,8 +589,8 @@ describe("mergeAnnotations strategies", () => {
 
   it("keep_new replaces with copies of other's", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfC = new UserCentroid({ x: 1, y: 2});
-    const otherC = new UserCentroid({ x: 3, y: 4});
+    const selfC = new UserCentroid({ x: 1, y: 2 });
+    const otherC = new UserCentroid({ x: 3, y: 4 });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfC] });
     const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherC] });
@@ -517,13 +605,21 @@ describe("mergeAnnotations strategies", () => {
 
   it("replace_predictions keeps user from self, replaces predicted with other's", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfUser = new UserCentroid({ x: 1, y: 2});
+    const selfUser = new UserCentroid({ x: 1, y: 2 });
     const selfPred = new PredictedCentroid({ x: 5, y: 6, score: 0.9 });
     const otherPred = new PredictedCentroid({ x: 7, y: 8, score: 0.8 });
-    const otherUser = new UserCentroid({ x: 9, y: 10});
+    const otherUser = new UserCentroid({ x: 9, y: 10 });
 
-    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred, otherUser] });
+    const lf1 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [selfUser, selfPred],
+    });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [otherPred, otherUser],
+    });
 
     lf1.mergeAnnotations(lf2, "replace_predictions");
 
@@ -537,12 +633,20 @@ describe("mergeAnnotations strategies", () => {
 
   it("auto spatial matching resolves user-vs-predicted", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfUser = new UserCentroid({ x: 1, y: 2});
+    const selfUser = new UserCentroid({ x: 1, y: 2 });
     const selfPred = new PredictedCentroid({ x: 5, y: 6, score: 0.9 });
     const otherPred = new PredictedCentroid({ x: 7, y: 8, score: 0.8 });
 
-    const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser, selfPred] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherPred] });
+    const lf1 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [selfUser, selfPred],
+    });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [otherPred],
+    });
 
     lf1.mergeAnnotations(lf2, "auto");
 
@@ -554,12 +658,16 @@ describe("mergeAnnotations strategies", () => {
 
   it("auto adds unmatched user from other", () => {
     const video = new Video({ filename: "test.mp4" });
-    const selfUser = new UserCentroid({ x: 1, y: 2});
+    const selfUser = new UserCentroid({ x: 1, y: 2 });
     // Far away — won't match self_user (distance > 5.0)
-    const otherUser = new UserCentroid({ x: 50, y: 60});
+    const otherUser = new UserCentroid({ x: 50, y: 60 });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfUser] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [otherUser],
+    });
 
     lf1.mergeAnnotations(lf2, "auto");
 
@@ -573,10 +681,14 @@ describe("mergeAnnotations strategies", () => {
   it("auto user replaces prediction when spatially matched", () => {
     const video = new Video({ filename: "test.mp4" });
     const selfPred = new PredictedCentroid({ x: 10, y: 20, score: 0.9 });
-    const otherUser = new UserCentroid({ x: 11, y: 20.5});
+    const otherUser = new UserCentroid({ x: 11, y: 20.5 });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [otherUser],
+    });
 
     lf1.mergeAnnotations(lf2, "auto");
 
@@ -590,10 +702,14 @@ describe("mergeAnnotations strategies", () => {
     const video = new Video({ filename: "test.mp4" });
     const selfPred = new PredictedCentroid({ x: 10, y: 20, score: 0.9 });
     // Far away — no match
-    const otherUser = new UserCentroid({ x: 80, y: 90});
+    const otherUser = new UserCentroid({ x: 80, y: 90 });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUser] });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [otherUser],
+    });
 
     lf1.mergeAnnotations(lf2, "auto");
 
@@ -606,10 +722,17 @@ describe("mergeAnnotations strategies", () => {
   it("auto spatial matching works for bounding boxes", () => {
     const video = new Video({ filename: "test.mp4" });
     const selfPred = new PredictedBoundingBox({
-      x1: 10, y1: 10, x2: 20, y2: 20, score: 0.8,
+      x1: 10,
+      y1: 10,
+      x2: 20,
+      y2: 20,
+      score: 0.8,
     });
     const otherUser = new UserBoundingBox({
-      x1: 11, y1: 11, x2: 21, y2: 21,
+      x1: 11,
+      y1: 11,
+      x2: 21,
+      y2: 21,
     });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, bboxes: [selfPred] });
@@ -659,11 +782,15 @@ describe("mergeAnnotations strategies", () => {
     // One prediction in self
     const selfPred = new PredictedCentroid({ x: 10, y: 10, score: 0.9 });
     // Two users in other, both within threshold of selfPred
-    const otherUserA = new UserCentroid({ x: 11, y: 10}); // dist=1.0
-    const otherUserB = new UserCentroid({ x: 10, y: 11}); // dist=1.0
+    const otherUserA = new UserCentroid({ x: 11, y: 10 }); // dist=1.0
+    const otherUserB = new UserCentroid({ x: 10, y: 11 }); // dist=1.0
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, centroids: [selfPred] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, centroids: [otherUserA, otherUserB] });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [otherUserA, otherUserB],
+    });
 
     lf1.mergeAnnotations(lf2, "auto");
 
@@ -744,7 +871,9 @@ describe("mergeAnnotations strategies", () => {
       data: new Int32Array([0, 1]),
       height: 1,
       width: 2,
-      objects: new Map([[1, { track: trackA, category: "cell", name: "", instance: null }]]),
+      objects: new Map([
+        [1, { track: trackA, category: "cell", name: "", instance: null }],
+      ]),
       video,
       frameIdx: 0,
     });
@@ -752,13 +881,19 @@ describe("mergeAnnotations strategies", () => {
       data: new Int32Array([0, 2]),
       height: 1,
       width: 2,
-      objects: new Map([[2, { track: trackB, category: "cell", name: "", instance: null }]]),
+      objects: new Map([
+        [2, { track: trackB, category: "cell", name: "", instance: null }],
+      ]),
       video,
       frameIdx: 0,
     });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liSelf] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liOther] });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      labelImages: [liOther],
+    });
 
     lf1.mergeAnnotations(lf2, "update_tracks");
 
@@ -774,7 +909,9 @@ describe("mergeAnnotations strategies", () => {
       data: new Int32Array([0, 1]),
       height: 1,
       width: 2,
-      objects: new Map([[1, { track, category: "cell", name: "", instance: null }]]),
+      objects: new Map([
+        [1, { track, category: "cell", name: "", instance: null }],
+      ]),
       video,
       frameIdx: 0,
     });
@@ -782,14 +919,20 @@ describe("mergeAnnotations strategies", () => {
       data: new Int32Array([0, 2]),
       height: 1,
       width: 2,
-      objects: new Map([[2, { track, category: "cell", name: "", instance: null }]]),
+      objects: new Map([
+        [2, { track, category: "cell", name: "", instance: null }],
+      ]),
       video,
       frameIdx: 0,
       score: 0.9,
     });
 
     const lf1 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liSelf] });
-    const lf2 = new LabeledFrame({ video, frameIdx: 0, labelImages: [liOther] });
+    const lf2 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      labelImages: [liOther],
+    });
 
     lf1.mergeAnnotations(lf2, "auto");
 
@@ -804,7 +947,15 @@ describe("mergeAnnotations strategies", () => {
     const selfPred = new PredictedROI({
       geometry: {
         type: "Polygon",
-        coordinates: [[[10, 10], [20, 10], [20, 20], [10, 20], [10, 10]]],
+        coordinates: [
+          [
+            [10, 10],
+            [20, 10],
+            [20, 20],
+            [10, 20],
+            [10, 10],
+          ],
+        ],
       },
       video,
       frameIdx: 0,
@@ -813,7 +964,15 @@ describe("mergeAnnotations strategies", () => {
     const otherUser = new UserROI({
       geometry: {
         type: "Polygon",
-        coordinates: [[[11, 11], [21, 11], [21, 21], [11, 21], [11, 11]]],
+        coordinates: [
+          [
+            [11, 11],
+            [21, 11],
+            [21, 21],
+            [11, 21],
+            [11, 11],
+          ],
+        ],
       },
       video,
       frameIdx: 0,
@@ -840,7 +999,15 @@ describe("mergeAnnotations strategies", () => {
     const normalRoi = new UserROI({
       geometry: {
         type: "Polygon",
-        coordinates: [[[10, 10], [20, 10], [20, 20], [10, 20], [10, 10]]],
+        coordinates: [
+          [
+            [10, 10],
+            [20, 10],
+            [20, 20],
+            [10, 20],
+            [10, 10],
+          ],
+        ],
       },
       video,
       frameIdx: 0,
@@ -871,7 +1038,15 @@ describe("_annotationCentroidXy", () => {
     const roi = new UserROI({
       geometry: {
         type: "Polygon",
-        coordinates: [[[0, 0], [10, 0], [10, 20], [0, 20], [0, 0]]],
+        coordinates: [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 20],
+            [0, 20],
+            [0, 0],
+          ],
+        ],
       },
     });
     expect(_annotationCentroidXy(roi, "rois")).toEqual([5, 10]);
@@ -946,7 +1121,12 @@ describe("_findAnnotationMatches", () => {
       new UserCentroid({ x: 11, y: 10 }),
       new UserCentroid({ x: 21, y: 20 }),
     ];
-    const matches = _findAnnotationMatches(selfList, otherList, "centroids", 5.0);
+    const matches = _findAnnotationMatches(
+      selfList,
+      otherList,
+      "centroids",
+      5.0,
+    );
     expect(matches).toHaveLength(2);
   });
 });

--- a/tests/python-compat-crop.test.ts
+++ b/tests/python-compat-crop.test.ts
@@ -89,14 +89,16 @@ function candidateRunners(): PyRunner[] {
   if (envPy) {
     runners.push({
       label: `$SLEAP_IO_PY (${envPy})`,
-      run: (s) => execFileSync(envPy, [s], { encoding: "utf-8", timeout: 60_000 }),
+      run: (s) =>
+        execFileSync(envPy, [s], { encoding: "utf-8", timeout: 60_000 }),
     });
   }
   const devVenv = "/home/talmo/code/sleap-io/.venv/bin/python";
   if (existsSync(devVenv)) {
     runners.push({
       label: `dev venv (${devVenv})`,
-      run: (s) => execFileSync(devVenv, [s], { encoding: "utf-8", timeout: 60_000 }),
+      run: (s) =>
+        execFileSync(devVenv, [s], { encoding: "utf-8", timeout: 60_000 }),
     });
   }
   runners.push({
@@ -154,9 +156,19 @@ describe("JS -> Python cross-compat: virtual crop (SLP 2.3)", () => {
         grayscale: true,
       },
     });
-    const inst = Instance.fromArray([[10, 20], [30, 40]], skel);
+    const inst = Instance.fromArray(
+      [
+        [10, 20],
+        [30, 40],
+      ],
+      skel,
+    );
     const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
-    const labels = new Labels({ skeletons: [skel], videos: [video], labeledFrames: [lf] });
+    const labels = new Labels({
+      skeletons: [skel],
+      videos: [video],
+      labeledFrames: [lf],
+    });
 
     const bytes = await saveSlpToBytes(labels);
     const slpPath = tmpFile(".slp");

--- a/tests/python-compat-gen.test.ts
+++ b/tests/python-compat-gen.test.ts
@@ -27,7 +27,10 @@ import { join } from "node:path";
 setDefaultTimeout(120_000);
 
 function tmpSlp(): string {
-  return join(tmpdir(), `sleap-io-js-test-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`);
+  return join(
+    tmpdir(),
+    `sleap-io-js-test-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`,
+  );
 }
 
 describe("Python compatibility (#76)", () => {
@@ -44,17 +47,31 @@ describe("Python compatibility (#76)", () => {
     });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
     const roi = ROI.fromBbox(10, 20, 100, 200, {
-      name: "roi1", category: "arena", source: "manual", video, track,
+      name: "roi1",
+      category: "arena",
+      source: "manual",
+      video,
+      track,
     });
 
     const maskData = new Uint8Array(10 * 10);
-    maskData[0] = 1; maskData[1] = 1;
+    maskData[0] = 1;
+    maskData[1] = 1;
     const mask = SegmentationMask.fromArray(maskData, 10, 10, {
-      name: "mask1", category: "cell", source: "model",
+      name: "mask1",
+      category: "cell",
+      source: "model",
     });
 
     const bbox = new UserBoundingBox({
-      x1: 0, y1: 20, x2: 100, y2: 100, track, category: "animal", name: "bb1", source: "manual",
+      x1: 0,
+      y1: 20,
+      x2: 100,
+      y2: 100,
+      track,
+      category: "animal",
+      name: "bb1",
+      source: "manual",
     });
 
     frame.masks.push(mask);
@@ -79,8 +96,14 @@ describe("Python compatibility (#76)", () => {
 
     function expectFixedString(ds: any, attrName: string) {
       const attr = ds.attrs[attrName];
-      expect(attr.metadata.type, `${ds.path}@${attrName} should be H5T_STRING`).toBe(3);
-      expect(attr.metadata.vlen, `${ds.path}@${attrName} should not be vlen`).toBe(false);
+      expect(
+        attr.metadata.type,
+        `${ds.path}@${attrName} should be H5T_STRING`,
+      ).toBe(3);
+      expect(
+        attr.metadata.vlen,
+        `${ds.path}@${attrName} should not be vlen`,
+      ).toBe(false);
     }
 
     try {
@@ -176,7 +199,13 @@ describe("Python compatibility (#76)", () => {
     try {
       const frames = file.get("frames") as any;
       const frameFields = JSON.parse(frames.attrs["field_names"].value);
-      expect(frameFields).toEqual(["frame_id", "video", "frame_idx", "instance_id_start", "instance_id_end"]);
+      expect(frameFields).toEqual([
+        "frame_id",
+        "video",
+        "frame_idx",
+        "instance_id_start",
+        "instance_id_end",
+      ]);
 
       const instances = file.get("instances") as any;
       const instFields = JSON.parse(instances.attrs["field_names"].value);
@@ -194,7 +223,10 @@ describe("Python compatibility (#76)", () => {
   });
 
   it("Python can decode metadata and skeletons from JS-written SLP", async () => {
-    const skeleton = new Skeleton({ name: "fly", nodes: ["head", "thorax", "abdomen"] });
+    const skeleton = new Skeleton({
+      name: "fly",
+      nodes: ["head", "thorax", "abdomen"],
+    });
     skeleton.addEdge("head", "thorax");
     skeleton.addEdge("thorax", "abdomen");
     const video = new Video({ filename: "test.mp4" });
@@ -254,14 +286,24 @@ assert len(skel.edges) == 2, f"Expected 2 edges, got {len(skel.edges)}"
 print("OK: Python reads metadata and skeletons from JS-written SLP")
 `;
       writeFileSync(pyPath, pyScript);
-      const result = execFileSync("uv", ["run", "--with", "sleap-io", "python", pyPath], {
-        encoding: "utf-8",
-        timeout: 30000,
-      });
-      expect(result).toContain("OK: Python reads metadata and skeletons from JS-written SLP");
+      const result = execFileSync(
+        "uv",
+        ["run", "--with", "sleap-io", "python", pyPath],
+        {
+          encoding: "utf-8",
+          timeout: 30000,
+        },
+      );
+      expect(result).toContain(
+        "OK: Python reads metadata and skeletons from JS-written SLP",
+      );
     } finally {
-      try { unlinkSync(slpPath); } catch {}
-      try { unlinkSync(pyPath); } catch {}
+      try {
+        unlinkSync(slpPath);
+      } catch {}
+      try {
+        unlinkSync(pyPath);
+      } catch {}
     }
   });
 });

--- a/tests/rendering/colors.test.ts
+++ b/tests/rendering/colors.test.ts
@@ -31,7 +31,9 @@ describe("colors", () => {
     });
 
     it("throws on unknown palette", () => {
-      expect(() => getPalette("nonexistent" as "standard", 5)).toThrow("Unknown palette");
+      expect(() => getPalette("nonexistent" as "standard", 5)).toThrow(
+        "Unknown palette",
+      );
     });
 
     it("works with all built-in palettes", () => {

--- a/tests/rendering/overlays.test.ts
+++ b/tests/rendering/overlays.test.ts
@@ -126,7 +126,10 @@ describe("drawMasks", () => {
     drawMasks(img, [mask]); // default color [255,0,0], alpha 0.3
 
     // Inside the block: white blended toward red at alpha 0.3.
-    expectRGBNear(pixel(img, 3, 3), blendRGB([255, 255, 255], [255, 0, 0], 0.3));
+    expectRGBNear(
+      pixel(img, 3, 3),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.3),
+    );
     // Outside the block: untouched.
     expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
     expectRGBNear(pixel(img, 9, 9), [255, 255, 255]);
@@ -152,8 +155,16 @@ describe("drawMasks", () => {
 
   it("uses per-mask colors when provided", async () => {
     const img = await makeImage(12, 12, [255, 255, 255]);
-    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 4, 4), 12, 12);
-    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 6, 6, 10, 10), 12, 12);
+    const m0 = UserSegmentationMask.fromArray(
+      squareMask(12, 12, 0, 0, 4, 4),
+      12,
+      12,
+    );
+    const m1 = UserSegmentationMask.fromArray(
+      squareMask(12, 12, 6, 6, 10, 10),
+      12,
+      12,
+    );
 
     drawMasks(img, [m0, m1], {
       colors: [
@@ -163,8 +174,14 @@ describe("drawMasks", () => {
       alpha: 0.4,
     });
 
-    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.4));
-    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], [0, 0, 255], 0.4));
+    expectRGBNear(
+      pixel(img, 1, 1),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.4),
+    );
+    expectRGBNear(
+      pixel(img, 7, 7),
+      blendRGB([255, 255, 255], [0, 0, 255], 0.4),
+    );
   });
 
   it("is a no-op for an empty mask list", async () => {
@@ -191,8 +208,14 @@ describe("drawMasks", () => {
     drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 });
 
     // After nearest-neighbor downscale to 2x2, the whole 2x2 extent is fg.
-    expectRGBNear(pixel(img, 0, 0), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
-    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 0, 0),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
+    expectRGBNear(
+      pixel(img, 1, 1),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
     // Beyond the 2x2 extent: untouched.
     expectRGBNear(pixel(img, 5, 5), [255, 255, 255]);
   });
@@ -210,8 +233,14 @@ describe("drawMasks", () => {
     drawMasks(img, [mask], { color: [0, 255, 0], alpha: 0.5 });
 
     // Offset (ox=4, oy=5): fg lands at image rows 5-7, cols 4-6.
-    expectRGBNear(pixel(img, 4, 5), blendRGB([255, 255, 255], [0, 255, 0], 0.5));
-    expectRGBNear(pixel(img, 6, 7), blendRGB([255, 255, 255], [0, 255, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 4, 5),
+      blendRGB([255, 255, 255], [0, 255, 0], 0.5),
+    );
+    expectRGBNear(
+      pixel(img, 6, 7),
+      blendRGB([255, 255, 255], [0, 255, 0], 0.5),
+    );
     // Origin untouched (offset moved the mask away).
     expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
   });
@@ -226,11 +255,19 @@ describe("drawMasks", () => {
       offset: [4, 4], // 4..8 but image is only 6 wide/tall -> clipped to 4..6
     });
 
-    expect(() => drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 })).not.toThrow();
+    expect(() =>
+      drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 }),
+    ).not.toThrow();
 
     // Inside the visible clipped window.
-    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
-    expectRGBNear(pixel(img, 4, 4), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 5, 5),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
+    expectRGBNear(
+      pixel(img, 4, 4),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
     // Outside the placement window untouched.
     expectRGBNear(pixel(img, 0, 0), [255, 255, 255]);
   });
@@ -264,8 +301,14 @@ describe("drawMasks", () => {
     ).not.toThrow();
 
     // Visible window is image (0,0)-(1,1); it shows the blended mask fg.
-    expectRGBNear(pixel(img, 0, 0), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
-    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 0, 0),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
+    expectRGBNear(
+      pixel(img, 1, 1),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
     // Beyond the placed 4x4 (which now ends at image (1,1)): untouched.
     expectRGBNear(pixel(img, 3, 3), [255, 255, 255]);
   });
@@ -286,8 +329,14 @@ describe("drawMasks", () => {
     drawMasks(img, [mask], { color: [255, 0, 0], alpha: 0.5 });
 
     // 2x2 extent placed at (3,3) covers image (3,3)-(4,4).
-    expectRGBNear(pixel(img, 3, 3), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
-    expectRGBNear(pixel(img, 4, 4), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 3, 3),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
+    expectRGBNear(
+      pixel(img, 4, 4),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
     // Before the offset and beyond the extent: untouched.
     expectRGBNear(pixel(img, 2, 2), [255, 255, 255]);
     expectRGBNear(pixel(img, 5, 5), [255, 255, 255]);
@@ -295,8 +344,16 @@ describe("drawMasks", () => {
 
   it("blends overlapping masks sequentially", async () => {
     const img = await makeImage(10, 10, [255, 255, 255]);
-    const m0 = UserSegmentationMask.fromArray(squareMask(10, 10, 2, 2, 6, 6), 10, 10);
-    const m1 = UserSegmentationMask.fromArray(squareMask(10, 10, 4, 4, 8, 8), 10, 10);
+    const m0 = UserSegmentationMask.fromArray(
+      squareMask(10, 10, 2, 2, 6, 6),
+      10,
+      10,
+    );
+    const m1 = UserSegmentationMask.fromArray(
+      squareMask(10, 10, 4, 4, 8, 8),
+      10,
+      10,
+    );
 
     drawMasks(img, [m0, m1], {
       colors: [
@@ -307,9 +364,15 @@ describe("drawMasks", () => {
     });
 
     // Non-overlap of m0 (rows/cols 2-3): just red blended once.
-    expectRGBNear(pixel(img, 2, 2), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 2, 2),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
     // Non-overlap of m1 (rows/cols 6-7): just blue blended once.
-    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], [0, 0, 255], 0.5));
+    expectRGBNear(
+      pixel(img, 7, 7),
+      blendRGB([255, 255, 255], [0, 0, 255], 0.5),
+    );
     // Overlap (rows/cols 4-5): red first, then blue on top of that result.
     const afterRed = blendRGB([255, 255, 255], [255, 0, 0], 0.5);
     const afterBlue = blendRGB(afterRed, [0, 0, 255], 0.5);
@@ -330,15 +393,33 @@ describe("drawMasks", () => {
     ).not.toThrow();
 
     // Only the top-left 6x6 of the 20x20 mask is visible; the whole image is fg.
-    expectRGBNear(pixel(img, 0, 0), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
-    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 0, 0),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
+    expectRGBNear(
+      pixel(img, 5, 5),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
   });
 
   it("cycles a short per-mask colors array via modulo", async () => {
     const img = await makeImage(12, 12, [255, 255, 255]);
-    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 3, 3), 12, 12);
-    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 4, 4, 7, 7), 12, 12);
-    const m2 = UserSegmentationMask.fromArray(squareMask(12, 12, 8, 8, 11, 11), 12, 12);
+    const m0 = UserSegmentationMask.fromArray(
+      squareMask(12, 12, 0, 0, 3, 3),
+      12,
+      12,
+    );
+    const m1 = UserSegmentationMask.fromArray(
+      squareMask(12, 12, 4, 4, 7, 7),
+      12,
+      12,
+    );
+    const m2 = UserSegmentationMask.fromArray(
+      squareMask(12, 12, 8, 8, 11, 11),
+      12,
+      12,
+    );
 
     // Two colors for three masks: index 2 must reuse colors[0] (modulo cycling),
     // not index out of bounds with `undefined`.
@@ -352,16 +433,29 @@ describe("drawMasks", () => {
       }),
     ).not.toThrow();
 
-    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
-    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], [0, 0, 255], 0.5));
+    expectRGBNear(
+      pixel(img, 1, 1),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
+    expectRGBNear(
+      pixel(img, 5, 5),
+      blendRGB([255, 255, 255], [0, 0, 255], 0.5),
+    );
     // m2 wraps back to colors[0] = red.
-    expectRGBNear(pixel(img, 9, 9), blendRGB([255, 255, 255], [255, 0, 0], 0.5));
+    expectRGBNear(
+      pixel(img, 9, 9),
+      blendRGB([255, 255, 255], [255, 0, 0], 0.5),
+    );
   });
 
   it("clamps an out-of-range alpha into [0, 1]", async () => {
     const high = await makeImage(8, 8, [255, 255, 255]);
     const opaque = await makeImage(8, 8, [255, 255, 255]);
-    const mask = UserSegmentationMask.fromArray(squareMask(8, 8, 0, 0, 4, 4), 8, 8);
+    const mask = UserSegmentationMask.fromArray(
+      squareMask(8, 8, 0, 0, 4, 4),
+      8,
+      8,
+    );
 
     // alpha = 2.0 must clamp to 1.0 (fully replace with the color), never
     // produce out-of-range/negative blends.
@@ -393,8 +487,14 @@ describe("drawLabelImage", () => {
     drawLabelImage(img, li, { alpha: 0.3, palette: "distinct" });
 
     // LUT: id1 -> distinct[1], id2 -> distinct[2].
-    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], DISTINCT[1], 0.3));
-    expectRGBNear(pixel(img, 5, 5), blendRGB([255, 255, 255], DISTINCT[2], 0.3));
+    expectRGBNear(
+      pixel(img, 1, 1),
+      blendRGB([255, 255, 255], DISTINCT[1], 0.3),
+    );
+    expectRGBNear(
+      pixel(img, 5, 5),
+      blendRGB([255, 255, 255], DISTINCT[2], 0.3),
+    );
     // Background (label 0) untouched.
     expectRGBNear(pixel(img, 7, 0), [255, 255, 255]);
   });
@@ -463,12 +563,11 @@ describe("drawLabelImage", () => {
   });
 
   it("makes a thicker outline when outlineWidth > 1 (dilation)", async () => {
-    const buildOutlined = async (
-      width: number,
-    ): Promise<ImageData> => {
+    const buildOutlined = async (width: number): Promise<ImageData> => {
       const img = await makeImage(12, 12, [255, 255, 255]);
       const data = new Int32Array(12 * 12);
-      for (let r = 3; r < 9; r++) for (let c = 3; c < 9; c++) data[r * 12 + c] = 1;
+      for (let r = 3; r < 9; r++)
+        for (let c = 3; c < 9; c++) data[r * 12 + c] = 1;
       const li = UserLabelImage.fromArray(data, 12, 12);
       drawLabelImage(img, li, {
         alpha: 0.3,
@@ -485,7 +584,11 @@ describe("drawLabelImage", () => {
     const countBlack = (img: ImageData): number => {
       let n = 0;
       for (let i = 0; i < img.data.length; i += 4) {
-        if (img.data[i] === 0 && img.data[i + 1] === 0 && img.data[i + 2] === 0) {
+        if (
+          img.data[i] === 0 &&
+          img.data[i + 1] === 0 &&
+          img.data[i + 2] === 0
+        ) {
           n++;
         }
       }
@@ -515,7 +618,12 @@ describe("drawLabelImage", () => {
   it("honors an offset spatial transform for placement", async () => {
     const img = await makeImage(10, 10, [255, 255, 255]);
     const data = new Int32Array(3 * 3).fill(1);
-    const li = new UserLabelImage({ data, height: 3, width: 3, offset: [4, 5] });
+    const li = new UserLabelImage({
+      data,
+      height: 3,
+      width: 3,
+      offset: [4, 5],
+    });
 
     drawLabelImage(img, li, { alpha: 0.5, palette: "distinct" });
 
@@ -718,8 +826,12 @@ describe("drawBboxes", () => {
       return false;
     };
 
-    expect(hasColor(4, 27, (r, g, b) => r > 150 && g < 100 && b < 100)).toBe(true);
-    expect(hasColor(48, 72, (r, g, b) => b > 150 && r < 100 && g < 100)).toBe(true);
+    expect(hasColor(4, 27, (r, g, b) => r > 150 && g < 100 && b < 100)).toBe(
+      true,
+    );
+    expect(hasColor(48, 72, (r, g, b) => b > 150 && r < 100 && g < 100)).toBe(
+      true,
+    );
   });
 
   it("is a no-op for an empty bbox list", async () => {
@@ -796,7 +908,9 @@ describe("drawRois", () => {
 
   it("draws a filled dot for a Point geometry", async () => {
     const img = await makeImage(30, 30, [255, 255, 255]);
-    const roi = new UserROI({ geometry: { type: "Point", coordinates: [15, 15] } });
+    const roi = new UserROI({
+      geometry: { type: "Point", coordinates: [15, 15] },
+    });
 
     drawRois(img, [roi], { color: [0, 0, 255], lineWidth: 4 });
 
@@ -956,20 +1070,37 @@ describe("applyOverlay", () => {
 
     applyOverlay(img, li, { alpha: 0.3, palette: "distinct" });
 
-    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], DISTINCT[1], 0.3));
+    expectRGBNear(
+      pixel(img, 1, 1),
+      blendRGB([255, 255, 255], DISTINCT[1], 0.3),
+    );
     expectRGBNear(pixel(img, 7, 7), [255, 255, 255]);
   });
 
   it("dispatches a SegmentationMask[] with per-item palette colors", async () => {
     const img = await makeImage(12, 12, [255, 255, 255]);
-    const m0 = UserSegmentationMask.fromArray(squareMask(12, 12, 0, 0, 4, 4), 12, 12);
-    const m1 = UserSegmentationMask.fromArray(squareMask(12, 12, 6, 6, 10, 10), 12, 12);
+    const m0 = UserSegmentationMask.fromArray(
+      squareMask(12, 12, 0, 0, 4, 4),
+      12,
+      12,
+    );
+    const m1 = UserSegmentationMask.fromArray(
+      squareMask(12, 12, 6, 6, 10, 10),
+      12,
+      12,
+    );
 
     applyOverlay(img, [m0, m1], { alpha: 0.4, palette: "distinct" });
 
     // Per-item colors from getPalette("distinct", 2): [0] and [1].
-    expectRGBNear(pixel(img, 1, 1), blendRGB([255, 255, 255], DISTINCT[0], 0.4));
-    expectRGBNear(pixel(img, 7, 7), blendRGB([255, 255, 255], DISTINCT[1], 0.4));
+    expectRGBNear(
+      pixel(img, 1, 1),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.4),
+    );
+    expectRGBNear(
+      pixel(img, 7, 7),
+      blendRGB([255, 255, 255], DISTINCT[1], 0.4),
+    );
   });
 
   it("dispatches an ROI[] to the vector path", async () => {
@@ -1025,10 +1156,9 @@ describe("applyOverlay", () => {
   it("throws a TypeError for an unknown element type", async () => {
     const img = await makeImage(8, 8, [255, 255, 255]);
     expect(() =>
-      applyOverlay(
-        img,
-        [{ foo: "bar" }] as unknown as Parameters<typeof applyOverlay>[1],
-      ),
+      applyOverlay(img, [{ foo: "bar" }] as unknown as Parameters<
+        typeof applyOverlay
+      >[1]),
     ).toThrow(TypeError);
   });
 
@@ -1143,7 +1273,9 @@ describe("renderImage with overlay", () => {
       4,
     );
     // Higher alpha pulls the green channel further from white.
-    expect(pixel(highAlpha, 20, 20)[1]).toBeLessThan(pixel(lowAlpha, 20, 20)[1]);
+    expect(pixel(highAlpha, 20, 20)[1]).toBeLessThan(
+      pixel(lowAlpha, 20, 20)[1],
+    );
   });
 
   it("renders a segmentation-only LabeledFrame (no instances) without throwing", async () => {
@@ -1180,7 +1312,8 @@ describe("renderImage with overlay", () => {
   it("applies a LabelImage overlay passed directly", async () => {
     const video = createVideo();
     const data = new Int32Array(30 * 30);
-    for (let r = 5; r < 20; r++) for (let c = 5; c < 20; c++) data[r * 30 + c] = 1;
+    for (let r = 5; r < 20; r++)
+      for (let c = 5; c < 20; c++) data[r * 30 + c] = 1;
     const li = UserLabelImage.fromArray(data, 30, 30);
     const frame = new LabeledFrame({
       video,
@@ -1271,8 +1404,18 @@ describe("renderVideo per-frame overlay", () => {
     // Attach the per-frame masks to each frame so renderImage has something to
     // render (the empty-frame guard is annotation-aware). The callable overlay
     // independently selects which mask to draw per frame index.
-    const f0 = new LabeledFrame({ video, frameIdx: 0, instances: [], masks: [maskA] });
-    const f1 = new LabeledFrame({ video, frameIdx: 1, instances: [], masks: [maskB] });
+    const f0 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [],
+      masks: [maskA],
+    });
+    const f1 = new LabeledFrame({
+      video,
+      frameIdx: 1,
+      instances: [],
+      masks: [maskB],
+    });
     const overlayFn = (frameIdx: number): SegmentationMask[] =>
       frameIdx === 0 ? [maskA] : [maskB];
 
@@ -1333,9 +1476,17 @@ describe("renderVideo per-frame overlay", () => {
 
     expect(Array.from(imgA.data)).not.toEqual(Array.from(imgB.data));
     // maskA region tinted in A, white in B; vice versa for maskB region.
-    expectRGBNear(pixel(imgA, 3, 3), blendRGB([255, 255, 255], DISTINCT[0], 0.5), 4);
+    expectRGBNear(
+      pixel(imgA, 3, 3),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
     expectRGBNear(pixel(imgB, 3, 3), [255, 255, 255]);
-    expectRGBNear(pixel(imgB, 15, 15), blendRGB([255, 255, 255], DISTINCT[0], 0.5), 4);
+    expectRGBNear(
+      pixel(imgB, 15, 15),
+      blendRGB([255, 255, 255], DISTINCT[0], 0.5),
+      4,
+    );
     expectRGBNear(pixel(imgA, 15, 15), [255, 255, 255]);
   });
 });

--- a/tests/rendering/render.test.ts
+++ b/tests/rendering/render.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "../bun-test";
-import { renderImage, toPNG, toJPEG, toDataURL } from "../../src/rendering/render";
+import {
+  renderImage,
+  toPNG,
+  toJPEG,
+  toDataURL,
+} from "../../src/rendering/render";
 import { RenderContext, InstanceContext } from "../../src/rendering/context";
 import { Skeleton } from "../../src/model/skeleton";
 import { Instance, Track } from "../../src/model/instance";
@@ -74,14 +79,14 @@ describe("renderImage", () => {
     });
 
     it("throws when no instances and no image provided", async () => {
-      await expect(renderImage([], { width: 100, height: 100 })).rejects.toThrow(
-        "No instances to render"
-      );
+      await expect(
+        renderImage([], { width: 100, height: 100 }),
+      ).rejects.toThrow("No instances to render");
     });
 
     it("throws when no frame size can be determined", async () => {
       await expect(renderImage([instance], {})).rejects.toThrow(
-        "Cannot determine frame size"
+        "Cannot determine frame size",
       );
     });
   });
@@ -136,7 +141,7 @@ describe("renderImage", () => {
       });
 
       await expect(
-        renderImage(frame, { width: 80, height: 80 })
+        renderImage(frame, { width: 80, height: 80 }),
       ).rejects.toThrow("No instances to render");
     });
   });
@@ -267,7 +272,13 @@ describe("renderImage", () => {
     });
 
     it("supports different marker shapes", async () => {
-      const shapes = ["circle", "square", "diamond", "triangle", "cross"] as const;
+      const shapes = [
+        "circle",
+        "square",
+        "diamond",
+        "triangle",
+        "cross",
+      ] as const;
 
       for (const shape of shapes) {
         const imageData = await renderImage([instance], {
@@ -388,7 +399,10 @@ describe("renderImage", () => {
     });
 
     it("handles many tracks correctly with track-based coloring", async () => {
-      const tracks = Array.from({ length: 20 }, (_, i) => new Track(`track_${i}`));
+      const tracks = Array.from(
+        { length: 20 },
+        (_, i) => new Track(`track_${i}`),
+      );
       const instances = tracks.map((track, i) => {
         const inst = createTestInstance(skeleton, track);
         inst.points[0].xy = [10 + i * 4, 30];
@@ -566,7 +580,7 @@ describe("RenderContext", () => {
       [],
       [],
       2.0, // scale
-      [10, 20] // offset
+      [10, 20], // offset
     );
 
     const [canvasX, canvasY] = ctx.worldToCanvas(50, 60);
@@ -589,7 +603,7 @@ describe("InstanceContext", () => {
         [Number.NaN, Number.NaN], // Invalid point should be skipped
       ],
       [],
-      ["a", "b", "c"]
+      ["a", "b", "c"],
     );
 
     const centroid = ctx.getCentroid();
@@ -606,7 +620,7 @@ describe("InstanceContext", () => {
         [Number.NaN, Number.NaN],
       ],
       [],
-      ["a", "b"]
+      ["a", "b"],
     );
 
     expect(ctx.getCentroid()).toBeNull();
@@ -622,7 +636,7 @@ describe("InstanceContext", () => {
         [20, 50],
       ],
       [],
-      ["a", "b", "c"]
+      ["a", "b", "c"],
     );
 
     const bbox = ctx.getBbox();
@@ -636,7 +650,7 @@ describe("InstanceContext", () => {
       0,
       [[Number.NaN, Number.NaN]],
       [],
-      ["a"]
+      ["a"],
     );
 
     expect(ctx.getBbox()).toBeNull();

--- a/tests/rendering/trails.test.ts
+++ b/tests/rendering/trails.test.ts
@@ -31,7 +31,7 @@ function twoNodeSkeleton(): Skeleton {
 function makeInstance(
   skeleton: Skeleton,
   points: Record<string, number[]>,
-  track?: Track
+  track?: Track,
 ): Instance {
   return new Instance({ points, skeleton, track });
 }
@@ -39,14 +39,14 @@ function makeInstance(
 function makeFrame(
   video: Video,
   frameIdx: number,
-  instances: Instance[]
+  instances: Instance[],
 ): LabeledFrame {
   return new LabeledFrame({ video, frameIdx, instances });
 }
 
 async function makeCtx(
   w: number,
-  h: number
+  h: number,
 ): Promise<{ ctx: CanvasRenderingContext2D; read: () => ImageData }> {
   const { Canvas } = await import("skia-canvas");
   const canvas = new Canvas(w, h);
@@ -65,7 +65,7 @@ function rgbaAt(
   img: ImageData,
   w: number,
   x: number,
-  y: number
+  y: number,
 ): [number, number, number, number] {
   const i = (y * w + x) * 4;
   return [img.data[i], img.data[i + 1], img.data[i + 2], img.data[i + 3]];
@@ -99,7 +99,7 @@ describe("resolveTrailNode", () => {
     const skel = twoNodeSkeleton();
     expect(() => resolveTrailNode("nope", skel)).toThrow("Unknown trailNode");
     expect(() => resolveTrailNode(["head", "nope"], skel)).toThrow(
-      "Unknown trailNode"
+      "Unknown trailNode",
     );
   });
 });
@@ -207,7 +207,12 @@ describe("computeTrails", () => {
     const skel2 = twoNodeSkeleton();
     const track = new Track("A");
     const frames = new Map<number, LabeledFrame>([
-      [0, makeFrame(video, 0, [makeInstance(skel2, { head: [5, 5], tail: [7, 7] }, track)])],
+      [
+        0,
+        makeFrame(video, 0, [
+          makeInstance(skel2, { head: [5, 5], tail: [7, 7] }, track),
+        ]),
+      ],
     ]);
     const { trails } = computeTrails({
       frameIdx: 0,
@@ -334,7 +339,12 @@ describe("computeTrails", () => {
   it("computes the centroid as the mean of visible nodes", () => {
     const skel2 = twoNodeSkeleton();
     const frames = new Map<number, LabeledFrame>([
-      [0, makeFrame(video, 0, [makeInstance(skel2, { head: [10, 20], tail: [30, 40] })])],
+      [
+        0,
+        makeFrame(video, 0, [
+          makeInstance(skel2, { head: [10, 20], tail: [30, 40] }),
+        ]),
+      ],
     ]);
     const { trails } = computeTrails({
       frameIdx: 0,
@@ -367,7 +377,12 @@ describe("computeTrails", () => {
   it("yields NaN for a node index beyond the instance points", () => {
     const skel2 = twoNodeSkeleton();
     const frames = new Map<number, LabeledFrame>([
-      [0, makeFrame(video, 0, [makeInstance(skel2, { head: [5, 5], tail: [7, 7] })])],
+      [
+        0,
+        makeFrame(video, 0, [
+          makeInstance(skel2, { head: [5, 5], tail: [7, 7] }),
+        ]),
+      ],
     ]);
     const { trails } = computeTrails({
       frameIdx: 0,
@@ -410,7 +425,16 @@ describe("computeTrails", () => {
 describe("drawTrails", () => {
   it("draws a polyline (covered pixels become opaque)", async () => {
     const { ctx, read } = await makeCtx(40, 40);
-    drawTrails(ctx, [[[10, 10], [10, 30]]], { lineWidth: 6, alphaFade: false });
+    drawTrails(
+      ctx,
+      [
+        [
+          [10, 10],
+          [10, 30],
+        ],
+      ],
+      { lineWidth: 6, alphaFade: false },
+    );
     const img = read();
     expect(alphaAt(img, 40, 10, 20)).toBeGreaterThan(200); // on the line
     expect(alphaAt(img, 40, 0, 0)).toBe(0); // corner untouched
@@ -432,10 +456,21 @@ describe("drawTrails", () => {
   it("breaks the line at NaN gaps", async () => {
     const { ctx, read } = await makeCtx(40, 60);
     // segment 0: (10,10)-(10,20) drawn; segments touching NaN skipped.
-    drawTrails(ctx, [[[10, 10], [10, 20], [NaN, NaN], [10, 40]]], {
-      lineWidth: 6,
-      alphaFade: false,
-    });
+    drawTrails(
+      ctx,
+      [
+        [
+          [10, 10],
+          [10, 20],
+          [NaN, NaN],
+          [10, 40],
+        ],
+      ],
+      {
+        lineWidth: 6,
+        alphaFade: false,
+      },
+    );
     const img = read();
     expect(alphaAt(img, 40, 10, 15)).toBeGreaterThan(200); // drawn segment
     expect(alphaAt(img, 40, 10, 40)).toBe(0); // isolated point: no segment
@@ -443,7 +478,17 @@ describe("drawTrails", () => {
 
   it("fades opacity from oldest to newest segment", async () => {
     const { ctx, read } = await makeCtx(40, 80);
-    drawTrails(ctx, [[[10, 10], [10, 40], [10, 70]]], { lineWidth: 6 });
+    drawTrails(
+      ctx,
+      [
+        [
+          [10, 10],
+          [10, 40],
+          [10, 70],
+        ],
+      ],
+      { lineWidth: 6 },
+    );
     const img = read();
     const older = alphaAt(img, 40, 10, 25); // segment 0 (frac 0.5)
     const newer = alphaAt(img, 40, 10, 55); // segment 1 (frac 1.0)
@@ -453,19 +498,37 @@ describe("drawTrails", () => {
 
   it("applies the global alpha multiplier", async () => {
     const half = await makeCtx(40, 40);
-    drawTrails(half.ctx, [[[10, 10], [10, 30]]], {
-      lineWidth: 6,
-      alphaFade: false,
-      alpha: 0.5,
-    });
+    drawTrails(
+      half.ctx,
+      [
+        [
+          [10, 10],
+          [10, 30],
+        ],
+      ],
+      {
+        lineWidth: 6,
+        alphaFade: false,
+        alpha: 0.5,
+      },
+    );
     const full = await makeCtx(40, 40);
-    drawTrails(full.ctx, [[[10, 10], [10, 30]]], {
-      lineWidth: 6,
-      alphaFade: false,
-      alpha: 1,
-    });
+    drawTrails(
+      full.ctx,
+      [
+        [
+          [10, 10],
+          [10, 30],
+        ],
+      ],
+      {
+        lineWidth: 6,
+        alphaFade: false,
+        alpha: 1,
+      },
+    );
     expect(alphaAt(half.read(), 40, 10, 20)).toBeLessThan(
-      alphaAt(full.read(), 40, 10, 20)
+      alphaAt(full.read(), 40, 10, 20),
     );
   });
 
@@ -476,10 +539,16 @@ describe("drawTrails", () => {
     drawTrails(
       ctx,
       [
-        [[10, 10], [10, 30]],
-        [[30, 10], [30, 30]],
+        [
+          [10, 10],
+          [10, 30],
+        ],
+        [
+          [30, 10],
+          [30, 30],
+        ],
       ],
-      { lineWidth: 6, alphaFade: false, colors: [red, blue] }
+      { lineWidth: 6, alphaFade: false, colors: [red, blue] },
     );
     const img = read();
     const [r1, , b1] = rgbaAt(img, 50, 10, 20);
@@ -491,19 +560,41 @@ describe("drawTrails", () => {
   it("throws when colors length does not match trails", async () => {
     const { ctx } = await makeCtx(20, 20);
     expect(() =>
-      drawTrails(ctx, [[[1, 1], [2, 2]], [[3, 3], [4, 4]]], {
-        colors: [[255, 0, 0]],
-      })
+      drawTrails(
+        ctx,
+        [
+          [
+            [1, 1],
+            [2, 2],
+          ],
+          [
+            [3, 3],
+            [4, 4],
+          ],
+        ],
+        {
+          colors: [[255, 0, 0]],
+        },
+      ),
     ).toThrow("must be the same length");
   });
 
   it("applies the offset", async () => {
     const { ctx, read } = await makeCtx(40, 40);
-    drawTrails(ctx, [[[20, 10], [20, 30]]], {
-      lineWidth: 6,
-      alphaFade: false,
-      offset: [10, 0],
-    });
+    drawTrails(
+      ctx,
+      [
+        [
+          [20, 10],
+          [20, 30],
+        ],
+      ],
+      {
+        lineWidth: 6,
+        alphaFade: false,
+        offset: [10, 0],
+      },
+    );
     const img = read();
     expect(alphaAt(img, 40, 10, 20)).toBeGreaterThan(200); // shifted left by 10
     expect(alphaAt(img, 40, 20, 20)).toBe(0); // original position empty
@@ -511,20 +602,47 @@ describe("drawTrails", () => {
 
   it("applies the scale factor", async () => {
     const { ctx, read } = await makeCtx(40, 40);
-    drawTrails(ctx, [[[5, 5], [5, 15]]], {
-      lineWidth: 4,
-      alphaFade: false,
-      scale: 2,
-    });
+    drawTrails(
+      ctx,
+      [
+        [
+          [5, 5],
+          [5, 15],
+        ],
+      ],
+      {
+        lineWidth: 4,
+        alphaFade: false,
+        scale: 2,
+      },
+    );
     const img = read();
     expect(alphaAt(img, 40, 10, 20)).toBeGreaterThan(200); // scaled to (10,10)-(10,30)
   });
 
   it("widens the stroke with lineWidth", async () => {
     const thin = await makeCtx(40, 40);
-    drawTrails(thin.ctx, [[[10, 5], [10, 35]]], { lineWidth: 1, alphaFade: false });
+    drawTrails(
+      thin.ctx,
+      [
+        [
+          [10, 5],
+          [10, 35],
+        ],
+      ],
+      { lineWidth: 1, alphaFade: false },
+    );
     const thick = await makeCtx(40, 40);
-    drawTrails(thick.ctx, [[[10, 5], [10, 35]]], { lineWidth: 9, alphaFade: false });
+    drawTrails(
+      thick.ctx,
+      [
+        [
+          [10, 5],
+          [10, 35],
+        ],
+      ],
+      { lineWidth: 9, alphaFade: false },
+    );
     // A pixel offset from the line center is covered only by the thick stroke.
     expect(alphaAt(thin.read(), 40, 13, 20)).toBe(0);
     expect(alphaAt(thick.read(), 40, 13, 20)).toBeGreaterThan(0);
@@ -541,9 +659,15 @@ describe("renderImage with motion trails", () => {
   /** Build a Labels whose rendered frame (labeledFrames[0]) is the newest. */
   function makeTrailLabels(track?: Track): Labels {
     const video = new Video({ filename: "v.mp4" });
-    const f0 = makeFrame(video, 0, [makeInstance(skel, { c: [20, 20] }, track)]);
-    const f1 = makeFrame(video, 1, [makeInstance(skel, { c: [20, 40] }, track)]);
-    const f2 = makeFrame(video, 2, [makeInstance(skel, { c: [20, 60] }, track)]);
+    const f0 = makeFrame(video, 0, [
+      makeInstance(skel, { c: [20, 20] }, track),
+    ]);
+    const f1 = makeFrame(video, 1, [
+      makeInstance(skel, { c: [20, 40] }, track),
+    ]);
+    const f2 = makeFrame(video, 2, [
+      makeInstance(skel, { c: [20, 60] }, track),
+    ]);
     // labeledFrames[0] is the current (newest) frame; trail reaches back to f0.
     return new Labels({ labeledFrames: [f2, f1, f0] });
   }
@@ -605,9 +729,15 @@ describe("renderImage with motion trails", () => {
   it("uses caller-provided trailFrames for a LabeledFrame source", async () => {
     const track = new Track("A");
     const video = new Video({ filename: "v.mp4" });
-    const f0 = makeFrame(video, 0, [makeInstance(skel, { c: [20, 20] }, track)]);
-    const f1 = makeFrame(video, 1, [makeInstance(skel, { c: [20, 40] }, track)]);
-    const f2 = makeFrame(video, 2, [makeInstance(skel, { c: [20, 60] }, track)]);
+    const f0 = makeFrame(video, 0, [
+      makeInstance(skel, { c: [20, 20] }, track),
+    ]);
+    const f1 = makeFrame(video, 1, [
+      makeInstance(skel, { c: [20, 40] }, track),
+    ]);
+    const f2 = makeFrame(video, 2, [
+      makeInstance(skel, { c: [20, 60] }, track),
+    ]);
     const img = await renderImage(f2, {
       width: 80,
       height: 80,
@@ -623,10 +753,22 @@ describe("renderImage with motion trails", () => {
     const skel2 = twoNodeSkeleton();
     const video = new Video({ filename: "v.mp4" });
     const f0 = makeFrame(video, 0, [
-      Instance.fromArray([[20, 20], [60, 60]], skel2),
+      Instance.fromArray(
+        [
+          [20, 20],
+          [60, 60],
+        ],
+        skel2,
+      ),
     ]);
     const f1 = makeFrame(video, 1, [
-      Instance.fromArray([[20, 40], [60, 60]], skel2),
+      Instance.fromArray(
+        [
+          [20, 40],
+          [60, 60],
+        ],
+        skel2,
+      ),
     ]);
     const labels = new Labels({ labeledFrames: [f1, f0] });
     const img = await renderImage(labels, {
@@ -646,10 +788,22 @@ describe("renderImage with motion trails", () => {
     const video = new Video({ filename: "v.mp4" });
     // head sweeps down x=20; tail sweeps down x=60.
     const f0 = makeFrame(video, 0, [
-      Instance.fromArray([[20, 20], [60, 20]], skel2),
+      Instance.fromArray(
+        [
+          [20, 20],
+          [60, 20],
+        ],
+        skel2,
+      ),
     ]);
     const f1 = makeFrame(video, 1, [
-      Instance.fromArray([[20, 50], [60, 50]], skel2),
+      Instance.fromArray(
+        [
+          [20, 50],
+          [60, 50],
+        ],
+        skel2,
+      ),
     ]);
     const labels = new Labels({ labeledFrames: [f1, f0] });
     const img = await renderImage(labels, {
@@ -683,8 +837,12 @@ describe("renderImage with motion trails", () => {
   it("renders trails on an empty current frame (Python PR #434 parity)", async () => {
     const track = new Track("A");
     const video = new Video({ filename: "v.mp4" });
-    const f1 = makeFrame(video, 1, [makeInstance(skel, { c: [20, 30] }, track)]);
-    const f2 = makeFrame(video, 2, [makeInstance(skel, { c: [20, 50] }, track)]);
+    const f1 = makeFrame(video, 1, [
+      makeInstance(skel, { c: [20, 30] }, track),
+    ]);
+    const f2 = makeFrame(video, 2, [
+      makeInstance(skel, { c: [20, 50] }, track),
+    ]);
     const f3 = makeFrame(video, 3, []); // current frame is empty
     const labels = new Labels({
       labeledFrames: [f3, f2, f1],
@@ -707,10 +865,20 @@ describe("renderImage with motion trails", () => {
     const track = new Track("A");
     const video = new Video({ filename: "v.mp4" });
     const f0 = makeFrame(video, 0, [
-      new PredictedInstance({ points: { c: [20, 20] }, skeleton: skel, track, score: 0.9 }),
+      new PredictedInstance({
+        points: { c: [20, 20] },
+        skeleton: skel,
+        track,
+        score: 0.9,
+      }),
     ]);
     const f1 = makeFrame(video, 1, [
-      new PredictedInstance({ points: { c: [20, 50] }, skeleton: skel, track, score: 0.8 }),
+      new PredictedInstance({
+        points: { c: [20, 50] },
+        skeleton: skel,
+        track,
+        score: 0.8,
+      }),
     ]);
     const labels = new Labels({ labeledFrames: [f1, f0] });
     const img = await renderImage(labels, {

--- a/tests/roi.test.ts
+++ b/tests/roi.test.ts
@@ -228,7 +228,14 @@ describe("ROI", () => {
 describe("New geometry types", () => {
   it("LineString ROI has correct bounds and zero area", () => {
     const roi = new UserROI({
-      geometry: { type: "LineString", coordinates: [[0, 0], [10, 5], [20, 0]] },
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [0, 0],
+          [10, 5],
+          [20, 0],
+        ],
+      },
     });
     expect(roi.area).toBe(0);
     const b = roi.bounds;
@@ -240,7 +247,14 @@ describe("New geometry types", () => {
 
   it("MultiPoint ROI has correct bounds and zero area", () => {
     const roi = new UserROI({
-      geometry: { type: "MultiPoint", coordinates: [[1, 2], [3, 4], [5, 6]] },
+      geometry: {
+        type: "MultiPoint",
+        coordinates: [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+        ],
+      },
     });
     expect(roi.area).toBe(0);
     const b = roi.bounds;
@@ -255,7 +269,18 @@ describe("New geometry types", () => {
       geometry: {
         type: "GeometryCollection",
         geometries: [
-          { type: "Polygon", coordinates: [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]] },
+          {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [10, 0],
+                [10, 10],
+                [0, 10],
+                [0, 0],
+              ],
+            ],
+          },
           { type: "Point", coordinates: [20, 20] },
         ],
       },
@@ -269,13 +294,25 @@ describe("New geometry types", () => {
   });
 
   it("rasterize LineString returns empty mask", () => {
-    const geom: Geometry = { type: "LineString", coordinates: [[0, 0], [10, 10]] };
+    const geom: Geometry = {
+      type: "LineString",
+      coordinates: [
+        [0, 0],
+        [10, 10],
+      ],
+    };
     const mask = rasterizeGeometry(geom, 20, 20);
     expect(mask.reduce((a, b) => a + b, 0)).toBe(0);
   });
 
   it("rasterize MultiPoint returns empty mask", () => {
-    const geom: Geometry = { type: "MultiPoint", coordinates: [[1, 1], [5, 5]] };
+    const geom: Geometry = {
+      type: "MultiPoint",
+      coordinates: [
+        [1, 1],
+        [5, 5],
+      ],
+    };
     const mask = rasterizeGeometry(geom, 10, 10);
     expect(mask.reduce((a, b) => a + b, 0)).toBe(0);
   });
@@ -284,7 +321,18 @@ describe("New geometry types", () => {
     const geom: Geometry = {
       type: "GeometryCollection",
       geometries: [
-        { type: "Polygon", coordinates: [[[2, 2], [8, 2], [8, 8], [2, 8], [2, 2]]] },
+        {
+          type: "Polygon",
+          coordinates: [
+            [
+              [2, 2],
+              [8, 2],
+              [8, 8],
+              [2, 8],
+              [2, 2],
+            ],
+          ],
+        },
       ],
     };
     const mask = rasterizeGeometry(geom, 10, 10);
@@ -295,10 +343,29 @@ describe("New geometry types", () => {
 
 describe("fromMultiPolygon and explode", () => {
   it("fromMultiPolygon creates correct geometry", () => {
-    const roi = ROI.fromMultiPolygon([
-      [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
-      [[[20, 20], [30, 20], [30, 30], [20, 30], [20, 20]]],
-    ], { name: "multi" });
+    const roi = ROI.fromMultiPolygon(
+      [
+        [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [20, 20],
+            [30, 20],
+            [30, 30],
+            [20, 30],
+            [20, 20],
+          ],
+        ],
+      ],
+      { name: "multi" },
+    );
     expect(roi.geometry.type).toBe("MultiPolygon");
     expect(roi.name).toBe("multi");
     if (roi.geometry.type === "MultiPolygon") {
@@ -307,10 +374,29 @@ describe("fromMultiPolygon and explode", () => {
   });
 
   it("explode MultiPolygon splits into individual Polygon ROIs", () => {
-    const roi = ROI.fromMultiPolygon([
-      [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
-      [[[20, 20], [30, 20], [30, 30], [20, 30], [20, 20]]],
-    ], { name: "multi", category: "cat" });
+    const roi = ROI.fromMultiPolygon(
+      [
+        [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [20, 20],
+            [30, 20],
+            [30, 30],
+            [20, 30],
+            [20, 20],
+          ],
+        ],
+      ],
+      { name: "multi", category: "cat" },
+    );
     const parts = roi.explode();
     expect(parts.length).toBe(2);
     expect(parts[0].geometry.type).toBe("Polygon");
@@ -325,7 +411,18 @@ describe("fromMultiPolygon and explode", () => {
         type: "GeometryCollection",
         geometries: [
           { type: "Point", coordinates: [1, 2] },
-          { type: "Polygon", coordinates: [[[0, 0], [5, 0], [5, 5], [0, 5], [0, 0]]] },
+          {
+            type: "Polygon",
+            coordinates: [
+              [
+                [0, 0],
+                [5, 0],
+                [5, 5],
+                [0, 5],
+                [0, 0],
+              ],
+            ],
+          },
         ],
       },
       name: "gc",
@@ -349,7 +446,11 @@ describe("fromMultiPolygon and explode", () => {
 
 describe("toGeoJSON", () => {
   it("returns correct Feature structure", () => {
-    const roi = ROI.fromBbox(0, 0, 10, 10, { name: "test", category: "cat", source: "src" });
+    const roi = ROI.fromBbox(0, 0, 10, 10, {
+      name: "test",
+      category: "cat",
+      source: "src",
+    });
     const feature = roi.toGeoJSON();
     expect(feature.type).toBe("Feature");
     expect(feature.geometry.type).toBe("Polygon");
@@ -375,8 +476,24 @@ describe("WKB", () => {
     const geom: Geometry = {
       type: "MultiPolygon",
       coordinates: [
-        [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]],
-        [[[15, 15], [20, 15], [20, 20], [15, 20], [15, 15]]],
+        [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [15, 15],
+            [20, 15],
+            [20, 20],
+            [15, 20],
+            [15, 15],
+          ],
+        ],
       ],
     };
     const wkb = encodeWkb(geom);
@@ -415,7 +532,11 @@ describe("WKB", () => {
   it("encode and decode LineString", () => {
     const geom: Geometry = {
       type: "LineString",
-      coordinates: [[0, 0], [5, 5], [10, 0]],
+      coordinates: [
+        [0, 0],
+        [5, 5],
+        [10, 0],
+      ],
     };
     const wkb = encodeWkb(geom);
     const decoded = decodeWkb(wkb);
@@ -431,7 +552,11 @@ describe("WKB", () => {
   it("encode and decode MultiPoint", () => {
     const geom: Geometry = {
       type: "MultiPoint",
-      coordinates: [[1, 2], [3, 4], [5, 6]],
+      coordinates: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
     };
     const wkb = encodeWkb(geom);
     const decoded = decodeWkb(wkb);
@@ -449,8 +574,25 @@ describe("WKB", () => {
       type: "GeometryCollection",
       geometries: [
         { type: "Point", coordinates: [1, 2] },
-        { type: "LineString", coordinates: [[0, 0], [10, 10]] },
-        { type: "Polygon", coordinates: [[[0, 0], [5, 0], [5, 5], [0, 5], [0, 0]]] },
+        {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [10, 10],
+          ],
+        },
+        {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [5, 0],
+              [5, 5],
+              [0, 5],
+              [0, 0],
+            ],
+          ],
+        },
       ],
     };
     const wkb = encodeWkb(geom);
@@ -465,7 +607,10 @@ describe("WKB", () => {
         expect(decoded.geometries[0].coordinates).toEqual([1, 2]);
       }
       if (decoded.geometries[1].type === "LineString") {
-        expect(decoded.geometries[1].coordinates).toEqual([[0, 0], [10, 10]]);
+        expect(decoded.geometries[1].coordinates).toEqual([
+          [0, 0],
+          [10, 10],
+        ]);
       }
     }
   });
@@ -473,14 +618,28 @@ describe("WKB", () => {
 
 describe("ROI abstract base and subclasses", () => {
   it("ROI cannot be instantiated directly", () => {
-    expect(() => new (ROI as any)({
-      geometry: { type: "Point", coordinates: [0, 0] },
-    })).toThrow(TypeError);
+    expect(
+      () =>
+        new (ROI as any)({
+          geometry: { type: "Point", coordinates: [0, 0] },
+        }),
+    ).toThrow(TypeError);
   });
 
   it("PredictedROI has score and isPredicted", () => {
     const roi = new PredictedROI({
-      geometry: { type: "Polygon", coordinates: [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]] },
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+        ],
+      },
       score: 0.75,
     });
     expect(roi.isPredicted).toBe(true);
@@ -490,8 +649,24 @@ describe("ROI abstract base and subclasses", () => {
   it("PredictedROI.explode() preserves score and subclass", () => {
     const roi = ROI.fromMultiPolygon(
       [
-        [[[0, 0], [5, 0], [5, 5], [0, 5], [0, 0]]],
-        [[[10, 10], [15, 10], [15, 15], [10, 15], [10, 10]]],
+        [
+          [
+            [0, 0],
+            [5, 0],
+            [5, 5],
+            [0, 5],
+            [0, 0],
+          ],
+        ],
+        [
+          [
+            [10, 10],
+            [15, 10],
+            [15, 15],
+            [10, 15],
+            [10, 10],
+          ],
+        ],
       ],
       { name: "multi" },
     );

--- a/tests/skeleton-json.test.ts
+++ b/tests/skeleton-json.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "./bun-test";
-import { readSkeletonJson, writeSkeletonJson } from "../src/codecs/skeleton-json.js";
+import {
+  readSkeletonJson,
+  writeSkeletonJson,
+} from "../src/codecs/skeleton-json.js";
 import { Skeleton, Node, Edge, Symmetry } from "../src/model/skeleton.js";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -46,7 +49,9 @@ describe("Skeleton JSON codec", () => {
     const raw = loadFixtureJson("mice_hc.json");
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     // mice_hc has nx_graph wrapper
-    const skeleton = readSkeletonJson(parsed.nx_graph as Record<string, unknown>);
+    const skeleton = readSkeletonJson(
+      parsed.nx_graph as Record<string, unknown>,
+    );
     expect(skeleton.nodes.length).toBe(5);
     expect(skeleton.nodeNames).toContain("nose1");
     expect(skeleton.edges.length).toBe(4);
@@ -118,8 +123,13 @@ describe("writeSkeletonJson", () => {
   });
 
   it("round-trips mice_hc", () => {
-    const parsed = JSON.parse(loadFixtureJson("mice_hc.json")) as Record<string, unknown>;
-    const original = readSkeletonJson(parsed.nx_graph as Record<string, unknown>);
+    const parsed = JSON.parse(loadFixtureJson("mice_hc.json")) as Record<
+      string,
+      unknown
+    >;
+    const original = readSkeletonJson(
+      parsed.nx_graph as Record<string, unknown>,
+    );
     const reparsed = roundTripFixture(original);
     expect(reparsed.nodes.length).toBe(5);
     expect(nameKeys(reparsed)).toEqual(nameKeys(original));
@@ -129,7 +139,10 @@ describe("writeSkeletonJson", () => {
 
   it("emits jsonpickle duplicate-object structure (py/object nodes, py/reduce then py/id edge types)", () => {
     const original = readSkeletonJson(loadFixtureJson("flies13.skeleton.json"));
-    const data = JSON.parse(writeSkeletonJson(original)) as Record<string, unknown>;
+    const data = JSON.parse(writeSkeletonJson(original)) as Record<
+      string,
+      unknown
+    >;
     expect(data.directed).toBe(true);
     expect(data.multigraph).toBe(true);
     const links = data.links as Array<Record<string, any>>;
@@ -137,7 +150,9 @@ describe("writeSkeletonJson", () => {
     expect(links[0].source["py/object"]).toBe("sleap.skeleton.Node");
     expect(links[0].source["py/state"]["py/tuple"][1]).toBe(1.0);
     // First edge type is a py/reduce; a later edge reuses it via py/id.
-    expect(links[0].type["py/reduce"][0]["py/type"]).toBe("sleap.skeleton.EdgeType");
+    expect(links[0].type["py/reduce"][0]["py/type"]).toBe(
+      "sleap.skeleton.EdgeType",
+    );
     expect(links[0].type["py/reduce"][1]["py/tuple"][0]).toBe(1);
     expect(links[1].type["py/id"]).toBe(1);
     // num_edges_inserted matches the edge count.
@@ -151,7 +166,9 @@ describe("writeSkeletonJson", () => {
     expect(Array.isArray(arr)).toBe(true);
     expect(arr.length).toBe(1);
     // Each element round-trips independently.
-    expect(readSkeletonJson(arr[0] as Record<string, unknown>).nodes.length).toBe(13);
+    expect(
+      readSkeletonJson(arr[0] as Record<string, unknown>).nodes.length,
+    ).toBe(13);
   });
 
   it("preserves an isolated node (no edges/symmetries) through round-trip", () => {

--- a/tests/slp-read-compat.test.ts
+++ b/tests/slp-read-compat.test.ts
@@ -6,7 +6,13 @@ import { LabeledFrame } from "../src/model/labeled-frame.js";
 import { Instance } from "../src/model/instance.js";
 import { Skeleton } from "../src/model/skeleton.js";
 import { Video } from "../src/model/video.js";
-import { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } from "../src/model/camera.js";
+import {
+  Camera,
+  CameraGroup,
+  InstanceGroup,
+  FrameGroup,
+  RecordingSession,
+} from "../src/model/camera.js";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -14,7 +20,10 @@ const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 
 describe("Backward compatibility", () => {
   it("loads multiview.slp fixture (no identities) without errors", async () => {
-    const labels = await readSlp(path.join(fixtureRoot, "slp", "multiview.slp"), { openVideos: false });
+    const labels = await readSlp(
+      path.join(fixtureRoot, "slp", "multiview.slp"),
+      { openVideos: false },
+    );
     expect(labels.identities).toEqual([]);
     if (labels.sessions.length > 0) {
       for (const fg of labels.sessions[0].frameGroups.values()) {
@@ -26,7 +35,9 @@ describe("Backward compatibility", () => {
   });
 
   it("loads typical.slp fixture (no sessions) without errors", async () => {
-    const labels = await readSlp(path.join(fixtureRoot, "slp", "typical.slp"), { openVideos: false });
+    const labels = await readSlp(path.join(fixtureRoot, "slp", "typical.slp"), {
+      openVideos: false,
+    });
     expect(labels.identities).toEqual([]);
     expect(labels.sessions).toEqual([]);
   });
@@ -42,18 +53,33 @@ describe("Backward compatibility", () => {
     const group = new InstanceGroup({ instanceByCamera });
     const lfByCamera = new Map<Camera, LabeledFrame>();
     lfByCamera.set(cam, lf);
-    const fg = new FrameGroup({ frameIdx: 0, instanceGroups: [group], labeledFrameByCamera: lfByCamera });
-    const session = new RecordingSession({ cameraGroup: new CameraGroup({ cameras: [cam] }) });
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [group],
+      labeledFrameByCamera: lfByCamera,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam] }),
+    });
     session.addVideo(video, cam);
     session.frameGroups.set(0, fg);
-    const labels = new Labels({ labeledFrames: [lf], videos: [video], skeletons: [skeleton], sessions: [session] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.identities).toEqual([]);
     expect(loaded.sessions).toHaveLength(1);
-    expect(loaded.sessions[0].frameGroups.get(0)!.instanceGroups[0].identity).toBeUndefined();
+    expect(
+      loaded.sessions[0].frameGroups.get(0)!.instanceGroups[0].identity,
+    ).toBeUndefined();
   });
 });
 
@@ -63,28 +89,65 @@ describe("Python format compatibility", () => {
     const skeleton = new Skeleton({ nodes: ["A", "B"], edges: [["A", "B"]] });
     const video1 = new Video({ filename: "cam1.mp4" });
     const video2 = new Video({ filename: "cam2.mp4" });
-    const inst1 = Instance.fromArray([[10, 20], [30, 40]], skeleton);
-    const inst2 = Instance.fromArray([[50, 60], [70, 80]], skeleton);
-    const lf1 = new LabeledFrame({ video: video1, frameIdx: 0, instances: [inst1] });
-    const lf2 = new LabeledFrame({ video: video2, frameIdx: 0, instances: [inst2] });
+    const inst1 = Instance.fromArray(
+      [
+        [10, 20],
+        [30, 40],
+      ],
+      skeleton,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [50, 60],
+        [70, 80],
+      ],
+      skeleton,
+    );
+    const lf1 = new LabeledFrame({
+      video: video1,
+      frameIdx: 0,
+      instances: [inst1],
+    });
+    const lf2 = new LabeledFrame({
+      video: video2,
+      frameIdx: 0,
+      instances: [inst2],
+    });
 
     const cam1 = new Camera({ name: "cam1", rvec: [0, 0, 0], tvec: [0, 0, 0] });
-    const cam2 = new Camera({ name: "cam2", rvec: [0.1, 0, 0], tvec: [100, 0, 0] });
+    const cam2 = new Camera({
+      name: "cam2",
+      rvec: [0.1, 0, 0],
+      tvec: [100, 0, 0],
+    });
     const instanceByCamera = new Map<Camera, Instance>();
     instanceByCamera.set(cam1, inst1);
     instanceByCamera.set(cam2, inst2);
     const lfByCamera = new Map<Camera, LabeledFrame>();
     lfByCamera.set(cam1, lf1);
     lfByCamera.set(cam2, lf2);
-    const fg = new FrameGroup({ frameIdx: 0, instanceGroups: [new InstanceGroup({ instanceByCamera })], labeledFrameByCamera: lfByCamera });
-    const session = new RecordingSession({ cameraGroup: new CameraGroup({ cameras: [cam1, cam2] }) });
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera })],
+      labeledFrameByCamera: lfByCamera,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam1, cam2] }),
+    });
     session.addVideo(video1, cam1);
     session.addVideo(video2, cam2);
     session.frameGroups.set(0, fg);
-    const labels = new Labels({ labeledFrames: [lf1, lf2], videos: [video1, video2], skeletons: [skeleton], sessions: [session] });
+    const labels = new Labels({
+      labeledFrames: [lf1, lf2],
+      videos: [video1, video2],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.sessions).toHaveLength(1);
     const loadedFg = loaded.sessions[0].frameGroups.get(0)!;
@@ -103,19 +166,38 @@ describe("Python format compatibility", () => {
     instanceByCamera.set(cam, inst);
     const lfByCamera = new Map<Camera, LabeledFrame>();
     lfByCamera.set(cam, lf);
-    const fg = new FrameGroup({ frameIdx: 0, instanceGroups: [new InstanceGroup({ instanceByCamera })], labeledFrameByCamera: lfByCamera });
-    const session = new RecordingSession({ cameraGroup: new CameraGroup({ cameras: [cam] }) });
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera })],
+      labeledFrameByCamera: lfByCamera,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam] }),
+    });
     session.addVideo(video, cam);
     session.frameGroups.set(0, fg);
-    const labels = new Labels({ labeledFrames: [lf], videos: [video], skeletons: [skeleton], sessions: [session] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
 
     const bytes = await saveSlpToBytes(labels);
 
     // Read the session JSON and strip JS-specific fields
-    const { openH5File, getH5Module, getH5FileSystem } = await import("../src/codecs/slp/h5.js");
-    const { file: origFile, close: closeOrig } = await openH5File(new Uint8Array(bytes).buffer);
+    const { openH5File, getH5Module, getH5FileSystem } = await import(
+      "../src/codecs/slp/h5.js"
+    );
+    const { file: origFile, close: closeOrig } = await openH5File(
+      new Uint8Array(bytes).buffer,
+    );
     const sessDs = origFile.get("sessions_json") as any;
-    const sessionJson = JSON.parse(typeof sessDs.value[0] === "string" ? sessDs.value[0] : new TextDecoder().decode(sessDs.value[0]));
+    const sessionJson = JSON.parse(
+      typeof sessDs.value[0] === "string"
+        ? sessDs.value[0]
+        : new TextDecoder().decode(sessDs.value[0]),
+    );
 
     // Verify the map exists before stripping
     const ig = sessionJson.frame_group_dicts[0].instance_groups[0];
@@ -130,18 +212,33 @@ describe("Python format compatibility", () => {
     const module = await getH5Module();
     const tmpPath = `/tmp/test_py_compat_${Date.now()}.slp`;
     const newFile = new module.File(tmpPath, "w");
-    const { file: srcFile, close: closeSrc } = await openH5File(new Uint8Array(bytes).buffer);
+    const { file: srcFile, close: closeSrc } = await openH5File(
+      new Uint8Array(bytes).buffer,
+    );
     try {
       // Copy metadata
       const metaGroup = srcFile.get("metadata") as any;
       newFile.create_group("metadata");
       const newMeta = newFile.get("metadata");
-      const fmtId = metaGroup.attrs?.format_id?.value ?? metaGroup.attrs?.format_id ?? 1.4;
+      const fmtId =
+        metaGroup.attrs?.format_id?.value ?? metaGroup.attrs?.format_id ?? 1.4;
       newMeta.create_attribute("format_id", Number(fmtId));
       const jsonVal = metaGroup.attrs?.json?.value ?? metaGroup.attrs?.json;
-      const jsonStr = typeof jsonVal === "string" ? jsonVal : new TextDecoder().decode(jsonVal instanceof Uint8Array ? jsonVal : new Uint8Array(jsonVal.buffer));
+      const jsonStr =
+        typeof jsonVal === "string"
+          ? jsonVal
+          : new TextDecoder().decode(
+              jsonVal instanceof Uint8Array
+                ? jsonVal
+                : new Uint8Array(jsonVal.buffer),
+            );
       const enc = new TextEncoder();
-      newMeta.create_attribute("json", jsonStr, null, `S${enc.encode(jsonStr).length}`);
+      newMeta.create_attribute(
+        "json",
+        jsonStr,
+        null,
+        `S${enc.encode(jsonStr).length}`,
+      );
 
       // Copy essential datasets
       for (const name of ["videos_json", "tracks_json", "suggestions_json"]) {
@@ -151,17 +248,39 @@ describe("Python format compatibility", () => {
       for (const name of ["frames", "instances", "points", "pred_points"]) {
         const src = srcFile.get(name) as any;
         if (src?.value != null) {
-          newFile.create_dataset({ name, data: src.value, shape: src.shape, dtype: src.dtype });
+          newFile.create_dataset({
+            name,
+            data: src.value,
+            shape: src.shape,
+            dtype: src.dtype,
+          });
           const fn = src.attrs?.field_names;
           if (fn) {
-            const fnStr = typeof (fn.value ?? fn) === "string" ? (fn.value ?? fn) : new TextDecoder().decode((fn.value ?? fn) instanceof Uint8Array ? (fn.value ?? fn) : new Uint8Array((fn.value ?? fn).buffer));
-            newFile.get(name).create_attribute("field_names", fnStr, null, `S${enc.encode(fnStr).length}`);
+            const fnStr =
+              typeof (fn.value ?? fn) === "string"
+                ? (fn.value ?? fn)
+                : new TextDecoder().decode(
+                    (fn.value ?? fn) instanceof Uint8Array
+                      ? (fn.value ?? fn)
+                      : new Uint8Array((fn.value ?? fn).buffer),
+                  );
+            newFile
+              .get(name)
+              .create_attribute(
+                "field_names",
+                fnStr,
+                null,
+                `S${enc.encode(fnStr).length}`,
+              );
           }
         }
       }
 
       // Write patched session JSON
-      newFile.create_dataset({ name: "sessions_json", data: [JSON.stringify(sessionJson)] });
+      newFile.create_dataset({
+        name: "sessions_json",
+        data: [JSON.stringify(sessionJson)],
+      });
     } finally {
       closeSrc();
     }
@@ -171,7 +290,9 @@ describe("Python format compatibility", () => {
     const patchedBytes = fs.readFile!(tmpPath);
     fs.unlink!(tmpPath);
 
-    const loaded = await readSlp(new Uint8Array(patchedBytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(patchedBytes).buffer, {
+      openVideos: false,
+    });
     expect(loaded.sessions).toHaveLength(1);
     const loadedFg = loaded.sessions[0].frameGroups.get(0)!;
     // Reconstructed from camcorder_to_lf_and_inst_idx_map

--- a/tests/slp-read.test.ts
+++ b/tests/slp-read.test.ts
@@ -7,7 +7,9 @@ import path from "node:path";
 const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 
 async function loadFixture(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+  });
 }
 
 describe("SLP read fixtures", () => {
@@ -23,7 +25,9 @@ describe("SLP read fixtures", () => {
   });
 
   it("reads provenance metadata", async () => {
-    const labels = await loadFixture("predictions_1.2.7_provenance_and_tracking.slp");
+    const labels = await loadFixture(
+      "predictions_1.2.7_provenance_and_tracking.slp",
+    );
     expect(labels.provenance.sleap_version).toBe("1.2.7");
   });
 

--- a/tests/slp-rois-masks.test.ts
+++ b/tests/slp-rois-masks.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect } from "./bun-test";
 import { Labels } from "../src/model/labels.js";
 import { ROI, PredictedROI } from "../src/model/roi.js";
-import { SegmentationMask, UserSegmentationMask, PredictedSegmentationMask } from "../src/model/mask.js";
+import {
+  SegmentationMask,
+  UserSegmentationMask,
+  PredictedSegmentationMask,
+} from "../src/model/mask.js";
 import { Video } from "../src/model/video.js";
 import { Track } from "../src/model/instance.js";
 import { Skeleton, Instance } from "../src/index.js";
 import { UserBoundingBox, PredictedBoundingBox } from "../src/model/bbox.js";
-import { UserLabelImage, PredictedLabelImage } from "../src/model/label-image.js";
+import {
+  UserLabelImage,
+  PredictedLabelImage,
+} from "../src/model/label-image.js";
 import { saveSlpToBytes } from "../src/codecs/slp/write.js";
 import { readSlp } from "../src/codecs/slp/read.js";
 import { LabeledFrame } from "../src/model/labeled-frame.js";
@@ -24,8 +31,9 @@ async function readFormatId(bytes: Uint8Array): Promise<number> {
   module.FS.writeFile(memPath, bytes);
   const file = new H5File(memPath, "r");
   try {
-    const fmtAttr = (file.get("metadata") as { attrs: Record<string, { value?: number }> })
-      .attrs["format_id"];
+    const fmtAttr = (
+      file.get("metadata") as { attrs: Record<string, { value?: number }> }
+    ).attrs["format_id"];
     return Number(fmtAttr?.value ?? fmtAttr);
   } finally {
     file.close();
@@ -53,7 +61,10 @@ describe("SLP ROI/Mask I/O", () => {
     const video = new Video({ filename: "test.mp4" });
     const track = new Track("track0");
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
+    const inst = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     const bboxRoi = ROI.fromBbox(10, 20, 100, 200, {
@@ -65,7 +76,12 @@ describe("SLP ROI/Mask I/O", () => {
     });
 
     const polyRoi = ROI.fromPolygon(
-      [[0, 0], [100, 0], [100, 100], [0, 100]],
+      [
+        [0, 0],
+        [100, 0],
+        [100, 100],
+        [0, 100],
+      ],
       {
         name: "roi2",
         category: "region",
@@ -167,7 +183,11 @@ describe("SLP ROI/Mask I/O", () => {
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     // Build a 100x100 binary mask raster shared by both masks.
-    const maskData = makeMaskRaster(100, 100, (r, c) => r >= 10 && r < 30 && c >= 20 && c < 50);
+    const maskData = makeMaskRaster(
+      100,
+      100,
+      (r, c) => r >= 10 && r < 30 && c >= 20 && c < 50,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const rle = encodeRle(maskData, 100, 100);
 
@@ -201,13 +221,16 @@ describe("SLP ROI/Mask I/O", () => {
     // Recording a link bumps the format to 2.4.
     expect(await readFormatId(bytes)).toBeGreaterThanOrEqual(2.4);
 
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     loaded.materialize();
 
     // Both masks survive: exactly one predicted, one user.
     expect(loaded.masks.length).toBe(2);
     const loadedPred = loaded.masks.find(
-      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+      (m): m is PredictedSegmentationMask =>
+        m instanceof PredictedSegmentationMask,
     )!;
     const loadedUser = loaded.masks.find(
       (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
@@ -233,7 +256,11 @@ describe("SLP ROI/Mask I/O", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
-    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const maskData = makeMaskRaster(
+      40,
+      40,
+      (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const rle = encodeRle(maskData, 40, 40);
 
@@ -247,7 +274,11 @@ describe("SLP ROI/Mask I/O", () => {
     const userMask = predMask.toUser(false);
     expect(userMask.fromPredicted).toBeNull();
 
-    const lfMask = new LabeledFrame({ video, frameIdx: 1, masks: [predMask, userMask] });
+    const lfMask = new LabeledFrame({
+      video,
+      frameIdx: 1,
+      masks: [predMask, userMask],
+    });
     const labels = new Labels({
       labeledFrames: [frame, lfMask],
       videos: [video],
@@ -258,7 +289,9 @@ describe("SLP ROI/Mask I/O", () => {
     // No mask records a link -> format must NOT be bumped to 2.4.
     expect(await readFormatId(bytes)).toBeLessThan(2.4);
 
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     loaded.materialize();
     const loadedUser = loaded.masks.find(
       (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
@@ -272,7 +305,11 @@ describe("SLP ROI/Mask I/O", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
-    const maskData = makeMaskRaster(50, 50, (r, c) => r >= 10 && r < 25 && c >= 10 && c < 25);
+    const maskData = makeMaskRaster(
+      50,
+      50,
+      (r, c) => r >= 10 && r < 25 && c >= 10 && c < 25,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const rle = encodeRle(maskData, 50, 50);
 
@@ -303,7 +340,8 @@ describe("SLP ROI/Mask I/O", () => {
     loaded.materialize();
 
     const loadedPred = loaded.masks.find(
-      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+      (m): m is PredictedSegmentationMask =>
+        m instanceof PredictedSegmentationMask,
     )!;
     const loadedUsers = loaded.masks.filter(
       (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
@@ -321,7 +359,11 @@ describe("SLP ROI/Mask I/O", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
-    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const maskData = makeMaskRaster(
+      40,
+      40,
+      (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const rle = encodeRle(maskData, 40, 40);
 
@@ -347,7 +389,9 @@ describe("SLP ROI/Mask I/O", () => {
     // Source absent -> no recorded link -> format not bumped.
     expect(await readFormatId(bytes)).toBeLessThan(2.4);
 
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
     loaded.materialize();
     expect(loaded.masks.length).toBe(1);
     const loadedUser = loaded.masks.find(
@@ -364,8 +408,16 @@ describe("SLP ROI/Mask I/O", () => {
     const { encodeRle } = await import("../src/model/mask.js");
 
     // Distinct rasters so the loaded masks are individually identifiable.
-    const rasterA = makeMaskRaster(30, 30, (r, c) => r >= 2 && r < 8 && c >= 2 && c < 8);
-    const rasterB = makeMaskRaster(30, 30, (r, c) => r >= 20 && r < 26 && c >= 20 && c < 26);
+    const rasterA = makeMaskRaster(
+      30,
+      30,
+      (r, c) => r >= 2 && r < 8 && c >= 2 && c < 8,
+    );
+    const rasterB = makeMaskRaster(
+      30,
+      30,
+      (r, c) => r >= 20 && r < 26 && c >= 20 && c < 26,
+    );
 
     const predA = new PredictedSegmentationMask({
       rleCounts: encodeRle(rasterA, 30, 30),
@@ -396,10 +448,12 @@ describe("SLP ROI/Mask I/O", () => {
     loaded.materialize();
 
     const loadedUserA = loaded.masks.find(
-      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask && m.name === "A",
+      (m): m is UserSegmentationMask =>
+        m instanceof UserSegmentationMask && m.name === "A",
     )!;
     const loadedUserB = loaded.masks.find(
-      (m): m is UserSegmentationMask => m instanceof UserSegmentationMask && m.name === "B",
+      (m): m is UserSegmentationMask =>
+        m instanceof UserSegmentationMask && m.name === "B",
     )!;
     expect(loadedUserA.fromPredicted).not.toBeNull();
     expect(loadedUserB.fromPredicted).not.toBeNull();
@@ -416,7 +470,11 @@ describe("SLP ROI/Mask I/O", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
-    const maskData = makeMaskRaster(60, 60, (r, c) => r >= 10 && r < 30 && c >= 10 && c < 30);
+    const maskData = makeMaskRaster(
+      60,
+      60,
+      (r, c) => r >= 10 && r < 30 && c >= 10 && c < 30,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const predMask = new PredictedSegmentationMask({
       rleCounts: encodeRle(maskData, 60, 60),
@@ -426,7 +484,11 @@ describe("SLP ROI/Mask I/O", () => {
     });
     const userMask = predMask.toUser(true);
 
-    const lfMask = new LabeledFrame({ video, frameIdx: 4, masks: [predMask, userMask] });
+    const lfMask = new LabeledFrame({
+      video,
+      frameIdx: 4,
+      masks: [predMask, userMask],
+    });
     const labels = new Labels({
       labeledFrames: [frame, lfMask],
       videos: [video],
@@ -439,7 +501,8 @@ describe("SLP ROI/Mask I/O", () => {
     twice.materialize();
 
     const loadedPred = twice.masks.find(
-      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+      (m): m is PredictedSegmentationMask =>
+        m instanceof PredictedSegmentationMask,
     )!;
     const loadedUser = twice.masks.find(
       (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
@@ -462,7 +525,11 @@ describe("SLP ROI/Mask I/O", () => {
     expect(userInst.fromPredicted).toBe(predInst);
 
     // Predicted mask adopted to a user mask (mask fromPredicted).
-    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const maskData = makeMaskRaster(
+      40,
+      40,
+      (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const predMask = new PredictedSegmentationMask({
       rleCounts: encodeRle(maskData, 40, 40),
@@ -491,7 +558,8 @@ describe("SLP ROI/Mask I/O", () => {
       (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
     )!;
     const loadedPredMask = loaded.masks.find(
-      (m): m is PredictedSegmentationMask => m instanceof PredictedSegmentationMask,
+      (m): m is PredictedSegmentationMask =>
+        m instanceof PredictedSegmentationMask,
     )!;
     expect(loadedUserMask.fromPredicted).toBe(loadedPredMask);
 
@@ -509,7 +577,11 @@ describe("SLP ROI/Mask I/O", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
-    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const maskData = makeMaskRaster(
+      40,
+      40,
+      (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const predMask = new PredictedSegmentationMask({
       rleCounts: encodeRle(maskData, 40, 40),
@@ -518,7 +590,11 @@ describe("SLP ROI/Mask I/O", () => {
       score: 0.8,
     });
     const userMask = predMask.toUser(true);
-    const lfMask = new LabeledFrame({ video, frameIdx: 1, masks: [predMask, userMask] });
+    const lfMask = new LabeledFrame({
+      video,
+      frameIdx: 1,
+      masks: [predMask, userMask],
+    });
     const labels = new Labels({
       labeledFrames: [frame, lfMask],
       videos: [video],
@@ -537,7 +613,12 @@ describe("SLP ROI/Mask I/O", () => {
       const f = new H5File(memPath, "a");
       const masksDs = f.get("masks") as {
         attrs: Record<string, { value?: unknown }>;
-        create_attribute: (name: string, value: unknown, shape: unknown, dtype: string) => void;
+        create_attribute: (
+          name: string,
+          value: unknown,
+          shape: unknown,
+          dtype: string,
+        ) => void;
         delete_attribute: (name: string) => void;
       };
       const fieldNames: string[] = JSON.parse(
@@ -560,7 +641,9 @@ describe("SLP ROI/Mask I/O", () => {
     const legacyBytes = module.FS.readFile(memPath) as Uint8Array;
     module.FS.unlink(memPath);
 
-    const loaded = await readSlp(new Uint8Array(legacyBytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(legacyBytes).buffer, {
+      openVideos: false,
+    });
     loaded.materialize();
     const loadedUser = loaded.masks.find(
       (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
@@ -574,7 +657,11 @@ describe("SLP ROI/Mask I/O", () => {
     const inst = new Instance({ points: { A: [10, 20] }, skeleton });
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
-    const maskData = makeMaskRaster(40, 40, (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15);
+    const maskData = makeMaskRaster(
+      40,
+      40,
+      (r, c) => r >= 5 && r < 15 && c >= 5 && c < 15,
+    );
     const { encodeRle } = await import("../src/model/mask.js");
     const predMask = new PredictedSegmentationMask({
       rleCounts: encodeRle(maskData, 40, 40),
@@ -583,7 +670,11 @@ describe("SLP ROI/Mask I/O", () => {
       score: 0.8,
     });
     const userMask = predMask.toUser(true);
-    const lfMask = new LabeledFrame({ video, frameIdx: 1, masks: [predMask, userMask] });
+    const lfMask = new LabeledFrame({
+      video,
+      frameIdx: 1,
+      masks: [predMask, userMask],
+    });
     const labels = new Labels({
       labeledFrames: [frame, lfMask],
       videos: [video],
@@ -602,7 +693,10 @@ describe("SLP ROI/Mask I/O", () => {
       const masksDs = f.get("masks") as {
         shape: number[];
         attrs: Record<string, { value?: unknown }>;
-        write_slice: (ranges: Array<[number, number]>, data: Float64Array) => void;
+        write_slice: (
+          ranges: Array<[number, number]>,
+          data: Float64Array,
+        ) => void;
       };
       const fieldNames: string[] = JSON.parse(
         String((masksDs.attrs["field_names"] as { value?: unknown }).value),
@@ -623,7 +717,9 @@ describe("SLP ROI/Mask I/O", () => {
     const corruptBytes = module.FS.readFile(memPath) as Uint8Array;
     module.FS.unlink(memPath);
 
-    const loaded = await readSlp(new Uint8Array(corruptBytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(corruptBytes).buffer, {
+      openVideos: false,
+    });
     loaded.materialize();
     const loadedUser = loaded.masks.find(
       (m): m is UserSegmentationMask => m instanceof UserSegmentationMask,
@@ -767,10 +863,21 @@ describe("SLP BoundingBox I/O", () => {
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     const bb1 = new UserBoundingBox({
-      x1: 0, y1: 20, x2: 100, y2: 100, track, category: "animal", name: "bb1", source: "manual",
+      x1: 0,
+      y1: 20,
+      x2: 100,
+      y2: 100,
+      track,
+      category: "animal",
+      name: "bb1",
+      source: "manual",
     });
     const bb2 = new PredictedBoundingBox({
-      x1: 0, y1: 5, x2: 40, y2: 55, score: 0.95,
+      x1: 0,
+      y1: 5,
+      x2: 40,
+      y2: 55,
+      score: 0.95,
     });
 
     const lfBb1 = new LabeledFrame({ video, frameIdx: 3, bboxes: [bb1] });
@@ -836,12 +943,27 @@ describe("SLP ROI instance association (format 1.6)", () => {
   it("round-trips ROI instance references", async () => {
     const video = new Video({ filename: "test.mp4" });
     const skeleton = new Skeleton({ nodes: ["A", "B"] });
-    const inst0 = new Instance({ points: { A: [10, 20], B: [30, 40] }, skeleton });
-    const inst1 = new Instance({ points: { A: [50, 60], B: [70, 80] }, skeleton });
-    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst0, inst1] });
+    const inst0 = new Instance({
+      points: { A: [10, 20], B: [30, 40] },
+      skeleton,
+    });
+    const inst1 = new Instance({
+      points: { A: [50, 60], B: [70, 80] },
+      skeleton,
+    });
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst0, inst1],
+    });
 
     const roi = ROI.fromPolygon(
-      [[0, 0], [100, 0], [100, 100], [0, 100]],
+      [
+        [0, 0],
+        [100, 0],
+        [100, 100],
+        [0, 100],
+      ],
       { name: "inst-roi", instance: inst1 },
     );
     frame.rois.push(roi);
@@ -889,12 +1011,28 @@ describe("SLP Predicted Variant Roundtrips", () => {
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     const roi = new PredictedROI({
-      geometry: { type: "Polygon", coordinates: [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]] },
-      score: 0.75, name: "pred", category: "obj",
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [0, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10],
+            [0, 0],
+          ],
+        ],
+      },
+      score: 0.75,
+      name: "pred",
+      category: "obj",
     });
 
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton], rois: [roi],
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
+      rois: [roi],
     });
 
     const loaded = await roundTrip(labels);
@@ -915,13 +1053,20 @@ describe("SLP Predicted Variant Roundtrips", () => {
     data[12] = 1; // single pixel
     const rle = (await import("../src/model/mask.js")).encodeRle(data, 5, 5);
     const mask = new PredictedSegmentationMask({
-      rleCounts: rle, height: 5, width: 5, score: 0.92,
-      name: "pmask", category: "seg", instance: inst,
+      rleCounts: rle,
+      height: 5,
+      width: 5,
+      score: 0.92,
+      name: "pmask",
+      category: "seg",
+      instance: inst,
     });
 
     frame.masks.push(mask);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);
@@ -929,7 +1074,9 @@ describe("SLP Predicted Variant Roundtrips", () => {
     expect(loaded.masks).toHaveLength(1);
     expect(loaded.masks[0].isPredicted).toBe(true);
     expect(loaded.masks[0]).toBeInstanceOf(PredictedSegmentationMask);
-    expect((loaded.masks[0] as PredictedSegmentationMask).score).toBeCloseTo(0.92);
+    expect((loaded.masks[0] as PredictedSegmentationMask).score).toBeCloseTo(
+      0.92,
+    );
     expect(loaded.masks[0].name).toBe("pmask");
   });
 
@@ -943,19 +1090,26 @@ describe("SLP Predicted Variant Roundtrips", () => {
     data[0] = 1;
     data[4] = 2;
     const li = new PredictedLabelImage({
-      data, height: 3, width: 3, score: 0.85,
+      data,
+      height: 3,
+      width: 3,
+      score: 0.85,
     });
 
     frame.labelImages.push(li);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);
     expect(loaded.labelImages).toHaveLength(1);
     expect(loaded.labelImages[0].isPredicted).toBe(true);
     expect(loaded.labelImages[0]).toBeInstanceOf(PredictedLabelImage);
-    expect((loaded.labelImages[0] as PredictedLabelImage).score).toBeCloseTo(0.85);
+    expect((loaded.labelImages[0] as PredictedLabelImage).score).toBeCloseTo(
+      0.85,
+    );
   });
 });
 
@@ -967,13 +1121,17 @@ describe("SLP Scale/Offset Roundtrips", () => {
     const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
 
     const mask = SegmentationMask.fromArray(
-      new Uint8Array([1, 0, 0, 1, 0, 0, 1, 0, 0]), 3, 3,
+      new Uint8Array([1, 0, 0, 1, 0, 0, 1, 0, 0]),
+      3,
+      3,
       { video, frameIdx: 0, scale: [2, 3], offset: [10, 20] },
     );
 
     frame.masks.push(mask);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);
@@ -993,13 +1151,18 @@ describe("SLP Scale/Offset Roundtrips", () => {
     const data = new Int32Array(4);
     data[0] = 1;
     const li = new UserLabelImage({
-      data, height: 2, width: 2,
-      scale: [0.5, 0.5], offset: [3, 7],
+      data,
+      height: 2,
+      width: 2,
+      scale: [0.5, 0.5],
+      offset: [3, 7],
     });
 
     frame.labelImages.push(li);
     const labels = new Labels({
-      labeledFrames: [frame], videos: [video], skeletons: [skeleton],
+      labeledFrames: [frame],
+      videos: [video],
+      skeletons: [skeleton],
     });
 
     const loaded = await roundTrip(labels);

--- a/tests/slp-write-3d.test.ts
+++ b/tests/slp-write-3d.test.ts
@@ -4,39 +4,84 @@ import { LabeledFrame } from "../src/model/labeled-frame.js";
 import { Instance } from "../src/model/instance.js";
 import { Skeleton } from "../src/model/skeleton.js";
 import { Video } from "../src/model/video.js";
-import { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } from "../src/model/camera.js";
+import {
+  Camera,
+  CameraGroup,
+  InstanceGroup,
+  FrameGroup,
+  RecordingSession,
+} from "../src/model/camera.js";
 import { Identity } from "../src/model/identity.js";
 import { Instance3D, PredictedInstance3D } from "../src/model/instance3d.js";
 import { saveSlpToBytes } from "../src/codecs/slp/write.js";
 import { readSlp } from "../src/codecs/slp/read.js";
 
-function makeTestLabels(options?: { withIdentity?: boolean; withInstance3d?: boolean; withPredicted3d?: boolean }): Labels {
-  const skeleton = new Skeleton({ nodes: ["nose", "tail"], edges: [["nose", "tail"]] });
+function makeTestLabels(options?: {
+  withIdentity?: boolean;
+  withInstance3d?: boolean;
+  withPredicted3d?: boolean;
+}): Labels {
+  const skeleton = new Skeleton({
+    nodes: ["nose", "tail"],
+    edges: [["nose", "tail"]],
+  });
   const video1 = new Video({ filename: "cam1.mp4" });
   const video2 = new Video({ filename: "cam2.mp4" });
   const cam1 = new Camera({ name: "cam1", rvec: [0, 0, 0], tvec: [0, 0, 0] });
-  const cam2 = new Camera({ name: "cam2", rvec: [0.1, 0, 0], tvec: [100, 0, 0] });
+  const cam2 = new Camera({
+    name: "cam2",
+    rvec: [0.1, 0, 0],
+    tvec: [100, 0, 0],
+  });
 
-  const inst1 = Instance.fromArray([[100, 200], [300, 400]], skeleton);
-  const inst2 = Instance.fromArray([[150, 250], [350, 450]], skeleton);
+  const inst1 = Instance.fromArray(
+    [
+      [100, 200],
+      [300, 400],
+    ],
+    skeleton,
+  );
+  const inst2 = Instance.fromArray(
+    [
+      [150, 250],
+      [350, 450],
+    ],
+    skeleton,
+  );
 
-  const lf1 = new LabeledFrame({ video: video1, frameIdx: 0, instances: [inst1] });
-  const lf2 = new LabeledFrame({ video: video2, frameIdx: 0, instances: [inst2] });
+  const lf1 = new LabeledFrame({
+    video: video1,
+    frameIdx: 0,
+    instances: [inst1],
+  });
+  const lf2 = new LabeledFrame({
+    video: video2,
+    frameIdx: 0,
+    instances: [inst2],
+  });
 
-  const identity = options?.withIdentity ? new Identity({ name: "mouse_A", color: "#ff0000" }) : undefined;
+  const identity = options?.withIdentity
+    ? new Identity({ name: "mouse_A", color: "#ff0000" })
+    : undefined;
   const identities = identity ? [identity] : [];
 
   let instance3d: Instance3D | undefined;
   if (options?.withPredicted3d) {
     instance3d = new PredictedInstance3D({
-      points: [[50, 100, 200], [150, 300, 400]],
+      points: [
+        [50, 100, 200],
+        [150, 300, 400],
+      ],
       skeleton,
       score: 0.92,
       pointScores: [0.95, 0.88],
     });
   } else if (options?.withInstance3d) {
     instance3d = new Instance3D({
-      points: [[50, 100, 200], [150, 300, 400]],
+      points: [
+        [50, 100, 200],
+        [150, 300, 400],
+      ],
       skeleton,
       score: 0.92,
     });
@@ -50,7 +95,11 @@ function makeTestLabels(options?: { withIdentity?: boolean; withInstance3d?: boo
   const labeledFrameByCamera = new Map<Camera, LabeledFrame>();
   labeledFrameByCamera.set(cam1, lf1);
   labeledFrameByCamera.set(cam2, lf2);
-  const frameGroup = new FrameGroup({ frameIdx: 0, instanceGroups: [group], labeledFrameByCamera });
+  const frameGroup = new FrameGroup({
+    frameIdx: 0,
+    instanceGroups: [group],
+    labeledFrameByCamera,
+  });
 
   const cameraGroup = new CameraGroup({ cameras: [cam1, cam2] });
   const session = new RecordingSession({ cameraGroup });
@@ -71,7 +120,9 @@ describe("SLP write with identity and 3D data", () => {
   it("round-trips identity through write and read", async () => {
     const labels = makeTestLabels({ withIdentity: true });
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.identities).toHaveLength(1);
     expect(loaded.identities[0].name).toBe("mouse_A");
@@ -88,21 +139,28 @@ describe("SLP write with identity and 3D data", () => {
   it("round-trips Instance3D through write and read", async () => {
     const labels = makeTestLabels({ withInstance3d: true });
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     const session = loaded.sessions[0];
     const frameGroup = session.frameGroups.get(0)!;
     const group = frameGroup.instanceGroups[0];
     expect(group.instance3d).toBeDefined();
     expect(group.instance3d).toBeInstanceOf(Instance3D);
-    expect(group.instance3d!.points).toEqual([[50, 100, 200], [150, 300, 400]]);
+    expect(group.instance3d!.points).toEqual([
+      [50, 100, 200],
+      [150, 300, 400],
+    ]);
     expect(group.instance3d!.score).toBe(0.92);
   });
 
   it("round-trips PredictedInstance3D through write and read", async () => {
     const labels = makeTestLabels({ withPredicted3d: true });
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     const group = loaded.sessions[0].frameGroups.get(0)!.instanceGroups[0];
     expect(group.instance3d).toBeInstanceOf(PredictedInstance3D);
@@ -143,13 +201,18 @@ describe("SLP write with identity and 3D data", () => {
   it("round-trips identity + instance3d together", async () => {
     const labels = makeTestLabels({ withIdentity: true, withInstance3d: true });
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.identities).toHaveLength(1);
     const group = loaded.sessions[0].frameGroups.get(0)!.instanceGroups[0];
     expect(group.identity).toBe(loaded.identities[0]);
     expect(group.instance3d).toBeDefined();
-    expect(group.instance3d!.points).toEqual([[50, 100, 200], [150, 300, 400]]);
+    expect(group.instance3d!.points).toEqual([
+      [50, 100, 200],
+      [150, 300, 400],
+    ]);
   });
 
   it("writes camcorder_to_lf_and_inst_idx_map with numeric keys", async () => {
@@ -159,7 +222,11 @@ describe("SLP write with identity and 3D data", () => {
     const { file, close } = await openH5File(new Uint8Array(bytes).buffer);
     try {
       const ds = file.get("sessions_json") as any;
-      const sessionJson = JSON.parse(typeof ds.value[0] === "string" ? ds.value[0] : new TextDecoder().decode(ds.value[0]));
+      const sessionJson = JSON.parse(
+        typeof ds.value[0] === "string"
+          ? ds.value[0]
+          : new TextDecoder().decode(ds.value[0]),
+      );
       const fg = sessionJson.frame_group_dicts[0];
       const ig = fg.instance_groups[0];
 
@@ -183,7 +250,11 @@ describe("SLP write with identity and 3D data", () => {
   });
 
   it("identity metadata does not clobber name/color", async () => {
-    const id = new Identity({ name: "real_name", color: "#ff0000", metadata: { name: "shadow", color: "#00ff00", extra: 42 } });
+    const id = new Identity({
+      name: "real_name",
+      color: "#ff0000",
+      metadata: { name: "shadow", color: "#00ff00", extra: 42 },
+    });
     const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
     const video = new Video({ filename: "v.mp4" });
     const inst = Instance.fromArray([[1, 2]], skeleton);
@@ -195,7 +266,9 @@ describe("SLP write with identity and 3D data", () => {
       identities: [id],
     });
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.identities[0].name).toBe("real_name");
     expect(loaded.identities[0].color).toBe("#ff0000");
@@ -207,21 +280,39 @@ describe("SLP write with identity and 3D data", () => {
   it("round-trips camera size field", async () => {
     const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
     const video = new Video({ filename: "v.mp4" });
-    const cam = new Camera({ name: "cam", rvec: [0, 0, 0], tvec: [0, 0, 0], size: [640, 480] });
+    const cam = new Camera({
+      name: "cam",
+      rvec: [0, 0, 0],
+      tvec: [0, 0, 0],
+      size: [640, 480],
+    });
     const inst = Instance.fromArray([[1, 2]], skeleton);
     const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
     const instanceByCamera = new Map<Camera, Instance>();
     instanceByCamera.set(cam, inst);
     const lfByCamera = new Map<Camera, LabeledFrame>();
     lfByCamera.set(cam, lf);
-    const fg = new FrameGroup({ frameIdx: 0, instanceGroups: [new InstanceGroup({ instanceByCamera })], labeledFrameByCamera: lfByCamera });
-    const session = new RecordingSession({ cameraGroup: new CameraGroup({ cameras: [cam] }) });
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera })],
+      labeledFrameByCamera: lfByCamera,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam] }),
+    });
     session.addVideo(video, cam);
     session.frameGroups.set(0, fg);
-    const labels = new Labels({ labeledFrames: [lf], videos: [video], skeletons: [skeleton], sessions: [session] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.sessions[0].cameraGroup.cameras[0].size).toEqual([640, 480]);
   });

--- a/tests/slp-write.test.ts
+++ b/tests/slp-write.test.ts
@@ -14,7 +14,9 @@ import { ready, File as H5File } from "h5wasm/node";
 const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 
 async function loadFixture(filename: string) {
-  return loadSlp(path.join(fixtureRoot, "slp", filename), { openVideos: false });
+  return loadSlp(path.join(fixtureRoot, "slp", filename), {
+    openVideos: false,
+  });
 }
 
 describe("saveSlpToBytes", () => {
@@ -83,7 +85,11 @@ describe("saveSlpToBytes", () => {
 
     expect(loaded.skeletons.length).toBe(1);
     expect(loaded.skeletons[0].name).toBe("fly");
-    expect(loaded.skeletons[0].nodeNames).toEqual(["head", "thorax", "abdomen"]);
+    expect(loaded.skeletons[0].nodeNames).toEqual([
+      "head",
+      "thorax",
+      "abdomen",
+    ]);
     expect(loaded.skeletons[0].edges.length).toBe(2);
     expect(loaded.videos.length).toBe(1);
     expect(loaded.videos[0].filename).toBe("video.mp4");
@@ -110,8 +116,12 @@ describe("saveSlpToBytes", () => {
     expect(loaded.tracks.length).toBe(original.tracks.length);
 
     for (let i = 0; i < original.labeledFrames.length; i++) {
-      expect(loaded.labeledFrames[i].frameIdx).toBe(original.labeledFrames[i].frameIdx);
-      expect(loaded.labeledFrames[i].instances.length).toBe(original.labeledFrames[i].instances.length);
+      expect(loaded.labeledFrames[i].frameIdx).toBe(
+        original.labeledFrames[i].frameIdx,
+      );
+      expect(loaded.labeledFrames[i].instances.length).toBe(
+        original.labeledFrames[i].instances.length,
+      );
     }
   });
 
@@ -180,11 +190,20 @@ describe("saveSlpToBytes", () => {
 
     const centroids = [
       new UserCentroid({ x: 10, y: 20, track, category: "cell" }),
-      new PredictedCentroid({ x: 50, y: 60, z: 3.5, score: 0.95, track, trackingScore: 0.8, name: "spot1", source: "trackmate" }),
+      new PredictedCentroid({
+        x: 50,
+        y: 60,
+        z: 3.5,
+        score: 0.95,
+        track,
+        trackingScore: 0.8,
+        name: "spot1",
+        source: "trackmate",
+      }),
     ];
 
-    const frames = centroids.map((cent, i) =>
-      new LabeledFrame({ video, frameIdx: i, centroids: [cent] })
+    const frames = centroids.map(
+      (cent, i) => new LabeledFrame({ video, frameIdx: i, centroids: [cent] }),
     );
     const labels = new Labels({
       labeledFrames: frames,
@@ -228,8 +247,21 @@ describe("saveSlpToBytes", () => {
     const track = new Track("t1");
 
     const bboxes = [
-      new UserBoundingBox({ x1: 0, y1: 0, x2: 100, y2: 100, trackingScore: 0.75 }),
-      new PredictedBoundingBox({ x1: 10, y1: 10, x2: 50, y2: 50, score: 0.9, track }),
+      new UserBoundingBox({
+        x1: 0,
+        y1: 0,
+        x2: 100,
+        y2: 100,
+        trackingScore: 0.75,
+      }),
+      new PredictedBoundingBox({
+        x1: 10,
+        y1: 10,
+        x2: 50,
+        y2: 50,
+        score: 0.9,
+        track,
+      }),
     ];
 
     const lfBbox = new LabeledFrame({ video, frameIdx: 0, bboxes });

--- a/tests/streaming-field-names.test.ts
+++ b/tests/streaming-field-names.test.ts
@@ -57,7 +57,7 @@ describe("getFieldNamesFromMeta — h5wasm 0.10.x array-of-pairs compound dtype 
         shape: [1, 4],
         dtype:
           "{'names':['x','y','visible','complete'],'formats':['<d','<d','|b1','|b1']}",
-      })
+      }),
     ).toEqual(["x", "y", "visible", "complete"]);
   });
 

--- a/tests/streaming-sessions.test.ts
+++ b/tests/streaming-sessions.test.ts
@@ -7,26 +7,37 @@ const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
 
 describe("Streaming Sessions", () => {
   it("non-streaming reader loads sessions from multiview.slp", async () => {
-    const labels = await readSlp(path.join(fixtureRoot, "slp", "multiview.slp"), { openVideos: false });
+    const labels = await readSlp(
+      path.join(fixtureRoot, "slp", "multiview.slp"),
+      { openVideos: false },
+    );
     expect(labels.sessions.length).toBeGreaterThan(0);
     const session = labels.sessions[0];
     expect(session.cameraGroup.cameras.length).toBeGreaterThan(0);
   });
 
   it("sessions round-trip through write and read", async () => {
-    const labels = await readSlp(path.join(fixtureRoot, "slp", "multiview.slp"), { openVideos: false });
+    const labels = await readSlp(
+      path.join(fixtureRoot, "slp", "multiview.slp"),
+      { openVideos: false },
+    );
     if (labels.sessions.length === 0) return;
 
     const { saveSlpToBytes } = await import("../src/codecs/slp/write.js");
     const bytes = await saveSlpToBytes(labels);
-    const reloaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(reloaded.sessions.length).toBe(labels.sessions.length);
-    expect(reloaded.sessions[0].cameraGroup.cameras.length).toBe(labels.sessions[0].cameraGroup.cameras.length);
+    expect(reloaded.sessions[0].cameraGroup.cameras.length).toBe(
+      labels.sessions[0].cameraGroup.cameras.length,
+    );
   });
 
   it("round-trips camera size field through session write/read", async () => {
-    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } = await import("../src/model/camera.js");
+    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } =
+      await import("../src/model/camera.js");
     const { Instance } = await import("../src/model/instance.js");
     const { Skeleton } = await import("../src/model/skeleton.js");
     const { Video } = await import("../src/model/video.js");
@@ -36,27 +47,48 @@ describe("Streaming Sessions", () => {
 
     const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
     const video = new Video({ filename: "v.mp4" });
-    const cam = new Camera({ name: "cam", rvec: [0, 0, 0], tvec: [0, 0, 0], size: [1920, 1080] });
+    const cam = new Camera({
+      name: "cam",
+      rvec: [0, 0, 0],
+      tvec: [0, 0, 0],
+      size: [1920, 1080],
+    });
     const inst = Instance.fromArray([[1, 2]], skeleton);
     const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
     const instanceByCamera = new Map();
     instanceByCamera.set(cam, inst);
     const lfByCamera = new Map();
     lfByCamera.set(cam, lf);
-    const fg = new FrameGroup({ frameIdx: 0, instanceGroups: [new InstanceGroup({ instanceByCamera })], labeledFrameByCamera: lfByCamera });
-    const session = new RecordingSession({ cameraGroup: new CameraGroup({ cameras: [cam] }) });
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera })],
+      labeledFrameByCamera: lfByCamera,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam] }),
+    });
     session.addVideo(video, cam);
     session.frameGroups.set(0, fg);
-    const labels = new Labels({ labeledFrames: [lf], videos: [video], skeletons: [skeleton], sessions: [session] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
-    expect(loaded.sessions[0].cameraGroup.cameras[0].size).toEqual([1920, 1080]);
+    expect(loaded.sessions[0].cameraGroup.cameras[0].size).toEqual([
+      1920, 1080,
+    ]);
   });
 
   it("writes and reads camcorder_to_lf_and_inst_idx_map in session data", async () => {
-    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } = await import("../src/model/camera.js");
+    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } =
+      await import("../src/model/camera.js");
     const { Instance } = await import("../src/model/instance.js");
     const { Skeleton } = await import("../src/model/skeleton.js");
     const { Video } = await import("../src/model/video.js");
@@ -68,11 +100,35 @@ describe("Streaming Sessions", () => {
     const video1 = new Video({ filename: "cam1.mp4" });
     const video2 = new Video({ filename: "cam2.mp4" });
     const cam1 = new Camera({ name: "cam1", rvec: [0, 0, 0], tvec: [0, 0, 0] });
-    const cam2 = new Camera({ name: "cam2", rvec: [0.1, 0, 0], tvec: [100, 0, 0] });
-    const inst1 = Instance.fromArray([[10, 20], [30, 40]], skeleton);
-    const inst2 = Instance.fromArray([[50, 60], [70, 80]], skeleton);
-    const lf1 = new LabeledFrame({ video: video1, frameIdx: 0, instances: [inst1] });
-    const lf2 = new LabeledFrame({ video: video2, frameIdx: 0, instances: [inst2] });
+    const cam2 = new Camera({
+      name: "cam2",
+      rvec: [0.1, 0, 0],
+      tvec: [100, 0, 0],
+    });
+    const inst1 = Instance.fromArray(
+      [
+        [10, 20],
+        [30, 40],
+      ],
+      skeleton,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [50, 60],
+        [70, 80],
+      ],
+      skeleton,
+    );
+    const lf1 = new LabeledFrame({
+      video: video1,
+      frameIdx: 0,
+      instances: [inst1],
+    });
+    const lf2 = new LabeledFrame({
+      video: video2,
+      frameIdx: 0,
+      instances: [inst2],
+    });
 
     const instanceByCamera = new Map();
     instanceByCamera.set(cam1, inst1);
@@ -80,15 +136,28 @@ describe("Streaming Sessions", () => {
     const lfByCamera = new Map();
     lfByCamera.set(cam1, lf1);
     lfByCamera.set(cam2, lf2);
-    const fg = new FrameGroup({ frameIdx: 0, instanceGroups: [new InstanceGroup({ instanceByCamera })], labeledFrameByCamera: lfByCamera });
-    const session = new RecordingSession({ cameraGroup: new CameraGroup({ cameras: [cam1, cam2] }) });
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera })],
+      labeledFrameByCamera: lfByCamera,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam1, cam2] }),
+    });
     session.addVideo(video1, cam1);
     session.addVideo(video2, cam2);
     session.frameGroups.set(0, fg);
-    const labels = new Labels({ labeledFrames: [lf1, lf2], videos: [video1, video2], skeletons: [skeleton], sessions: [session] });
+    const labels = new Labels({
+      labeledFrames: [lf1, lf2],
+      videos: [video1, video2],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.sessions).toHaveLength(1);
     const loadedFg = loaded.sessions[0].frameGroups.get(0)!;

--- a/tests/suggestions.test.ts
+++ b/tests/suggestions.test.ts
@@ -17,13 +17,21 @@ describe("SuggestionFrame", () => {
 
   it("accepts explicit group", () => {
     const video = new Video({ filename: "test.mp4" });
-    const suggestion = new SuggestionFrame({ video, frameIdx: 0, group: "initial" });
+    const suggestion = new SuggestionFrame({
+      video,
+      frameIdx: 0,
+      group: "initial",
+    });
     expect(suggestion.group).toBe("initial");
   });
 
   it("extracts group from metadata if not explicitly set", () => {
     const video = new Video({ filename: "test.mp4" });
-    const suggestion = new SuggestionFrame({ video, frameIdx: 0, metadata: { group: "batch1" } });
+    const suggestion = new SuggestionFrame({
+      video,
+      frameIdx: 0,
+      metadata: { group: "batch1" },
+    });
     expect(suggestion.group).toBe("batch1");
   });
 
@@ -35,10 +43,16 @@ describe("SuggestionFrame", () => {
       new SuggestionFrame({ video, frameIdx: 5, group: "group_b" }),
       new SuggestionFrame({ video, frameIdx: 10 }),
     ];
-    const labels = new Labels({ videos: [video], skeletons: [skeleton], suggestions });
+    const labels = new Labels({
+      videos: [video],
+      skeletons: [skeleton],
+      suggestions,
+    });
 
     const bytes = await saveSlpToBytes(labels);
-    const loaded = await readSlp(new Uint8Array(bytes).buffer, { openVideos: false });
+    const loaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
 
     expect(loaded.suggestions.length).toBe(3);
     expect(loaded.suggestions[0].group).toBe("group_a");
@@ -47,7 +61,10 @@ describe("SuggestionFrame", () => {
   });
 
   it("reads suggestions from fixture files", async () => {
-    const labels = await loadSlp(path.join(fixtureRoot, "slp", "centered_pair_predictions.slp"), { openVideos: false });
+    const labels = await loadSlp(
+      path.join(fixtureRoot, "slp", "centered_pair_predictions.slp"),
+      { openVideos: false },
+    );
     for (const suggestion of labels.suggestions) {
       expect(suggestion.group).toBeDefined();
       expect(typeof suggestion.group).toBe("string");

--- a/tests/trackmate.test.ts
+++ b/tests/trackmate.test.ts
@@ -131,7 +131,9 @@ describe("readTrackMateCsv", () => {
 
     // Don't pass edgesPath — should be auto-detected
     const labels = readTrackMateCsv(path.join(dir, "sample_spots.csv"));
-    expect((labels.centroids[1] as PredictedCentroid).trackingScore).toBeCloseTo(0.8);
+    expect(
+      (labels.centroids[1] as PredictedCentroid).trackingScore,
+    ).toBeCloseTo(0.8);
 
     fs.rmSync(dir, { recursive: true });
   });
@@ -142,7 +144,9 @@ describe("readTrackMateCsv", () => {
       "ID1,1,0,5.0,1.0,2.0,0.0,0.0,0,11.5,1",
     ]);
 
-    const labels = readTrackMateCsv(path.join(dir, "test_spots.csv"), { video: "my_video.tif" });
+    const labels = readTrackMateCsv(path.join(dir, "test_spots.csv"), {
+      video: "my_video.tif",
+    });
 
     expect(labels.videos).toHaveLength(1);
     expect(labels.videos[0].filename).toBe("my_video.tif");
@@ -182,7 +186,9 @@ describe("readTrackMateCsv", () => {
   });
 
   it("throws for missing file", () => {
-    expect(() => readTrackMateCsv("/tmp/nonexistent_spots.csv")).toThrow(/not found/);
+    expect(() => readTrackMateCsv("/tmp/nonexistent_spots.csv")).toThrow(
+      /not found/,
+    );
   });
 
   it("throws for non-TrackMate CSV", () => {

--- a/tests/training-config.test.ts
+++ b/tests/training-config.test.ts
@@ -32,7 +32,7 @@ describe("Training Config Skeleton", () => {
 
   it("reads skeleton-order-bug/training_config_13pt_fly.json", () => {
     const json = loadFixtureJson(
-      "skeleton-order-bug/training_config_13pt_fly.json"
+      "skeleton-order-bug/training_config_13pt_fly.json",
     );
     const skeleton = readTrainingConfigSkeleton(json);
     expect(skeleton.nodes.length).toBe(13);
@@ -41,10 +41,10 @@ describe("Training Config Skeleton", () => {
 
   it("training config skeleton matches standalone skeleton", () => {
     const configJson = loadFixtureJson(
-      "skeleton-order-bug/training_config_13pt_fly.json"
+      "skeleton-order-bug/training_config_13pt_fly.json",
     );
     const standaloneJson = loadFixtureJson(
-      "skeleton-order-bug/skeleton_13pt_fly.json"
+      "skeleton-order-bug/skeleton_13pt_fly.json",
     );
 
     const configSkeleton = readTrainingConfigSkeleton(configJson);

--- a/tests/transform/frame.test.ts
+++ b/tests/transform/frame.test.ts
@@ -110,7 +110,12 @@ describe("cropFrame — ImageData (browser RGBA) path", () => {
     const h = 3;
     const data = new Uint8ClampedArray(w * h * 4);
     for (let i = 0; i < data.length; i++) data[i] = i;
-    const imageData = { data, width: w, height: h, colorSpace: "srgb" } as ImageData;
+    const imageData = {
+      data,
+      width: w,
+      height: h,
+      colorSpace: "srgb",
+    } as ImageData;
 
     const out = cropFrame(imageData, [1, 0, 3, 2], 0);
     // ImageData result has no `channels` field and is RGBA (4 lanes/pixel).

--- a/tests/video/crop-backend.test.ts
+++ b/tests/video/crop-backend.test.ts
@@ -55,9 +55,17 @@ class FakeBackend implements VideoBackend {
 describe("CropVideoBackend.wrap — flatten matrix (WRAP LAW)", () => {
   it("flattens crop-of-crop when fills agree AND outer is in-bounds", () => {
     const inner = new FakeBackend(100, 100);
-    const c1 = CropVideoBackend.wrap({ inner, crop: [10, 20, 60, 70], fill: 0 });
+    const c1 = CropVideoBackend.wrap({
+      inner,
+      crop: [10, 20, 60, 70],
+      fill: 0,
+    });
     // Outer in-bounds of the inner cropped frame (50x50): [5,5,25,25].
-    const c2 = CropVideoBackend.wrap({ inner: c1, crop: [5, 5, 25, 25], fill: 0 });
+    const c2 = CropVideoBackend.wrap({
+      inner: c1,
+      crop: [5, 5, 25, 25],
+      fill: 0,
+    });
 
     // Composed source rect = (10+5, 20+5, 10+25, 20+25) = (15,25,35,45).
     expect(c2.crop).toEqual([15, 25, 35, 45]);
@@ -68,8 +76,16 @@ describe("CropVideoBackend.wrap — flatten matrix (WRAP LAW)", () => {
 
   it("NESTS when fills differ", () => {
     const inner = new FakeBackend(100, 100);
-    const c1 = CropVideoBackend.wrap({ inner, crop: [10, 20, 60, 70], fill: 0 });
-    const c2 = CropVideoBackend.wrap({ inner: c1, crop: [5, 5, 25, 25], fill: 99 });
+    const c1 = CropVideoBackend.wrap({
+      inner,
+      crop: [10, 20, 60, 70],
+      fill: 0,
+    });
+    const c2 = CropVideoBackend.wrap({
+      inner: c1,
+      crop: [5, 5, 25, 25],
+      fill: 99,
+    });
 
     // Different fills -> nest (inner stays the crop wrapper, outer rect unchanged).
     expect(c2.inner).toBe(c1);
@@ -79,9 +95,17 @@ describe("CropVideoBackend.wrap — flatten matrix (WRAP LAW)", () => {
 
   it("NESTS when the outer crop exceeds the inner cropped frame", () => {
     const inner = new FakeBackend(100, 100);
-    const c1 = CropVideoBackend.wrap({ inner, crop: [10, 20, 60, 70], fill: 0 });
+    const c1 = CropVideoBackend.wrap({
+      inner,
+      crop: [10, 20, 60, 70],
+      fill: 0,
+    });
     // Inner cropped frame is 50x50; outer x2=60 > 50 -> out of bounds -> nest.
-    const c2 = CropVideoBackend.wrap({ inner: c1, crop: [0, 0, 60, 30], fill: 0 });
+    const c2 = CropVideoBackend.wrap({
+      inner: c1,
+      crop: [0, 0, 60, 30],
+      fill: 0,
+    });
 
     expect(c2.inner).toBe(c1);
     expect(c2.inner instanceof CropVideoBackend).toBe(true);
@@ -90,14 +114,22 @@ describe("CropVideoBackend.wrap — flatten matrix (WRAP LAW)", () => {
 
   it("does not flatten a non-crop inner (just wraps)", () => {
     const inner = new FakeBackend(100, 100);
-    const c1 = CropVideoBackend.wrap({ inner, crop: [10, 20, 60, 70], fill: 0 });
+    const c1 = CropVideoBackend.wrap({
+      inner,
+      crop: [10, 20, 60, 70],
+      fill: 0,
+    });
     expect(c1.inner).toBe(inner);
     expect(c1.crop).toEqual([10, 20, 60, 70]);
   });
 
   it("truncates float crop bounds toward zero", () => {
     const inner = new FakeBackend(100, 100);
-    const c = CropVideoBackend.wrap({ inner, crop: [1.9, 2.9, 5.9, 6.9], fill: 0 });
+    const c = CropVideoBackend.wrap({
+      inner,
+      crop: [1.9, 2.9, 5.9, 6.9],
+      fill: 0,
+    });
     expect(c.crop).toEqual([1, 2, 5, 6]);
   });
 });
@@ -105,7 +137,11 @@ describe("CropVideoBackend.wrap — flatten matrix (WRAP LAW)", () => {
 describe("CropVideoBackend — shape math + delegated metadata", () => {
   it("reports a cropped [F, h, w, c] shape", () => {
     const inner = new FakeBackend(256, 192); // shape [1,192,256,1]
-    const c = CropVideoBackend.wrap({ inner, crop: [10, 20, 100, 80], fill: 0 });
+    const c = CropVideoBackend.wrap({
+      inner,
+      crop: [10, 20, 100, 80],
+      fill: 0,
+    });
     // h = 80-20 = 60, w = 100-10 = 90, F and C from inner.
     expect(c.shape).toEqual([1, 60, 90, 1]);
   });

--- a/tests/video/embedded-frame.test.ts
+++ b/tests/video/embedded-frame.test.ts
@@ -15,7 +15,11 @@ import {
   trimPaddedRow,
 } from "../../src/video/embedded-frame.js";
 import { Hdf5VideoBackend } from "../../src/video/hdf5-video.js";
-import { getH5Module, ensureH5StagingDir, openH5File } from "../../src/codecs/slp/h5.js";
+import {
+  getH5Module,
+  ensureH5StagingDir,
+  openH5File,
+} from "../../src/codecs/slp/h5.js";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -80,8 +84,15 @@ describe("embedded-frame helpers", () => {
   });
 
   it("rowSlice selects only the first dim", () => {
-    expect(rowSlice([3, 100], 1)).toEqual([[1, 2], [0, 100]]);
-    expect(rowSlice([3, 4, 5], 2)).toEqual([[2, 3], [0, 4], [0, 5]]);
+    expect(rowSlice([3, 100], 1)).toEqual([
+      [1, 2],
+      [0, 100],
+    ]);
+    expect(rowSlice([3, 4, 5], 2)).toEqual([
+      [2, 3],
+      [0, 4],
+      [0, 5],
+    ]);
   });
 
   it("computeOffsetsFromSizes is a cumulative sum", () => {
@@ -129,7 +140,12 @@ describe("readEmbeddedFrameBytes", () => {
     expect(out).not.toBeNull();
     expect(Array.from(out!)).toEqual([0x89, 0x50, 0x4e, 0x47, 0x01]);
     // Exactly one slice, targeting only row 1 — never the whole dataset.
-    expect(calls).toEqual([[[1, 2], [0, M]]]);
+    expect(calls).toEqual([
+      [
+        [1, 2],
+        [0, M],
+      ],
+    ]);
   });
 
   it("padded 2D: trims to frame_sizes[index] when present", async () => {
@@ -173,12 +189,18 @@ describe("readEmbeddedFrameBytes", () => {
       frameCount: 2, // == 2 -> vlen
       format: "png",
       onSlice: () => {
-        throw new Error("readSlice must not be called for vlen when readVlenElement exists");
+        throw new Error(
+          "readSlice must not be called for vlen when readVlenElement exists",
+        );
       },
       onVlenElement: (i) => blobs[i],
     });
-    expect(Array.from((await readEmbeddedFrameBytes(reader, 1))!)).toEqual([0x89, 0x50, 0x02]);
-    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual([0x89, 0x50, 0x01]);
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 1))!)).toEqual([
+      0x89, 0x50, 0x02,
+    ]);
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual([
+      0x89, 0x50, 0x01,
+    ]);
     expect(vlenCalls).toEqual([1, 0]);
     expect(calls.length).toBe(0); // no hyperslab slice, no whole read
   });
@@ -187,19 +209,28 @@ describe("readEmbeddedFrameBytes", () => {
     // When the backend can't do the manual read (no Module access), the vlen
     // layout falls back to a single whole-dataset read + cache — never the
     // crashing per-element hyperslab slice.
-    const blobs = [int8([0x89, 0x50, 0x01]), int8([0x89, 0x50, 0x02]), int8([0x89, 0x50, 0x03])];
+    const blobs = [
+      int8([0x89, 0x50, 0x01]),
+      int8([0x89, 0x50, 0x02]),
+      int8([0x89, 0x50, 0x03]),
+    ];
     const { reader, calls } = fakeReader({
       shape: [3],
       frameCount: 3, // == length -> vlen
       format: "png",
       onSlice: (slice) => {
         // Only the whole-dataset read (no slice arg) is allowed.
-        if (slice !== undefined) throw new Error("vlen fallback must not sub-slice");
+        if (slice !== undefined)
+          throw new Error("vlen fallback must not sub-slice");
         return blobs;
       },
     });
-    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual([0x89, 0x50, 0x01]);
-    expect(Array.from((await readEmbeddedFrameBytes(reader, 2))!)).toEqual([0x89, 0x50, 0x03]);
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual([
+      0x89, 0x50, 0x01,
+    ]);
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 2))!)).toEqual([
+      0x89, 0x50, 0x03,
+    ]);
     expect(calls).toEqual([undefined]); // whole read exactly once, then cached
   });
 
@@ -251,8 +282,12 @@ describe("readEmbeddedFrameBytes", () => {
         return whole; // TypedArray -> magic-scan branch
       },
     });
-    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual(Array.from(frameA));
-    expect(Array.from((await readEmbeddedFrameBytes(reader, 1))!)).toEqual(Array.from(frameB));
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 0))!)).toEqual(
+      Array.from(frameA),
+    );
+    expect(Array.from((await readEmbeddedFrameBytes(reader, 1))!)).toEqual(
+      Array.from(frameB),
+    );
     expect(calls.length).toBe(1); // read whole once, cached
   });
 });
@@ -312,7 +347,11 @@ function fakeModule(blobs: Uint8Array[]): {
 }
 
 describe("readVlenElementManual", () => {
-  const vlenDs = { file_id: 0, path: "/video0/video", metadata: { size: 8, type: 9 } };
+  const vlenDs = {
+    file_id: 0,
+    path: "/video0/video",
+    metadata: { size: 8, type: 9 },
+  };
 
   it("reads one element, copies the bytes, and frees the inner blob + struct", () => {
     const blobs = [
@@ -343,9 +382,21 @@ describe("readVlenElementManual", () => {
   it("returns null (falls back) when not a wasm32 vlen dataset", () => {
     const { Module } = fakeModule([Uint8Array.from([1, 2, 3])]);
     // Wrong hvl_t size.
-    expect(readVlenElementManual(Module, { file_id: 0, path: "x", metadata: { size: 16, type: 9 } }, 0)).toBeNull();
+    expect(
+      readVlenElementManual(
+        Module,
+        { file_id: 0, path: "x", metadata: { size: 16, type: 9 } },
+        0,
+      ),
+    ).toBeNull();
     // Not the vlen datatype class (and vlen flag false).
-    expect(readVlenElementManual(Module, { file_id: 0, path: "x", metadata: { size: 8, type: 0 } }, 0)).toBeNull();
+    expect(
+      readVlenElementManual(
+        Module,
+        { file_id: 0, path: "x", metadata: { size: 8, type: 0 } },
+        0,
+      ),
+    ).toBeNull();
     // No Module.
     expect(readVlenElementManual(null, vlenDs, 0)).toBeNull();
   });
@@ -399,12 +450,16 @@ async function makePaddedFixture(frames: Uint8Array[]): Promise<{
  * not whole-dataset reads — is used. frame_numbers/frame_sizes are passed
  * through unwrapped (the backend reads those eagerly and small).
  */
-function wrapWithSpy(rf: any, close: () => void): { file: any; spy: { value: number; slice: number } } {
+function wrapWithSpy(
+  rf: any,
+  close: () => void,
+): { file: any; spy: { value: number; slice: number } } {
   const spy = { value: 0, slice: 0 };
   const file = {
     get(p: string) {
       const ds = rf.get(p);
-      if (!ds || p.endsWith("frame_numbers") || p.endsWith("frame_sizes")) return ds;
+      if (!ds || p.endsWith("frame_numbers") || p.endsWith("frame_sizes"))
+        return ds;
       return new Proxy(ds, {
         get(target, prop, recv) {
           if (prop === "value") {
@@ -457,9 +512,17 @@ describe("Hdf5VideoBackend single-frame slicing (2D padded)", () => {
     // A JPEG payload that contains the 3-byte JPEG magic (FF D8 FF) mid-stream,
     // which would defeat the old magic-byte scan but is irrelevant to slicing.
     const frame = Uint8Array.from([
-      0xff, 0xd8, 0xff, 0xe0, // SOI + APP0
-      0x12, 0xff, 0xd8, 0xff, 0x34, // embedded false-positive magic
-      0xff, 0xd9, // EOI
+      0xff,
+      0xd8,
+      0xff,
+      0xe0, // SOI + APP0
+      0x12,
+      0xff,
+      0xd8,
+      0xff,
+      0x34, // embedded false-positive magic
+      0xff,
+      0xd9, // EOI
     ]);
     const { file, spy } = await makePaddedFixture([frame]);
 
@@ -495,8 +558,12 @@ describe("Hdf5VideoBackend single-frame slicing (2D padded)", () => {
       channelOrder: "RGB",
     });
 
-    expect(Array.from((await backend.getFrame(20)) as Uint8Array)).toEqual(Array.from(frame20));
-    expect(Array.from((await backend.getFrame(10)) as Uint8Array)).toEqual(Array.from(frame10));
+    expect(Array.from((await backend.getFrame(20)) as Uint8Array)).toEqual(
+      Array.from(frame20),
+    );
+    expect(Array.from((await backend.getFrame(10)) as Uint8Array)).toEqual(
+      Array.from(frame10),
+    );
     expect(await backend.getFrame(15)).toBeNull(); // not an embedded frame number
     expect(spy.value).toBe(0);
 
@@ -506,11 +573,15 @@ describe("Hdf5VideoBackend single-frame slicing (2D padded)", () => {
 
 describe("Hdf5VideoBackend frame reads (real vlen pkg.slp)", () => {
   it("reads a vlen element via the manual hvl_t path — neither slice() nor value", async () => {
-    const bytes = fs.readFileSync(path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"));
+    const bytes = fs.readFileSync(
+      path.join(fixtureRoot, "slp", "minimal_instance.pkg.slp"),
+    );
     const { file: rawFile, close } = await openH5File(new Uint8Array(bytes));
     const { file, spy } = wrapWithSpy(rawFile, close);
 
-    const frameNumbers = Array.from(rawFile.get("video0/frame_numbers").value).map((v: any) => Number(v));
+    const frameNumbers = Array.from(
+      rawFile.get("video0/frame_numbers").value,
+    ).map((v: any) => Number(v));
     const backend = new Hdf5VideoBackend({
       filename: ".",
       file,
@@ -531,9 +602,15 @@ describe("Hdf5VideoBackend frame reads (real vlen pkg.slp)", () => {
 
     // Byte-for-byte identical to the same element from the safe whole-dataset read.
     const whole = rawFile.get("video0/video").value as Int8Array[];
-    const ref = new Uint8Array(whole[0].buffer, whole[0].byteOffset, whole[0].length);
+    const ref = new Uint8Array(
+      whole[0].buffer,
+      whole[0].byteOffset,
+      whole[0].length,
+    );
     expect(out.length).toBe(ref.length);
-    expect(Array.from(out.subarray(0, 16))).toEqual(Array.from(ref.subarray(0, 16)));
+    expect(Array.from(out.subarray(0, 16))).toEqual(
+      Array.from(ref.subarray(0, 16)),
+    );
 
     file._close();
   });
@@ -546,7 +623,9 @@ describe("Hdf5VideoBackend frame reads (real vlen pkg.slp)", () => {
   // does not. This is the regression guard for the N>1 case that minimal_instance
   // (N=1) can't cover, since a 1-element slice happens to select the whole dataset.
   it("multi-frame (N>1) vlen: reads every frame via the manual path, byte-identical, flat heap", async () => {
-    const bytes = fs.readFileSync(path.join(fixtureRoot, "slp", "vlen_multiframe.pkg.slp"));
+    const bytes = fs.readFileSync(
+      path.join(fixtureRoot, "slp", "vlen_multiframe.pkg.slp"),
+    );
     const { file: rawFile, close } = await openH5File(new Uint8Array(bytes));
     const { file, spy } = wrapWithSpy(rawFile, close);
 
@@ -555,7 +634,9 @@ describe("Hdf5VideoBackend frame reads (real vlen pkg.slp)", () => {
     expect(ds.metadata.size).toBe(8); // wasm32 hvl_t
     const whole = ds.value as Int8Array[]; // safe whole-read ground truth (off the raw file)
 
-    const frameNumbers = Array.from(rawFile.get("video0/frame_numbers").value).map((v: any) => Number(v));
+    const frameNumbers = Array.from(
+      rawFile.get("video0/frame_numbers").value,
+    ).map((v: any) => Number(v));
     const backend = new Hdf5VideoBackend({
       filename: ".",
       file,
@@ -569,13 +650,19 @@ describe("Hdf5VideoBackend frame reads (real vlen pkg.slp)", () => {
     // the whole-read — and NO abort (the whole point of the fix).
     for (let i = 0; i < frameNumbers.length; i++) {
       const out = (await backend.getFrame(frameNumbers[i])) as Uint8Array;
-      const ref = new Uint8Array(whole[i].buffer, whole[i].byteOffset, whole[i].length);
+      const ref = new Uint8Array(
+        whole[i].buffer,
+        whole[i].byteOffset,
+        whole[i].length,
+      );
       expect(Array.from(out.subarray(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
       expect(out.length).toBe(ref.length);
       expect(Array.from(out)).toEqual(Array.from(ref));
     }
     // Per-element lengths genuinely vary (it is vlen, not 2D-padded/concat).
-    expect([...new Set(frameNumbers.map((_, i) => whole[i].length))].length).toBeGreaterThan(1);
+    expect(
+      [...new Set(frameNumbers.map((_, i) => whole[i].length))].length,
+    ).toBeGreaterThan(1);
 
     // The crashing high-level slice() is never called, and the whole vlen dataset
     // is never read through the backend — only the manual per-element read.
@@ -587,7 +674,8 @@ describe("Hdf5VideoBackend frame reads (real vlen pkg.slp)", () => {
     // whole-dataset read on the hot path).
     const mod: any = await getH5Module();
     const heap0 = mod.Module.HEAPU8.byteLength;
-    for (let r = 0; r < 300; r++) await backend.getFrame(frameNumbers[r % frameNumbers.length]);
+    for (let r = 0; r < 300; r++)
+      await backend.getFrame(frameNumbers[r % frameNumbers.length]);
     expect(mod.Module.HEAPU8.byteLength).toBe(heap0);
 
     file._close();

--- a/tests/video/factory-imagevideo.test.ts
+++ b/tests/video/factory-imagevideo.test.ts
@@ -11,7 +11,7 @@ import { setImageBytesReader } from "../../src/video/image-source.js";
 async function makePng(
   w: number,
   h: number,
-  rgb: [number, number, number]
+  rgb: [number, number, number],
 ): Promise<Uint8Array> {
   const sc = await import("skia-canvas");
   const canvas = new sc.Canvas(w, h);

--- a/tests/video/factory.test.ts
+++ b/tests/video/factory.test.ts
@@ -22,9 +22,16 @@ describe("createVideoBackend", () => {
   beforeEach(() => {
     // Mock browser globals for WebCodecs detection
     (globalThis as any).window = globalThis;
-    (globalThis as any).document = { createElement: vi.fn(() => ({})), head: { appendChild: vi.fn() } };
-    globalThis.VideoDecoder = { isConfigSupported: async () => ({ supported: true }) } as any;
-    globalThis.EncodedVideoChunk = class { constructor() {} } as any;
+    (globalThis as any).document = {
+      createElement: vi.fn(() => ({})),
+      head: { appendChild: vi.fn() },
+    };
+    globalThis.VideoDecoder = {
+      isConfigSupported: async () => ({ supported: true }),
+    } as any;
+    globalThis.EncodedVideoChunk = class {
+      constructor() {}
+    } as any;
     (globalThis as any).createImageBitmap = async () => ({ close() {} });
     vi.resetModules();
   });
@@ -40,7 +47,9 @@ describe("createVideoBackend", () => {
 
   it("selects MediaBunny for .webm files", async () => {
     const { createVideoBackend } = await import("../../src/video/factory.js");
-    await expect(createVideoBackend("video.webm")).rejects.toThrow(/MediaBunny/);
+    await expect(createVideoBackend("video.webm")).rejects.toThrow(
+      /MediaBunny/,
+    );
   });
 
   it("selects MediaBunny for .mkv files", async () => {
@@ -52,7 +61,7 @@ describe("createVideoBackend", () => {
     const { createVideoBackend } = await import("../../src/video/factory.js");
     // Forcing mediabunny on an mp4 should attempt MediaBunny, not Mp4Box
     await expect(
-      createVideoBackend("video.mp4", { backend: "mediabunny" })
+      createVideoBackend("video.mp4", { backend: "mediabunny" }),
     ).rejects.toThrow(/MediaBunny/);
   });
 
@@ -67,7 +76,7 @@ describe("createVideoBackend", () => {
     const { createVideoBackend } = await import("../../src/video/factory.js");
     const file = new File([new Blob(["fake"])], "clip.mp4");
     await expect(
-      createVideoBackend(file, { backend: "mediabunny" })
+      createVideoBackend(file, { backend: "mediabunny" }),
     ).rejects.toThrow(/MediaBunny/);
   });
 
@@ -93,7 +102,9 @@ describe("createVideoBackend", () => {
         caught = e;
       }
       expect(caught).toBeInstanceOf(UnsupportedVideoFormatError);
-      expect((caught as InstanceType<typeof UnsupportedVideoFormatError>).extension).toBe(ext);
+      expect(
+        (caught as InstanceType<typeof UnsupportedVideoFormatError>).extension,
+      ).toBe(ext);
       // Traceable, not an opaque MediaBunny mid-decode failure; points at MP4.
       expect((caught as Error).message).not.toMatch(/MediaBunny/);
       expect((caught as Error).message).toMatch(/MP4/);
@@ -105,7 +116,9 @@ describe("createVideoBackend", () => {
       "../../src/video/factory.js"
     );
     const file = new File([new Blob(["fake"])], "clip.avi");
-    await expect(createVideoBackend(file)).rejects.toThrow(UnsupportedVideoFormatError);
+    await expect(createVideoBackend(file)).rejects.toThrow(
+      UnsupportedVideoFormatError,
+    );
   });
 
   it("honors an explicit backend override for unsupported extensions (escape hatch)", async () => {
@@ -113,7 +126,7 @@ describe("createVideoBackend", () => {
     // Forcing a backend bypasses the unsupported-format guard, so this attempts
     // MediaBunny (mock throws /MediaBunny/) rather than UnsupportedVideoFormatError.
     await expect(
-      createVideoBackend("clip.avi", { backend: "mediabunny" })
+      createVideoBackend("clip.avi", { backend: "mediabunny" }),
     ).rejects.toThrow(/MediaBunny/);
   });
 });

--- a/tests/video/image-decode.test.ts
+++ b/tests/video/image-decode.test.ts
@@ -14,7 +14,7 @@ import { decodeEncoded } from "../../src/video/image-decode.js";
 async function makePng(
   w: number,
   h: number,
-  rgb: [number, number, number]
+  rgb: [number, number, number],
 ): Promise<Uint8Array> {
   const sc = await import("skia-canvas");
   const canvas = new sc.Canvas(w, h);

--- a/tests/video/image-video-cache.test.ts
+++ b/tests/video/image-video-cache.test.ts
@@ -15,7 +15,7 @@ import path from "node:path";
 import fs from "node:fs";
 
 const jpgPath = fileURLToPath(
-  new URL("../data/videos/imgs/img.00.jpg", import.meta.url)
+  new URL("../data/videos/imgs/img.00.jpg", import.meta.url),
 );
 const realJpg = new Uint8Array(fs.readFileSync(jpgPath));
 

--- a/tests/video/image-video-prefetch.test.ts
+++ b/tests/video/image-video-prefetch.test.ts
@@ -12,8 +12,8 @@ import fs from "node:fs";
 
 const realJpg = new Uint8Array(
   fs.readFileSync(
-    fileURLToPath(new URL("../data/videos/imgs/img.00.jpg", import.meta.url))
-  )
+    fileURLToPath(new URL("../data/videos/imgs/img.00.jpg", import.meta.url)),
+  ),
 );
 const names = (n: number) => Array.from({ length: n }, (_, i) => `img${i}.jpg`);
 
@@ -58,10 +58,19 @@ describe("ImageVideoBackend.prefetch (mechanism)", () => {
       active--;
       return realJpg;
     };
-    return { reader, reads, get maxActive() { return maxActive; } };
+    return {
+      reader,
+      reads,
+      get maxActive() {
+        return maxActive;
+      },
+    };
   }
 
-  async function make(t: { reader: (p: string) => Promise<Uint8Array> }, opts = {}) {
+  async function make(
+    t: { reader: (p: string) => Promise<Uint8Array> },
+    opts = {},
+  ) {
     return ImageVideoBackend.create({
       filename: names(50),
       shape: [50, 8, 8, 3],
@@ -80,7 +89,10 @@ describe("ImageVideoBackend.prefetch (mechanism)", () => {
     const t = trackingReader();
     const be = await make(t);
     await be.prefetch([2, 4, 6]);
-    expect(t.reads.filter((p) => ["img2.jpg", "img4.jpg", "img6.jpg"].includes(p)).length).toBe(3);
+    expect(
+      t.reads.filter((p) => ["img2.jpg", "img4.jpg", "img6.jpg"].includes(p))
+        .length,
+    ).toBe(3);
     // Now getFrame(4) must NOT trigger another read (bytes already cached).
     const before = t.reads.length;
     await be.getFrame(4);

--- a/tests/video/image-video.test.ts
+++ b/tests/video/image-video.test.ts
@@ -16,7 +16,7 @@ import { ImageVideoBackend } from "../../src/video/image-video.js";
 async function makePng(
   w: number,
   h: number,
-  rgb: [number, number, number]
+  rgb: [number, number, number],
 ): Promise<Uint8Array> {
   const sc = await import("skia-canvas");
   const canvas = new sc.Canvas(w, h);
@@ -54,7 +54,10 @@ describe("ImageVideoBackend", () => {
   it("reports C=1 for a grayscale first frame (Python detect_grayscale parity)", async () => {
     const gray = await makePng(2, 2, [128, 128, 128]);
     const { fn } = stubReader({ "g.png": gray });
-    const be = await ImageVideoBackend.create({ filename: ["g.png"], reader: fn });
+    const be = await ImageVideoBackend.create({
+      filename: ["g.png"],
+      reader: fn,
+    });
     expect(be.shape).toEqual([1, 2, 2, 1]);
   });
 
@@ -75,7 +78,10 @@ describe("ImageVideoBackend", () => {
   it("returns null for an out-of-range frame index", async () => {
     const red = await makePng(2, 2, [255, 0, 0]);
     const { fn } = stubReader({ "0.png": red });
-    const be = await ImageVideoBackend.create({ filename: ["0.png"], reader: fn });
+    const be = await ImageVideoBackend.create({
+      filename: ["0.png"],
+      reader: fn,
+    });
     expect(await be.getFrame(1)).toBeNull();
     expect(await be.getFrame(-1)).toBeNull();
   });
@@ -83,7 +89,10 @@ describe("ImageVideoBackend", () => {
   it("caches decoded frames (reader hit once per index)", async () => {
     const red = await makePng(2, 2, [255, 0, 0]);
     const { fn, reads } = stubReader({ "0.png": red });
-    const be = await ImageVideoBackend.create({ filename: ["0.png"], reader: fn });
+    const be = await ImageVideoBackend.create({
+      filename: ["0.png"],
+      reader: fn,
+    });
     await be.getFrame(0);
     await be.getFrame(0);
     // One read for the shape probe + at most one for the frame; never re-read.

--- a/tests/video/mediabunny-integration.test.ts
+++ b/tests/video/mediabunny-integration.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "../bun-test";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-const WEBM_PATH = resolve(__dirname, "../data/videos/centered_pair_low_quality.webm");
+const WEBM_PATH = resolve(
+  __dirname,
+  "../data/videos/centered_pair_low_quality.webm",
+);
 
 describe("MediaBunnyVideoBackend integration (real WebM file)", () => {
   beforeEach(() => {

--- a/tests/video/mp4box-backend.test.ts
+++ b/tests/video/mp4box-backend.test.ts
@@ -65,32 +65,43 @@ function createMp4BoxMock() {
 }
 
 function createFetchMock(supportsRange = true) {
-  return vi.fn(async (_url: string, options?: { method?: string; headers?: Record<string, string> }) => {
-    if (options?.headers?.Range) {
-      if (supportsRange) {
+  return vi.fn(
+    async (
+      _url: string,
+      options?: { method?: string; headers?: Record<string, string> },
+    ) => {
+      if (options?.headers?.Range) {
+        if (supportsRange) {
+          return {
+            ok: true,
+            status: 206,
+            headers: {
+              get(name: string) {
+                return name.toLowerCase() === "content-range"
+                  ? "bytes 0-0/1024"
+                  : null;
+              },
+            },
+            arrayBuffer: async () => new ArrayBuffer(1),
+          } as any;
+        }
         return {
           ok: true,
-          status: 206,
+          status: 200,
           headers: {
-            get(name: string) {
-              return name.toLowerCase() === "content-range" ? "bytes 0-0/1024" : null;
+            get() {
+              return null;
             },
           },
-          arrayBuffer: async () => new ArrayBuffer(1),
+          blob: async () => new Blob([new Uint8Array(16)]),
         } as any;
       }
       return {
         ok: true,
-        status: 200,
-        headers: { get() { return null; } },
         blob: async () => new Blob([new Uint8Array(16)]),
       } as any;
-    }
-    return {
-      ok: true,
-      blob: async () => new Blob([new Uint8Array(16)]),
-    } as any;
-  });
+    },
+  );
 }
 
 describe("Mp4BoxVideoBackend", () => {
@@ -108,7 +119,7 @@ describe("Mp4BoxVideoBackend", () => {
 
     (globalThis as any).window = globalThis;
     (globalThis as any).document = {
-      createElement: vi.fn(() => ({ })),
+      createElement: vi.fn(() => ({})),
       head: { appendChild: vi.fn() },
     };
 
@@ -165,7 +176,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("returns frame times sorted by CTS", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const backend = new Mp4BoxVideoBackend("https://example.com/video.mp4");
     const times = await backend.getFrameTimes();
     expect(times).toEqual([0, 1, 2]);
@@ -174,7 +187,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("selects mp4box backend for mp4 files", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const { createVideoBackend } = await import("../../src/video/factory.js");
     const backend = await createVideoBackend("https://example.com/video.mp4");
     expect(backend).toBeInstanceOf(Mp4BoxVideoBackend);
@@ -185,7 +200,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("accepts a Blob source without calling fetch", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const blob = new Blob([new Uint8Array(16)]);
     const backend = new Mp4BoxVideoBackend(blob);
     const times = await backend.getFrameTimes();
@@ -195,8 +212,12 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("accepts a File source without calling fetch", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
-    const file = new File([new Uint8Array(16)], "test.mp4", { type: "video/mp4" });
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
+    const file = new File([new Uint8Array(16)], "test.mp4", {
+      type: "video/mp4",
+    });
     const backend = new Mp4BoxVideoBackend(file);
     const times = await backend.getFrameTimes();
     expect(times).toEqual([0, 1, 2]);
@@ -207,7 +228,9 @@ describe("Mp4BoxVideoBackend", () => {
 
   it("falls back to blob when range requests are not supported", async () => {
     globalThis.fetch = createFetchMock(false) as any;
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const backend = new Mp4BoxVideoBackend("https://example.com/video.mp4");
     const times = await backend.getFrameTimes();
     expect(times).toEqual([0, 1, 2]);
@@ -215,7 +238,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("does not send HEAD requests", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const backend = new Mp4BoxVideoBackend("https://example.com/video.mp4");
     await backend.getFrameTimes();
     const calls = (globalThis.fetch as any).mock.calls;
@@ -225,7 +250,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("cache hit returns immediately without decoding", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const backend = new Mp4BoxVideoBackend("https://example.com/video.mp4");
     await backend.getFrameTimes();
 
@@ -238,7 +265,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("concurrent getFrame calls all resolve without hanging", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const blob = new Blob([new Uint8Array(16)]);
     const backend = new Mp4BoxVideoBackend(blob);
     const results = await Promise.all([
@@ -252,7 +281,9 @@ describe("Mp4BoxVideoBackend", () => {
 
   it("rapid sequential calls only decode the latest frame", async () => {
     let decodeRangeCallCount = 0;
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const blob = new Blob([new Uint8Array(16)]);
     const backend = new Mp4BoxVideoBackend(blob);
     await backend.getFrameTimes();
@@ -274,7 +305,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("AbortSignal cancels decode before it starts", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const blob = new Blob([new Uint8Array(16)]);
     const backend = new Mp4BoxVideoBackend(blob);
     const controller = new AbortController();
@@ -285,7 +318,9 @@ describe("Mp4BoxVideoBackend", () => {
   });
 
   it("returns null for out-of-range frame indices", async () => {
-    const { Mp4BoxVideoBackend } = await import("../../src/video/mp4box-video.js");
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
     const blob = new Blob([new Uint8Array(16)]);
     const backend = new Mp4BoxVideoBackend(blob);
     expect(await backend.getFrame(-1)).toBeNull();

--- a/tests/video/seq.test.ts
+++ b/tests/video/seq.test.ts
@@ -155,7 +155,7 @@ function fakeJpeg(len: number, seed: number): Uint8Array {
 async function encodePng(
   width: number,
   height: number,
-  rgb: [number, number, number]
+  rgb: [number, number, number],
 ): Promise<Uint8Array> {
   const sc = await import("skia-canvas");
   const canvas = new sc.Canvas(width, height);
@@ -169,7 +169,7 @@ async function encodePng(
 async function encodeJpeg(
   width: number,
   height: number,
-  rgb: [number, number, number]
+  rgb: [number, number, number],
 ): Promise<Uint8Array> {
   const sc = await import("skia-canvas");
   const canvas = new sc.Canvas(width, height);
@@ -180,12 +180,17 @@ async function encodeJpeg(
   return new Uint8Array(buf);
 }
 
-function px(img: ImageData, x: number, y: number): [number, number, number, number] {
+function px(
+  img: ImageData,
+  x: number,
+  y: number,
+): [number, number, number, number] {
   const i = (y * img.width + x) * 4;
   return [img.data[i], img.data[i + 1], img.data[i + 2], img.data[i + 3]];
 }
 
-const blobOf = (bytes: Uint8Array): Blob => new Blob([bytes.buffer as ArrayBuffer]);
+const blobOf = (bytes: Uint8Array): Blob =>
+  new Blob([bytes.buffer as ArrayBuffer]);
 
 // ---------------------------------------------------------------------------
 // Header
@@ -412,8 +417,8 @@ describe("SeqVideoBackend — fps", () => {
           fps: 5, // header fps deliberately wrong
           frames,
           timestamps,
-        })
-      )
+        }),
+      ),
     );
     expect(be.fps).toBeCloseTo(100, 1);
     be.close();
@@ -437,8 +442,8 @@ describe("SeqVideoBackend — fps", () => {
           fps: 5,
           frames,
           timestamps,
-        })
-      )
+        }),
+      ),
     );
     expect(be.numFrames).toBe(150);
     expect(be.fps).toBeCloseTo(100, 1);
@@ -456,8 +461,8 @@ describe("SeqVideoBackend — fps", () => {
           fps: 24,
           frames: [new Uint8Array([0])],
           timestamps: [{ sec: 1, ms: 0 }],
-        })
-      )
+        }),
+      ),
     );
     expect(be.fps).toBe(24);
     be.close();
@@ -483,8 +488,8 @@ describe("SeqVideoBackend — fps", () => {
           fps: 7,
           frames,
           timestamps,
-        })
-      )
+        }),
+      ),
     );
     expect(be.fps).toBe(7);
     be.close();
@@ -586,7 +591,9 @@ describe("SeqVideoBackend — errors", () => {
       payloads: [fakeJpeg(20, 1)],
       timestamps: [{ sec: 1, ms: 0 }],
     });
-    await expect(SeqVideoBackend.create(blobOf(bytes))).rejects.toThrow("Bayer");
+    await expect(SeqVideoBackend.create(blobOf(bytes))).rejects.toThrow(
+      "Bayer",
+    );
   });
 
   it("rejects a missing file path", async () => {


### PR DESCRIPTION
## What

The deferred follow-up to #177. That PR added Biome as a **lint-only** tool with `formatter.enabled: false`. This PR flips it to `true` and applies the formatter across `src/` and `tests/` in a single pass.

## Nature of the diff

**Mechanical and behavior-preserving** — pure `biome format` output, no logic changes. The large line count (+8.4k / −2.3k across 144 files) is entirely reflow + trailing commas to Biome's style: 2-space indent, **80-column** width, double quotes, semicolons, trailing commas.

## How to review

- Read **`biome.json`** (the one-line `formatter.enabled` flip) and **`CONTRIBUTING.md`** (formatter now documented as active).
- The remaining 144 files are deterministic formatter output — `git checkout main -- src tests && bun run format` reproduces them exactly. No need to read line-by-line.

## Verification (all green locally)

`tsc` · `bun run check` (lint **+ formatting**) · `tsup build` · `check:pack` (🟢 esm-only) · **1560 pass / 1 skip / 0 fail**

## `git blame` hygiene

`.git-blame-ignore-revs` is included so `git blame` skips this bulk reformat. ⚠️ **Because this lands via squash-merge, the commit hash isn't known until after merge** — the file currently has a documented placeholder. Right after you squash-merge, I'll push a one-line follow-up adding the squash commit's hash (or say the word and I'll set it up however you prefer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)