### PR TITLE
fix(merge): preserve point order + from_predicted provenance across merge

### DIFF
--- a/src/model/instance.ts
+++ b/src/model/instance.ts
@@ -404,6 +404,7 @@ export class PredictedInstance extends Instance {
     track?: Track | null;
     score?: number;
     trackingScore?: number;
+    fromPredicted?: PredictedInstance | null;
   }) {
     const { score = 0, ...rest } = options;
     const pts = Array.isArray(rest.points)
@@ -417,6 +418,7 @@ export class PredictedInstance extends Instance {
       skeleton: rest.skeleton,
       track: rest.track,
       trackingScore: rest.trackingScore,
+      fromPredicted: rest.fromPredicted,
     });
     this.score = score;
   }

--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -39,6 +39,68 @@ function _shallowCopy<T>(item: T): T {
 }
 
 /**
+ * Shallow-copy an annotation, recording `original -> copy` in `memo`.
+ *
+ * Mirrors Python `_copy_with_memo` (labeled_frame.py). The memo lets a later
+ * {@link _relinkFromPredicted} pass repair `fromPredicted` provenance links:
+ * when both a predicted annotation and the user annotation that adopted it are
+ * copied independently during a merge, the user copy's `fromPredicted` still
+ * points at the *original* predicted object rather than its copy now living in
+ * the merged frame. Recording the original->copy mapping here lets the link be
+ * rewritten to the in-frame copy.
+ *
+ * JS uses a `Map` keyed by the original object reference as the analog of
+ * Python's `id()`-keyed dict.
+ *
+ * @param item - The annotation to copy.
+ * @param memo - Map from an original annotation to its copy, mutated in place.
+ * @returns The shallow copy of `item`.
+ */
+function _copyWithMemo<T extends object>(
+  item: T,
+  memo: Map<object, object>,
+): T {
+  const itemCopy = _shallowCopy(item);
+  memo.set(item, itemCopy);
+  return itemCopy;
+}
+
+/**
+ * Rewrite `fromPredicted` links to copied sources within a merged frame.
+ *
+ * Mirrors Python `_relink_from_predicted` (labeled_frame.py). After annotations
+ * are copied into a merged frame, a user annotation's `fromPredicted` may still
+ * reference the *original* predicted source rather than the copy that was placed
+ * in the frame. This pass redirects each such link to the copied source (looked
+ * up in `memo`) so the provenance link points at the in-frame object and would
+ * survive serialization (which resolves links by object identity). Links whose
+ * source was not copied (not in `memo`) are left unchanged.
+ *
+ * Generic over modality via `ann.fromPredicted`: only segmentation masks and
+ * `Instance`s carry a `fromPredicted` link today, so other annotation types are
+ * left untouched.
+ *
+ * @param annotations - The merged annotation list to repair in place.
+ * @param memo - Map from an original annotation to its copy, as built by
+ *   {@link _copyWithMemo} (or `Labels._mapInstance`).
+ */
+export function _relinkFromPredicted(
+  // biome-ignore lint/suspicious/noExplicitAny: generic over heterogeneous annotation modalities.
+  annotations: any[],
+  memo: Map<object, object>,
+): void {
+  for (const ann of annotations) {
+    const src = ann?.fromPredicted;
+    if (src != null) {
+      const replacement = memo.get(src);
+      if (replacement !== undefined) {
+        ann.fromPredicted = replacement;
+      }
+    }
+  }
+}
+
+/**
  * Extract centroid (x, y) from an annotation based on its modality.
  *
  * @returns A tuple of [x, y] coordinates, or null if the centroid cannot be
@@ -170,6 +232,9 @@ function _resolveAnnotationAuto(
 ): Annotation[] {
   const merged: Annotation[] = [];
   const usedSelfIndices = new Set<number>();
+  // Track copied annotations so `fromPredicted` links can be repaired to point
+  // at the in-frame copy of their source rather than the original.
+  const memo = new Map<object, object>();
 
   // 1. Keep all user annotations from self
   for (const ann of selfList) {
@@ -214,16 +279,16 @@ function _resolveAnnotationAuto(
         // user + user → keep self (already in merged)
       } else if (selfAnn.isPredicted && !otherAnn.isPredicted) {
         // predicted + user → replace with other's user
-        merged.push(_shallowCopy(otherAnn));
+        merged.push(_copyWithMemo(otherAnn, memo));
       } else if (!selfAnn.isPredicted && otherAnn.isPredicted) {
         // user + predicted → keep self (already in merged)
       } else {
         // predicted + predicted → keep other's (newer)
-        merged.push(_shallowCopy(otherAnn));
+        merged.push(_copyWithMemo(otherAnn, memo));
       }
     } else {
       // No match → add from other
-      merged.push(_shallowCopy(otherAnn));
+      merged.push(_copyWithMemo(otherAnn, memo));
     }
   }
 
@@ -233,6 +298,10 @@ function _resolveAnnotationAuto(
       merged.push(selfList[selfIdx]);
     }
   }
+
+  // Repair `fromPredicted` links so a copied user annotation references the
+  // copied source prediction now in the merged frame, not the original.
+  _relinkFromPredicted(merged, memo);
 
   return merged;
 }
@@ -483,19 +552,26 @@ export class LabeledFrame {
 
     if (strategy === "keep_new") {
       for (const attr of ANNOTATION_ATTRS) {
-        this[attr] = (other[attr] as Annotation[]).map(_shallowCopy) as any;
+        const memo = new Map<object, object>();
+        const newList = (other[attr] as Annotation[]).map((item) =>
+          _copyWithMemo(item, memo),
+        );
+        _relinkFromPredicted(newList, memo);
+        this[attr] = newList as any;
       }
       return;
     }
 
     if (strategy === "replace_predictions") {
       for (const attr of ANNOTATION_ATTRS) {
+        const memo = new Map<object, object>();
         const kept = (this[attr] as Annotation[]).filter((a) => !a.isPredicted);
         for (const item of other[attr] as Annotation[]) {
           if (item.isPredicted) {
-            kept.push(_shallowCopy(item));
+            kept.push(_copyWithMemo(item, memo));
           }
         }
+        _relinkFromPredicted(kept, memo);
         (this as any)[attr] = kept;
       }
       return;
@@ -527,12 +603,15 @@ export class LabeledFrame {
 
     // "keep_both" (default): identity dedup + shallow copy
     for (const attr of ANNOTATION_ATTRS) {
-      const existing = new Set(this[attr] as unknown[]);
-      for (const item of other[attr] as unknown[]) {
+      const memo = new Map<object, object>();
+      const target = this[attr] as Annotation[];
+      const existing = new Set(target as unknown[]);
+      for (const item of other[attr] as Annotation[]) {
         if (!existing.has(item)) {
-          (this[attr] as unknown[]).push(_shallowCopy(item));
+          target.push(_copyWithMemo(item, memo));
         }
       }
+      _relinkFromPredicted(target, memo);
     }
   }
 

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -1,6 +1,15 @@
-import { LabeledFrame, _resolveMergedIsNegative } from "./labeled-frame.js";
+import {
+  LabeledFrame,
+  _relinkFromPredicted,
+  _resolveMergedIsNegative,
+} from "./labeled-frame.js";
 import { Instance, PredictedInstance, Track } from "./instance.js";
-import type { PredictedPointsArray } from "./instance.js";
+import type {
+  Point,
+  PointsArray,
+  PredictedPoint,
+  PredictedPointsArray,
+} from "./instance.js";
 import { Skeleton, Node, Edge, Symmetry } from "./skeleton.js";
 import { SuggestionFrame } from "./suggestions.js";
 import { Video } from "./video.js";
@@ -1525,21 +1534,35 @@ export class Labels {
   /**
    * Map an instance to use mapped skeleton and track, returning a NEW instance.
    *
-   * Mirrors Python `Labels._map_instance` (labels.py:3650-3687). The source
+   * Mirrors Python `Labels._map_instance` (labels.py:3953-4020). The source
    * instance is never mutated: its points are deep-copied and the returned
    * instance is a fresh object of the SAME exact type (`Instance` vs
    * `PredictedInstance`, dispatched via `constructor ===`). Skeleton/track are
    * resolved through the maps with `?? original` fallback.
    *
+   * When the source instance's node order differs from the mapped skeleton's
+   * node order (e.g. the default structure matcher matched `[A, B, C]` with
+   * `[C, B, A]`), the points are reordered by node NAME so that each node's
+   * coordinates and score follow its name rather than its position (Python
+   * #489). When the node orders are identical (the common case) the points are
+   * copied positionally to avoid any overhead on the hot path. Nodes present in
+   * the mapped skeleton but absent from the source are filled with a missing,
+   * invisible point (NaN xy).
+   *
    * @param instance - Instance to map.
    * @param skeletonMap - Map from old skeletons to new skeletons.
    * @param trackMap - Map from old tracks to new tracks.
+   * @param memo - Optional map from the source instance to the new instance,
+   *   mutated in place. Used by {@link _relinkFromPredicted} to repair
+   *   `fromPredicted` links so a remapped user instance references the remapped
+   *   source prediction now in the merged frame (Python #491).
    * @returns New instance with mapped skeleton and track.
    */
   _mapInstance(
     instance: Instance | PredictedInstance,
     skeletonMap: Map<Skeleton, Skeleton>,
     trackMap: Map<Track, Track>,
+    memo?: Map<object, object>,
   ): Instance | PredictedInstance {
     const mappedSkeleton =
       skeletonMap.get(instance.skeleton) ?? instance.skeleton;
@@ -1547,29 +1570,76 @@ export class Labels {
       ? (trackMap.get(instance.track) ?? instance.track)
       : null;
 
-    // Deep/independent copy of the points so the source is never aliased.
-    const newPoints = instance.points.map((p) => ({
-      ...p,
-      xy: [...p.xy] as [number, number],
-    }));
+    const isPredicted = instance.constructor === PredictedInstance;
+    const sourcePoints = instance.points;
+    const mappedNames = mappedSkeleton.nodeNames;
 
-    if (instance.constructor === PredictedInstance) {
+    // Reorder points by node name when the source order differs from the mapped
+    // skeleton's order, otherwise the per-node coordinates/scores would be
+    // carried over positionally and silently misaligned (Python #489). When the
+    // orders already match, copy positionally on the hot path.
+    let mappedPoints: PointsArray | PredictedPointsArray;
+    const sameOrder =
+      sourcePoints.length === mappedNames.length &&
+      sourcePoints.every((p, i) => p.name === mappedNames[i]);
+    if (sameOrder) {
+      mappedPoints = sourcePoints.map((p) => ({
+        ...p,
+        xy: [...p.xy] as [number, number],
+      })) as PointsArray | PredictedPointsArray;
+    } else {
+      // Index the source points by node name so each mapped-skeleton node can
+      // copy the coordinates/score that belong to its name.
+      const sourceByName = new Map<string, Point | PredictedPoint>();
+      for (const p of sourcePoints) {
+        if (p.name !== undefined) sourceByName.set(p.name, p);
+      }
+      mappedPoints = mappedNames.map((name) => {
+        const src = sourceByName.get(name);
+        if (src !== undefined) {
+          return { ...src, xy: [...src.xy] as [number, number], name };
+        }
+        // Node absent from the source skeleton: fill a missing/invisible point
+        // (NaN xy), mirroring how missing nodes are represented elsewhere.
+        return isPredicted
+          ? {
+              xy: [Number.NaN, Number.NaN] as [number, number],
+              visible: false,
+              complete: false,
+              score: Number.NaN,
+              name,
+            }
+          : {
+              xy: [Number.NaN, Number.NaN] as [number, number],
+              visible: false,
+              complete: false,
+              name,
+            };
+      }) as PointsArray | PredictedPointsArray;
+    }
+
+    let newInstance: Instance | PredictedInstance;
+    if (isPredicted) {
       const predicted = instance as PredictedInstance;
-      return new PredictedInstance({
-        points: newPoints as unknown as PredictedPointsArray,
+      newInstance = new PredictedInstance({
+        points: mappedPoints as PredictedPointsArray,
         skeleton: mappedSkeleton,
         score: predicted.score,
         track: mappedTrack,
         trackingScore: predicted.trackingScore,
+        fromPredicted: predicted.fromPredicted,
+      });
+    } else {
+      newInstance = new Instance({
+        points: mappedPoints as PointsArray,
+        skeleton: mappedSkeleton,
+        track: mappedTrack,
+        trackingScore: instance.trackingScore,
+        fromPredicted: instance.fromPredicted,
       });
     }
-    return new Instance({
-      points: newPoints,
-      skeleton: mappedSkeleton,
-      track: mappedTrack,
-      trackingScore: instance.trackingScore,
-      fromPredicted: instance.fromPredicted,
-    });
+    if (memo !== undefined) memo.set(instance, newInstance);
+    return newInstance;
   }
 
   /**
@@ -1862,12 +1932,15 @@ export class Labels {
             instances: [],
             isNegative: otherFrame.isNegative,
           });
+          const instanceMemo = new Map<object, object>();
           for (const inst of otherFrame.instances) {
             newFrame.instances.push(
-              this._mapInstance(inst, skeletonMap, trackMap),
+              this._mapInstance(inst, skeletonMap, trackMap, instanceMemo),
             );
             result.instancesAdded += 1; // per instance
           }
+          // Repair `fromPredicted` links to the remapped source.
+          _relinkFromPredicted(newFrame.instances, instanceMemo);
           newFrame.mergeAnnotations(otherFrame); // default "keep_both"
           Labels._remapFrameAnnotations(newFrame, videoMap, trackMap);
           this.append(newFrame);
@@ -1883,11 +1956,15 @@ export class Labels {
           });
 
           // Remap skeleton/track of instances that came from `other`.
+          const instanceMemo = new Map<object, object>();
           const mergedInstances = rawMerged.map((inst) =>
             skeletonMap.has(inst.skeleton)
-              ? this._mapInstance(inst, skeletonMap, trackMap)
+              ? this._mapInstance(inst, skeletonMap, trackMap, instanceMemo)
               : inst,
           );
+          // Repair `fromPredicted` links so a remapped user instance references
+          // the remapped source prediction in this frame.
+          _relinkFromPredicted(mergedInstances, instanceMemo);
 
           const nBefore = selfFrame.instances.length; // BEFORE reassignment
           const nAfter = mergedInstances.length;

--- a/tests/model/merge-fidelity.test.ts
+++ b/tests/model/merge-fidelity.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Port of Python merge-fidelity regression tests:
+ *   - PR #489: reorder points by node NAME when matched skeletons differ in order
+ *     (tests/model/test_merging_integration.py :: TestMergeNodeOrderReorder)
+ *   - PR #491: preserve from_predicted provenance across merge
+ *     (tests/model/test_labeled_frame.py :: *_from_predicted_relinked,
+ *      tests/io/test_slp.py :: *_from_predicted_survives_merge)
+ *
+ * The TS port has no SLP codec, so the Python save/load round-trip assertions
+ * (which prove the saved link index is not -1) are reproduced here as the
+ * equivalent invariant: the merged user annotation's `fromPredicted` points by
+ * OBJECT IDENTITY at the prediction copy that now lives in the merged frame
+ * (not the original object outside it). That identity is exactly what the SLP
+ * codec resolves to a stored index, so it is the meaningful equivalent.
+ */
+import { describe, it, expect } from "../bun-test";
+import { Instance, PredictedInstance } from "../../src/model/instance.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { Video } from "../../src/model/video.js";
+import { Labels } from "../../src/model/labels.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import {
+  type UserSegmentationMask,
+  PredictedSegmentationMask,
+  encodeRle,
+} from "../../src/model/mask.js";
+
+// --- Fix A (#489): reorder points by node name -------------------------------
+
+describe("Labels.merge point reorder when skeletons differ in order", () => {
+  // The default skeleton matcher uses STRUCTURE matching with
+  // require_same_order=false, so a skeleton [A, B, C] matches a
+  // structurally-equal [C, B, A]. The merge must map points by node name, not
+  // positionally, so each node's coordinates/score follow its name.
+
+  function makeVideo(): Video {
+    return new Video({ filename: "test.mp4", openBackend: false });
+  }
+
+  it("new-frame merge maps points by node name", async () => {
+    const baseSkel = new Skeleton({ nodes: ["A", "B", "C"] });
+    const otherSkel = new Skeleton({ nodes: ["C", "B", "A"] });
+    const video = makeVideo();
+
+    const base = new Labels({ skeletons: [baseSkel] });
+    base.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [
+          Instance.fromNumpy({
+            pointsData: [
+              [1, 1],
+              [2, 2],
+              [3, 3],
+            ],
+            skeleton: baseSkel,
+          }),
+        ],
+      }),
+    );
+
+    // Built from rows in [C, B, A] order -> C=(10,10), B=(11,11), A=(12,12).
+    const other = new Labels({ skeletons: [otherSkel] });
+    other.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 1,
+        instances: [
+          Instance.fromNumpy({
+            pointsData: [
+              [10, 10],
+              [11, 11],
+              [12, 12],
+            ],
+            skeleton: otherSkel,
+          }),
+        ],
+      }),
+    );
+
+    await base.merge(other);
+
+    const merged = base.labeledFrames[1].instances[0];
+    // Merged instance adopts the base skeleton's node order.
+    expect(merged.skeleton.nodeNames).toEqual(["A", "B", "C"]);
+    const idx = (name: string) => merged.skeleton.index(name);
+    const pts = merged.numpy();
+    // Each node's coordinates must follow its name, not its original position.
+    expect(pts[idx("A")]).toEqual([12, 12]);
+    expect(pts[idx("B")]).toEqual([11, 11]);
+    expect(pts[idx("C")]).toEqual([10, 10]);
+  });
+
+  it("overlapping-frame merge maps points by node name", async () => {
+    const baseSkel = new Skeleton({ nodes: ["A", "B", "C"] });
+    const otherSkel = new Skeleton({ nodes: ["C", "B", "A"] });
+    const video = makeVideo();
+
+    const base = new Labels({ skeletons: [baseSkel] });
+    base.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [
+          Instance.fromNumpy({
+            pointsData: [
+              [1, 1],
+              [2, 2],
+              [3, 3],
+            ],
+            skeleton: baseSkel,
+          }),
+        ],
+      }),
+    );
+
+    // Same frame_idx so the instance is merged into the existing frame. Built in
+    // [C, B, A] order -> C=(10,10), B=(11,11), A=(12,12). Placed far from the
+    // base instance so the matcher keeps it as a distinct instance.
+    const other = new Labels({ skeletons: [otherSkel] });
+    other.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [
+          Instance.fromNumpy({
+            pointsData: [
+              [10, 10],
+              [11, 11],
+              [12, 12],
+            ],
+            skeleton: otherSkel,
+          }),
+        ],
+      }),
+    );
+
+    await base.merge(other, { frame: "keep_both" });
+
+    const frame = base.labeledFrames[0];
+    expect(frame.instances.length).toBe(2);
+    // Locate the merged-in instance (the one carrying the other's coordinates).
+    const merged = frame.instances.filter((i) => {
+      const pts = i.numpy();
+      const a = pts[i.skeleton.index("A")];
+      return a[0] === 12 && a[1] === 12;
+    });
+    expect(merged.length).toBe(1);
+    const m = merged[0];
+    expect(m.skeleton.nodeNames).toEqual(["A", "B", "C"]);
+    const idx = (name: string) => m.skeleton.index(name);
+    const pts = m.numpy();
+    expect(pts[idx("A")]).toEqual([12, 12]);
+    expect(pts[idx("B")]).toEqual([11, 11]);
+    expect(pts[idx("C")]).toEqual([10, 10]);
+  });
+
+  it("predicted reorder preserves per-node scores by name", async () => {
+    const baseSkel = new Skeleton({ nodes: ["A", "B", "C"] });
+    const otherSkel = new Skeleton({ nodes: ["C", "B", "A"] });
+    const video = makeVideo();
+
+    const base = new Labels({ skeletons: [baseSkel] });
+    base.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [
+          PredictedInstance.fromNumpy({
+            pointsData: [
+              [1, 1],
+              [2, 2],
+              [3, 3],
+            ],
+            skeleton: baseSkel,
+            score: 0.5,
+          }),
+        ],
+      }),
+    );
+
+    // Built in [C, B, A] order with matching per-node scores (3rd column).
+    const other = new Labels({ skeletons: [otherSkel] });
+    other.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 1,
+        instances: [
+          PredictedInstance.fromNumpy({
+            pointsData: [
+              [10, 10, 0.1],
+              [11, 11, 0.2],
+              [12, 12, 0.3],
+            ],
+            skeleton: otherSkel,
+            score: 0.9,
+          }),
+        ],
+      }),
+    );
+
+    await base.merge(other);
+
+    const merged = base.labeledFrames[1].instances[0] as PredictedInstance;
+    expect(merged).toBeInstanceOf(PredictedInstance);
+    expect(merged.skeleton.nodeNames).toEqual(["A", "B", "C"]);
+    const idx = (name: string) => merged.skeleton.index(name);
+    const pts = merged.numpy();
+    expect(pts[idx("A")]).toEqual([12, 12]);
+    expect(pts[idx("C")]).toEqual([10, 10]);
+    // Scores follow node name: A->0.3, B->0.2, C->0.1.
+    expect(merged.points[idx("A")].score).toBe(0.3);
+    expect(merged.points[idx("B")].score).toBe(0.2);
+    expect(merged.points[idx("C")].score).toBe(0.1);
+    // Instance-level metadata is preserved exactly.
+    expect(merged.score).toBe(0.9);
+  });
+
+  it("identical node order leaves points untouched (control)", async () => {
+    const skel1 = new Skeleton({ nodes: ["A", "B", "C"] });
+    const skel2 = new Skeleton({ nodes: ["A", "B", "C"] });
+    const video = makeVideo();
+
+    const base = new Labels({ skeletons: [skel1] });
+    base.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [
+          Instance.fromNumpy({
+            pointsData: [
+              [1, 1],
+              [2, 2],
+              [3, 3],
+            ],
+            skeleton: skel1,
+          }),
+        ],
+      }),
+    );
+
+    const other = new Labels({ skeletons: [skel2] });
+    other.append(
+      new LabeledFrame({
+        video,
+        frameIdx: 1,
+        instances: [
+          Instance.fromNumpy({
+            pointsData: [
+              [7, 7],
+              [8, 8],
+              [9, 9],
+            ],
+            skeleton: skel2,
+          }),
+        ],
+      }),
+    );
+
+    await base.merge(other);
+
+    const merged = base.labeledFrames[1].instances[0];
+    expect(merged.skeleton.nodeNames).toEqual(["A", "B", "C"]);
+    expect(merged.numpy()).toEqual([
+      [7, 7],
+      [8, 8],
+      [9, 9],
+    ]);
+  });
+});
+
+// --- Fix B (#491): preserve from_predicted provenance across merge -----------
+
+describe("merge preserves from_predicted provenance (masks)", () => {
+  const video = new Video({ filename: "test.mp4", openBackend: false });
+
+  // 5x5 raster with a 3x3 block at rows/cols 1..3.
+  function rle3x3(): Uint32Array {
+    const flat = new Uint8Array(25);
+    for (let r = 1; r < 4; r++) for (let c = 1; c < 4; c++) flat[r * 5 + c] = 1;
+    return encodeRle(flat, 5, 5);
+  }
+
+  function makePred(
+    offset: [number, number] = [0, 0],
+  ): PredictedSegmentationMask {
+    return new PredictedSegmentationMask({
+      rleCounts: rle3x3(),
+      height: 5,
+      width: 5,
+      score: 0.9,
+      offset,
+    });
+  }
+
+  it("auto: relinks a copied user mask to the copied source prediction", () => {
+    const pred = makePred([5, 5]);
+    const user = pred.toUser(); // user.fromPredicted === pred
+    // Move far enough that the link, not spatial proximity, carries the match.
+    user.offset = [500, 500];
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [pred, user] });
+
+    lf1.mergeAnnotations(lf2, "auto");
+
+    const mergedPreds = lf1.masks.filter(
+      (m) => m.isPredicted,
+    ) as PredictedSegmentationMask[];
+    const mergedUsers = lf1.masks.filter(
+      (m) => !m.isPredicted,
+    ) as UserSegmentationMask[];
+    expect(mergedPreds.length).toBe(1);
+    expect(mergedUsers.length).toBe(1);
+    // The link points at the in-frame copy, not the original object.
+    expect(mergedUsers[0].fromPredicted).toBe(mergedPreds[0]);
+    expect(mergedUsers[0].fromPredicted).not.toBe(pred);
+  });
+
+  it("keep_both: relinks a copied user mask to the copied source prediction", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [pred, user] });
+
+    lf1.mergeAnnotations(lf2, "keep_both");
+
+    const mergedPreds = lf1.masks.filter(
+      (m) => m.isPredicted,
+    ) as PredictedSegmentationMask[];
+    const mergedUsers = lf1.masks.filter(
+      (m) => !m.isPredicted,
+    ) as UserSegmentationMask[];
+    expect(mergedUsers[0].fromPredicted).toBe(mergedPreds[0]);
+    expect(mergedUsers[0].fromPredicted).not.toBe(pred);
+  });
+
+  it("keep_new: relinks a copied user mask to the copied source prediction", () => {
+    const pred = makePred();
+    const user = pred.toUser();
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [pred, user] });
+
+    lf1.mergeAnnotations(lf2, "keep_new");
+
+    const mergedPreds = lf1.masks.filter(
+      (m) => m.isPredicted,
+    ) as PredictedSegmentationMask[];
+    const mergedUsers = lf1.masks.filter(
+      (m) => !m.isPredicted,
+    ) as UserSegmentationMask[];
+    expect(mergedUsers[0].fromPredicted).toBe(mergedPreds[0]);
+    expect(mergedUsers[0].fromPredicted).not.toBe(pred);
+  });
+
+  it("replace_predictions: keeps self user and adds other's prediction (no relink needed)", () => {
+    // replace_predictions drops user annotations from other, so the user mask in
+    // `lf2` is not copied; only the prediction is. This exercises the relink pass
+    // on a list where the only fromPredicted source is absent -> link unchanged.
+    const pred = makePred();
+
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, masks: [] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 0, masks: [pred] });
+
+    lf1.mergeAnnotations(lf2, "replace_predictions");
+
+    const mergedPreds = lf1.masks.filter((m) => m.isPredicted);
+    expect(mergedPreds.length).toBe(1);
+    // Predicted mask was copied, not aliased to the original.
+    expect(mergedPreds[0]).not.toBe(pred);
+  });
+});
+
+describe("Labels.merge preserves from_predicted provenance (instances)", () => {
+  function makeVideo(): Video {
+    return new Video({ filename: "test.mp4", openBackend: false });
+  }
+
+  function makeLinkedFrame(
+    video: Video,
+    skeleton: Skeleton,
+    frameIdx: number,
+  ): { frame: LabeledFrame; pred: PredictedInstance; user: Instance } {
+    const pts = [
+      [1.0, 2.0],
+      [3.0, 4.0],
+    ];
+    const pred = PredictedInstance.fromNumpy({
+      pointsData: pts,
+      skeleton,
+      score: 0.9,
+    });
+    const user = Instance.fromNumpy({ pointsData: pts, skeleton });
+    user.fromPredicted = pred;
+    const frame = new LabeledFrame({
+      video,
+      frameIdx,
+      instances: [pred, user],
+    });
+    return { frame, pred, user };
+  }
+
+  it("overlapping-frame merge relinks remapped user instance to remapped prediction", async () => {
+    // Destination has a frame at the SAME frame_idx, so the merge takes the
+    // existing-frame remap path (_map_instance + _relink_from_predicted).
+    const skeleton = new Skeleton({ nodes: ["A", "B"] });
+    const video = makeVideo();
+
+    const dst = new Labels({
+      videos: [video],
+      skeletons: [skeleton],
+      labeledFrames: [new LabeledFrame({ video, frameIdx: 0, instances: [] })],
+    });
+    const srcSkeleton = new Skeleton({ nodes: ["A", "B"] });
+    const { frame } = makeLinkedFrame(video, srcSkeleton, 0);
+    const src = new Labels({
+      videos: [video],
+      skeletons: [srcSkeleton],
+      labeledFrames: [frame],
+    });
+
+    await dst.merge(src, { frame: "auto" });
+
+    const insts = dst.labeledFrames[0].instances;
+    const reloadedPred = insts.find(
+      (i) => i.constructor === PredictedInstance,
+    ) as PredictedInstance;
+    const reloadedUser = insts.find(
+      (i) => i.constructor === Instance,
+    ) as Instance;
+    expect(reloadedPred).toBeDefined();
+    expect(reloadedUser).toBeDefined();
+    // The user instance links to the remapped prediction now in the frame.
+    expect(reloadedUser.fromPredicted).toBe(reloadedPred);
+  });
+
+  it("new-frame merge relinks remapped user instance to remapped prediction", async () => {
+    // Destination has a frame at a DIFFERENT frame_idx, so merging the source
+    // frame (at frameIdx=0) creates a brand-new LabeledFrame (new-frame path).
+    const skeleton = new Skeleton({ nodes: ["A", "B"] });
+    const video = makeVideo();
+
+    const dst = new Labels({
+      videos: [video],
+      skeletons: [skeleton],
+      labeledFrames: [new LabeledFrame({ video, frameIdx: 99, instances: [] })],
+    });
+    const srcSkeleton = new Skeleton({ nodes: ["A", "B"] });
+    const { frame } = makeLinkedFrame(video, srcSkeleton, 0);
+    const src = new Labels({
+      videos: [video],
+      skeletons: [srcSkeleton],
+      labeledFrames: [frame],
+    });
+
+    await dst.merge(src, { frame: "auto" });
+
+    const newFrame = dst.labeledFrames.find((lf) => lf.frameIdx === 0)!;
+    const insts = newFrame.instances;
+    const reloadedPred = insts.find(
+      (i) => i.constructor === PredictedInstance,
+    ) as PredictedInstance;
+    const reloadedUser = insts.find(
+      (i) => i.constructor === Instance,
+    ) as Instance;
+    expect(reloadedPred).toBeDefined();
+    expect(reloadedUser).toBeDefined();
+    expect(reloadedUser.fromPredicted).toBe(reloadedPred);
+    // The relinked prediction is the in-frame copy, not the original source.
+    expect(reloadedUser.fromPredicted).not.toBe(frame.instances[0]);
+  });
+});


### PR DESCRIPTION
Ports two upstream sleap-io merge-fidelity fixes to the TypeScript port.

## Python PRs ported
- talmolab/sleap-io#489 — reorder points by node NAME when matched skeletons differ in order.
- talmolab/sleap-io#491 — preserve `from_predicted` provenance across merge.

## Fix A (#489): reorder points by node name
The default skeleton matcher uses STRUCTURE matching with `require_same_order=false`, so a skeleton `[A, B, C]` matches a structurally-equal `[C, B, A]`. `Labels._mapInstance` previously rebuilt the mapped instance's points POSITIONALLY, silently mis-assigning each node's coordinates/score with respect to its name.

`_mapInstance` now:
- Copies points positionally only when the source point names already equal the mapped skeleton's node order (the common-case hot path).
- Otherwise reorders by node name: each mapped-skeleton node copies the source point of the same name; nodes absent from the source skeleton are filled with a missing/invisible point (NaN xy), consistent with how missing nodes are represented elsewhere.
- Preserves exact-type dispatch (`Instance` vs `PredictedInstance`) and all currently-copied fields (per-node scores included).

This mirrors Python `_map_instance` exactly (`type(source_points).empty(...)` + `match_nodes` reorder).

## Fix B (#491): preserve from_predicted provenance
When both a prediction and the user annotation adopted from it are copied independently during a merge, the user copy's `fromPredicted` kept pointing at the ORIGINAL prediction outside the merged frame. On save the link would serialize as `-1` (provenance lost), breaking the infer → correct → retrain loop.

Adds two helpers mirroring Python `_copy_with_memo` / `_relink_from_predicted`:
- `_copyWithMemo(item, memo)` — shallow-copies and records `original -> copy` (a `Map` keyed by object reference, the JS analog of Python's `id()` dict).
- `_relinkFromPredicted(annotations, memo)` — rewrites each copied user annotation's `fromPredicted` to the in-frame copy when its source was itself copied; leaves links whose source was not copied unchanged.

Wired into every merge copy path the Python PR touches:
- `labeled-frame.ts`: `_resolveAnnotationAuto` (auto), `keep_new`, `replace_predictions`, `keep_both`.
- `labels.ts`: both `_mapInstance` call sites (new-frame and existing-frame branches) via an instance memo; `_mapInstance` records itself in the memo and forwards `fromPredicted` on the `PredictedInstance` branch.

`PredictedInstance`'s constructor gains a `fromPredicted` option to mirror Python (where it is inherited from `Instance`). The relink is generic over modality (today: segmentation masks and `Instance`s).

## Test coverage
New `tests/model/merge-fidelity.test.ts`:
- **#489 reorder**: new-frame merge, overlapping-frame merge (`keep_both`), predicted instance (per-node scores follow node name; instance-level score preserved), and an identical-order control.
- **#491 provenance**: object-identity relinking of `fromPredicted` to the in-frame copy across `auto` / `keep_both` / `keep_new` / `replace_predictions` mask merges, and across both instance merge branches (new-frame and overlapping-frame).

The TS port has no SLP codec yet, so the Python `save`/`load` round-trip assertions (which prove the saved link index is not `-1`) are reproduced as the equivalent invariant: the merged user annotation's `fromPredicted` points by object identity at the prediction copy now in the merged frame — exactly the identity the codec resolves to a stored index.

All checks pass: `bun run check`, `bun run lint` (tsc), `bun run build`, `bun run test` (1570 pass, 1 unrelated env skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm