### PR TITLE
chore: record Biome reformat commit in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,5 +4,5 @@
 #   git config blame.ignoreRevsFile .git-blame-ignore-revs
 # (GitHub applies this file automatically in its blame view.)
 #
-# Enable Biome formatter + reformat src/ and tests/.
-# The squash-merge commit hash is added here once this PR lands on main:
+# style: enable Biome formatter and reformat src + tests (#178)
+1fb4619d7bb736184c736635877efc2a7b25af17


### PR DESCRIPTION
One-line follow-up to #178: fills in the squash-merge SHA of the whole-tree Biome reformat (`1fb4619`) in `.git-blame-ignore-revs` so `git blame` skips it. This had to be separate because the squash commit hash only existed after #178 landed.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)