### PR TITLE
feat(merge)!: default track matching to identity + spatial-divergence warning

### DIFF
--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -86,7 +86,11 @@ function coerceVideoMatcher(
   return x;
 }
 
-/** Coerce a track-matcher argument: `null` -> default `TrackMatcher()` (NAME). */
+/**
+ * Coerce a track-matcher argument: `null` -> default `TrackMatcher()`, whose
+ * constructor default is now IDENTITY (matches only the same Track object;
+ * correctness-first). Pass `"name"` to opt in to name-based matching.
+ */
 function coerceTrackMatcher(
   x: string | TrackMatcher | null | undefined,
 ): TrackMatcher {
@@ -1659,7 +1663,13 @@ export class Labels {
    * @param opts.skeleton - Skeleton matcher (`null` -> STRUCTURE; string ->
    *   validated; else used as-is).
    * @param opts.video - Video matcher (`null` -> AUTO).
-   * @param opts.track - Track matcher (`null` -> NAME).
+   * @param opts.track - Track matcher (`null` -> IDENTITY). The default matches
+   *   tracks only by object identity (the same Track instance) and appends all
+   *   other tracks as new — a correctness-first default that never collapses
+   *   distinct tracks by their (often arbitrary, tracker-assigned) names. Pass
+   *   `"name"` to match tracks by their name attribute instead, for cases where
+   *   track names are semantically meaningful (e.g. user-assigned identities or
+   *   identity-classification model outputs).
    * @param opts.frame - The frame merge strategy as a RAW string (default
    *   `"auto"`; NOT validated against the enum — an invalid value falls through
    *   `LabeledFrame.merge`'s strategy chain into the AUTO branch).
@@ -1900,6 +1910,17 @@ export class Labels {
         }
       }
 
+      // Warn (diagnostic only) if any name-matched track pair carries instances
+      // that diverge spatially on every shared frame. This does not alter
+      // trackMap or any merge result.
+      this._warnTrackNameDivergence(
+        other,
+        videoMap,
+        trackMap,
+        trackMatcher,
+        instanceMatcher,
+      );
+
       // ----- §6.7 STEP 4: frames ------------------------------------------
       total = other.labeledFrames.length;
 
@@ -2064,6 +2085,123 @@ export class Labels {
   }
 
   /**
+   * Warn when name-matched tracks diverge spatially on all shared frames.
+   *
+   * Faithful port of Python `Labels._warn_track_name_divergence`
+   * (labels.py:3672-3776, PR talmolab/sleap-io#448). Name-based track merging
+   * silently coalesces tracks that share a name across two `Labels`. If those
+   * tracks actually label different animals, this can glue distinct tracks
+   * together. This helper emits a diagnostic `console.warn` (purely additive; it
+   * never changes the merge result) when a track pair matched by name carries
+   * instances on overlapping frames that do not spatially correspond under the
+   * merge's instance matcher.
+   *
+   * The check is a no-op unless track matching is by NAME (divergence is
+   * meaningless for identity/object track matching) and the instance matcher is
+   * spatial (SPATIAL or IOU). A warning fires at most once per colliding
+   * `(otherTrack, selfTrack)` pair, only when the pair has at least one shared
+   * frame with instances on both sides and zero spatial instance matches across
+   * all such frames.
+   *
+   * @param other - The other `Labels` being merged into `self`.
+   * @param videoMap - Mapping from `other` videos to the matched `self` videos,
+   *   as built in {@link merge}.
+   * @param trackMap - Mapping from `other` tracks to the matched `self` tracks
+   *   (or back to themselves if appended as new), as built in {@link merge}.
+   * @param trackMatcher - The `TrackMatcher` used for the merge. The check is
+   *   skipped unless its method is NAME.
+   * @param instanceMatcher - The `InstanceMatcher` used for the merge. Reused
+   *   here as the divergence primitive (no new threshold introduced). Skipped
+   *   when its method is IDENTITY (see below).
+   */
+  private _warnTrackNameDivergence(
+    other: Labels,
+    videoMap: Map<Video, Video>,
+    trackMap: Map<Track, Track>,
+    trackMatcher: TrackMatcher,
+    instanceMatcher: InstanceMatcher,
+  ): void {
+    // Only name-based merging can silently glue distinct tracks together.
+    if (trackMatcher.method !== TrackMatchMethod.NAME) {
+      return;
+    }
+
+    // Divergence is a spatial question. An IDENTITY instance matcher compares
+    // track-object identity, which is always false across a name collision (the
+    // tracks are distinct objects by definition), so it cannot assess spatial
+    // divergence and would warn unconditionally. Skip it.
+    if (instanceMatcher.method === InstanceMatchMethod.IDENTITY) {
+      return;
+    }
+
+    // Select true name collisions: an otherTrack coalesced onto a distinct
+    // selfTrack object with an equal name (not a track appended as new).
+    const collidingPairs: Array<[Track, Track]> = [];
+    for (const [otherTrack, selfTrack] of trackMap.entries()) {
+      if (selfTrack !== otherTrack && selfTrack.name === otherTrack.name) {
+        collidingPairs.push([otherTrack, selfTrack]);
+      }
+    }
+    if (collidingPairs.length === 0) {
+      return;
+    }
+
+    for (const [otherTrack, selfTrack] of collidingPairs) {
+      let nShared = 0;
+      let nMatches = 0;
+      let divergentVideo: Video | null = null;
+
+      for (const otherFrame of other.labeledFrames) {
+        const mappedVideo = videoMap.get(otherFrame.video) ?? otherFrame.video;
+        const matchingFrames = this.find({
+          video: mappedVideo,
+          frameIdx: otherFrame.frameIdx,
+        });
+        if (matchingFrames.length === 0) {
+          continue;
+        }
+
+        const selfInsts: Instance[] = [];
+        for (const frame of matchingFrames) {
+          for (const inst of frame.instances) {
+            if (inst.track === selfTrack) {
+              selfInsts.push(inst);
+            }
+          }
+        }
+        const otherInsts = otherFrame.instances.filter(
+          (inst) => inst.track === otherTrack,
+        );
+        if (selfInsts.length === 0 || otherInsts.length === 0) {
+          continue;
+        }
+
+        nShared += 1;
+        nMatches += instanceMatcher.findMatches(selfInsts, otherInsts).length;
+        if (divergentVideo === null) {
+          divergentVideo = mappedVideo;
+        }
+      }
+
+      if (nShared >= 1 && nMatches === 0) {
+        const videoRepr =
+          divergentVideo != null
+            ? filenameRepr(divergentVideo.filename)
+            : "None";
+        console.warn(
+          `Track '${selfTrack.name}' was merged by name across labels that ` +
+            `share video ${videoRepr} but instances on that track ` +
+            `diverge spatially on all ${nShared} overlapping frame(s) (no ` +
+            `instance matched under the merge's instance matcher). If these ` +
+            `tracking runs label different animals, name-based merging may ` +
+            `glue distinct tracks together. Review the merge or resolve tracks ` +
+            `at the instance level.`,
+        );
+      }
+    }
+  }
+
+  /**
    * Build correspondence maps between this `Labels` and another WITHOUT mutating
    * either (read-only twin of {@link merge}).
    *
@@ -2078,7 +2216,13 @@ export class Labels {
    * @param other - The `Labels` to match against (maps `other` -> `self`).
    * @param opts.video - Video matcher (`null` -> AUTO).
    * @param opts.skeleton - Skeleton matcher (`null` -> STRUCTURE).
-   * @param opts.track - Track matcher (`null` -> NAME).
+   * @param opts.track - Track matcher (`null` -> IDENTITY). The default matches
+   *   tracks only by object identity (the same Track instance); all other tracks
+   *   map to `null` — a correctness-first default that never collapses distinct
+   *   tracks by their (often arbitrary, tracker-assigned) names. Pass `"name"` to
+   *   match tracks by their name attribute instead, for cases where track names
+   *   are semantically meaningful (e.g. user-assigned identities or
+   *   identity-classification model outputs).
    */
   async match(
     other: Labels,

--- a/src/model/matching.ts
+++ b/src/model/matching.ts
@@ -1440,10 +1440,11 @@ export class TrackMatcher {
   method: TrackMatchMethod;
 
   /**
-   * @param method - The matching method (default NAME). A bare string is coerced
-   *   + validated.
+   * @param method - The matching method (default IDENTITY — matches only the
+   *   same Track object; correctness-first). Use NAME to match by track name. A
+   *   bare string is coerced + validated.
    */
-  constructor(method: TrackMatchMethod | string = TrackMatchMethod.NAME) {
+  constructor(method: TrackMatchMethod | string = TrackMatchMethod.IDENTITY) {
     this.method =
       typeof method === "string" ? toTrackMatchMethod(method) : method;
   }

--- a/tests/model/labels-match.test.ts
+++ b/tests/model/labels-match.test.ts
@@ -190,10 +190,45 @@ describe("Labels.match (read-only)", () => {
       tracks: [trackPred],
     });
 
-    const result = await gtLabels.match(predLabels);
+    // Opt in to name-based matching: these are two distinct Track objects with
+    // the same name, which only coalesce under track="name" (the identity
+    // default would keep them as separate tracks).
+    const result = await gtLabels.match(predLabels, { track: "name" });
 
     expect(result.allTracksMatched).toBe(true);
     expect(result.trackMap.get(trackPred)).toBe(trackGt);
+  });
+
+  // test_match_default_keeps_same_named_distinct_tracks_unmatched (PR #449)
+  it("default (identity) does not match distinct same-named tracks", async () => {
+    // Locks match()/merge() consistency: both resolve `track=null` to a bare
+    // `TrackMatcher()` and therefore share the identity default. `track="name"`
+    // is the opt-in that matches by name.
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const video = new Video({ filename: "v.mp4", openBackend: false });
+
+    const trackGt = new Track("track_0");
+    const trackPred = new Track("track_0"); // Same name, distinct object.
+
+    const gtLabels = new Labels({
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackGt],
+    });
+    const predLabels = new Labels({
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackPred],
+    });
+
+    // Default identity: distinct objects do not match (track maps to null).
+    const result = await gtLabels.match(predLabels);
+    expect(result.trackMap.get(trackPred)).not.toBe(trackGt);
+    expect(result.trackMap.get(trackPred)).toBe(null);
+
+    // Opt-in name matching: they match.
+    const resultNamed = await gtLabels.match(predLabels, { track: "name" });
+    expect(resultNamed.trackMap.get(trackPred)).toBe(trackGt);
   });
 
   // test_labels_match_string_method (test_labels.py:4701-4715)

--- a/tests/model/labels-merge-track-divergence.test.ts
+++ b/tests/model/labels-merge-track-divergence.test.ts
@@ -1,0 +1,438 @@
+//
+// Port of Python `tests/model/test_merging_integration.py`
+// ::TestTrackNameDivergenceWarning (sleap-io PR talmolab/sleap-io#448),
+// covering the name-collision spatial-divergence warning emitted by
+// `Labels.merge()`.
+//
+// Python emits a `UserWarning` via `warnings.warn`; the JS port emits a
+// `console.warn` (the codebase's diagnostic-warning convention). Tests capture
+// `console.warn` and assert on the message text, mirroring the Python
+// `pytest.warns(...)` / `warnings.catch_warnings(record=True)` patterns.
+
+import { describe, it, expect } from "../bun-test";
+import { Labels } from "../../src/model/labels.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { Instance, Track } from "../../src/model/instance.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { Video } from "../../src/model/video.js";
+import {
+  InstanceMatcher,
+  InstanceMatchMethod,
+  TrackMatcher,
+  TrackMatchMethod,
+} from "../../src/model/matching.js";
+
+/** Run `fn` with `console.warn` captured; returns the captured message strings. */
+async function captureWarnings(
+  fn: () => Promise<void> | void,
+): Promise<string[]> {
+  const warnings: string[] = [];
+  const orig = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(String(args[0]));
+  try {
+    await fn();
+  } finally {
+    console.warn = orig;
+  }
+  return warnings;
+}
+
+/**
+ * Build a single-frame, single-instance Labels for divergence tests.
+ *
+ * Mirrors the Python `_make_run` fixture: one `LabeledFrame` holding one tracked
+ * `Instance`. NOTE: Python `Labels.append` auto-collects each instance's track
+ * into `labels.tracks`; the JS `append` does NOT collect *instance* tracks (only
+ * annotation tracks), so the instance's track is registered explicitly to
+ * reproduce the same post-append state.
+ */
+function makeRun(
+  trackName: string,
+  points: number[][],
+  opts: { frameIdx?: number; skeleton?: Skeleton; video?: Video } = {},
+): Labels {
+  const skeleton = opts.skeleton ?? new Skeleton({ nodes: ["head", "tail"] });
+  const video =
+    opts.video ?? new Video({ filename: "test.mp4", openBackend: false });
+  const track = new Track(trackName);
+  const labels = new Labels({ tracks: [track] });
+  const frame = new LabeledFrame({ video, frameIdx: opts.frameIdx ?? 0 });
+  const inst = Instance.fromNumpy({
+    pointsData: points.map((p) => [...p]),
+    skeleton,
+    track,
+  });
+  frame.instances = [inst];
+  labels.append(frame);
+  return labels;
+}
+
+describe("Labels.merge — track-name divergence warning (PR 448)", () => {
+  it("warns on spatial divergence", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton },
+    );
+    const run2 = makeRun(
+      "track_0",
+      [
+        [500, 500],
+        [510, 510],
+      ],
+      { skeleton },
+    );
+
+    let result!: Awaited<ReturnType<Labels["merge"]>>;
+    const warnings = await captureWarnings(async () => {
+      result = await run1.merge(run2, { track: "name" });
+    });
+
+    expect(warnings.some((w) => /track_0.*diverge spatially/.test(w))).toBe(
+      true,
+    );
+    expect(result.successful).toBe(true);
+    // Diagnostic only: tracks still collapse by name.
+    expect(run1.tracks.length).toBe(1);
+  });
+
+  it("does not warn when same-named tracks overlap spatially", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton },
+    );
+    const run2 = makeRun(
+      "track_0",
+      [
+        [11, 11],
+        [21, 21],
+      ],
+      { skeleton },
+    );
+
+    let result!: Awaited<ReturnType<Labels["merge"]>>;
+    const warnings = await captureWarnings(async () => {
+      result = await run1.merge(run2, { track: "name" });
+    });
+
+    expect(result.successful).toBe(true);
+    expect(warnings.some((w) => /diverge spatially/.test(w))).toBe(false);
+    expect(run1.tracks.length).toBe(1);
+  });
+
+  it("is skipped when track matching is by identity (string)", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton },
+    );
+    const run2 = makeRun(
+      "track_0",
+      [
+        [500, 500],
+        [510, 510],
+      ],
+      { skeleton },
+    );
+
+    const warnings = await captureWarnings(async () => {
+      await run1.merge(run2, { track: "identity" });
+    });
+
+    expect(warnings.some((w) => /diverge spatially/.test(w))).toBe(false);
+  });
+
+  it("is skipped for a custom non-NAME TrackMatcher", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton },
+    );
+    const run2 = makeRun(
+      "track_0",
+      [
+        [500, 500],
+        [510, 510],
+      ],
+      { skeleton },
+    );
+
+    const matcher = new TrackMatcher(TrackMatchMethod.IDENTITY);
+    const warnings = await captureWarnings(async () => {
+      await run1.merge(run2, { track: matcher });
+    });
+
+    expect(warnings.some((w) => /diverge spatially/.test(w))).toBe(false);
+  });
+
+  it("is skipped when the instance matcher is identity-based", async () => {
+    // Identity instance matching compares track-object identity, which is always
+    // false across a name collision, so it cannot assess spatial divergence and
+    // must not warn unconditionally (even on divergent points).
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton },
+    );
+    const run2 = makeRun(
+      "track_0",
+      [
+        [500, 500],
+        [510, 510],
+      ],
+      { skeleton },
+    );
+
+    const matcher = new InstanceMatcher(InstanceMatchMethod.IDENTITY);
+    const warnings = await captureWarnings(async () => {
+      await run1.merge(run2, { track: "name", instance: matcher });
+    });
+
+    expect(warnings.some((w) => /diverge spatially/.test(w))).toBe(false);
+  });
+
+  it("does not warn without shared frames", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { frameIdx: 0, skeleton },
+    );
+    const run2 = makeRun(
+      "track_0",
+      [
+        [500, 500],
+        [510, 510],
+      ],
+      { frameIdx: 5, skeleton },
+    );
+
+    const warnings = await captureWarnings(async () => {
+      await run1.merge(run2, { track: "name" });
+    });
+
+    expect(warnings.some((w) => /diverge spatially/.test(w))).toBe(false);
+  });
+
+  it("does not warn when the colliding track has no instance on a shared frame", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const video = new Video({ filename: "test.mp4", openBackend: false });
+
+    // run1 has track_0 on frame 0.
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton, video },
+    );
+
+    // run2 has both track_0 and track_1 in its track list (so track_0 collides),
+    // but on the shared frame 0 only a track_1 instance appears. (JS `append`
+    // does not collect instance tracks, so `tracks` is registered explicitly.)
+    const track0 = new Track("track_0");
+    const track1 = new Track("track_1");
+    const run2 = new Labels({ tracks: [track1, track0] });
+    // Frame 0 (shared): only a track_1 instance.
+    const f0 = new LabeledFrame({ video, frameIdx: 0 });
+    f0.instances = [
+      Instance.fromNumpy({
+        pointsData: [
+          [500.0, 500.0],
+          [510.0, 510.0],
+        ],
+        skeleton,
+        track: track1,
+      }),
+    ];
+    // Frame 5 (not shared): a track_0 instance, so track_0 is in run2.tracks.
+    const f5 = new LabeledFrame({ video, frameIdx: 5 });
+    f5.instances = [
+      Instance.fromNumpy({
+        pointsData: [
+          [500.0, 500.0],
+          [510.0, 510.0],
+        ],
+        skeleton,
+        track: track0,
+      }),
+    ];
+    run2.append(f0);
+    run2.append(f5);
+
+    const warnings = await captureWarnings(async () => {
+      await run1.merge(run2, { track: "name" });
+    });
+
+    expect(warnings.some((w) => /diverge spatially/.test(w))).toBe(false);
+  });
+
+  it("does not warn for an appended new track", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton },
+    );
+    const run2 = makeRun(
+      "track_2",
+      [
+        [500, 500],
+        [510, 510],
+      ],
+      { skeleton },
+    );
+
+    const warnings = await captureWarnings(async () => {
+      await run1.merge(run2, { track: "name" });
+    });
+
+    expect(warnings.some((w) => /diverge spatially/.test(w))).toBe(false);
+    // The new track is appended.
+    expect(run1.tracks.length).toBe(2);
+  });
+
+  it("warns once per pair across multiple frames", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const video = new Video({ filename: "test.mp4", openBackend: false });
+
+    // One Track object per run, reused across all frames, so the same
+    // (selfTrack, otherTrack) pair spans every shared frame. (JS `append` does
+    // not collect instance tracks, so `tracks` is registered explicitly.)
+    const selfTrack = new Track("track_0");
+    const otherTrack = new Track("track_0");
+    const run1 = new Labels({ tracks: [selfTrack] });
+    const run2 = new Labels({ tracks: [otherTrack] });
+    for (let idx = 0; idx < 3; idx += 1) {
+      const f1 = new LabeledFrame({ video, frameIdx: idx });
+      f1.instances = [
+        Instance.fromNumpy({
+          pointsData: [
+            [10.0, 10.0],
+            [20.0, 20.0],
+          ],
+          skeleton,
+          track: selfTrack,
+        }),
+      ];
+      run1.append(f1);
+
+      const f2 = new LabeledFrame({ video, frameIdx: idx });
+      f2.instances = [
+        Instance.fromNumpy({
+          pointsData: [
+            [500.0, 500.0],
+            [510.0, 510.0],
+          ],
+          skeleton,
+          track: otherTrack,
+        }),
+      ];
+      run2.append(f2);
+    }
+
+    const warnings = await captureWarnings(async () => {
+      await run1.merge(run2, { track: "name" });
+    });
+
+    const divergence = warnings.filter((w) => /diverge spatially/.test(w));
+    expect(divergence.length).toBe(1);
+    expect(/3 overlapping/.test(divergence[0])).toBe(true);
+  });
+
+  it("warns per other-track on a many-to-one collision", async () => {
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const video = new Video({ filename: "test.mp4", openBackend: false });
+
+    const run1 = makeRun(
+      "track_0",
+      [
+        [10, 10],
+        [20, 20],
+      ],
+      { skeleton, video },
+    );
+
+    // run2: two distinct Track objects both named track_0 on distinct frames.
+    // (JS `append` does not collect instance tracks, so register explicitly.)
+    const trackA = new Track("track_0");
+    const trackB = new Track("track_0");
+    const run2 = new Labels({ tracks: [trackA, trackB] });
+    const fa = new LabeledFrame({ video, frameIdx: 0 });
+    fa.instances = [
+      Instance.fromNumpy({
+        pointsData: [
+          [500.0, 500.0],
+          [510.0, 510.0],
+        ],
+        skeleton,
+        track: trackA,
+      }),
+    ];
+    // Distinct frame_idx so both frames coexist in run2.
+    const fb = new LabeledFrame({ video, frameIdx: 1 });
+    fb.instances = [
+      Instance.fromNumpy({
+        pointsData: [
+          [600.0, 600.0],
+          [610.0, 610.0],
+        ],
+        skeleton,
+        track: trackB,
+      }),
+    ];
+    const run1Extra = new LabeledFrame({ video, frameIdx: 1 });
+    run1Extra.instances = [
+      Instance.fromNumpy({
+        pointsData: [
+          [10.0, 10.0],
+          [20.0, 20.0],
+        ],
+        skeleton,
+        track: run1.tracks[0],
+      }),
+    ];
+    run1.append(run1Extra);
+    run2.append(fa);
+    run2.append(fb);
+
+    let result!: Awaited<ReturnType<Labels["merge"]>>;
+    const warnings = await captureWarnings(async () => {
+      result = await run1.merge(run2, { track: "name" });
+    });
+
+    expect(result.successful).toBe(true);
+    const divergence = warnings.filter((w) => /diverge spatially/.test(w));
+    // Both incoming track_0 objects collide onto self's single track_0 and both
+    // diverge, so one warning per colliding other_track (two total).
+    expect(divergence.length).toBe(2);
+  });
+});

--- a/tests/model/labels-merge.test.ts
+++ b/tests/model/labels-merge.test.ts
@@ -1362,3 +1362,123 @@ describe("Labels.merge — original_video OR-logic (GROUP J)", () => {
 // `hasattr(result, "unresolved_videos")`; the hard requirements (successful, +1
 // video for an unmatched pred) are already covered by GROUP G/B AUTO no-match
 // cases above.
+
+// ============================================================================
+// Identity-default track matching (PR talmolab/sleap-io#449)
+// Ports test_labels.py::test_merge_default_keeps_same_named_distinct_tracks_separate
+// and ::test_merge_track_name_opt_in_collapses_and_warns.
+// ============================================================================
+
+describe("Labels.merge — identity-default track matching (PR 449)", () => {
+  it("default merge (identity) keeps distinct same-named tracks separate", async () => {
+    // Locks in the correctness-first identity default: two independently loaded
+    // files often have positionally-named tracks (e.g. "track_0") that are
+    // *different* animals, so the default must NOT collapse them by name.
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const video = new Video({ filename: "v.mp4", openBackend: false });
+
+    const trackSelf = new Track("track_0");
+    const trackOther = new Track("track_0"); // Same name, distinct object.
+
+    const instSelf = Instance.fromNumpy({
+      pointsData: [[1.0, 2.0]],
+      skeleton,
+      track: trackSelf,
+    });
+    const selfLabels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [instSelf] }),
+      ],
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackSelf],
+    });
+
+    const instOther = Instance.fromNumpy({
+      pointsData: [[3.0, 4.0]],
+      skeleton,
+      track: trackOther,
+    });
+    const otherLabels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 1, instances: [instOther] }),
+      ],
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackOther],
+    });
+
+    await selfLabels.merge(otherLabels);
+
+    // No silent collapse: both distinct tracks survive as the original objects.
+    expect(selfLabels.tracks.length).toBe(2);
+    expect(selfLabels.tracks[0]).toBe(trackSelf);
+    expect(selfLabels.tracks[1]).toBe(trackOther);
+    // The incoming instance keeps its own (distinct) track; nothing was rebound.
+    expect(instOther.track).toBe(trackOther);
+  });
+
+  it('track="name" still collapses same-named tracks and warns on divergence', async () => {
+    // Mirrors the divergence-warning fixture: two distinct `track_0` tracks
+    // whose instances are spatially far apart. The explicit name opt-in must
+    // (a) coalesce them into a single track and (b) emit the spatial-divergence
+    // warning.
+    const skeleton = new Skeleton({ nodes: ["head", "tail"] });
+    const video = new Video({ filename: "v.mp4", openBackend: false });
+
+    const trackSelf = new Track("track_0");
+    const trackOther = new Track("track_0");
+
+    const instSelf = Instance.fromNumpy({
+      pointsData: [
+        [10.0, 10.0],
+        [20.0, 20.0],
+      ],
+      skeleton,
+      track: trackSelf,
+    });
+    const selfLabels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [instSelf] }),
+      ],
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackSelf],
+    });
+
+    const instOther = Instance.fromNumpy({
+      pointsData: [
+        [500.0, 500.0],
+        [510.0, 510.0],
+      ],
+      skeleton,
+      track: trackOther,
+    });
+    const otherLabels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [instOther] }),
+      ],
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackOther],
+    });
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(String(args[0]));
+    try {
+      await selfLabels.merge(otherLabels, {
+        frame: "keep_both",
+        track: "name",
+      });
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(warnings.some((w) => /track_0.*diverge spatially/.test(w))).toBe(
+      true,
+    );
+    // Opt-in name matching collapses the two same-named tracks into one.
+    expect(selfLabels.tracks.length).toBe(1);
+  });
+});

--- a/tests/slp-write.test.ts
+++ b/tests/slp-write.test.ts
@@ -105,6 +105,64 @@ describe("saveSlpToBytes", () => {
     expect(loadedInstance.points[2].visible).toBe(false);
   });
 
+  // Port of test_slp.py::test_duplicate_track_name_roundtrip (PR #449).
+  it("round-trips two distinct same-named tracks losslessly", async () => {
+    // The identity-default merge makes duplicate-name Labels more common, so
+    // verify that the SLP reader/writer (which keys tracks by positional index)
+    // preserves two distinct `track_0` tracks rather than collapsing them.
+    const video = new Video({ filename: "test.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+
+    const trackA = new Track("track_0");
+    const trackB = new Track("track_0"); // Same name, distinct object.
+
+    const instA = Instance.fromNumpy({
+      pointsData: [[1.0, 2.0]],
+      skeleton,
+      track: trackA,
+    });
+    const instB = Instance.fromNumpy({
+      pointsData: [[3.0, 4.0]],
+      skeleton,
+      track: trackB,
+    });
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      instances: [instA, instB],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      tracks: [trackA, trackB],
+    });
+
+    const bytes = await saveSlpToBytes(labels);
+    const loaded = await loadSlp(bytes, { openVideos: false });
+
+    // Both distinct tracks survive with the same name.
+    expect(loaded.tracks.length).toBe(2);
+    expect(loaded.tracks.map((t) => t.name)).toEqual(["track_0", "track_0"]);
+
+    // Per-instance track references resolve to distinct positional indices.
+    const loadedLf = loaded.labeledFrames[0];
+    const trackIndices = loadedLf.instances
+      .map((inst) => loaded.tracks.indexOf(inst.track!))
+      .sort((a, b) => a - b);
+    expect(trackIndices).toEqual([0, 1]);
+
+    // Points are exact and correctly associated with their (distinct) track.
+    const byIndex = new Map<number, Instance>();
+    for (const inst of loadedLf.instances) {
+      byIndex.set(loaded.tracks.indexOf(inst.track!), inst as Instance);
+    }
+    expect(byIndex.get(0)!.numpy()[0][0]).toBeCloseTo(1.0);
+    expect(byIndex.get(0)!.numpy()[0][1]).toBeCloseTo(2.0);
+    expect(byIndex.get(1)!.numpy()[0][0]).toBeCloseTo(3.0);
+    expect(byIndex.get(1)!.numpy()[0][1]).toBeCloseTo(4.0);
+  });
+
   it("round-trips a fixture file", async () => {
     const original = await loadFixture("typical.slp");
     const bytes = await saveSlpToBytes(original);


### PR DESCRIPTION
## Summary

Ports two upstream changes from `talmolab/sleap-io` to the TypeScript port:

- **#449** — flips the default track-matching method from NAME to IDENTITY (BREAKING).
- **#448** — adds a diagnostic spatial-divergence warning for name-matched track collisions.

Closes #151.

## Python PRs ported

- [talmolab/sleap-io#449](https://github.com/talmolab/sleap-io/pull/449) — `feat!: default track matching to identity`
- [talmolab/sleap-io#448](https://github.com/talmolab/sleap-io/pull/448) — `feat(merge): warn on spatial divergence of name-matched tracks`

## Changes

### Fix A — identity-default track matching (#449)

- `TrackMatcher` constructor default `TrackMatchMethod.NAME` -> `TrackMatchMethod.IDENTITY` (`src/model/matching.ts`).
- `coerceTrackMatcher` null/undefined path keeps delegating to the (now IDENTITY) bare `TrackMatcher()` constructor default; comment updated to make the intent explicit.
- `merge()` and `match()` JSDoc updated to document the identity default and the `"name"` opt-in.

### Fix B — spatial-divergence warning (#448)

- New private `Labels._warnTrackNameDivergence(other, videoMap, trackMap, trackMatcher, instanceMatcher)`, wired into `merge()` immediately after Step 3 (tracks) and before Step 4 (frames), exactly where Python wires it.
- Emits a `console.warn` **once** per NAME-collision track pair that satisfies all three conditions:
  1. matches by NAME onto a *distinct* self `Track` object (not a track appended as new),
  2. co-occurs on a shared `(video, frameIdx)` with instances on **both** matched tracks, and
  3. has **no** spatial instance correspondence on any shared frame (per the merge's instance matcher).
- No-op unless track matching is `NAME` (divergence is meaningless for identity matching) **and** the instance matcher is spatial — the `IDENTITY` instance matcher is skipped because it compares track-object identity, which is always false across a name collision and would warn unconditionally.
- Purely diagnostic: never alters `trackMap` or any merge result.

Python emits a `UserWarning`; the JS port uses `console.warn`, the codebase's existing diagnostic-warning convention.

## BREAKING CHANGE

The default track matcher for `Labels.merge()` and `Labels.match()` (and the bare `new TrackMatcher()` constructor) is now **IDENTITY** instead of **NAME**.

An unspecified track matcher now merges/matches tracks **only by object identity** (the same `Track` instance) and appends all other tracks as new, rather than coalescing tracks that merely share a name.

**Migration:** pass `track: "name"` (or a `new TrackMatcher(TrackMatchMethod.NAME)`) to restore the prior name-based merging:

```ts
// Old default behavior (name-based) — now opt-in:
await base.merge(other, { track: "name" });
await base.match(other, { track: "name" });
```

**Rationale (asymmetry of errors):** name-based **over-merge** — gluing two different animals together because both happen to be named `"track_0"` (e.g. from two independent tracker runs) — is silent and unrecoverable, while identity-based **under-merge** (keeping tracks separate that you wanted combined) is visible and recoverable. The default therefore favors correctness-first under-merge. Opt in to `"name"` only when track names are semantically meaningful (user-assigned identities or identity-classification model outputs).

## Test fallout

Flipping the default broke one pre-existing test that assumed NAME-default matching:

- `tests/model/labels-match.test.ts` — "matches tracks by name (different object, same name)" now passes `{ track: "name" }`. The two `Track` objects are distinct with the same name, so they only coalesce under the name opt-in (the identity default keeps them separate). This mirrors the equivalent Python test update in #449.

No other pre-existing tests regressed.

## Test coverage (ported from the Python PRs)

- **`tests/model/labels-merge-track-divergence.test.ts`** (new, #448): 10 cases — warns on spatial divergence; no warning on spatial overlap / no shared frame / colliding track absent from shared frame / appended-new track / identity track matcher (string + custom) / identity instance matcher; warns once per pair across multiple frames; warns per other-track on a many-to-one collision.
- **`tests/model/labels-merge.test.ts`** (#449): default merge (identity) keeps distinct same-named tracks separate; `track: "name"` still collapses them and still warns on divergence.
- **`tests/model/labels-match.test.ts`** (#449): `match()` default (identity) does not match distinct same-named tracks (maps to `null`); `track: "name"` does match.
- **`tests/slp-write.test.ts`** (#449): two distinct same-named `track_0` tracks round-trip losslessly through SLP (positional track indexing preserves them).

## Checks

`bun run format` (own files), `bun run check`, `bun run lint` (tsc), and `bun run build` all pass. Full suite: 1563 pass / 1 skip; the only failures are 11 pre-existing `Mp4BoxVideoBackend` cases that require WebCodecs (unavailable in this environment) and fail identically on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm
