### PR TITLE
fix(render): auto-draw + track-color segmentation masks

### DIFF
--- a/src/rendering/overlays.ts
+++ b/src/rendering/overlays.ts
@@ -719,7 +719,11 @@ function isROI(value: unknown): value is ROI {
  * @param image - RGBA ImageData, mutated in place.
  * @param overlay - A LabelImage, or a list of SegmentationMask / ROI / BoundingBox.
  * @param opts - `alpha` (0.3), `palette` ("distinct"), `outline` (false),
- *   `outlineWidth` (1), `outlineColor` (null).
+ *   `outlineWidth` (1), `outlineColor` (null), plus optional per-element
+ *   `colors` for a list overlay. When `colors` is provided it overrides the
+ *   positional `palette` coloring (used by callers to color overlays by track
+ *   identity); it must match the overlay length and is ignored for label
+ *   images. Mirrors Python `_apply_overlay` (core.py L473-566, PR #470).
  * @returns The same ImageData.
  */
 export function applyOverlay(
@@ -736,6 +740,7 @@ export function applyOverlay(
     outline?: boolean;
     outlineWidth?: number;
     outlineColor?: RGB | null;
+    colors?: RGB[] | null;
   },
 ): ImageData {
   const alpha = clampAlpha(opts?.alpha ?? 0.3);
@@ -743,6 +748,7 @@ export function applyOverlay(
   const outline = opts?.outline ?? false;
   const outlineWidth = opts?.outlineWidth ?? 1;
   const outlineColor = opts?.outlineColor ?? null;
+  const explicitColors = opts?.colors ?? null;
 
   // Single LabelImage (or raw Int32Array-backed) overlay.
   if (!Array.isArray(overlay)) {
@@ -772,7 +778,8 @@ export function applyOverlay(
     );
   }
 
-  const colors = getPalette(palette, overlay.length);
+  // Explicit per-element colors (e.g. track-keyed) override positional palette.
+  const colors = explicitColors ?? getPalette(palette, overlay.length);
 
   if (isSegmentationMask(first)) {
     drawMasks(image, overlay as SegmentationMask[], { colors, alpha });

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -45,6 +45,9 @@ const DEFAULT_OPTIONS: Required<
     // `overlay` is absence-checked (undefined = no overlay), so it has no
     // default value; `overlayOutlineColor` is null by default below.
     | "overlay"
+    // `overlayTrackIndexMap` is absence-checked (null/undefined = derive from
+    // a Labels source), so it has no default value.
+    | "overlayTrackIndexMap"
   >
 > = {
   colorBy: "auto",
@@ -174,11 +177,30 @@ export async function renderImage(
 
   // Determine the color scheme up front (hoisted above the overlay block so
   // track-colored overlays can match the pose/centroid/trail track colors).
-  // Mirrors Python render_image (core.py L1183-1187, PR #470). `hasTracks` is
-  // instance-based here (consistent with the existing pose path); the overlay
-  // track-color gate below additionally requires a Labels source with tracks.
-  const hasTracks = instances.some((inst) => inst.track != null);
+  // Mirrors Python render_image (core.py L1183-1187, PR #470). For a Labels
+  // source, `hasTracks` is keyed off the project track list (core.py
+  // L1029/L1633: `has_tracks = len(source.tracks) > 0`), so a mask- or
+  // centroid-only tracked project still resolves color_by="auto" to "track".
+  // For a bare LabeledFrame / instance-array source there is no `.tracks`
+  // list, so fall back to the instance-based determination.
+  const hasTracks =
+    !Array.isArray(source) && "labeledFrames" in source
+      ? (source as Labels).tracks.length > 0
+      : instances.some((inst) => inst.track != null);
   const colorScheme = determineColorScheme(opts.colorBy, hasTracks, true);
+
+  // The GLOBAL track -> index map to key track colors off (stable across
+  // frames). When renderVideo renders a bare per-frame LabeledFrame it passes
+  // its project-level map via `overlayTrackIndexMap`; this overrides the
+  // per-frame map (built from this frame's instance order) so both poses and
+  // overlay elements color by global track identity. Mirrors Python
+  // render_video `_track_idx_map` (core.py L1929-1934).
+  const globalTrackIndexMap: Map<Track, number> = opts.overlayTrackIndexMap
+    ? opts.overlayTrackIndexMap
+    : trackIndexMap;
+  const globalTracks: Track[] = opts.overlayTrackIndexMap
+    ? Array.from(opts.overlayTrackIndexMap.keys())
+    : tracks;
 
   // Apply the annotation overlay AFTER the background and BEFORE trails/poses,
   // mirroring Python render_image (core.py L1159-1180: overlay applied on the
@@ -195,27 +217,32 @@ export async function renderImage(
     // Color overlay elements (masks/ROIs/bboxes) by track identity when
     // color_by resolves to "track", matching poses/centroids/trails (same
     // `palette`). Otherwise fall through to positional `overlayPalette`
-    // coloring. Gated on a Labels source with tracks (track-less labels stay
-    // positional, mirroring Python `has_tracks` at render_video level). A
-    // single LabelImage overlay is not an array, so label images are skipped.
-    // Untracked elements fall back to the first palette color. Mirrors Python
-    // render_image (core.py L1216-1239, PR #470).
+    // coloring. A single LabelImage overlay is not an array, so label images
+    // are skipped. Untracked elements fall back to the first palette color.
+    // Mirrors Python render_image (core.py L1216-1239, PR #470).
+    //
+    // Track-color the overlay only when there is a GLOBAL track list to key
+    // off (a Labels source, or renderVideo's explicit `overlayTrackIndexMap`).
+    // A bare LabeledFrame / instance-array source with no project track list
+    // stays positional, matching Python `has_tracks` at the render_video level.
+    const trackColorable =
+      opts.overlayTrackIndexMap != null ||
+      (!Array.isArray(source) && "labeledFrames" in source);
     let overlayColors: RGB[] | null = null;
     if (
       colorScheme === "track" &&
-      !Array.isArray(source) &&
-      "labeledFrames" in source &&
-      tracks.length > 0 &&
+      trackColorable &&
+      globalTrackIndexMap.size > 0 &&
       Array.isArray(effectiveOverlay) &&
       effectiveOverlay.length > 0
     ) {
       const ovPal = getPalette(
         opts.palette as PaletteName,
-        Math.max(tracks.length, 1),
+        Math.max(globalTrackIndexMap.size, 1),
       );
       overlayColors = (effectiveOverlay as { track?: Track | null }[]).map(
         (el) => {
-          const tidx = el.track ? trackIndexMap.get(el.track) : undefined;
+          const tidx = el.track ? globalTrackIndexMap.get(el.track) : undefined;
           return tidx !== undefined ? ovPal[tidx % ovPal.length] : ovPal[0];
         },
       );
@@ -265,14 +292,15 @@ export async function renderImage(
   const edgeInds = skeleton?.edgeIndices ?? [];
   const nodeNames = skeleton?.nodeNames ?? [];
 
-  // Build color map
+  // Build color map. Pose track colors key off the global track map/list so
+  // they stay stable across frames (matches the overlay coloring above).
   const colors = buildColorMap(
     colorScheme,
     instances,
     nodeNames.length,
     opts.palette,
-    tracks,
-    trackIndexMap,
+    globalTracks,
+    globalTrackIndexMap,
   );
 
   // Create render context for callbacks
@@ -432,7 +460,7 @@ export async function renderImage(
     // Per-instance callback
     if (opts.perInstanceCallback) {
       const trackIdx = instance.track
-        ? (trackIndexMap.get(instance.track) ?? null)
+        ? (globalTrackIndexMap.get(instance.track) ?? null)
         : null;
       const instCtx = new InstanceContext(
         ctx as unknown as CanvasRenderingContext2D,

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -4,7 +4,13 @@ import type { Labels } from "../model/labels.js";
 import type { LabeledFrame } from "../model/labeled-frame.js";
 import type { Instance, PredictedInstance, Track } from "../model/instance.js";
 import type { Skeleton } from "../model/skeleton.js";
-import type { RenderOptions, RGB, ColorScheme, PaletteName } from "./types.js";
+import type {
+  RenderOptions,
+  RGB,
+  ColorScheme,
+  PaletteName,
+  Overlay,
+} from "./types.js";
 import {
   getPalette,
   resolveColor,
@@ -99,6 +105,19 @@ export async function renderImage(
   const { instances, skeleton, frameSize, frameIdx, tracks, trackIndexMap } =
     extractSourceData(source, opts);
 
+  // Auto-use the frame's segmentation masks as the overlay when no explicit
+  // overlay is given and the frame carries masks. Mirrors Python render_image
+  // (core.py L1142-1156): a segmentation-only frame still draws its masks. Only
+  // masks are auto-resolved here (not label images), and an explicit overlay
+  // always wins.
+  let effectiveOverlay: Overlay | undefined = opts.overlay ?? undefined;
+  if (effectiveOverlay == null && !Array.isArray(source)) {
+    const renderedFrame = renderedLabeledFrame(source);
+    if (renderedFrame && renderedFrame.masks.length > 0) {
+      effectiveOverlay = [...renderedFrame.masks];
+    }
+  }
+
   // Motion trails can contribute frames even when the current frame is empty
   // (past frames supply the trail), so they relax the "nothing to render" guard
   // for a Labels / LabeledFrame source. Mirrors Python PR #434.
@@ -153,6 +172,14 @@ export async function renderImage(
     ctx.fillRect(0, 0, scaledWidth, scaledHeight);
   }
 
+  // Determine the color scheme up front (hoisted above the overlay block so
+  // track-colored overlays can match the pose/centroid/trail track colors).
+  // Mirrors Python render_image (core.py L1183-1187, PR #470). `hasTracks` is
+  // instance-based here (consistent with the existing pose path); the overlay
+  // track-color gate below additionally requires a Labels source with tracks.
+  const hasTracks = instances.some((inst) => inst.track != null);
+  const colorScheme = determineColorScheme(opts.colorBy, hasTracks, true);
+
   // Apply the annotation overlay AFTER the background and BEFORE trails/poses,
   // mirroring Python render_image (core.py L1159-1180: overlay applied on the
   // base frame, before trails/centroids/poses).
@@ -164,20 +191,49 @@ export async function renderImage(
   // replicate that equivalent: read the canvas at source resolution, blend the
   // overlay in source space, then scale-composite back onto the (possibly
   // scaled) canvas. When `scale === 1` this is an in-place read/blend/write.
-  if (opts.overlay !== undefined && opts.overlay !== null) {
+  if (effectiveOverlay !== undefined && effectiveOverlay !== null) {
+    // Color overlay elements (masks/ROIs/bboxes) by track identity when
+    // color_by resolves to "track", matching poses/centroids/trails (same
+    // `palette`). Otherwise fall through to positional `overlayPalette`
+    // coloring. Gated on a Labels source with tracks (track-less labels stay
+    // positional, mirroring Python `has_tracks` at render_video level). A
+    // single LabelImage overlay is not an array, so label images are skipped.
+    // Untracked elements fall back to the first palette color. Mirrors Python
+    // render_image (core.py L1216-1239, PR #470).
+    let overlayColors: RGB[] | null = null;
+    if (
+      colorScheme === "track" &&
+      !Array.isArray(source) &&
+      "labeledFrames" in source &&
+      tracks.length > 0 &&
+      Array.isArray(effectiveOverlay) &&
+      effectiveOverlay.length > 0
+    ) {
+      const ovPal = getPalette(
+        opts.palette as PaletteName,
+        Math.max(tracks.length, 1),
+      );
+      overlayColors = (effectiveOverlay as { track?: Track | null }[]).map(
+        (el) => {
+          const tidx = el.track ? trackIndexMap.get(el.track) : undefined;
+          return tidx !== undefined ? ovPal[tidx % ovPal.length] : ovPal[0];
+        },
+      );
+    }
     const overlayOpts = {
       alpha: opts.overlayAlpha,
       palette: opts.overlayPalette,
       outline: opts.overlayOutline,
       outlineWidth: opts.overlayOutlineWidth,
       outlineColor: opts.overlayOutlineColor,
+      colors: overlayColors,
     };
     if (opts.scale === 1) {
       // Fast path: blend directly on the scaled canvas (== source resolution).
       const imageData = ctx.getImageData(0, 0, scaledWidth, scaledHeight);
       applyOverlay(
         imageData as unknown as ImageData,
-        opts.overlay,
+        effectiveOverlay,
         overlayOpts,
       );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -194,7 +250,7 @@ export async function renderImage(
       const imageData = srcCtx.getImageData(0, 0, width, height);
       applyOverlay(
         imageData as unknown as ImageData,
-        opts.overlay,
+        effectiveOverlay,
         overlayOpts,
       );
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -208,10 +264,6 @@ export async function renderImage(
   // Get skeleton info
   const edgeInds = skeleton?.edgeIndices ?? [];
   const nodeNames = skeleton?.nodeNames ?? [];
-
-  // Determine color scheme
-  const hasTracks = instances.some((inst) => inst.track != null);
-  const colorScheme = determineColorScheme(opts.colorBy, hasTracks, true);
 
   // Build color map
   const colors = buildColorMap(
@@ -411,6 +463,21 @@ export async function renderImage(
     scaledWidth,
     scaledHeight,
   ) as unknown as ImageData;
+}
+
+/**
+ * The single `LabeledFrame` that `renderImage` renders for a non-array source:
+ * the `LabeledFrame` itself, or a `Labels`' first labeled frame. Used to
+ * auto-resolve that frame's segmentation masks as the overlay. Returns
+ * `undefined` for an empty `Labels`.
+ */
+function renderedLabeledFrame(
+  source: Labels | LabeledFrame,
+): LabeledFrame | undefined {
+  if ("labeledFrames" in source) {
+    return (source as Labels).labeledFrames[0];
+  }
+  return source as LabeledFrame;
 }
 
 /**

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -105,6 +105,16 @@ export interface RenderOptions {
    * per render by `renderVideo` to avoid recomputing instance points.
    */
   trailPtsCache?: Map<Instance | PredictedInstance, number[][]>;
+  /**
+   * Advanced: global track -> index map used to color overlay elements
+   * (masks / ROIs / bboxes) by track identity under `colorBy: "track"`, keyed
+   * off the project's `Labels.tracks` (stable across frames). Populated by
+   * `renderVideo` so a bare per-frame `LabeledFrame` still gets GLOBAL
+   * track-identity overlay colors instead of per-frame positional colors
+   * (mirrors Python render_video `_track_idx_map`, fixing JS #162 flicker).
+   * For a `Labels` source this is derived automatically from `Labels.tracks`.
+   */
+  overlayTrackIndexMap?: Map<Track, number> | null;
 
   // Background
   background?: "transparent" | ColorSpec;

--- a/src/rendering/video.ts
+++ b/src/rendering/video.ts
@@ -84,6 +84,23 @@ export async function renderVideo(
       videoOverlay = videoLabelImages;
     }
   }
+  // Auto-use segmentation masks as overlay when no explicit overlay (and no
+  // label images) resolved. Masks live on specific frames at arbitrary frame
+  // indices, so resolve them per-frame via a callable keyed by the source frame
+  // index rather than a position-indexed list. label images take precedence
+  // (resolved above). Mirrors Python render_video (core.py L1572-1588).
+  if (
+    videoOverlay === undefined &&
+    !Array.isArray(source) &&
+    source.masks.length > 0
+  ) {
+    const targetVideo = selectedFrames[0].video;
+    const labels = source;
+    if (labels.getMasks({ video: targetVideo }).length > 0) {
+      videoOverlay = (frameIdx: number) =>
+        labels.getMasks({ video: targetVideo, frameIdx });
+    }
+  }
   const overlayForFrame = makeOverlayResolver(videoOverlay);
 
   // Build per-video temporal context for motion trails once (keyed by frame

--- a/src/rendering/video.ts
+++ b/src/rendering/video.ts
@@ -4,15 +4,17 @@ import type { ChildProcess } from "child_process";
 import type { Labels } from "../model/labels.js";
 import type { LabeledFrame } from "../model/labeled-frame.js";
 import type { Video } from "../model/video.js";
-import type { Instance, PredictedInstance } from "../model/instance.js";
+import type { Instance, PredictedInstance, Track } from "../model/instance.js";
 import type { LabelImage } from "../model/label-image.js";
 import type {
+  ColorScheme,
   Overlay,
   RenderOptions,
   VideoOptions,
   VideoOverlay,
 } from "./types.js";
 import { renderImage } from "./render.js";
+import { determineColorScheme } from "./colors.js";
 
 /**
  * Check if ffmpeg is available in PATH.
@@ -48,105 +50,10 @@ export async function renderVideo(
     );
   }
 
-  // Extract labeled frames
-  const frames = Array.isArray(source) ? source : source.labeledFrames;
-
-  // Apply frame selection
-  let selectedFrames = frames;
-  if (options.frameInds) {
-    selectedFrames = options.frameInds
-      .map((i) => frames[i])
-      .filter((f): f is LabeledFrame => f !== undefined);
-  } else if (options.start !== undefined || options.end !== undefined) {
-    const start = options.start ?? 0;
-    const end = options.end ?? frames.length;
-    selectedFrames = frames.slice(start, end);
-  }
-
-  if (selectedFrames.length === 0) {
-    throw new Error("No frames to render");
-  }
-
-  // Resolve the per-frame overlay parameter (mirrors Python render_video,
-  // core.py L1719-1754). Auto-detect: when no explicit overlay is given and a
-  // Labels source has label images for the rendered video, use them as a
-  // per-frame LabelImage[] (indexed by render position). Mirrors core.py
-  // L1549-1556.
-  let videoOverlay: VideoOverlay | undefined = options.overlay;
-  if (
-    videoOverlay === undefined &&
-    !Array.isArray(source) &&
-    source.labelImages.length > 0
-  ) {
-    const targetVideo = selectedFrames[0].video;
-    const videoLabelImages = source.getLabelImages({ video: targetVideo });
-    if (videoLabelImages.length > 0) {
-      videoOverlay = videoLabelImages;
-    }
-  }
-  // Auto-use segmentation masks as overlay when no explicit overlay (and no
-  // label images) resolved. Masks live on specific frames at arbitrary frame
-  // indices, so resolve them per-frame via a callable keyed by the source frame
-  // index rather than a position-indexed list. label images take precedence
-  // (resolved above). Mirrors Python render_video (core.py L1572-1588).
-  if (
-    videoOverlay === undefined &&
-    !Array.isArray(source) &&
-    source.masks.length > 0
-  ) {
-    const targetVideo = selectedFrames[0].video;
-    const labels = source;
-    if (labels.getMasks({ video: targetVideo }).length > 0) {
-      videoOverlay = (frameIdx: number) =>
-        labels.getMasks({ video: targetVideo, frameIdx });
-    }
-  }
-  const overlayForFrame = makeOverlayResolver(videoOverlay);
-
-  // Build per-video temporal context for motion trails once (keyed by frame
-  // index), using ALL source frames so a trail can reach back before the
-  // selected range. Each rendered frame then gets its video's frame map.
-  const framesByVideo = new Map<Video, Map<number, LabeledFrame>>();
-  // Shared points cache + canonical track list (computed once, like Python's
-  // render_video) so trail colors are stable across the whole pass and we avoid
-  // re-extracting instance points across overlapping trail windows.
-  const trailPtsCache = options.showTrails
-    ? new Map<Instance | PredictedInstance, number[][]>()
-    : undefined;
-  const canonicalTracks = Array.isArray(source) ? undefined : source.tracks;
-  if (options.showTrails) {
-    for (const lf of frames) {
-      let videoFrames = framesByVideo.get(lf.video);
-      if (!videoFrames) {
-        videoFrames = new Map<number, LabeledFrame>();
-        framesByVideo.set(lf.video, videoFrames);
-      }
-      videoFrames.set(lf.frameIdx, lf);
-    }
-  }
-  // Build the per-frame render options. Overlay is resolved per frame (static
-  // value, position-indexed list, frame-index-keyed Map, or callable) and
-  // passed through as the single-frame `overlay` that renderImage understands.
-  const optsForFrame = (
-    frame: LabeledFrame,
-    position: number,
-  ): RenderOptions => {
-    // Strip the video-level (per-frame) `overlay` so the spread does not leak a
-    // `VideoOverlay` into the single-frame `RenderOptions`; it is replaced by
-    // the resolved single-frame overlay below.
-    const { overlay: _ignored, ...rest } = options;
-    void _ignored;
-    const base: RenderOptions = options.showTrails
-      ? {
-          ...rest,
-          trailFrames: framesByVideo.get(frame.video),
-          trailTracks: options.trailTracks ?? canonicalTracks,
-          trailPtsCache,
-        }
-      : { ...rest };
-    base.overlay = overlayForFrame(frame, position);
-    return base;
-  };
+  // Resolve frame selection + the per-frame render-option builder (overlay,
+  // resolved color scheme, global track map). Shared with the ffmpeg-free
+  // per-frame rendering path so coloring is identical with or without ffmpeg.
+  const { selectedFrames, optsForFrame } = buildFrameRenderer(source, options);
 
   // Get frame dimensions from first frame
   const firstImage = await renderImage(
@@ -251,6 +158,170 @@ export async function renderVideo(
 
     ffmpeg.on("error", reject);
   });
+}
+
+/**
+ * The selected frames plus a per-frame `RenderOptions` builder shared by
+ * {@link renderVideo} and its ffmpeg-free per-frame rendering path.
+ */
+export interface FrameRenderer {
+  /** Frames to render, after applying `frameInds` / `start` / `end`. */
+  selectedFrames: LabeledFrame[];
+  /**
+   * Build the single-frame `RenderOptions` for `frame` at render `position`.
+   * Resolves the per-frame overlay, the video-level color scheme, and the
+   * global track -> index map (all computed once for the whole pass).
+   */
+  optsForFrame: (frame: LabeledFrame, position: number) => RenderOptions;
+}
+
+/**
+ * Resolve the frame selection and per-frame render-option builder for a video
+ * render pass.
+ *
+ * Extracted from {@link renderVideo} so the SAME coloring code path (per-frame
+ * overlay resolution, the video-level resolved color scheme, and the global
+ * track -> index map) can be exercised without ffmpeg: render each frame with
+ * `renderImage(frame, optsForFrame(frame, i))`. The global track map keys
+ * overlay (mask / ROI / bbox) and pose colors off the project's `Labels.tracks`
+ * (stable across frames), so a mask's color follows its GLOBAL track identity
+ * rather than its per-frame position within `frame.masks` (fixes JS #162
+ * flicker). Mirrors Python render_video `_track_idx_map` (core.py L1929-1934).
+ */
+export function buildFrameRenderer(
+  source: Labels | LabeledFrame[],
+  options: VideoOptions = {},
+): FrameRenderer {
+  // Extract labeled frames
+  const frames = Array.isArray(source) ? source : source.labeledFrames;
+
+  // Apply frame selection
+  let selectedFrames = frames;
+  if (options.frameInds) {
+    selectedFrames = options.frameInds
+      .map((i) => frames[i])
+      .filter((f): f is LabeledFrame => f !== undefined);
+  } else if (options.start !== undefined || options.end !== undefined) {
+    const start = options.start ?? 0;
+    const end = options.end ?? frames.length;
+    selectedFrames = frames.slice(start, end);
+  }
+
+  if (selectedFrames.length === 0) {
+    throw new Error("No frames to render");
+  }
+
+  // Resolve the per-frame overlay parameter (mirrors Python render_video,
+  // core.py L1719-1754). Auto-detect: when no explicit overlay is given and a
+  // Labels source has label images for the rendered video, use them as a
+  // per-frame LabelImage[] (indexed by render position). Mirrors core.py
+  // L1549-1556.
+  let videoOverlay: VideoOverlay | undefined = options.overlay;
+  if (
+    videoOverlay === undefined &&
+    !Array.isArray(source) &&
+    source.labelImages.length > 0
+  ) {
+    const targetVideo = selectedFrames[0].video;
+    const videoLabelImages = source.getLabelImages({ video: targetVideo });
+    if (videoLabelImages.length > 0) {
+      videoOverlay = videoLabelImages;
+    }
+  }
+  // Auto-use segmentation masks as overlay when no explicit overlay (and no
+  // label images) resolved. Masks live on specific frames at arbitrary frame
+  // indices, so resolve them per-frame via a callable keyed by the source frame
+  // index rather than a position-indexed list. label images take precedence
+  // (resolved above). Mirrors Python render_video (core.py L1572-1588).
+  if (
+    videoOverlay === undefined &&
+    !Array.isArray(source) &&
+    source.masks.length > 0
+  ) {
+    const targetVideo = selectedFrames[0].video;
+    const labels = source;
+    if (labels.getMasks({ video: targetVideo }).length > 0) {
+      videoOverlay = (frameIdx: number) =>
+        labels.getMasks({ video: targetVideo, frameIdx });
+    }
+  }
+  const overlayForFrame = makeOverlayResolver(videoOverlay);
+
+  // Build per-video temporal context for motion trails once (keyed by frame
+  // index), using ALL source frames so a trail can reach back before the
+  // selected range. Each rendered frame then gets its video's frame map.
+  const framesByVideo = new Map<Video, Map<number, LabeledFrame>>();
+  // Shared points cache + canonical track list (computed once, like Python's
+  // render_video) so trail colors are stable across the whole pass and we avoid
+  // re-extracting instance points across overlapping trail windows.
+  const trailPtsCache = options.showTrails
+    ? new Map<Instance | PredictedInstance, number[][]>()
+    : undefined;
+  const canonicalTracks = Array.isArray(source) ? undefined : source.tracks;
+
+  // Resolve the color scheme ONCE at the video level (mirrors Python
+  // render_video, core.py L1754-1758): keyed off the project's global track
+  // list so a mask-/centroid-only tracked project resolves "auto" -> "track".
+  // The resolved scheme is then passed to each frame's renderImage so a bare
+  // per-frame LabeledFrame (which has no `.tracks`) does not fall back to
+  // positional "instance"/"node" coloring.
+  const globalTracks: Track[] = canonicalTracks ?? [];
+  const hasTracks = globalTracks.length > 0;
+  const resolvedScheme: ColorScheme = determineColorScheme(
+    options.colorBy ?? "auto",
+    hasTracks,
+    false,
+  );
+  // Global track -> index map (stable across frames) used to color overlay
+  // elements (masks/ROIs/bboxes) by track identity. Mirrors Python
+  // render_video `_track_idx_map` (core.py L1929-1934). Keyed off the project
+  // track list so a mask's color follows its GLOBAL track identity rather than
+  // its per-frame position within `frame.masks` (fixes flicker, JS #162).
+  const overlayTrackIndexMap: Map<Track, number> | undefined = hasTracks
+    ? new Map(globalTracks.map((t, i) => [t, i]))
+    : undefined;
+
+  if (options.showTrails) {
+    for (const lf of frames) {
+      let videoFrames = framesByVideo.get(lf.video);
+      if (!videoFrames) {
+        videoFrames = new Map<number, LabeledFrame>();
+        framesByVideo.set(lf.video, videoFrames);
+      }
+      videoFrames.set(lf.frameIdx, lf);
+    }
+  }
+  // Build the per-frame render options. Overlay is resolved per frame (static
+  // value, position-indexed list, frame-index-keyed Map, or callable) and
+  // passed through as the single-frame `overlay` that renderImage understands.
+  const optsForFrame = (
+    frame: LabeledFrame,
+    position: number,
+  ): RenderOptions => {
+    // Strip the video-level (per-frame) `overlay` so the spread does not leak a
+    // `VideoOverlay` into the single-frame `RenderOptions`; it is replaced by
+    // the resolved single-frame overlay below.
+    const { overlay: _ignored, ...rest } = options;
+    void _ignored;
+    const base: RenderOptions = options.showTrails
+      ? {
+          ...rest,
+          trailFrames: framesByVideo.get(frame.video),
+          trailTracks: options.trailTracks ?? canonicalTracks,
+          trailPtsCache,
+        }
+      : { ...rest };
+    base.overlay = overlayForFrame(frame, position);
+    // Pass the video-level resolved color scheme and global track->index map so
+    // each bare per-frame LabeledFrame still colors poses AND overlay elements
+    // by GLOBAL track identity (stable across frames), instead of resolving
+    // "auto" per frame or coloring overlays by per-frame list position.
+    base.colorBy = resolvedScheme;
+    base.overlayTrackIndexMap = overlayTrackIndexMap;
+    return base;
+  };
+
+  return { selectedFrames, optsForFrame };
 }
 
 /** Whether a value is a `LabelImage`-like object (Int32Array-backed `data`). */

--- a/tests/rendering/mask-rendering.test.ts
+++ b/tests/rendering/mask-rendering.test.ts
@@ -8,7 +8,11 @@
 
 import { describe, it, expect } from "../bun-test";
 import { renderImage } from "../../src/rendering/render";
-import { renderVideo, checkFfmpeg } from "../../src/rendering/video";
+import {
+  renderVideo,
+  checkFfmpeg,
+  buildFrameRenderer,
+} from "../../src/rendering/video";
 import { UserSegmentationMask } from "../../src/model/mask";
 import { UserLabelImage } from "../../src/model/label-image";
 import { UserBoundingBox } from "../../src/model/bbox";
@@ -508,9 +512,64 @@ describe("color overlays by track identity", () => {
   });
 
   it("renderVideo per-frame masks keep stable track colors across frames", async () => {
-    if (!(await checkFfmpeg())) return; // ffmpeg-gated smoke test
-    // End-to-end: renderVideo auto-resolves masks per frame (callable keyed by
-    // frame index) and routes them to renderImage, which track-colors them.
+    // Real, ffmpeg-free pixel-sampling test for the renderVideo track-coloring
+    // path (JS #162). Two tracked masks SWAP their order within `frame.masks`
+    // between frame 0 and frame 1 while their `.track` stays fixed. We exercise
+    // the EXACT code path renderVideo uses by building its per-frame renderer
+    // (`buildFrameRenderer`) and rendering each frame with `renderImage` — this
+    // is what renderVideo does before piping the RGBA to ffmpeg, so the
+    // coloring assertions run in CI without ffmpeg installed.
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const labels = makeTrackedMaskLabels(
+      // frame 0: [A, B]; frame 1: [B, A] (positional coloring would flicker).
+      [boxMask(BOX_A, trackA), boxMask(BOX_B, trackB)],
+      [boxMask(BOX_B, trackB), boxMask(BOX_A, trackA)],
+      [trackA, trackB],
+    );
+
+    const { selectedFrames, optsForFrame } = buildFrameRenderer(labels, {
+      width: 64,
+      height: 64,
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+      fps: 30,
+    });
+    expect(selectedFrames.length).toBe(2);
+
+    // Render each selected frame exactly as renderVideo would (bare per-frame
+    // LabeledFrame + the per-frame options that carry the GLOBAL track map).
+    const frame0 = await renderImage(
+      selectedFrames[0],
+      optsForFrame(selectedFrames[0], 0),
+    );
+    const frame1 = await renderImage(
+      selectedFrames[1],
+      optsForFrame(selectedFrames[1], 1),
+    );
+
+    // Sample pixels inside each track's mask region in both frames.
+    const a0 = boxCenterColor(frame0, BOX_A);
+    const a1 = boxCenterColor(frame1, BOX_A);
+    const b0 = boxCenterColor(frame0, BOX_B);
+    const b1 = boxCenterColor(frame1, BOX_B);
+
+    // (a) No flicker: each track keeps the SAME color across both frames,
+    // despite its list index swapping between frames.
+    expect(a0).toEqual(a1);
+    expect(b0).toEqual(b1);
+    // (b) The two tracks have DISTINCT colors.
+    expect(arrEq(a0, b0)).toBe(false);
+    // The colors are GLOBAL-track-keyed (A=0, B=1) from the pose palette
+    // ("standard"), NOT the positional overlay_palette ("distinct").
+    expect(a0).toEqual(STANDARD[0]);
+    expect(b0).toEqual(STANDARD[1]);
+    expect(arrEq(a0, DISTINCT[0])).toBe(false);
+  });
+
+  it("renderVideo per-frame masks render to an mp4 (ffmpeg smoke)", async () => {
+    if (!(await checkFfmpeg())) return; // ffmpeg-gated end-to-end smoke test
     const trackA = new Track("A");
     const trackB = new Track("B");
     const labels = makeTrackedMaskLabels(

--- a/tests/rendering/mask-rendering.test.ts
+++ b/tests/rendering/mask-rendering.test.ts
@@ -1,0 +1,538 @@
+// Tests for auto-drawing segmentation masks and coloring overlay elements by
+// track identity. Ports Python sleap-io PR #462 (auto-draw masks) and PR #470
+// (color masks/ROIs/bboxes by track), covering JS issue #162 (mask color
+// flicker when a mask's list index changes across frames).
+//
+// The grayscale (H, W, 1) handling from #462 is N/A in JS: skia-canvas is RGBA,
+// so there is no numpy-broadcast crash to fix.
+
+import { describe, it, expect } from "../bun-test";
+import { renderImage } from "../../src/rendering/render";
+import { renderVideo, checkFfmpeg } from "../../src/rendering/video";
+import { UserSegmentationMask } from "../../src/model/mask";
+import { UserLabelImage } from "../../src/model/label-image";
+import { UserBoundingBox } from "../../src/model/bbox";
+import { UserROI } from "../../src/model/roi";
+import { Instance, Track } from "../../src/model/instance";
+import { Skeleton } from "../../src/model/skeleton";
+import { LabeledFrame } from "../../src/model/labeled-frame";
+import { Labels } from "../../src/model/labels";
+import { Video } from "../../src/model/video";
+import { getPalette } from "../../src/rendering/colors";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const STANDARD = getPalette("standard", 2);
+const DISTINCT = getPalette("distinct", 2);
+
+/** Box as (y0, y1, x0, x1) in image pixels. */
+type Box = [number, number, number, number];
+const BOX_A: Box = [5, 20, 5, 20];
+const BOX_B: Box = [40, 60, 40, 60];
+
+/** A `UserSegmentationMask` covering `box` (y0, y1, x0, x1). */
+function boxMask(
+  box: Box,
+  track: Track | null = null,
+  h = 64,
+  w = 64,
+): UserSegmentationMask {
+  const binary = new Uint8Array(h * w);
+  const [y0, y1, x0, x1] = box;
+  for (let r = y0; r < y1; r++) {
+    for (let c = x0; c < x1; c++) {
+      binary[r * w + c] = 1;
+    }
+  }
+  return UserSegmentationMask.fromArray(binary, h, w, { track });
+}
+
+/** RGB triple at the center of `box`. */
+function boxCenterColor(img: ImageData, box: Box): [number, number, number] {
+  const [y0, y1, x0, x1] = box;
+  const y = (y0 + y1) >> 1;
+  const x = (x0 + x1) >> 1;
+  const idx = (y * img.width + x) * 4;
+  return [img.data[idx], img.data[idx + 1], img.data[idx + 2]];
+}
+
+/** RGB triple at pixel (x, y). */
+function pixel(img: ImageData, x: number, y: number): [number, number, number] {
+  const idx = (y * img.width + x) * 4;
+  return [img.data[idx], img.data[idx + 1], img.data[idx + 2]];
+}
+
+function arrEq(
+  a: [number, number, number],
+  b: [number, number, number],
+): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+function makeTrackedMaskLabels(
+  frame0Masks: UserSegmentationMask[],
+  frame1Masks: UserSegmentationMask[],
+  tracks: Track[],
+): Labels {
+  const video = new Video({ filename: "v.mp4" });
+  const lf0 = new LabeledFrame({ video, frameIdx: 0, masks: frame0Masks });
+  const lf1 = new LabeledFrame({ video, frameIdx: 1, masks: frame1Masks });
+  return new Labels({
+    labeledFrames: [lf0, lf1],
+    videos: [video],
+    tracks,
+  });
+}
+
+// ===========================================================================
+// PR #462: auto-draw segmentation masks (no explicit overlay)
+// ===========================================================================
+
+describe("auto-draw segmentation masks", () => {
+  it("renderImage auto-draws the frame's masks when no overlay is passed", async () => {
+    const video = new Video({ filename: "dummy.mp4" });
+    const mask = boxMask(BOX_B);
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [mask] });
+
+    const img = await renderImage(lf, {
+      width: 64,
+      height: 64,
+      background: [128, 128, 128],
+    });
+
+    expect(img.width).toBe(64);
+    // Masked region is colored (differs from the plain background).
+    expect(arrEq(pixel(img, 50, 50), [128, 128, 128])).toBe(false);
+    // Background outside the mask is unchanged.
+    expect(arrEq(pixel(img, 0, 0), [128, 128, 128])).toBe(true);
+  });
+
+  it("renderImage auto-draws masks for a Labels source (first frame)", async () => {
+    const video = new Video({ filename: "dummy.mp4" });
+    const mask = boxMask(BOX_B);
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [mask] });
+    const labels = new Labels({ labeledFrames: [lf], videos: [video] });
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      background: [128, 128, 128],
+    });
+
+    expect(arrEq(boxCenterColor(img, BOX_B), [128, 128, 128])).toBe(false);
+  });
+
+  it("renderImage without masks/overlay leaves the background untouched", async () => {
+    const skeleton = new Skeleton({ nodes: ["a", "b"], edges: [["a", "b"]] });
+    const video = new Video({ filename: "dummy.mp4" });
+    const inst = new Instance({ points: { a: [5, 5], b: [10, 10] }, skeleton });
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+
+    const img = await renderImage(lf, {
+      width: 64,
+      height: 64,
+      background: [128, 128, 128],
+    });
+
+    // No mask -> a region away from the pose stays the plain background.
+    expect(arrEq(pixel(img, 50, 50), [128, 128, 128])).toBe(true);
+  });
+
+  it("explicit overlay takes precedence over the frame's masks", async () => {
+    const video = new Video({ filename: "dummy.mp4" });
+    // Frame mask is bottom-right; explicit label-image overlay is top-left.
+    const mask = boxMask(BOX_B);
+    const lf = new LabeledFrame({ video, frameIdx: 0, masks: [mask] });
+
+    const data = new Int32Array(64 * 64);
+    for (let r = 5; r < 25; r++)
+      for (let c = 5; c < 25; c++) data[r * 64 + c] = 1;
+    const li = UserLabelImage.fromArray(data, 64, 64);
+
+    const img = await renderImage(lf, {
+      width: 64,
+      height: 64,
+      background: [128, 128, 128],
+      overlay: li,
+      overlayAlpha: 0.6,
+    });
+
+    // Explicit overlay region (top-left) is colored.
+    expect(arrEq(pixel(img, 15, 15), [128, 128, 128])).toBe(false);
+    // Mask region (bottom-right) is NOT drawn since an explicit overlay won.
+    expect(arrEq(boxCenterColor(img, BOX_B), [128, 128, 128])).toBe(true);
+  });
+
+  it("renderVideo auto-draws labels.masks when no overlay is passed", async () => {
+    if (!(await checkFfmpeg())) return; // ffmpeg-gated smoke test
+    const video = new Video({ filename: "dummy.mp4" });
+    const lf0 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [boxMask(BOX_B)],
+    });
+    const lf1 = new LabeledFrame({
+      video,
+      frameIdx: 1,
+      masks: [boxMask(BOX_B)],
+    });
+    const labels = new Labels({ labeledFrames: [lf0, lf1], videos: [video] });
+
+    const tmp = `/tmp/auto-mask-${Date.now()}.mp4`;
+    await expect(
+      renderVideo(labels, tmp, {
+        width: 64,
+        height: 64,
+        background: [128, 128, 128],
+        overlayAlpha: 0.6,
+        fps: 30,
+      }),
+    ).resolves.toBeUndefined();
+
+    const fs = await import("node:fs");
+    expect(fs.existsSync(tmp)).toBe(true);
+    fs.unlinkSync(tmp);
+  });
+});
+
+// ===========================================================================
+// PR #470: color masks (and ROI/bbox) by track identity
+// ===========================================================================
+
+describe("color overlays by track identity", () => {
+  it("renderImage colors masks by track index, not list position", async () => {
+    // track_b first, track_a second — order is the reverse of track index.
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const video = new Video({ filename: "v.mp4" });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [boxMask(BOX_B, trackB), boxMask(BOX_A, trackA)],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      tracks: [trackA, trackB],
+    });
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    // Track A -> index 0, track B -> index 1, using the pose palette
+    // ("standard"), NOT overlay_palette.
+    expect(boxCenterColor(img, BOX_A)).toEqual(STANDARD[0]);
+    expect(boxCenterColor(img, BOX_B)).toEqual(STANDARD[1]);
+  });
+
+  it("a tracked mask keeps its color when its list position shuffles", async () => {
+    // Core flicker regression (JS #162): two tracked masks swap order within
+    // lf.masks between frames while their .track stays fixed. Under
+    // color_by="track" each track's region must render the same color across
+    // frames (positional coloring would flicker).
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+
+    // Render each frame as its own single-frame Labels (sharing the track list)
+    // — this is exactly the per-frame source renderVideo's mask callable routes
+    // to renderImage. Frame 1 swaps the list order of the two masks.
+    const video = new Video({ filename: "v.mp4" });
+    const lf0 = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [boxMask(BOX_A, trackA), boxMask(BOX_B, trackB)],
+    });
+    const lf1 = new LabeledFrame({
+      video,
+      frameIdx: 1,
+      masks: [boxMask(BOX_B, trackB), boxMask(BOX_A, trackA)],
+    });
+    const tracks = [trackA, trackB];
+
+    const opts = {
+      width: 64,
+      height: 64,
+      colorBy: "track" as const,
+      background: "black" as const,
+      overlayAlpha: 1.0,
+    };
+    const frame0 = await renderImage(
+      new Labels({ labeledFrames: [lf0], videos: [video], tracks }),
+      opts,
+    );
+    const frame1 = await renderImage(
+      new Labels({ labeledFrames: [lf1], videos: [video], tracks }),
+      opts,
+    );
+
+    const a0 = boxCenterColor(frame0, BOX_A);
+    const a1 = boxCenterColor(frame1, BOX_A);
+    const b0 = boxCenterColor(frame0, BOX_B);
+    const b1 = boxCenterColor(frame1, BOX_B);
+    expect(a0).toEqual(a1); // track A did not flicker
+    expect(b0).toEqual(b1); // track B did not flicker
+    expect(arrEq(a0, b0)).toBe(false); // distinct tracks -> distinct colors
+    // And the colors are track-keyed (A=0, B=1) from the pose palette.
+    expect(a0).toEqual(STANDARD[0]);
+    expect(b0).toEqual(STANDARD[1]);
+  });
+
+  it("untracked masks fall back to palette[0] under color_by=track", async () => {
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const video = new Video({ filename: "v.mp4" });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [boxMask(BOX_A, null), boxMask(BOX_B, trackB)],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      tracks: [trackA, trackB],
+    });
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    expect(boxCenterColor(img, BOX_A)).toEqual(STANDARD[0]); // untracked -> palette[0]
+    expect(boxCenterColor(img, BOX_B)).toEqual(STANDARD[1]); // track B -> its index
+  });
+
+  it("color_by != track keeps positional overlay_palette coloring", async () => {
+    // Regression guard: the non-track path stays byte-identical to old behavior
+    // — masks colored by list position from overlay_palette ("distinct").
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const video = new Video({ filename: "v.mp4" });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [boxMask(BOX_A, trackA), boxMask(BOX_B, trackB)],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      tracks: [trackA, trackB],
+    });
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      colorBy: "instance",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    expect(boxCenterColor(img, BOX_A)).toEqual(DISTINCT[0]); // first in list
+    expect(boxCenterColor(img, BOX_B)).toEqual(DISTINCT[1]); // second in list
+  });
+
+  it("a LabeledFrame source falls back to positional coloring under track", async () => {
+    // A bare LabeledFrame builds no track index map, so the track branch is
+    // skipped (gated on a Labels source) and masks render positionally.
+    const trackA = new Track("A");
+    const video = new Video({ filename: "v.mp4" });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [boxMask(BOX_A, trackA)],
+    });
+
+    const img = await renderImage(lf, {
+      width: 64,
+      height: 64,
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    expect(img.width).toBe(64);
+    // Positional: first (only) mask gets overlay_palette ("distinct") index 0.
+    expect(boxCenterColor(img, BOX_A)).toEqual(getPalette("distinct", 1)[0]);
+  });
+
+  it("track-less labels under color_by=track stay positional", async () => {
+    const video = new Video({ filename: "v.mp4" });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      masks: [boxMask(BOX_A), boxMask(BOX_B)], // untracked
+    });
+    const labels = new Labels({ labeledFrames: [lf], videos: [video] }); // no tracks
+    expect(labels.tracks.length).toBe(0);
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    expect(boxCenterColor(img, BOX_A)).toEqual(DISTINCT[0]);
+    expect(boxCenterColor(img, BOX_B)).toEqual(DISTINCT[1]);
+  });
+
+  it("explicit ROI overlays are track-colored, not positional", async () => {
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const video = new Video({ filename: "v.mp4" });
+
+    const roi = (b: Box, t: Track): UserROI => {
+      const [y0, y1, x0, x1] = b;
+      const r = UserROI.fromPolygon([
+        [x0, y0],
+        [x1, y0],
+        [x1, y1],
+        [x0, y1],
+      ]);
+      r.track = t;
+      return r;
+    };
+
+    // track_b first, track_a second — reverse of track index. The ROIs live on
+    // the frame and are also passed as the explicit overlay.
+    const overlayRois = [roi(BOX_B, trackB), roi(BOX_A, trackA)];
+    const lf = new LabeledFrame({ video, frameIdx: 0, rois: overlayRois });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      tracks: [trackA, trackB],
+    });
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      overlay: overlayRois,
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    // ROI fill at box centers is track-keyed (A=0, B=1).
+    expect(boxCenterColor(img, BOX_A)).toEqual(STANDARD[0]);
+    expect(boxCenterColor(img, BOX_B)).toEqual(STANDARD[1]);
+  });
+
+  it("explicit BoundingBox overlays are track-colored, not positional", async () => {
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const video = new Video({ filename: "v.mp4" });
+
+    const bb = (b: Box, t: Track): UserBoundingBox => {
+      const [y0, y1, x0, x1] = b;
+      const box = UserBoundingBox.fromXyxy(x0, y0, x1, y1);
+      box.track = t;
+      return box;
+    };
+
+    const overlayBboxes = [bb(BOX_B, trackB), bb(BOX_A, trackA)];
+    const lf = new LabeledFrame({ video, frameIdx: 0, bboxes: overlayBboxes });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      tracks: [trackA, trackB],
+    });
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      overlay: overlayBboxes,
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    // Sample on a box edge (bbox is an outline, not filled) — the stroke color
+    // is track-keyed.
+    const onTopEdge = (box: Box): [number, number, number] => {
+      const [y0, , x0, x1] = box;
+      return pixel(img, (x0 + x1) >> 1, y0);
+    };
+    expect(onTopEdge(BOX_A)).toEqual(STANDARD[0]);
+    expect(onTopEdge(BOX_B)).toEqual(STANDARD[1]);
+  });
+
+  it("label-image overlays are not track-recolored under color_by=track", async () => {
+    // Label images color by integer object ID, never by track. The overlay
+    // color guard skips them (a single LabelImage is not an array), so a tracked
+    // project with a label-image overlay still renders by ID without crashing.
+    const trackA = new Track("A");
+    const skeleton = new Skeleton({ nodes: ["a", "b"], edges: [["a", "b"]] });
+    const video = new Video({ filename: "v.mp4" });
+    const data = new Int32Array(64 * 64);
+    for (let r = 5; r < 25; r++)
+      for (let c = 5; c < 25; c++) data[r * 64 + c] = 1;
+    const inst = new Instance({
+      points: { a: [50, 50], b: [55, 55] },
+      skeleton,
+      track: trackA,
+    });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [inst],
+      labelImages: [UserLabelImage.fromArray(data, 64, 64)],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackA],
+    });
+
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      overlay: lf.labelImages[0],
+      colorBy: "track",
+      background: "black",
+      overlayAlpha: 1.0,
+    });
+
+    // Label-image region (top-left) is drawn (by ID), not left as background.
+    expect(arrEq(boxCenterColor(img, [5, 25, 5, 25]), [0, 0, 0])).toBe(false);
+  });
+
+  it("renderVideo per-frame masks keep stable track colors across frames", async () => {
+    if (!(await checkFfmpeg())) return; // ffmpeg-gated smoke test
+    // End-to-end: renderVideo auto-resolves masks per frame (callable keyed by
+    // frame index) and routes them to renderImage, which track-colors them.
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const labels = makeTrackedMaskLabels(
+      [boxMask(BOX_A, trackA), boxMask(BOX_B, trackB)],
+      [boxMask(BOX_B, trackB), boxMask(BOX_A, trackA)],
+      [trackA, trackB],
+    );
+
+    const tmp = `/tmp/track-mask-${Date.now()}.mp4`;
+    await expect(
+      renderVideo(labels, tmp, {
+        width: 64,
+        height: 64,
+        colorBy: "track",
+        background: "black",
+        overlayAlpha: 1.0,
+        fps: 30,
+      }),
+    ).resolves.toBeUndefined();
+
+    const fs = await import("node:fs");
+    expect(fs.existsSync(tmp)).toBe(true);
+    fs.unlinkSync(tmp);
+  });
+});


### PR DESCRIPTION
## Summary

Ports two upstream Python sleap-io rendering changes to the TypeScript port so segmentation predictions render out of the box and stay color-stable:

- **Python PR #462** — auto-draw `SegmentationMask` overlays when no explicit overlay is passed.
- **Python PR #470** — color masks/ROIs/bboxes by track identity (matching poses/centroids/trails).

**Closes #162** (per-frame mask color flicker when a mask's index within `frame.masks` changes across frames).

## Fix A — auto-draw masks (#462)

- `src/rendering/video.ts` (`renderVideo`): after the existing label-image auto-detect, fall back to a **per-frame callable resolver** `source.getMasks({ video, frameIdx })` keyed by the source frame index. Masks live on arbitrary frame indices, so a flat position-indexed list would misalign them — the callable routes each frame's masks to the correct frame. Precedence preserved: **explicit overlay > label images > masks**.
- `src/rendering/render.ts` (`renderImage`): when no `overlay` is given, auto-draw the rendered frame's own `frame.masks`. An explicit overlay always wins.

## Fix B — color overlays by track (#470)

- `src/rendering/render.ts`: hoisted `determineColorScheme` **above** the overlay block so the resolved scheme is known when the overlay is drawn.
- When the scheme resolves to `"track"` AND a `Labels` source has tracks, per-overlay-element colors are computed from the existing `trackIndexMap` using the pose `palette` (`"standard"`, the same index map used for poses/centroids/trails), falling back to `palette[0]` for `track == null`. These are passed as a `colors` array into `applyOverlay` → `drawMasks`/`drawRois`/`drawBboxes`.
- The positional path (non-track scheme, track-less labels, bare-`LabeledFrame` source, or a single label-image overlay) keeps `overlayPalette` coloring **unchanged**.
- `src/rendering/overlays.ts`: `applyOverlay` now accepts an optional per-element `colors` array that overrides the positional palette for list overlays (`drawMasks` already supported per-mask colors).

This eliminates per-frame mask color flicker: a tracked mask keeps a stable color across frames even when its position within `frame.masks` changes.

## Intentionally skipped

The grayscale `(H, W, 1)` crash fix from #462 is **N/A in JS**: skia-canvas is RGBA, so there is no numpy single-channel broadcasting mismatch to guard against.

## Test coverage

New `tests/rendering/mask-rendering.test.ts` (skia-canvas pixel sampling, mirroring the Python PR tests):

- mask-only project auto-draws masks via `renderImage` and `renderVideo` (no explicit overlay; renderVideo cases are ffmpeg-gated smoke tests);
- explicit overlay takes precedence over a frame's masks;
- under `color_by="track"`, a tracked mask keeps the **same** color across two frames even when its index within `frame.masks` differs (the flicker fix), and the color is track-keyed from the pose palette;
- untracked masks fall back to `palette[0]`; mixed tracked/untracked frames render correctly;
- explicit ROI and BoundingBox overlays are track-colored (not positional);
- label-image overlays are not track-recolored;
- non-track scheme and track-less labels keep positional `overlayPalette` coloring (regression guard).

All checks green: `bun run format`, `bun run check`, `bun run lint` (tsc), `bun run build` (tsup), `bun run test` (1575 pass, 1 unrelated skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm
