### PR TITLE
feat(io): remote loading hardening — auth headers, cloud schemes, Google Drive (Python #439/#445/#441)

### DIFF
--- a/src/codecs/slp/h5-node.ts
+++ b/src/codecs/slp/h5-node.ts
@@ -12,10 +12,13 @@
 import {
   _registerNodeH5,
   _registerNodeFileOps,
+  fetchRemoteSlpBytes,
   type H5Module,
+  type OpenH5Options,
   type SlpSource,
   type H5File,
 } from "./h5.js";
+import { isUrl } from "../../io/remote.js";
 import { _registerFileWriter } from "./write.js";
 
 let modulePromise: Promise<H5Module> | null = null;
@@ -34,35 +37,53 @@ async function getH5ModuleNode(): Promise<H5Module> {
 async function openH5FileNode(
   module: H5Module,
   source: SlpSource,
-): Promise<{ file: H5File; close: () => void }> {
+  options?: OpenH5Options,
+): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
+  // Remote URL: h5wasm/node cannot open a URL directly, so download the bytes
+  // (header-aware, scheme-resolved, redacted) and stage them to a temp file.
+  // Surface the bytes so embedded-pkg.slp reopens reuse them.
+  if (typeof source === "string" && isUrl(source)) {
+    const bytes = await fetchRemoteSlpBytes(source, options);
+    return openBytesNode(module, bytes);
+  }
+
   if (typeof source === "string") {
     const file = new module.File(source, "r");
     return { file, close: () => file.close() };
   }
 
   if (source instanceof Uint8Array || source instanceof ArrayBuffer) {
-    const { writeFileSync, unlinkSync } = await import("node:fs");
-    const { tmpdir } = await import("node:os");
-    const { join } = await import("node:path");
     const data = source instanceof Uint8Array ? source : new Uint8Array(source);
-    const tempPath = join(
-      tmpdir(),
-      `sleap-io-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`,
-    );
-    writeFileSync(tempPath, data);
-    const file = new module.File(tempPath, "r");
-    return {
-      file,
-      close: () => {
-        file.close();
-        unlinkSync(tempPath);
-      },
-    };
+    return openBytesNode(module, data);
   }
 
   throw new Error(
     "Node environments only support string paths or byte buffers for SLP inputs.",
   );
+}
+
+/** Stage bytes to a temp file and open them with h5wasm/node. */
+async function openBytesNode(
+  module: H5Module,
+  data: Uint8Array,
+): Promise<{ file: H5File; close: () => void; urlBytes: Uint8Array }> {
+  const { writeFileSync, unlinkSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempPath = join(
+    tmpdir(),
+    `sleap-io-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`,
+  );
+  writeFileSync(tempPath, data);
+  const file = new module.File(tempPath, "r");
+  return {
+    file,
+    close: () => {
+      file.close();
+      unlinkSync(tempPath);
+    },
+    urlBytes: data,
+  };
 }
 
 // Register Node providers on import (side-effect)

--- a/src/codecs/slp/h5-node.ts
+++ b/src/codecs/slp/h5-node.ts
@@ -38,10 +38,9 @@ async function openH5FileNode(
   module: H5Module,
   source: SlpSource,
   options?: OpenH5Options,
-): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
+): Promise<{ file: H5File; close: () => void }> {
   // Remote URL: h5wasm/node cannot open a URL directly, so download the bytes
   // (header-aware, scheme-resolved, redacted) and stage them to a temp file.
-  // Surface the bytes so embedded-pkg.slp reopens reuse them.
   if (typeof source === "string" && isUrl(source)) {
     const bytes = await fetchRemoteSlpBytes(source, options);
     return openBytesNode(module, bytes);
@@ -66,7 +65,7 @@ async function openH5FileNode(
 async function openBytesNode(
   module: H5Module,
   data: Uint8Array,
-): Promise<{ file: H5File; close: () => void; urlBytes: Uint8Array }> {
+): Promise<{ file: H5File; close: () => void }> {
   const { writeFileSync, unlinkSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");
   const { join } = await import("node:path");
@@ -82,7 +81,6 @@ async function openBytesNode(
       file.close();
       unlinkSync(tempPath);
     },
-    urlBytes: data,
   };
 }
 

--- a/src/codecs/slp/h5-streaming.ts
+++ b/src/codecs/slp/h5-streaming.ts
@@ -13,6 +13,7 @@ import {
   type H5WorkerMessage,
   type H5WorkerResponse,
 } from "./h5-worker.js";
+import { RemoteIOError, isUrl, resolveUrl } from "../../io/remote.js";
 
 /**
  * Options for opening a streaming HDF5 file.
@@ -172,6 +173,15 @@ export class StreamingH5File {
   /**
    * Open a remote HDF5 file for streaming access via URL.
    *
+   * The scheme is resolved on the MAIN thread (the worker cannot import the
+   * scheme gate): `gs://`/`gcs://` are mapped to `storage.googleapis.com`, and
+   * `s3://`/`az://`/`abfs://` fail fast with a redacted {@link RemoteIOError}.
+   * Google Drive is NOT supported on the streaming worker path (Drive requires a
+   * buffered, interstitial-following download, not range streaming); a Drive URL
+   * throws a redacted {@link RemoteIOError} directing the caller to the
+   * non-streaming reader. The worker only ever fetches an already-resolved
+   * http(s) URL.
+   *
    * @param url - URL to the HDF5 file (must support HTTP range requests)
    * @param options - Optional settings
    */
@@ -179,10 +189,29 @@ export class StreamingH5File {
     // Initialize if not already done
     await this.init(options);
 
+    // Resolve the scheme up front so gs:// works in explicit stream mode (the
+    // worker can't resolve it) and unsupported schemes / Drive fail fast with a
+    // redacted typed error rather than a confusing worker error.
+    let resolvedUrl = url;
+    if (isUrl(url)) {
+      const { url: resolved, gdrive } = resolveUrl(url);
+      if (gdrive) {
+        throw new RemoteIOError({
+          message:
+            'Google Drive URLs are not supported on the streaming worker path (Drive needs a buffered download); use the non-streaming reader (stream:"download" / loadSlp)',
+          url,
+          status: null,
+        });
+      }
+      resolvedUrl = resolved;
+    }
+
     const filename =
-      options?.filenameHint || url.split("/").pop()?.split("?")[0] || "data.h5";
+      options?.filenameHint ||
+      resolvedUrl.split("/").pop()?.split("?")[0] ||
+      "data.h5";
     const result = await this.send("openUrl", {
-      url,
+      url: resolvedUrl,
       filename,
       headers: options?.headers,
     });

--- a/src/codecs/slp/h5-streaming.ts
+++ b/src/codecs/slp/h5-streaming.ts
@@ -22,6 +22,12 @@ export interface StreamingH5Options {
   h5wasmUrl?: string;
   /** Filename hint for the HDF5 file. */
   filenameHint?: string;
+  /**
+   * Extra HTTP request headers forwarded to the worker's `openUrl`. When
+   * non-empty, the worker buffer-downloads the file (authenticated) instead of
+   * using header-free `createLazyFile` range streaming.
+   */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -175,7 +181,11 @@ export class StreamingH5File {
 
     const filename =
       options?.filenameHint || url.split("/").pop()?.split("?")[0] || "data.h5";
-    const result = await this.send("openUrl", { url, filename });
+    const result = await this.send("openUrl", {
+      url,
+      filename,
+      headers: options?.headers,
+    });
     this._keys = (result.keys as string[]) || [];
     this._isOpen = true;
   }

--- a/src/codecs/slp/h5-worker.ts
+++ b/src/codecs/slp/h5-worker.ts
@@ -40,7 +40,7 @@ self.onmessage = async function(e) {
         break;
 
       case 'openUrl':
-        const urlResult = await openRemoteFile(payload.url, payload.filename);
+        const urlResult = await openRemoteFile(payload.url, payload.filename, payload.headers);
         respond(id, urlResult);
         break;
 
@@ -126,13 +126,40 @@ async function initH5Wasm(h5wasmUrl) {
   FS = h5wasm.FS;
 }
 
-async function openRemoteFile(url, filename = 'data.h5') {
+async function openRemoteFile(url, filename = 'data.h5', headers) {
   if (!h5wasmModule) {
     throw new Error('h5wasm not initialized');
   }
 
   // Close any existing file
   closeFile();
+
+  // createLazyFile (synchronous XHR) has NO header API. When custom headers are
+  // present we cannot authenticate a range stream, so buffer-download the file
+  // with the headers applied and mount it as a MEMFS buffer instead. Header-free
+  // requests keep the efficient createLazyFile range streaming path.
+  const hasHeaders = headers && typeof headers === 'object' && Object.keys(headers).length > 0;
+  if (hasHeaders) {
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      throw new Error('Failed to fetch remote HDF5 file: ' + response.status);
+    }
+    const data = new Uint8Array(await response.arrayBuffer());
+    const basename = (filename.split('/').pop() || '').split('\\\\').pop() || 'data.h5';
+    mountPath = '/remote-buffer-' + Date.now() + '/' + basename;
+    mountType = 'buffer';
+    currentFilename = basename;
+    const dir = mountPath.substring(0, mountPath.lastIndexOf('/'));
+    FS.mkdir(dir);
+    FS.writeFile(mountPath, data);
+    currentFile = new h5wasm.File(mountPath, 'r');
+    return {
+      success: true,
+      path: currentFile.path,
+      filename: currentFile.filename,
+      keys: currentFile.keys()
+    };
+  }
 
   // Create mount point
   mountPath = '/remote-' + Date.now();

--- a/src/codecs/slp/h5-worker.ts
+++ b/src/codecs/slp/h5-worker.ts
@@ -22,6 +22,70 @@ let h5wasmModule = null;
 let FS = null;
 let currentFile = null;
 let mountPath = null;
+
+// Inlined subset of ../../io/remote.ts (the worker runs in an isolated context
+// via importScripts and cannot import the module). Keep in lockstep with
+// RETRYABLE_STATUSES / withRetries / identityHeaders there.
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+// Force Accept-Encoding: identity (drop any user-supplied value, any case) so a
+// gzip transfer-encoding cannot corrupt ranged reads. Applied to remote fetches
+// here for parity with the main-thread ranged paths.
+function identityHeadersWorker(headers) {
+  const out = {};
+  for (const k of Object.keys(headers || {})) {
+    if (k.toLowerCase() === 'accept-encoding') continue;
+    out[k] = headers[k];
+  }
+  out['Accept-Encoding'] = 'identity';
+  return out;
+}
+
+function parseRetryAfterMsWorker(value) {
+  if (!value) return undefined;
+  const secs = parseInt(value, 10);
+  if (!isFinite(secs) || String(secs) !== String(value).trim()) return undefined;
+  return Math.min(secs * 1000, 30000);
+}
+
+// fetch wrapped in retry/backoff: retries transient network errors and
+// retryable statuses (429/5xx), honoring Retry-After. Returns the Response for
+// any non-retryable status so the caller handles it. Mirrors fetchRetrying in
+// ../../io/remote.ts. Errors are NOT redacted here because the worker only ever
+// sees URLs the main thread already resolved; the main thread re-wraps worker
+// failures, and no token-bearing URL reaches this transport in the streaming
+// path (Drive/headers route through the buffer download, not createLazyFile).
+async function fetchRetryingWorker(url, init, retries) {
+  const max = retries == null ? 3 : retries;
+  let attempt = 0;
+  while (true) {
+    let response;
+    let networkError = false;
+    try {
+      response = await fetch(url, init);
+    } catch (e) {
+      networkError = true;
+    }
+    if (!networkError && !RETRYABLE_STATUSES.has(response.status)) {
+      return response;
+    }
+    if (attempt >= max) {
+      if (networkError) throw new Error('Failed to fetch remote HDF5 file');
+      return response;
+    }
+    let delayMs = Math.min(200 * Math.pow(2, attempt), 30000);
+    if (!networkError) {
+      const ra = parseRetryAfterMsWorker(
+        response.headers && response.headers.get
+          ? response.headers.get('Retry-After')
+          : null,
+      );
+      if (ra != null) delayMs = Math.min(ra, 30000);
+    }
+    attempt += 1;
+    await new Promise(function(r) { setTimeout(r, delayMs); });
+  }
+}
 // Track how the current file was mounted so closeFile can clean up correctly:
 // 'remote' = MEMFS dir + createLazyFile, 'local' = WORKERFS mount,
 // 'buffer' = MEMFS dir + FS.writeFile. Required because FS.rmdir fails on
@@ -140,7 +204,9 @@ async function openRemoteFile(url, filename = 'data.h5', headers) {
   // requests keep the efficient createLazyFile range streaming path.
   const hasHeaders = headers && typeof headers === 'object' && Object.keys(headers).length > 0;
   if (hasHeaders) {
-    const response = await fetch(url, { headers });
+    // Retried with backoff on transient failures / 429/5xx; identity encoding
+    // forced so a gzip transfer-encoding can't corrupt the bytes.
+    const response = await fetchRetryingWorker(url, { headers: identityHeadersWorker(headers) });
     if (!response.ok) {
       throw new Error('Failed to fetch remote HDF5 file: ' + response.status);
     }

--- a/src/codecs/slp/h5.ts
+++ b/src/codecs/slp/h5.ts
@@ -1,7 +1,7 @@
 import {
   RemoteIOError,
+  fetchRetrying,
   isUrl,
-  raiseRemote,
   resolveUrl,
   statusToMessage,
 } from "../../io/remote.js";
@@ -75,7 +75,7 @@ let _nodeOpenFile:
       module: H5Module,
       source: SlpSource,
       options?: OpenH5Options,
-    ) => Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }>)
+    ) => Promise<{ file: H5File; close: () => void }>)
   | null = null;
 
 /**
@@ -89,7 +89,7 @@ export function _registerNodeH5(
     module: H5Module,
     source: SlpSource,
     options?: OpenH5Options,
-  ) => Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }>,
+  ) => Promise<{ file: H5File; close: () => void }>,
 ): void {
   _nodeGetModule = getModule;
   _nodeOpenFile = openFile;
@@ -190,7 +190,7 @@ export async function getH5EmscriptenModule(): Promise<unknown> {
 export async function openH5File(
   source: SlpSource,
   options?: OpenH5Options,
-): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
+): Promise<{ file: H5File; close: () => void }> {
   const module = await getH5Module();
 
   if (_nodeOpenFile) {
@@ -208,7 +208,7 @@ async function openH5FileBrowser(
   module: H5Module,
   source: SlpSource,
   options?: OpenH5Options,
-): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
+): Promise<{ file: H5File; close: () => void }> {
   const fs = getH5FileSystem(module);
 
   if (typeof source === "string" && isUrl(source)) {
@@ -244,7 +244,7 @@ async function openFromUrl(
   fs: H5FileSystem,
   url: string,
   options?: OpenH5Options,
-): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
+): Promise<{ file: H5File; close: () => void }> {
   const filename =
     options?.filenameHint ??
     url.split("/").pop()?.split("?")[0] ??
@@ -259,14 +259,13 @@ async function openFromUrl(
   const { url: resolved, gdrive } = resolveUrl(url);
 
   // Google Drive: resolve ONCE to bytes and feed the in-memory open path. Drive
-  // is always download-mode; streamMode/range are ignored. Surface the bytes so
-  // embedded-pkg.slp reopens reuse them (per-file download quota).
+  // is always download-mode; streamMode/range are ignored.
   if (gdrive) {
     const bytes = await openGdrive(url, { headers: options?.headers });
     const localPath = "/tmp-slp.slp";
     fs.writeFile(localPath, bytes);
     const file = new module.File(localPath, "r");
-    return { file, close: () => file.close(), urlBytes: bytes };
+    return { file, close: () => file.close() };
   }
 
   // createLazyFile (Emscripten synchronous XHR) cannot carry custom headers.
@@ -295,15 +294,11 @@ async function openFromUrl(
     }
   }
 
-  // Header-aware full download. All URL-bearing errors go through RemoteIOError
-  // (redacted); the raw transport error is never re-thrown.
+  // Header-aware full download, retried with backoff on transient failures /
+  // retryable statuses (429/5xx). All URL-bearing errors go through
+  // RemoteIOError (redacted); the raw transport error is never re-thrown.
   const init: RequestInit = { headers: options?.headers ?? {} };
-  let response: Response;
-  try {
-    response = await fetch(resolved, init);
-  } catch (e) {
-    raiseRemote(resolved, e);
-  }
+  const response = await fetchRetrying(resolved, init);
   if (!response.ok) {
     throw new RemoteIOError({
       message: statusToMessage(response.status),
@@ -315,7 +310,7 @@ async function openFromUrl(
   const localPath = "/tmp-slp.slp";
   fs.writeFile(localPath, buffer);
   const file = new module.File(localPath, "r");
-  return { file, close: () => file.close(), urlBytes: buffer };
+  return { file, close: () => file.close() };
 }
 
 async function openFromFile(
@@ -370,12 +365,7 @@ export async function fetchRemoteSlpBytes(
     return openGdrive(url, { headers: options?.headers });
   }
   const init: RequestInit = { headers: options?.headers ?? {} };
-  let response: Response;
-  try {
-    response = await fetch(resolved, init);
-  } catch (e) {
-    raiseRemote(resolved, e);
-  }
+  const response = await fetchRetrying(resolved, init);
   if (!response.ok) {
     throw new RemoteIOError({
       message: statusToMessage(response.status),

--- a/src/codecs/slp/h5.ts
+++ b/src/codecs/slp/h5.ts
@@ -1,3 +1,12 @@
+import {
+  RemoteIOError,
+  isUrl,
+  raiseRemote,
+  resolveUrl,
+  statusToMessage,
+} from "../../io/remote.js";
+import { openGdrive } from "../../io/gdrive.js";
+
 export type H5Module = typeof import("h5wasm");
 export type H5File = InstanceType<H5Module["File"]>;
 
@@ -19,6 +28,18 @@ export type OpenH5Options = {
   stream?: StreamMode;
   /** Filename hint for the HDF5 file */
   filenameHint?: string;
+  /**
+   * Extra HTTP request headers (e.g. `{ Authorization: "Bearer …" }`) applied to
+   * every remote byte fetch for this file AND persisted onto embedded-video
+   * backends so later reopens/probes stay authenticated. Header NAMES are
+   * case-insensitive; `"Accept-Encoding"` is always overridden to `"identity"`
+   * on range requests. Ignored for Google Drive URLs (credentials are stripped).
+   *
+   * Limitation: `createLazyFile` (Emscripten synchronous XHR) cannot carry
+   * custom headers, so authenticated remote `.slp` is downloaded in full;
+   * range streaming with custom headers is not yet supported on the main thread.
+   */
+  headers?: Record<string, string>;
 };
 
 // Re-export streaming utilities for advanced use cases
@@ -53,7 +74,8 @@ let _nodeOpenFile:
   | ((
       module: H5Module,
       source: SlpSource,
-    ) => Promise<{ file: H5File; close: () => void }>)
+      options?: OpenH5Options,
+    ) => Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }>)
   | null = null;
 
 /**
@@ -66,7 +88,8 @@ export function _registerNodeH5(
   openFile: (
     module: H5Module,
     source: SlpSource,
-  ) => Promise<{ file: H5File; close: () => void }>,
+    options?: OpenH5Options,
+  ) => Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }>,
 ): void {
   _nodeGetModule = getModule;
   _nodeOpenFile = openFile;
@@ -167,18 +190,14 @@ export async function getH5EmscriptenModule(): Promise<unknown> {
 export async function openH5File(
   source: SlpSource,
   options?: OpenH5Options,
-): Promise<{ file: H5File; close: () => void }> {
+): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
   const module = await getH5Module();
 
   if (_nodeOpenFile) {
-    return _nodeOpenFile(module, source);
+    return _nodeOpenFile(module, source, options);
   }
 
   return openH5FileBrowser(module, source, options);
-}
-
-function isProbablyUrl(value: string): boolean {
-  return /^https?:\/\//i.test(value);
 }
 
 function isFileHandle(value: SlpSource): value is FileSystemFileHandle {
@@ -189,10 +208,10 @@ async function openH5FileBrowser(
   module: H5Module,
   source: SlpSource,
   options?: OpenH5Options,
-): Promise<{ file: H5File; close: () => void }> {
+): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
   const fs = getH5FileSystem(module);
 
-  if (typeof source === "string" && isProbablyUrl(source)) {
+  if (typeof source === "string" && isUrl(source)) {
     return openFromUrl(module, fs, source, options);
   }
 
@@ -225,18 +244,43 @@ async function openFromUrl(
   fs: H5FileSystem,
   url: string,
   options?: OpenH5Options,
-): Promise<{ file: H5File; close: () => void }> {
+): Promise<{ file: H5File; close: () => void; urlBytes?: Uint8Array }> {
   const filename =
     options?.filenameHint ??
     url.split("/").pop()?.split("?")[0] ??
     "slp-data.slp";
   const streamMode = options?.stream ?? "auto";
+  const hasHeaders = !!(
+    options?.headers && Object.keys(options.headers).length > 0
+  );
 
-  if (fs.createLazyFile && (streamMode === "auto" || streamMode === "range")) {
+  // Resolve the scheme: http(s) passthrough, gs:// -> storage.googleapis.com,
+  // Drive flagged for the buffered resolver, s3/az/abfs rejected (redacted).
+  const { url: resolved, gdrive } = resolveUrl(url);
+
+  // Google Drive: resolve ONCE to bytes and feed the in-memory open path. Drive
+  // is always download-mode; streamMode/range are ignored. Surface the bytes so
+  // embedded-pkg.slp reopens reuse them (per-file download quota).
+  if (gdrive) {
+    const bytes = await openGdrive(url, { headers: options?.headers });
+    const localPath = "/tmp-slp.slp";
+    fs.writeFile(localPath, bytes);
+    const file = new module.File(localPath, "r");
+    return { file, close: () => file.close(), urlBytes: bytes };
+  }
+
+  // createLazyFile (Emscripten synchronous XHR) cannot carry custom headers.
+  // Only use it for range/auto WITHOUT headers; with headers we fall back to the
+  // header-aware full-download path below so the request stays authenticated.
+  if (
+    !hasHeaders &&
+    fs.createLazyFile &&
+    (streamMode === "auto" || streamMode === "range")
+  ) {
     const mountPath = `/slp-remote-${Date.now()}`;
     fs.mkdir?.(mountPath);
     try {
-      fs.createLazyFile(mountPath, filename, url, true, false);
+      fs.createLazyFile(mountPath, filename, resolved, true, false);
       const file = new module.File(`${mountPath}/${filename}`, "r");
       return {
         file,
@@ -251,17 +295,27 @@ async function openFromUrl(
     }
   }
 
-  const response = await fetch(url);
+  // Header-aware full download. All URL-bearing errors go through RemoteIOError
+  // (redacted); the raw transport error is never re-thrown.
+  const init: RequestInit = { headers: options?.headers ?? {} };
+  let response: Response;
+  try {
+    response = await fetch(resolved, init);
+  } catch (e) {
+    raiseRemote(resolved, e);
+  }
   if (!response.ok) {
-    throw new Error(
-      `Failed to fetch SLP file: ${response.status} ${response.statusText}`,
-    );
+    throw new RemoteIOError({
+      message: statusToMessage(response.status),
+      url: resolved,
+      status: response.status,
+    });
   }
   const buffer = new Uint8Array(await response.arrayBuffer());
   const localPath = "/tmp-slp.slp";
   fs.writeFile(localPath, buffer);
   const file = new module.File(localPath, "r");
-  return { file, close: () => file.close() };
+  return { file, close: () => file.close(), urlBytes: buffer };
 }
 
 async function openFromFile(
@@ -293,6 +347,43 @@ async function openFromFile(
   fs.writeFile(localPath, buffer);
   const h5file = new module.File(localPath, "r");
   return { file: h5file, close: () => h5file.close() };
+}
+
+/**
+ * Resolve a remote `.slp` URL and download its bytes (header-aware, redacted).
+ *
+ * Routes through {@link resolveUrl}: `gs://` -> `storage.googleapis.com`,
+ * Google Drive -> {@link openGdrive}, `s3://`/`az://`/`abfs://` -> a redacted
+ * {@link RemoteIOError}. Used by the Node provider (which cannot stream a URL
+ * via h5wasm) and as a building block for the browser download path. All
+ * URL-bearing errors go through {@link RemoteIOError}; the raw transport error
+ * is never re-thrown.
+ *
+ * @internal
+ */
+export async function fetchRemoteSlpBytes(
+  url: string,
+  options?: OpenH5Options,
+): Promise<Uint8Array> {
+  const { url: resolved, gdrive } = resolveUrl(url);
+  if (gdrive) {
+    return openGdrive(url, { headers: options?.headers });
+  }
+  const init: RequestInit = { headers: options?.headers ?? {} };
+  let response: Response;
+  try {
+    response = await fetch(resolved, init);
+  } catch (e) {
+    raiseRemote(resolved, e);
+  }
+  if (!response.ok) {
+    throw new RemoteIOError({
+      message: statusToMessage(response.status),
+      url: resolved,
+      status: response.status,
+    });
+  }
+  return new Uint8Array(await response.arrayBuffer());
 }
 
 export function getH5FileSystem(module: H5Module): H5FileSystem {

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -61,6 +61,12 @@ export interface StreamingSlpOptions {
   h5wasmUrl?: string;
   /** Filename hint for the HDF5 file */
   filenameHint?: string;
+  /**
+   * Extra HTTP request headers (e.g. `{ Authorization: "Bearer …" }`) forwarded
+   * to the streaming worker. When non-empty, the worker downloads the file in a
+   * buffer (authenticated) rather than using header-free range streaming.
+   */
+  headers?: Record<string, string>;
   /** Whether to open video backends for embedded videos (default: false) */
   openVideos?: boolean;
   /**
@@ -118,6 +124,7 @@ export async function readSlpStreaming(
   const file = await openH5Worker(source, {
     h5wasmUrl: options?.h5wasmUrl,
     filenameHint: options?.filenameHint,
+    headers: options?.headers,
   });
 
   const openVideos = options?.openVideos ?? false;

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -112,7 +112,15 @@ export async function readSlp(
   const onProgress = options?.onProgress;
   const report = (i: number) => onProgress?.(i, total, EAGER_STAGES[i]);
 
-  const { file, close } = await openH5File(source, options?.h5);
+  const { file, close, urlBytes } = await openH5File(source, options?.h5);
+  // Remote auth context to persist onto video backends (so reopens/probes stay
+  // authenticated). Only present when loading a remote `.slp` with headers, or
+  // when Drive bytes were resolved (reused for embedded reopen).
+  const remote = {
+    urlHeaders: options?.h5?.headers,
+    urlStreamMode: options?.h5?.stream,
+    urlBytes,
+  };
   try {
     report(0); // Reading metadata
     const metadataGroup = file.get("metadata");
@@ -153,6 +161,7 @@ export async function readSlp(
       openVideos
         ? (i, n) => onProgress?.(2, total, `Opening videos (${i}/${n})`)
         : undefined,
+      remote,
     );
     report(3); // Reading suggestions
     const suggestions = readSuggestions(file.get("suggestions_json"), videos);
@@ -363,7 +372,12 @@ export async function readSlpLazy(
   const onProgress = options?.onProgress;
   const report = (i: number) => onProgress?.(i, total, LAZY_STAGES[i]);
 
-  const { file, close } = await openH5File(source, options?.h5);
+  const { file, close, urlBytes } = await openH5File(source, options?.h5);
+  const remote = {
+    urlHeaders: options?.h5?.headers,
+    urlStreamMode: options?.h5?.stream,
+    urlBytes,
+  };
   try {
     report(0); // Reading metadata
     const metadataGroup = file.get("metadata");
@@ -404,6 +418,7 @@ export async function readSlpLazy(
       openVideos
         ? (i, n) => onProgress?.(2, total, `Opening videos (${i}/${n})`)
         : undefined,
+      remote,
     );
     report(3); // Reading suggestions
     const suggestions = readSuggestions(file.get("suggestions_json"), videos);
@@ -661,8 +676,14 @@ async function readVideos(
   formatId: number,
   videoCrops?: Map<number, VideoCropEntry>,
   onVideoProgress?: (current: number, total: number) => void,
+  remote?: {
+    urlHeaders?: Record<string, string>;
+    urlStreamMode?: import("./h5.js").StreamMode;
+    urlBytes?: Uint8Array;
+  },
 ): Promise<Video[]> {
   if (!dataset) return [];
+  const urlHeaders = remote?.urlHeaders;
   const values = dataset.value ?? [];
   const videos: Video[] = [];
 
@@ -773,6 +794,11 @@ async function readVideos(
           channelOrder,
           shape,
           fps: backendMeta.fps,
+          // Persist the remote `.slp` auth headers onto remote/embedded video
+          // backends so reopens / existence probes stay authenticated. The
+          // factory only uses them for URL-backed backends; embedded/local
+          // backends ignore them.
+          headers: urlHeaders,
         });
       } catch (err) {
         // Resilient load: a single video whose backend can't be built — an
@@ -835,17 +861,27 @@ async function readVideos(
       backendMetadata.crop_fill = cropEntry.fill;
     }
 
-    videos.push(
-      new Video({
-        filename,
-        backend,
-        backendError,
-        backendMetadata,
-        sourceVideo,
-        openBackend: openVideos,
-        embedded,
-      }),
-    );
+    const video = new Video({
+      filename,
+      backend,
+      backendError,
+      backendMetadata,
+      sourceVideo,
+      openBackend: openVideos,
+      embedded,
+    });
+    // Persist remote auth headers / stream mode (and any Drive bytes) so a later
+    // reopen or Video.exists() probe stays authenticated. Mirrors Python
+    // HDF5Video._url_headers. Only meaningful for videos backed by a remote
+    // `.slp` (urlHeaders is undefined for local loads).
+    if (urlHeaders || remote?.urlStreamMode || remote?.urlBytes) {
+      video._setUrlPersistence({
+        headers: urlHeaders,
+        streamMode: remote?.urlStreamMode,
+        bytes: remote?.urlBytes,
+      });
+    }
+    videos.push(video);
   }
 
   return videos;

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -112,14 +112,12 @@ export async function readSlp(
   const onProgress = options?.onProgress;
   const report = (i: number) => onProgress?.(i, total, EAGER_STAGES[i]);
 
-  const { file, close, urlBytes } = await openH5File(source, options?.h5);
-  // Remote auth context to persist onto video backends (so reopens/probes stay
-  // authenticated). Only present when loading a remote `.slp` with headers, or
-  // when Drive bytes were resolved (reused for embedded reopen).
+  const { file, close } = await openH5File(source, options?.h5);
+  // Remote auth headers to persist onto video backends (so existence probes /
+  // URL-backed reopens stay authenticated). Only present when loading a remote
+  // `.slp` with headers.
   const remote = {
     urlHeaders: options?.h5?.headers,
-    urlStreamMode: options?.h5?.stream,
-    urlBytes,
   };
   try {
     report(0); // Reading metadata
@@ -372,11 +370,9 @@ export async function readSlpLazy(
   const onProgress = options?.onProgress;
   const report = (i: number) => onProgress?.(i, total, LAZY_STAGES[i]);
 
-  const { file, close, urlBytes } = await openH5File(source, options?.h5);
+  const { file, close } = await openH5File(source, options?.h5);
   const remote = {
     urlHeaders: options?.h5?.headers,
-    urlStreamMode: options?.h5?.stream,
-    urlBytes,
   };
   try {
     report(0); // Reading metadata
@@ -678,8 +674,6 @@ async function readVideos(
   onVideoProgress?: (current: number, total: number) => void,
   remote?: {
     urlHeaders?: Record<string, string>;
-    urlStreamMode?: import("./h5.js").StreamMode;
-    urlBytes?: Uint8Array;
   },
 ): Promise<Video[]> {
   if (!dataset) return [];
@@ -870,16 +864,12 @@ async function readVideos(
       openBackend: openVideos,
       embedded,
     });
-    // Persist remote auth headers / stream mode (and any Drive bytes) so a later
-    // reopen or Video.exists() probe stays authenticated. Mirrors Python
+    // Persist remote auth headers so a later Video.exists() probe (or a
+    // URL-backed backend reopen) stays authenticated. Mirrors Python
     // HDF5Video._url_headers. Only meaningful for videos backed by a remote
     // `.slp` (urlHeaders is undefined for local loads).
-    if (urlHeaders || remote?.urlStreamMode || remote?.urlBytes) {
-      video._setUrlPersistence({
-        headers: urlHeaders,
-        streamMode: remote?.urlStreamMode,
-        bytes: remote?.urlBytes,
-      });
+    if (urlHeaders) {
+      video._setUrlPersistence({ headers: urlHeaders });
     }
     videos.push(video);
   }

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -47,6 +47,14 @@ export {
   type CropWrapOptions,
 } from "./video/crop-backend.js";
 export * from "./io/main.js";
+export * from "./io/remote.js";
+export {
+  parseGdrive,
+  urlFromConfirmation,
+  checkDownloadHost,
+  openGdrive,
+  DEFAULT_MAX_BYTES,
+} from "./io/gdrive.js";
 export * from "./io/geojson.js";
 export * from "./io/coco.js";
 export * from "./codecs/dictionary.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,14 @@ export {
   type CropWrapOptions,
 } from "./video/crop-backend.js";
 export * from "./io/main.js";
+export * from "./io/remote.js";
+export {
+  parseGdrive,
+  urlFromConfirmation,
+  checkDownloadHost,
+  openGdrive,
+  DEFAULT_MAX_BYTES,
+} from "./io/gdrive.js";
 export * from "./io/geojson.js";
 export * from "./io/trackmate.js";
 export * from "./io/ultralytics.js";

--- a/src/io/gdrive.ts
+++ b/src/io/gdrive.ts
@@ -13,6 +13,7 @@
 import {
   RemoteIOError,
   SENSITIVE_HEADERS,
+  fetchRetrying,
   raiseRemote,
   redactUrl,
 } from "./remote.js";
@@ -336,15 +337,13 @@ export async function openGdrive(
     const headers = { ...baseHeaders };
     if (node && cookie) headers["Cookie"] = cookie;
 
-    let response: Response;
-    try {
-      response = await fetch(
-        current,
-        node ? { headers, redirect: "manual" } : { headers },
-      );
-    } catch (e) {
-      raiseRemote(current, e);
-    }
+    // Retried with backoff on transient failures / retryable statuses (429/5xx);
+    // 3xx redirects are returned unchanged (not retryable) so the Node
+    // manual-redirect loop below can follow them within the allowlist.
+    let response: Response = await fetchRetrying(
+      current,
+      node ? { headers, redirect: "manual" } : { headers },
+    );
 
     // Node manual-redirect: follow within the Drive allowlist, carrying cookies.
     if (node) {
@@ -363,14 +362,10 @@ export async function openGdrive(
         const hopHeaders = { ...baseHeaders };
         if (cookie) hopHeaders["Cookie"] = cookie;
         current = next;
-        try {
-          response = await fetch(current, {
-            headers: hopHeaders,
-            redirect: "manual",
-          });
-        } catch (e) {
-          raiseRemote(current, e);
-        }
+        response = await fetchRetrying(current, {
+          headers: hopHeaders,
+          redirect: "manual",
+        });
         redirects++;
       }
       const setCookie = extractCookie(response);

--- a/src/io/gdrive.ts
+++ b/src/io/gdrive.ts
@@ -1,0 +1,401 @@
+/**
+ * Google Drive share-link resolver (browser + Node portable).
+ *
+ * Ports the realistic subset of Python sleap-io's `_gdrive.py` (PRs #441/#445):
+ * parse a Drive file id from any share-link shape, scrape the virus-scan
+ * interstitial to a real download URL, enforce a host allowlist (SSRF guard),
+ * and buffer-download the file capped at a maximum in-memory size. Credentials
+ * are stripped before any request and never sent to Google hosts.
+ *
+ * @module
+ */
+
+import {
+  RemoteIOError,
+  SENSITIVE_HEADERS,
+  raiseRemote,
+  redactUrl,
+} from "./remote.js";
+
+const UC_URL_TEMPLATE = (id: string): string =>
+  `https://drive.google.com/uc?id=${id}`;
+const BROWSER_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+const MAX_HOPS = 4;
+/** Default cap for a buffered Drive download: 8 GiB. */
+export const DEFAULT_MAX_BYTES = 8 * 1024 ** 3;
+const READ_CHUNK = 1024 ** 2; // 1 MiB
+
+/** Hosts Drive download requests may target (exact match). */
+const DOWNLOAD_HOSTS = new Set([
+  "drive.google.com",
+  "docs.google.com",
+  "drive.usercontent.google.com",
+]);
+const DOWNLOAD_HOST_SUFFIX = ".googleusercontent.com";
+
+const FOLDER_RE = /(?:drive\/)?folders\//;
+const FILE_PATH_RE =
+  /^\/file\/(?:u\/[0-9]+\/)?d\/([^/]+)(?:\/(?:edit|view|preview))?\/?$/;
+const HREF_RE = /href="(\/uc\?export=download[^"]+)"/;
+const DOWNLOAD_URL_JSON_RE = /"downloadUrl":"([^"]+)"/;
+const ERROR_CAPTION_RE = /<p class="uc-error-subcaption">([\s\S]*?)<\/p>/;
+
+function isNode(): boolean {
+  return typeof process !== "undefined" && !!process?.versions?.node;
+}
+
+/**
+ * Extract a Google Drive file id from any share-link shape.
+ *
+ * Order matters: folders are rejected first, then an `id=` query param, then the
+ * `/file/d/<ID>/...` path form. Throws (with a redacted url) for folder URLs,
+ * trailing-segment URLs, and anything else unparsable. Port of `_parse_gdrive`.
+ */
+export function parseGdrive(url: string): string {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    throw new Error(
+      `Could not parse a Google Drive file ID from URL: ${redactUrl(url)}`,
+    );
+  }
+  // Folder reject FIRST (covers /drive/folders/<ID> and /folders/<ID>).
+  if (FOLDER_RE.test(u.pathname)) {
+    throw new Error(
+      `Google Drive folder URLs are not supported: ${redactUrl(url)}`,
+    );
+  }
+  // `id=` query param wins next (covers /open?id=, /uc?id=&export=download).
+  const idParam = u.searchParams.get("id");
+  if (idParam) return idParam;
+  // Path form: /file/d/<ID>/{view,edit,preview}, bare, trailing slash, /u/0/.
+  const m = FILE_PATH_RE.exec(u.pathname);
+  if (m) return m[1];
+  throw new Error(
+    `Could not parse a Google Drive file ID from URL: ${redactUrl(url)}`,
+  );
+}
+
+/** Strip HTML tags and unescape the common entities from a caption fragment. */
+function stripTags(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+/**
+ * Parse the `<form id="download-form">` out of an interstitial page: return its
+ * action URL with the hidden inputs merged in (hidden inputs win). Prefers the
+ * DOM parser when available, falling back to regex in Node.
+ */
+function parseDownloadForm(html: string): string | null {
+  // Prefer DOMParser (browser) for robustness; fall back to regex (Node).
+  if (typeof DOMParser !== "undefined") {
+    try {
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      const form = doc.querySelector(
+        'form#download-form, form[id="download-form"]',
+      ) as HTMLFormElement | null;
+      if (form) {
+        const action = form.getAttribute("action") ?? "";
+        if (action) {
+          const target = new URL(action);
+          const inputs = form.querySelectorAll("input");
+          inputs.forEach((input) => {
+            const name = input.getAttribute("name");
+            if (!name) return;
+            target.searchParams.set(name, input.getAttribute("value") ?? "");
+          });
+          return target.toString();
+        }
+      }
+    } catch {
+      // Fall through to regex.
+    }
+  }
+  // Regex fallback.
+  const formMatch =
+    /<form[^>]*id="download-form"[^>]*>([\s\S]*?)<\/form>/i.exec(html) ??
+    /<form[^>]*\bid='download-form'[^>]*>([\s\S]*?)<\/form>/i.exec(html);
+  if (!formMatch) return null;
+  const formTag = /<form[^>]*id=["']download-form["'][^>]*>/i.exec(html)?.[0];
+  const actionMatch = formTag ? /action=["']([^"']+)["']/i.exec(formTag) : null;
+  if (!actionMatch) return null;
+  let target: URL;
+  try {
+    target = new URL(actionMatch[1].replace(/&amp;/g, "&"));
+  } catch {
+    return null;
+  }
+  const body = formMatch[1];
+  const inputRe = /<input\b[^>]*>/gi;
+  for (const match of body.matchAll(inputRe)) {
+    const tag = match[0];
+    const name = /name=["']([^"']*)["']/i.exec(tag)?.[1];
+    if (!name) continue;
+    const value = /value=["']([^"']*)["']/i.exec(tag)?.[1] ?? "";
+    target.searchParams.set(name, value);
+  }
+  return target.toString();
+}
+
+/**
+ * Scrape the next download URL out of a Drive confirmation page. Tries, in EXACT
+ * precedence order: small-file href, large-file `#download-form`, JSON
+ * `downloadUrl`, then an error caption (→ throws). Port of `_url_from_confirmation`.
+ *
+ * @param html The interstitial HTML.
+ * @param url The originating URL (for redacted error context).
+ */
+export function urlFromConfirmation(html: string, url = ""): string {
+  // 1. Small-file href.
+  const href = HREF_RE.exec(html);
+  if (href) {
+    return "https://docs.google.com" + href[1].replace(/&amp;/g, "&");
+  }
+  // 2. Large-file #download-form (dominant path).
+  const form = parseDownloadForm(html);
+  if (form) return form;
+  // 3. JSON variant.
+  const json = DOWNLOAD_URL_JSON_RE.exec(html);
+  if (json) {
+    return json[1].replace(/\\u003d/g, "=").replace(/\\u0026/g, "&");
+  }
+  // 4. Quota/permission error page.
+  const err = ERROR_CAPTION_RE.exec(html);
+  if (err) {
+    const caption = stripTags(err[1]);
+    throw new RemoteIOError({
+      message: `Google Drive refused the download: ${caption} (if quota, retry later; if permission, set sharing to 'Anyone with the link')`,
+      url,
+      status: null,
+    });
+  }
+  // 5. Nothing matched.
+  throw new Error(
+    "Could not find a Google Drive download link in the confirmation page",
+  );
+}
+
+/**
+ * SSRF guard: allow only http(s) URLs whose host is in the Drive allowlist or
+ * ends with `.googleusercontent.com`. Throws a redacted {@link RemoteIOError}
+ * otherwise. Call before EVERY cookie-carrying GET. Port of `_check_download_host`.
+ */
+export function checkDownloadHost(url: string): void {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    throw new RemoteIOError({
+      message: `Refusing to follow a Google Drive redirect to an unexpected host: ${redactUrl(url)}`,
+      url,
+      status: null,
+    });
+  }
+  const scheme = u.protocol.replace(/:$/, "").toLowerCase();
+  const host = u.hostname.toLowerCase();
+  const allowed =
+    (scheme === "http" || scheme === "https") &&
+    (DOWNLOAD_HOSTS.has(host) || host.endsWith(DOWNLOAD_HOST_SUFFIX));
+  if (!allowed) {
+    throw new RemoteIOError({
+      message: `Refusing to follow a Google Drive redirect to an unexpected host: ${redactUrl(url)}`,
+      url,
+      status: null,
+    });
+  }
+}
+
+/**
+ * Read a response body into a Uint8Array, capped at `cap` bytes. Enforces both a
+ * `Content-Length` pre-check and a running total (Drive often omits the length
+ * and streams chunked). On overflow, throws and discards the partial buffer.
+ * Port of `_read_body_capped`.
+ */
+async function readBodyCapped(
+  response: Response,
+  cap: number,
+  url: string,
+): Promise<Uint8Array> {
+  const len = response.headers.get("Content-Length");
+  if (len && Number(len) > cap) {
+    throw new RemoteIOError({
+      message: `Google Drive file exceeds the maximum in-memory download size (cap=${cap}, Content-Length=${len})`,
+      url,
+      status: null,
+    });
+  }
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const overflow = (): never => {
+    // Discard partial buffer on overflow.
+    chunks.length = 0;
+    throw new RemoteIOError({
+      message: `Google Drive file exceeds the maximum in-memory download size (cap=${cap})`,
+      url,
+      status: null,
+    });
+  };
+
+  const body = response.body;
+  if (body && typeof (body as ReadableStream).getReader === "function") {
+    const reader = (body as ReadableStream<Uint8Array>).getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        // Slice into READ_CHUNK increments only matters for the running check
+        // granularity; accumulate directly and check the running total.
+        total += value.byteLength;
+        if (total > cap) overflow();
+        chunks.push(value);
+      }
+    }
+  } else {
+    // No streaming body (test stubs): fall back to arrayBuffer, still capped.
+    const buf = new Uint8Array(await response.arrayBuffer());
+    if (buf.byteLength > cap) overflow();
+    return buf;
+  }
+
+  // Concatenate (READ_CHUNK referenced for parity with the Python chunk size).
+  void READ_CHUNK;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return out;
+}
+
+/** Extract a minimal `Cookie` header value from a response's `set-cookie`. */
+function extractCookie(response: Response): string | null {
+  // Node fetch exposes set-cookie via headers.get (joined) or getSetCookie.
+  const getSetCookie = (
+    response.headers as Headers & { getSetCookie?: () => string[] }
+  ).getSetCookie;
+  let raw: string | null = null;
+  if (typeof getSetCookie === "function") {
+    const all = getSetCookie.call(response.headers);
+    if (all?.length) raw = all.join(", ");
+  }
+  if (!raw) raw = response.headers.get("set-cookie");
+  if (!raw) return null;
+  // Keep only name=value pairs (drop attributes like Path/Expires/HttpOnly).
+  const pairs = raw
+    .split(/,(?=[^;]+=)/)
+    .map((c) => c.split(";")[0].trim())
+    .filter(Boolean);
+  return pairs.length ? pairs.join("; ") : null;
+}
+
+/**
+ * Resolve a Google Drive share link and buffer-download the file.
+ *
+ * Strips sensitive headers, sends a browser User-Agent, follows the virus-scan
+ * interstitial through up to {@link MAX_HOPS} hops (enforcing the host
+ * allowlist on each), and caps the in-memory download at `maxBytes`. Port of
+ * `_resolve_and_fetch`.
+ *
+ * Drive is always download-mode; `streamMode`/range options do not apply. Drive
+ * VIDEO is unsupported (the SLP caller rejects it before reaching here).
+ *
+ * @returns The downloaded file bytes.
+ */
+export async function openGdrive(
+  url: string,
+  options?: { headers?: Record<string, string>; maxBytes?: number },
+): Promise<Uint8Array> {
+  const maxBytes = options?.maxBytes ?? DEFAULT_MAX_BYTES;
+  const fileId = parseGdrive(url);
+  let current = UC_URL_TEMPLATE(fileId);
+
+  // Strip sensitive headers; never send Authorization/Cookie to Google hosts.
+  const baseHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(options?.headers ?? {})) {
+    if (SENSITIVE_HEADERS.has(k.toLowerCase())) continue;
+    baseHeaders[k] = v;
+  }
+  baseHeaders["User-Agent"] = BROWSER_UA;
+
+  const node = isNode();
+  let cookie: string | null = null;
+
+  for (let hop = 0; hop < MAX_HOPS; hop++) {
+    checkDownloadHost(current);
+    const headers = { ...baseHeaders };
+    if (node && cookie) headers["Cookie"] = cookie;
+
+    let response: Response;
+    try {
+      response = await fetch(
+        current,
+        node ? { headers, redirect: "manual" } : { headers },
+      );
+    } catch (e) {
+      raiseRemote(current, e);
+    }
+
+    // Node manual-redirect: follow within the Drive allowlist, carrying cookies.
+    if (node) {
+      let redirects = 0;
+      while (
+        response.status >= 300 &&
+        response.status < 400 &&
+        redirects < MAX_HOPS
+      ) {
+        const location = response.headers.get("location");
+        if (!location) break;
+        const next = new URL(location, current).toString();
+        checkDownloadHost(next);
+        const setCookie = extractCookie(response);
+        if (setCookie) cookie = cookie ? `${cookie}; ${setCookie}` : setCookie;
+        const hopHeaders = { ...baseHeaders };
+        if (cookie) hopHeaders["Cookie"] = cookie;
+        current = next;
+        try {
+          response = await fetch(current, {
+            headers: hopHeaders,
+            redirect: "manual",
+          });
+        } catch (e) {
+          raiseRemote(current, e);
+        }
+        redirects++;
+      }
+      const setCookie = extractCookie(response);
+      if (setCookie) cookie = cookie ? `${cookie}; ${setCookie}` : setCookie;
+    }
+
+    if (!response.ok) {
+      raiseRemote(current, undefined, response.status);
+    }
+
+    const contentDisposition = response.headers.get("Content-Disposition");
+    const contentType = response.headers.get("Content-Type") ?? "";
+    if (contentDisposition || !contentType.startsWith("text/html")) {
+      // This is the file.
+      return readBodyCapped(response, maxBytes, current);
+    }
+
+    // Otherwise it is an interstitial — scrape the next URL.
+    const html = await response.text();
+    current = urlFromConfirmation(html, current);
+  }
+
+  throw new RemoteIOError({
+    message: `Google Drive download did not converge within ${MAX_HOPS} hops`,
+    url,
+    status: null,
+  });
+}

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -10,6 +10,7 @@ import {
   SlpSource,
   isStreamingSupported,
 } from "../codecs/slp/h5.js";
+import { redactedCauseSummary } from "./remote.js";
 import {
   readLabels as readAnalysisH5,
   writeLabels as writeAnalysisH5,
@@ -87,14 +88,16 @@ export async function loadSlp(
       try {
         return await readSlpStreaming(streamingSource, {
           filenameHint: options?.h5?.filenameHint,
+          headers: options?.h5?.headers,
           openVideos,
           onProgress: options?.onProgress,
         });
       } catch (e) {
         if (streamMode === "auto") {
+          // Redact: the raw error can embed ?token= / userinfo (a remote URL).
           console.warn(
             "[sleap-io] Worker-based loading failed, falling back to main thread:",
-            e,
+            redactedCauseSummary(e),
           );
         } else {
           throw e;

--- a/src/io/remote.ts
+++ b/src/io/remote.ts
@@ -1,0 +1,428 @@
+/**
+ * Remote-loading helpers: URL/scheme resolution, credential redaction, a typed
+ * {@link RemoteIOError}, retry/backoff, header transforms, and a non-throwing
+ * existence probe.
+ *
+ * This is the browser+Node-portable subset of Python sleap-io's `_remote.py`
+ * (PRs #439/#445). It threads auth headers end-to-end and guarantees that no
+ * thrown error or log line leaks credentials (userinfo / sensitive query
+ * params). See {@link redactUrl} and {@link RemoteIOError}.
+ *
+ * @module
+ */
+
+/** URL schemes recognized as remote (vs. a local path). Port of Python `URL_SCHEMES`. */
+export const URL_SCHEMES = new Set([
+  "http",
+  "https",
+  "s3",
+  "gs",
+  "gcs",
+  "az",
+  "abfs",
+]);
+
+/** Cloud schemes that need a provider SDK (not available in the browser). */
+export const CLOUD_SCHEMES = new Set(["s3", "gs", "gcs", "az", "abfs"]);
+
+/** Hosts handled by the Google Drive resolver. */
+export const GDRIVE_HOSTS = new Set(["drive.google.com", "docs.google.com"]);
+
+/**
+ * Headers dropped on a cross-origin redirect and never sent to Google Drive
+ * hosts. Lowercase for case-insensitive matching.
+ */
+export const SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+]);
+
+/**
+ * Query-param names (lowercased) whose VALUE is masked to `***` in
+ * {@link redactUrl}. Other params are left untouched.
+ */
+export const SENSITIVE_QUERY_PARAMS = new Set([
+  "token",
+  "access_token",
+  "x-amz-security-token",
+  "sas",
+  "sig",
+]);
+
+/** HTTP status codes that {@link withRetries} treats as retryable. */
+export const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+/** Matches URL tokens embedded in arbitrary error text for scrubbing. */
+const URL_IN_TEXT_PATTERN = /(?:http|https|s3|gs|gcs|az|abfs):\/\/[^\s"'<>]+/gi;
+
+/**
+ * Whether `value` looks like a remote URL (one of {@link URL_SCHEMES}).
+ *
+ * Port of Python `_is_url`. The `scheme.length > 1` guard is mandatory so a
+ * Windows drive letter (`C:\...`) is not misread as a URL.
+ */
+export function isUrl(value: unknown): boolean {
+  if (typeof value !== "string" || value.length === 0) return false;
+  const colon = value.indexOf(":");
+  if (colon <= 1) return false; // length-1 scheme (drive letter) or no scheme
+  const scheme = value.slice(0, colon).toLowerCase();
+  return scheme.length > 1 && URL_SCHEMES.has(scheme);
+}
+
+/**
+ * Whether `value` is a Google Drive share URL. Port of Python `_is_gdrive_url`.
+ * Never throws on malformed input.
+ */
+export function isGdriveUrl(value: unknown): boolean {
+  if (!isUrl(value)) return false;
+  try {
+    return GDRIVE_HOSTS.has(new URL(value as string).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mask credentials in a URL: userinfo becomes `***:***@host`, and the VALUES of
+ * sensitive query params ({@link SENSITIVE_QUERY_PARAMS}) become `***`
+ * (serialized percent-encoded as `%2A%2A%2A`, matching Python). Other params are
+ * left intact. On parse failure the input is returned unchanged.
+ *
+ * Port of Python `_redact_url`.
+ */
+export function redactUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  if (parsed.username || parsed.password) {
+    parsed.username = "***";
+    parsed.password = "***";
+  }
+  for (const key of [...parsed.searchParams.keys()]) {
+    if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+      parsed.searchParams.set(key, "***");
+    }
+  }
+  return parsed.toString();
+}
+
+/**
+ * A short, credential-scrubbed one-line summary of an arbitrary error, suitable
+ * for logging and for the `cause=` segment of {@link RemoteIOError}. Any URL
+ * tokens embedded in the message are run through {@link redactUrl}.
+ *
+ * Port of Python `_redacted_cause_summary`.
+ */
+export function redactedCauseSummary(e: unknown): string {
+  const typeName =
+    (e as { constructor?: { name?: string } } | null)?.constructor?.name ??
+    "Error";
+  const rawMsg = String(
+    (e as { message?: unknown } | null)?.message ?? (e as unknown),
+  );
+  const redactedMsg = rawMsg
+    .replace(URL_IN_TEXT_PATTERN, (m) => redactUrl(m))
+    .replace(/\s*\n\s*/g, " ")
+    .trim();
+  return `${typeName}: ${redactedMsg}`;
+}
+
+/**
+ * Typed error for every remote-loading failure. The `url` is ALWAYS stored
+ * redacted (redaction happens in the constructor from the RAW url passed in),
+ * and the raw transport error is NEVER chained as `.cause` — only a redacted
+ * {@link redactedCauseSummary} is kept, so credentials cannot leak through a
+ * re-throw or `.cause` inspection.
+ *
+ * Port of Python `RemoteIOError`.
+ */
+export class RemoteIOError extends Error {
+  readonly status: number | null;
+  /** ALWAYS redacted. */
+  readonly url: string;
+  readonly causeSummary?: string;
+  /**
+   * Delay (ms) hinted by a `Retry-After` response header, threaded to
+   * {@link withRetries}. Not part of Python; a JS-side channel so the retry
+   * loop can honor server backoff without re-issuing the failed request.
+   */
+  retryAfterMs?: number;
+
+  constructor(opts: {
+    message: string;
+    url: string;
+    status?: number | null;
+    cause?: unknown;
+  }) {
+    const redactedUrl = redactUrl(opts.url);
+    const causeSummary =
+      opts.cause !== undefined ? redactedCauseSummary(opts.cause) : undefined;
+    const parts = [
+      opts.message,
+      `status=${opts.status ?? "null"}`,
+      `url=${redactedUrl}`,
+    ];
+    if (causeSummary) parts.push(`cause=${causeSummary}`);
+    super(parts.join("; "));
+    this.name = "RemoteIOError";
+    this.status = opts.status ?? null;
+    this.url = redactedUrl;
+    this.causeSummary = causeSummary;
+    // CRITICAL: do NOT set this.cause = opts.cause. The raw fetch/transport
+    // error string can embed ?token= / userinfo and would leak through .cause
+    // or a re-throw. We keep only the redacted causeSummary.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** Result of {@link resolveUrl}. */
+export interface ResolvedUrl {
+  /** Fetchable HTTPS URL (passthrough for http(s); mapped for gs/gcs). */
+  url: string;
+  /** When true, the caller must route through the Google Drive resolver. */
+  gdrive: boolean;
+}
+
+/**
+ * Turn any user-supplied URL into a fetchable HTTPS URL (or flag it for Google
+ * Drive). The single public scheme gate.
+ *
+ * - `http(s)://` (non-Drive host): passthrough, `gdrive: false`.
+ * - Google Drive host: `gdrive: true` (caller routes to `openGdrive`).
+ * - `gs://<bucket>/<obj>` / `gcs://...`: mapped to
+ *   `https://storage.googleapis.com/<bucket>/<obj>` (object path + query
+ *   preserved verbatim). NOTE: this only resolves PUBLIC objects without auth;
+ *   private buckets still need a presigned HTTPS URL — no signing is attempted.
+ * - `s3://` / `az://` / `abfs://`: throws {@link RemoteIOError} (no in-browser
+ *   SDK) directing the user to a presigned `https://` URL.
+ * - non-URL input: throws {@link RemoteIOError} (`resolveUrl` only acts on URLs).
+ *
+ * Port of Python's scheme handling.
+ */
+export function resolveUrl(url: string): ResolvedUrl {
+  if (!isUrl(url)) {
+    throw new RemoteIOError({ message: "Not a URL", url, status: null });
+  }
+  if (isGdriveUrl(url)) {
+    return { url, gdrive: true };
+  }
+  const colon = url.indexOf(":");
+  const scheme = url.slice(0, colon).toLowerCase();
+  if (scheme === "http" || scheme === "https") {
+    return { url, gdrive: false };
+  }
+  if (scheme === "gs" || scheme === "gcs") {
+    // Split once on "://", then once on "/" -> bucket + rest. Preserve the
+    // object path (including extra slashes) and any query string verbatim.
+    const rest = url.slice(url.indexOf("://") + 3);
+    const slash = rest.indexOf("/");
+    const bucket = slash === -1 ? rest : rest.slice(0, slash);
+    const objectPath = slash === -1 ? "" : rest.slice(slash + 1);
+    return {
+      url: `https://storage.googleapis.com/${bucket}/${objectPath}`,
+      gdrive: false,
+    };
+  }
+  // s3 / az / abfs — no in-browser SDK.
+  throw new RemoteIOError({
+    message: `Cloud scheme '${scheme}' is not supported in the browser. Pass a presigned https:// URL instead.`,
+    url,
+    status: null,
+  });
+}
+
+/**
+ * Map an HTTP status to a short human message. Port of Python's `_raise_remote`
+ * table.
+ */
+export function statusToMessage(status: number): string {
+  switch (status) {
+    case 404:
+      return "file not found";
+    case 416:
+      return "range past end of file";
+    case 412:
+      return "file changed since cached (ETag mismatch)";
+    default:
+      return `HTTP ${status}`;
+  }
+}
+
+/**
+ * Build and throw a {@link RemoteIOError} from a transport-level failure (no
+ * `response`). Classifies fetch network errors / aborts. Port of Python's
+ * fetch-level classification in `_raise_remote`.
+ *
+ * @param url Raw URL (redacted by the error constructor).
+ * @param e The thrown transport error.
+ * @param status Optional HTTP status when a response was received.
+ */
+export function raiseRemote(
+  url: string,
+  e: unknown,
+  status?: number | null,
+): never {
+  let message: string;
+  if (status != null) {
+    message = statusToMessage(status);
+  } else if (
+    e instanceof Error &&
+    (e.name === "AbortError" ||
+      (typeof DOMException !== "undefined" &&
+        e instanceof DOMException &&
+        e.name === "AbortError"))
+  ) {
+    message = "timeout";
+  } else if (e instanceof TypeError) {
+    message = "connection error";
+  } else {
+    const typeName =
+      (e as { constructor?: { name?: string } } | null)?.constructor?.name ??
+      "Error";
+    message = `unexpected error: ${typeName}`;
+  }
+  throw new RemoteIOError({ message, url, status: status ?? null, cause: e });
+}
+
+/**
+ * Copy `headers`, force `Accept-Encoding: identity`, and drop any user-supplied
+ * `Accept-Encoding` (case-insensitive) so it cannot be overridden. Apply to
+ * every ranged request. Port of Python `_identity_headers`.
+ */
+export function identityHeaders(
+  headers?: Record<string, string>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers ?? {})) {
+    if (k.toLowerCase() === "accept-encoding") continue;
+    out[k] = v;
+  }
+  out["Accept-Encoding"] = "identity";
+  return out;
+}
+
+/**
+ * Drop sensitive headers ({@link SENSITIVE_HEADERS}) when `toUrl` is a different
+ * origin than `fromUrl`; otherwise return `headers` unchanged. Port of Python
+ * `_strip_cross_origin_headers`. Invoked only where WE follow redirects
+ * manually (Node range reader, Drive); the browser strips `Authorization`
+ * cross-origin natively.
+ */
+export function stripCrossOriginHeaders(
+  headers: Record<string, string>,
+  fromUrl: string,
+  toUrl: string,
+): Record<string, string> {
+  let sameOrigin = false;
+  try {
+    sameOrigin = new URL(toUrl).origin === new URL(fromUrl).origin;
+  } catch {
+    sameOrigin = false;
+  }
+  if (sameOrigin) return headers;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (SENSITIVE_HEADERS.has(k.toLowerCase())) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Run `fn`, retrying on retryable {@link RemoteIOError}s (retryable status or a
+ * connection-error classification) with exponential backoff, honoring a
+ * `Retry-After` hint when present.
+ *
+ * Backoff: `min(200 * 2**attempt, 30000)` ms (attempt 0-indexed). Port of
+ * Python `_open_with_retries` / `_retry_sleep_seconds`.
+ */
+export async function withRetries<T>(
+  fn: () => Promise<T>,
+  options?: { retries?: number },
+): Promise<T> {
+  const retries = options?.retries ?? 3;
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await fn();
+    } catch (e) {
+      const retryable =
+        e instanceof RemoteIOError &&
+        (e.status === null || RETRYABLE_STATUSES.has(e.status ?? -1));
+      if (!retryable || attempt >= retries) {
+        throw e;
+      }
+      const retryAfterMs = (e as RemoteIOError).retryAfterMs;
+      const delayMs =
+        retryAfterMs != null
+          ? Math.min(retryAfterMs, 30000)
+          : Math.min(200 * 2 ** attempt, 30000);
+      attempt += 1;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+}
+
+/**
+ * Parse a `Retry-After` header into milliseconds. Only the integer-seconds form
+ * is honored; the HTTP-date form is ignored (returns undefined → computed
+ * backoff). Used by fetch wrappers to attach `retryAfterMs` to a thrown error.
+ */
+export function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const secs = Number.parseInt(value, 10);
+  if (!Number.isFinite(secs) || String(secs) !== value.trim()) return undefined;
+  return Math.min(secs * 1000, 30000);
+}
+
+/**
+ * Non-throwing existence probe for a URL. Tries HEAD, falling back to a
+ * `Range: bytes=0-0` GET when HEAD is unavailable. ALWAYS returns a boolean
+ * (any thrown error → `false`). Port of Python `_head_or_range_probe`.
+ *
+ * For Google Drive, HEAD is rejected by Google, so success is approximated by
+ * whether a file id can be parsed from the URL (no network).
+ */
+export async function headOrRangeProbe(
+  url: string,
+  options?: { headers?: Record<string, string> },
+): Promise<boolean> {
+  let resolved: ResolvedUrl;
+  try {
+    resolved = resolveUrl(url);
+  } catch {
+    return false;
+  }
+  if (resolved.gdrive) {
+    // Drive rejects HEAD; treat a parseable file id as "exists" without network.
+    try {
+      const { parseGdrive } = await import("./gdrive.js");
+      parseGdrive(url);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  const headers = options?.headers ?? {};
+  try {
+    const head = await fetch(resolved.url, { method: "HEAD", headers });
+    if (head.ok) return true;
+    // Fall through to a ranged GET for 405 (and any other non-ok).
+  } catch {
+    // HEAD itself threw (network error / method blocked) — try GET below.
+  }
+  try {
+    const ranged = await fetch(resolved.url, {
+      method: "GET",
+      headers: { ...headers, Range: "bytes=0-0" },
+    });
+    return ranged.ok || ranged.status === 206;
+  } catch {
+    return false;
+  }
+}

--- a/src/io/remote.ts
+++ b/src/io/remote.ts
@@ -381,6 +381,56 @@ export function parseRetryAfterMs(value: string | null): number | undefined {
 }
 
 /**
+ * `fetch` wrapped in {@link withRetries}: every remote byte fetch goes through
+ * here so transient failures are retried with backoff (mirrors Python's
+ * `_open_with_retries`, which wraps every remote open).
+ *
+ * Retries on:
+ * - transient network errors (`raiseRemote` classifies a `TypeError` →
+ *   "connection error" / an `AbortError` → "timeout" as a retryable
+ *   {@link RemoteIOError} with `status === null`), and
+ * - retryable HTTP statuses ({@link RETRYABLE_STATUSES}: 429/500/502/503/504),
+ *   honoring a `Retry-After` header via {@link parseRetryAfterMs}.
+ *
+ * For a NON-retryable status (e.g. 206/404/redirect) the `Response` is returned
+ * unchanged so the caller applies its own handling. Every thrown error is the
+ * redacted typed {@link RemoteIOError}; the raw transport error never escapes.
+ *
+ * @param url Resolved fetch URL (raw; redacted by the error constructor).
+ * @param init `RequestInit` (headers, method, Range, etc.).
+ * @param options `retries` forwarded to {@link withRetries}.
+ */
+export async function fetchRetrying(
+  url: string,
+  init?: RequestInit,
+  options?: { retries?: number },
+): Promise<Response> {
+  return withRetries(async () => {
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (e) {
+      // Throws a redacted RemoteIOError; network errors (TypeError/AbortError)
+      // are classified with status === null, which withRetries treats as
+      // retryable.
+      raiseRemote(url, e);
+    }
+    if (RETRYABLE_STATUSES.has(response.status)) {
+      const err = new RemoteIOError({
+        message: statusToMessage(response.status),
+        url,
+        status: response.status,
+      });
+      err.retryAfterMs = parseRetryAfterMs(
+        response.headers?.get?.("Retry-After") ?? null,
+      );
+      throw err;
+    }
+    return response;
+  }, options);
+}
+
+/**
  * Non-throwing existence probe for a URL. Tries HEAD, falling back to a
  * `Range: bytes=0-0` GET when HEAD is unavailable. ALWAYS returns a boolean
  * (any thrown error → `false`). Port of Python `_head_or_range_probe`.

--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -9,7 +9,6 @@ import {
 } from "../transform/points.js";
 import type { Fill } from "../transform/frame.js";
 import { headOrRangeProbe, isUrl } from "../io/remote.js";
-import type { StreamMode } from "../codecs/slp/h5.js";
 
 /**
  * Default TTL (ms) for the per-instance {@link Video.exists} URL probe cache.
@@ -164,10 +163,6 @@ export class Video {
   private _fps: number | null = null;
   /** Auth headers persisted from a remote `.slp` load (mirror Python `_url_headers`). */
   private _urlHeaders?: Record<string, string>;
-  /** Stream mode persisted from a remote `.slp` load. */
-  private _urlStreamMode?: StreamMode;
-  /** Drive bytes reused for embedded reopen (avoids re-hitting per-file quota). */
-  private _urlBytes?: Uint8Array;
   /** Per-instance TTL cache for {@link exists}. */
   private _existsCache?: { key: string; value: boolean; expiresAt: number };
 
@@ -258,19 +253,13 @@ export class Video {
   }
 
   /**
-   * Persist the remote auth context from a remote `.slp` load so later reopens
-   * and {@link exists} probes stay authenticated. Mirrors Python's
-   * `HDF5Video._url_headers`. Internal — set by the SLP reader.
+   * Persist the remote auth headers from a remote `.slp` load so later
+   * {@link exists} probes (and any URL-backed backend) stay authenticated.
+   * Mirrors Python's `HDF5Video._url_headers`. Internal — set by the SLP reader.
    * @internal
    */
-  _setUrlPersistence(persistence: {
-    headers?: Record<string, string>;
-    streamMode?: StreamMode;
-    bytes?: Uint8Array;
-  }): void {
+  _setUrlPersistence(persistence: { headers?: Record<string, string> }): void {
     if (persistence.headers) this._urlHeaders = persistence.headers;
-    if (persistence.streamMode) this._urlStreamMode = persistence.streamMode;
-    if (persistence.bytes) this._urlBytes = persistence.bytes;
   }
 
   /**
@@ -282,6 +271,10 @@ export class Video {
   _backendUrlHeaders(): Record<string, string> | undefined {
     return (
       this._urlHeaders ??
+      // Python-parity placeholder: no JS backend currently sets `_urlHeaders`,
+      // so this fallback is inert today. Kept so a future URL-backed backend
+      // that carries its own headers (as Python's HDF5Video does) is honored
+      // without changing this accessor.
       (this.backend as { _urlHeaders?: Record<string, string> } | null)
         ?._urlHeaders
     );

--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -1,4 +1,4 @@
-import { VideoBackend, VideoFrame } from "../video/backend.js";
+import type { VideoBackend, VideoFrame } from "../video/backend.js";
 import { CropVideoBackend } from "../video/crop-backend.js";
 import {
   cropPoints,
@@ -8,6 +8,14 @@ import {
   type PointPairs,
 } from "../transform/points.js";
 import type { Fill } from "../transform/frame.js";
+import { headOrRangeProbe, isUrl } from "../io/remote.js";
+import type { StreamMode } from "../codecs/slp/h5.js";
+
+/**
+ * Default TTL (ms) for the per-instance {@link Video.exists} URL probe cache.
+ * Analogous to Python's `SLEAP_IO_EXISTS_TTL`.
+ */
+export const EXISTS_TTL_MS = 60_000;
 
 /**
  * Bounding-box / region specs accepted by {@link Video.crop} and
@@ -154,6 +162,14 @@ export class Video {
   private _embedded: boolean;
   private _shape: [number, number, number, number] | null = null;
   private _fps: number | null = null;
+  /** Auth headers persisted from a remote `.slp` load (mirror Python `_url_headers`). */
+  private _urlHeaders?: Record<string, string>;
+  /** Stream mode persisted from a remote `.slp` load. */
+  private _urlStreamMode?: StreamMode;
+  /** Drive bytes reused for embedded reopen (avoids re-hitting per-file quota). */
+  private _urlBytes?: Uint8Array;
+  /** Per-instance TTL cache for {@link exists}. */
+  private _existsCache?: { key: string; value: boolean; expiresAt: number };
 
   constructor(options: {
     filename: string | string[];
@@ -239,6 +255,74 @@ export class Video {
 
   close(): void {
     this.backend?.close();
+  }
+
+  /**
+   * Persist the remote auth context from a remote `.slp` load so later reopens
+   * and {@link exists} probes stay authenticated. Mirrors Python's
+   * `HDF5Video._url_headers`. Internal — set by the SLP reader.
+   * @internal
+   */
+  _setUrlPersistence(persistence: {
+    headers?: Record<string, string>;
+    streamMode?: StreamMode;
+    bytes?: Uint8Array;
+  }): void {
+    if (persistence.headers) this._urlHeaders = persistence.headers;
+    if (persistence.streamMode) this._urlStreamMode = persistence.streamMode;
+    if (persistence.bytes) this._urlBytes = persistence.bytes;
+  }
+
+  /**
+   * The auth headers to use for remote requests on this video, preferring the
+   * value persisted on this `Video`, then any persisted on the backend. Mirrors
+   * Python `Video._backend_url_headers`.
+   * @internal
+   */
+  _backendUrlHeaders(): Record<string, string> | undefined {
+    return (
+      this._urlHeaders ??
+      (this.backend as { _urlHeaders?: Record<string, string> } | null)
+        ?._urlHeaders
+    );
+  }
+
+  /**
+   * Non-throwing check that this video's source is reachable.
+   *
+   * For a URL filename, probes with HEAD (falling back to a `Range: bytes=0-0`
+   * GET), forwarding any persisted auth headers, and caches the result
+   * per-instance for {@link EXISTS_TTL_MS}. Never throws (a probe failure → a
+   * cached `false`). For a non-URL (local/embedded) filename, this returns
+   * `true` only when a backend is present (the JS port has no generic
+   * filesystem stat); callers needing real local existence should use a Node
+   * file check.
+   *
+   * Port of Python `Video.exists`.
+   */
+  async exists(): Promise<boolean> {
+    const filename = this.filename;
+    // Image sequences / non-URL paths: presence is implied by an open backend.
+    if (Array.isArray(filename) || !isUrl(filename)) {
+      return this.backend != null;
+    }
+
+    const dataset = (this.backendMetadata?.dataset as string | undefined) ?? "";
+    const key = `${filename} ${dataset}`;
+    const now = Date.now();
+    if (
+      this._existsCache &&
+      this._existsCache.key === key &&
+      this._existsCache.expiresAt > now
+    ) {
+      return this._existsCache.value;
+    }
+
+    const value = await headOrRangeProbe(filename, {
+      headers: this._backendUrlHeaders(),
+    });
+    this._existsCache = { key, value, expiresAt: now + EXISTS_TTL_MS };
+    return value;
   }
 
   /**
@@ -799,7 +883,7 @@ function shapeTupleEqual(
 
 /** Real key-presence check (a stored `null`/`undefined` still counts as present). */
 function hasOwn(obj: Record<string, unknown>, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(obj, key);
+  return Object.hasOwn(obj, key);
 }
 
 /**

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -6,6 +6,7 @@ import { MediaBunnyVideoBackend } from "./mediabunny-video.js";
 import { SeqVideoBackend } from "./seq-video.js";
 import { ImageVideoBackend } from "./image-video.js";
 import { openH5File } from "../codecs/slp/h5.js";
+import { RemoteIOError, isUrl, redactUrl, resolveUrl } from "../io/remote.js";
 
 /** Supported video backend identifiers for user selection. */
 export type VideoBackendType = "mp4box" | "mediabunny" | "media";
@@ -84,6 +85,13 @@ export async function createVideoBackend(
     shape?: [number, number, number, number];
     fps?: number;
     backend?: VideoBackendType;
+    /**
+     * Extra HTTP request headers (e.g. `{ Authorization: "Bearer …" }`) applied
+     * to remote video byte fetches. Forwarded to {@link Mp4BoxVideoBackend} and
+     * {@link MediaBunnyVideoBackend.fromUrl}. URL filenames are run through
+     * {@link resolveUrl} (rejecting `s3://`/`az://`/`abfs://`).
+     */
+    headers?: Record<string, string>;
   },
 ): Promise<VideoBackend> {
   // Image-sequence video (Python `ImageVideo`): `source` is a LIST of image
@@ -99,10 +107,15 @@ export async function createVideoBackend(
   const filename = isBlob ? ((source as File).name ?? "") : (source as string);
   const normalized = filename.split("?")[0]?.toLowerCase() ?? "";
   const ext = normalized.split(".").pop() ?? "";
+  const headers = options?.headers;
 
-  // HDF5/SLP files always use the HDF5 backend (not overridable)
+  // HDF5/SLP files always use the HDF5 backend (not overridable). Embedded
+  // videos reuse the parent `.slp` (resolved/authenticated by the SLP reader),
+  // so they are NOT run through the video scheme gate below.
   if (options?.embedded || ext === "slp" || ext === "h5" || ext === "hdf5") {
-    const { file } = await openH5File(isBlob ? (source as File) : filename);
+    const { file } = await openH5File(isBlob ? (source as File) : filename, {
+      headers,
+    });
     const datasetPath = options?.dataset ?? "";
     return new Hdf5VideoBackend({
       filename,
@@ -134,19 +147,29 @@ export async function createVideoBackend(
     });
   }
 
+  // For real remote VIDEO backends (below), resolve the URL through the scheme
+  // gate: gs:// -> storage.googleapis.com, http(s) passthrough, s3/az/abfs ->
+  // RemoteIOError, Google Drive video -> unsupported. Local paths and Blobs are
+  // left untouched. (HDF5/seq/image sources above are never resolved here.)
+  const videoUrl =
+    !isBlob && typeof filename === "string" && isUrl(filename)
+      ? resolveVideoUrl(filename)
+      : filename;
+
   // User-specified backend override
   if (options?.backend === "mediabunny") {
     if (isBlob)
       return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
-    return MediaBunnyVideoBackend.fromUrl(filename);
+    return MediaBunnyVideoBackend.fromUrl(videoUrl, { headers });
   }
   if (options?.backend === "mp4box") {
-    return new Mp4BoxVideoBackend(source);
+    if (isBlob) return new Mp4BoxVideoBackend(source);
+    return new Mp4BoxVideoBackend(videoUrl, { headers });
   }
   if (options?.backend === "media") {
     if (isBlob)
       return new MediaVideoBackend(URL.createObjectURL(source as Blob));
-    return new MediaVideoBackend(filename);
+    return new MediaVideoBackend(videoUrl);
   }
 
   // Formats no web backend can decode: fail loudly with a clean, catchable
@@ -164,17 +187,36 @@ export async function createVideoBackend(
 
   // MP4: prefer Mp4Box (better sequential performance)
   if (supportsWebCodecs && ext === "mp4") {
-    return new Mp4BoxVideoBackend(source);
+    if (isBlob) return new Mp4BoxVideoBackend(source);
+    return new Mp4BoxVideoBackend(videoUrl, { headers });
   }
 
   // Non-MP4 video formats: use MediaBunny
   if (supportsWebCodecs && MEDIABUNNY_EXTENSIONS.includes(ext)) {
     if (isBlob)
       return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
-    return MediaBunnyVideoBackend.fromUrl(filename);
+    return MediaBunnyVideoBackend.fromUrl(videoUrl, { headers });
   }
 
   // Fallback: HTML5 video element
   if (isBlob) return new MediaVideoBackend(URL.createObjectURL(source as Blob));
-  return new MediaVideoBackend(filename);
+  return new MediaVideoBackend(videoUrl);
+}
+
+/**
+ * Resolve a video URL through the scheme gate. `gs://`/`gcs://` map to
+ * `storage.googleapis.com`; `http(s)://` pass through; `s3://`/`az://`/`abfs://`
+ * throw a redacted {@link RemoteIOError}; Google Drive videos are unsupported.
+ */
+function resolveVideoUrl(url: string): string {
+  const { url: resolved, gdrive } = resolveUrl(url);
+  if (gdrive) {
+    // Drive video is unsupported (single-file download quota; no range access).
+    throw new RemoteIOError({
+      message: `Google Drive videos are not supported: ${redactUrl(url)}`,
+      url,
+      status: null,
+    });
+  }
+  return resolved;
 }

--- a/src/video/mediabunny-video.ts
+++ b/src/video/mediabunny-video.ts
@@ -43,11 +43,17 @@ export class MediaBunnyVideoBackend implements VideoBackend {
 
   static async fromUrl(
     url: string,
-    options?: MediaBunnyOptions,
+    options?: MediaBunnyOptions & { headers?: Record<string, string> },
   ): Promise<MediaBunnyVideoBackend> {
     const backend = new MediaBunnyVideoBackend(url, options);
+    // MediaBunny applies the custom headers to every byte fetch and overrides
+    // `Range`/`signal` itself (so a user `Range` header cannot clobber it).
+    const requestInit =
+      options?.headers && Object.keys(options.headers).length > 0
+        ? { headers: options.headers }
+        : undefined;
     backend.input = new Input({
-      source: new UrlSource(url),
+      source: new UrlSource(url, requestInit ? { requestInit } : undefined),
       formats: ALL_FORMATS,
     });
     await backend.initialize();

--- a/src/video/mp4box-video.ts
+++ b/src/video/mp4box-video.ts
@@ -1,4 +1,5 @@
 import { VideoBackend, VideoFrame } from "./backend.js";
+import { RemoteIOError, raiseRemote, statusToMessage } from "../io/remote.js";
 
 const isBrowser =
   typeof window !== "undefined" && typeof document !== "undefined";
@@ -69,10 +70,16 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   private fileBlob: Blob | null;
   private decodeQueue: Promise<void>;
   private latestRequestedFrame: number | null;
+  /** Extra HTTP headers (e.g. Authorization) applied to every byte fetch. */
+  private headers: Record<string, string>;
 
   constructor(
     source: string | File | Blob,
-    options?: { cacheSize?: number; lookahead?: number },
+    options?: {
+      cacheSize?: number;
+      lookahead?: number;
+      headers?: Record<string, string>;
+    },
   ) {
     if (!hasWebCodecs) {
       throw new Error("Mp4BoxVideoBackend requires WebCodecs support.");
@@ -83,6 +90,7 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     this.filename =
       source instanceof Blob ? ((source as File).name ?? "") : source;
     this.dataset = null;
+    this.headers = options?.headers ?? {};
     this.samples = [];
     this.keyframeIndices = [];
     this.cache = new Map();
@@ -218,9 +226,16 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   }
 
   private async openSource(): Promise<void> {
-    const response = await fetch(this.filename, {
-      headers: { Range: "bytes=0-0" },
-    });
+    // Range always wins over a user-supplied Range header (never let a user
+    // header override the byte range we need).
+    let response: Response;
+    try {
+      response = await fetch(this.filename, {
+        headers: { ...this.headers, Range: "bytes=0-0" },
+      });
+    } catch (e) {
+      raiseRemote(this.filename, e);
+    }
 
     if (response.status === 206) {
       const contentRange = response.headers.get("Content-Range");
@@ -233,11 +248,26 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     }
 
     if (!response.ok && response.status !== 206) {
-      throw new Error(`Failed to fetch video: ${response.status}`);
+      throw new RemoteIOError({
+        message: statusToMessage(response.status),
+        url: this.filename,
+        status: response.status,
+      });
     }
 
-    const full = await fetch(this.filename);
-    if (!full.ok) throw new Error(`Failed to fetch video: ${full.status}`);
+    let full: Response;
+    try {
+      full = await fetch(this.filename, { headers: { ...this.headers } });
+    } catch (e) {
+      raiseRemote(this.filename, e);
+    }
+    if (!full.ok) {
+      throw new RemoteIOError({
+        message: statusToMessage(full.status),
+        url: this.filename,
+        status: full.status,
+      });
+    }
     const blob = await full.blob();
     this.fileBlob = blob;
     this.fileSize = blob.size;
@@ -247,9 +277,14 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   private async readChunk(offset: number, size: number): Promise<ArrayBuffer> {
     const end = Math.min(offset + size, this.fileSize);
     if (this.supportsRangeRequests) {
-      const response = await fetch(this.filename, {
-        headers: { Range: `bytes=${offset}-${end - 1}` },
-      });
+      let response: Response;
+      try {
+        response = await fetch(this.filename, {
+          headers: { ...this.headers, Range: `bytes=${offset}-${end - 1}` },
+        });
+      } catch (e) {
+        raiseRemote(this.filename, e);
+      }
       return await response.arrayBuffer();
     }
     if (this.fileBlob) {

--- a/src/video/mp4box-video.ts
+++ b/src/video/mp4box-video.ts
@@ -1,5 +1,10 @@
 import { VideoBackend, VideoFrame } from "./backend.js";
-import { RemoteIOError, raiseRemote, statusToMessage } from "../io/remote.js";
+import {
+  RemoteIOError,
+  fetchRetrying,
+  identityHeaders,
+  statusToMessage,
+} from "../io/remote.js";
 
 const isBrowser =
   typeof window !== "undefined" && typeof document !== "undefined";
@@ -226,16 +231,13 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   }
 
   private async openSource(): Promise<void> {
-    // Range always wins over a user-supplied Range header (never let a user
-    // header override the byte range we need).
-    let response: Response;
-    try {
-      response = await fetch(this.filename, {
-        headers: { ...this.headers, Range: "bytes=0-0" },
-      });
-    } catch (e) {
-      raiseRemote(this.filename, e);
-    }
+    // Ranged probe: force Accept-Encoding: identity so a gzip transfer-encoding
+    // can't corrupt byte-range semantics, and let Range win over any
+    // user-supplied Range header (never let a user header override the byte
+    // range we need). Retried with backoff on transient failures / 429/5xx.
+    const response = await fetchRetrying(this.filename, {
+      headers: { ...identityHeaders(this.headers), Range: "bytes=0-0" },
+    });
 
     if (response.status === 206) {
       const contentRange = response.headers.get("Content-Range");
@@ -255,12 +257,9 @@ export class Mp4BoxVideoBackend implements VideoBackend {
       });
     }
 
-    let full: Response;
-    try {
-      full = await fetch(this.filename, { headers: { ...this.headers } });
-    } catch (e) {
-      raiseRemote(this.filename, e);
-    }
+    const full = await fetchRetrying(this.filename, {
+      headers: { ...this.headers },
+    });
     if (!full.ok) {
       throw new RemoteIOError({
         message: statusToMessage(full.status),
@@ -277,14 +276,14 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   private async readChunk(offset: number, size: number): Promise<ArrayBuffer> {
     const end = Math.min(offset + size, this.fileSize);
     if (this.supportsRangeRequests) {
-      let response: Response;
-      try {
-        response = await fetch(this.filename, {
-          headers: { ...this.headers, Range: `bytes=${offset}-${end - 1}` },
-        });
-      } catch (e) {
-        raiseRemote(this.filename, e);
-      }
+      // Ranged read: force Accept-Encoding: identity (gzip would corrupt the
+      // byte range) and retry transient failures with backoff.
+      const response = await fetchRetrying(this.filename, {
+        headers: {
+          ...identityHeaders(this.headers),
+          Range: `bytes=${offset}-${end - 1}`,
+        },
+      });
       return await response.arrayBuffer();
     }
     if (this.fileBlob) {

--- a/tests/codecs/slp-remote-headers.test.ts
+++ b/tests/codecs/slp-remote-headers.test.ts
@@ -91,7 +91,76 @@ describe("SLP remote header threading", () => {
     expect(calls[0][0]).toBe("https://storage.googleapis.com/bucket/obj.slp");
   });
 
-  it("loads a Google Drive SLP via the two-hop flow and does not re-resolve on embedded reopen", async () => {
+  it("retries the download on a 503 (honoring Retry-After) then succeeds", async () => {
+    // First call: 503 with Retry-After: 0 (instant backoff). Second: 200 bytes.
+    // Proves withRetries is actually wired into the prod download path.
+    let call = 0;
+    const mock = vi.fn(async () => {
+      call++;
+      if (call === 1) {
+        return {
+          ok: false,
+          status: 503,
+          headers: new Headers({ "Retry-After": "0" }),
+          arrayBuffer: async () => new ArrayBuffer(0),
+        } as unknown as Response;
+      }
+      return slpOkResponse();
+    });
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    const labels = await loadSlp("https://example.com/data.slp?token=SECRET", {
+      openVideos: false,
+      h5: { headers: { Authorization: "Bearer T" }, stream: "download" },
+    });
+    expect(labels).toBeTruthy();
+
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    // Retried exactly once (2 fetches total); auth header forwarded on both.
+    expect(calls).toHaveLength(2);
+    for (const c of calls) {
+      const init = c[1] as RequestInit & { headers: Record<string, string> };
+      expect(init.headers.Authorization).toBe("Bearer T");
+    }
+  });
+
+  it("surfaces a redacted RemoteIOError after retries are exhausted on 503", async () => {
+    // Always 503: withRetries exhausts and the FINAL thrown error is still the
+    // redacted typed error (no raw token leak).
+    const mock = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 503,
+          headers: new Headers({ "Retry-After": "0" }),
+          arrayBuffer: async () => new ArrayBuffer(0),
+        }) as unknown as Response,
+    );
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    let err: unknown;
+    try {
+      await loadSlp("https://h/x.slp?token=SECRET", {
+        openVideos: false,
+        h5: { stream: "download" },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    const e = err as RemoteIOError;
+    expect(e.status).toBe(503);
+    expect(e.url).not.toContain("SECRET");
+    expect(e.message).not.toContain("SECRET");
+    expect(String(e.stack)).not.toContain("SECRET");
+    // Exhausted: initial attempt + 3 retries = 4 fetches.
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(calls).toHaveLength(4);
+  });
+
+  it("loads a Google Drive SLP via the two-hop confirmation flow (no extra hops)", async () => {
     const FILE_ID = "ABC123";
     const form = `
       <form id="download-form" action="https://drive.usercontent.google.com/download?confirm=t">

--- a/tests/codecs/slp-remote-headers.test.ts
+++ b/tests/codecs/slp-remote-headers.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "../bun-test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadSlp } from "../../src/io/main.js";
+import { createVideoBackend } from "../../src/video/factory.js";
+import { RemoteIOError, headOrRangeProbe } from "../../src/io/remote.js";
+
+const FIXTURE = join(
+  import.meta.dir,
+  "..",
+  "data",
+  "slp",
+  "minimal_instance.slp",
+);
+const SLP_BYTES = new Uint8Array(readFileSync(FIXTURE));
+
+/** A 200 OK response delivering the fixture bytes via arrayBuffer. */
+function slpOkResponse() {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    arrayBuffer: async () =>
+      SLP_BYTES.buffer.slice(
+        SLP_BYTES.byteOffset,
+        SLP_BYTES.byteOffset + SLP_BYTES.byteLength,
+      ),
+  } as unknown as Response;
+}
+
+describe("SLP remote header threading", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("forwards Authorization header on the download fetch", async () => {
+    const mock = vi.fn(async () => slpOkResponse());
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    const labels = await loadSlp("https://example.com/data.slp", {
+      openVideos: false,
+      h5: { headers: { Authorization: "Bearer T" }, stream: "download" },
+    });
+    expect(labels).toBeTruthy();
+
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const init = calls[0][1] as RequestInit & {
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe("Bearer T");
+  });
+
+  it("takes the download path (single header-bearing fetch) with stream:auto + headers", async () => {
+    const mock = vi.fn(async () => slpOkResponse());
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    await loadSlp("https://example.com/data.slp", {
+      openVideos: false,
+      h5: { headers: { Authorization: "Bearer T" }, stream: "auto" },
+    });
+
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    // A single header-bearing download fetch (no createLazyFile range path).
+    expect(calls).toHaveLength(1);
+    const init = calls[0][1] as RequestInit & {
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe("Bearer T");
+  });
+
+  it("maps gs:// to storage.googleapis.com on the fetch URL", async () => {
+    const mock = vi.fn(async () => slpOkResponse());
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    await loadSlp("gs://bucket/obj.slp", {
+      openVideos: false,
+      h5: { stream: "download" },
+    });
+
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(calls[0][0]).toBe("https://storage.googleapis.com/bucket/obj.slp");
+  });
+
+  it("loads a Google Drive SLP via the two-hop flow and does not re-resolve on embedded reopen", async () => {
+    const FILE_ID = "ABC123";
+    const form = `
+      <form id="download-form" action="https://drive.usercontent.google.com/download?confirm=t">
+        <input type="hidden" name="id" value="${FILE_ID}">
+        <input type="hidden" name="uuid" value="u-1">
+      </form>`;
+    let hop = 0;
+    const mock = vi.fn(async (_url: string) => {
+      hop++;
+      if (hop === 1) {
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ "Content-Type": "text/html" }),
+          text: async () => form,
+          arrayBuffer: async () => new ArrayBuffer(0),
+          body: null,
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({
+          "Content-Type": "application/octet-stream",
+          "Content-Disposition": 'attachment; filename="data.slp"',
+        }),
+        text: async () => "",
+        arrayBuffer: async () =>
+          SLP_BYTES.buffer.slice(
+            SLP_BYTES.byteOffset,
+            SLP_BYTES.byteOffset + SLP_BYTES.byteLength,
+          ),
+        body: null,
+      } as unknown as Response;
+    });
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    const labels = await loadSlp(
+      `https://drive.google.com/file/d/${FILE_ID}/view`,
+      { openVideos: false, h5: { stream: "auto" } },
+    );
+    expect(labels).toBeTruthy();
+    // Exactly two Drive hops; no further Drive resolution.
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(calls).toHaveLength(2);
+  });
+
+  it("throws a redacted RemoteIOError on 404, hiding the secret token", async () => {
+    const mock = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 404,
+          headers: new Headers(),
+          arrayBuffer: async () => new ArrayBuffer(0),
+        }) as unknown as Response,
+    );
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    let err: unknown;
+    try {
+      await loadSlp("https://h/x.slp?token=SECRET", {
+        openVideos: false,
+        h5: { stream: "download" },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    const e = err as RemoteIOError;
+    expect(e.message).toContain("file not found");
+    expect(e.url).not.toContain("SECRET");
+    expect(e.message).not.toContain("SECRET");
+    expect(String(e.stack)).not.toContain("SECRET");
+  });
+
+  it("rejects s3:// with a redacted RemoteIOError pointing to presigned https", async () => {
+    let err: unknown;
+    try {
+      await loadSlp("s3://bucket/obj.slp", {
+        openVideos: false,
+        h5: { stream: "download" },
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain("presigned https");
+  });
+
+  it("headOrRangeProbe forwards Authorization on HEAD->Range fallback", async () => {
+    const mock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "HEAD")
+        return { ok: false, status: 405 } as Response;
+      return { ok: false, status: 206 } as Response;
+    });
+    globalThis.fetch = mock as unknown as typeof fetch;
+    const ok = await headOrRangeProbe("https://h/x.slp", {
+      headers: { Authorization: "Bearer T" },
+    });
+    expect(ok).toBe(true);
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(calls).toHaveLength(2);
+    for (const c of calls) {
+      const init = c[1] as RequestInit & { headers: Record<string, string> };
+      expect(init.headers.Authorization).toBe("Bearer T");
+    }
+  });
+});
+
+describe("createVideoBackend remote URL handling", () => {
+  it("rejects s3:// video URLs with a redacted RemoteIOError", async () => {
+    let err: unknown;
+    try {
+      await createVideoBackend("s3://bucket/video.mp4");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain("presigned https");
+  });
+
+  it("rejects Google Drive video URLs as unsupported", async () => {
+    let err: unknown;
+    try {
+      await createVideoBackend(
+        "https://drive.google.com/file/d/ABC/view?ext=.mp4",
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain(
+      "Google Drive videos are not supported",
+    );
+  });
+});

--- a/tests/codecs/streaming-scheme.test.ts
+++ b/tests/codecs/streaming-scheme.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "../bun-test";
+import { StreamingH5File } from "../../src/codecs/slp/h5-streaming.js";
+import { RemoteIOError } from "../../src/io/remote.js";
+
+/**
+ * The streaming worker path resolves the URL scheme on the MAIN thread before
+ * the worker fetch (the worker can't import the scheme gate). These tests
+ * stub the worker transport so nothing hits the network: a fake `send` records
+ * the `openUrl` payload and `worker` is replaced with a no-op so construction +
+ * close never spin up a real Web Worker.
+ */
+function stubbedStreamingFile(): {
+  file: StreamingH5File;
+  openUrlPayloads: Array<Record<string, unknown>>;
+} {
+  const file = new StreamingH5File();
+  const openUrlPayloads: Array<Record<string, unknown>> = [];
+  // Replace the real worker (created in the ctor) so terminate() is a no-op and
+  // no CDN import ever runs.
+  (file as unknown as { worker: { terminate: () => void } }).worker = {
+    terminate: () => {},
+  };
+  // Stub the private message transport: resolve init/openUrl without a worker.
+  (
+    file as unknown as {
+      send: (
+        type: string,
+        payload?: Record<string, unknown>,
+      ) => Promise<Record<string, unknown>>;
+    }
+  ).send = async (type, payload) => {
+    if (type === "openUrl" && payload) openUrlPayloads.push(payload);
+    return { success: true, keys: [] };
+  };
+  return { file, openUrlPayloads };
+}
+
+describe("StreamingH5File.open scheme resolution", () => {
+  it("resolves gs:// to storage.googleapis.com before the worker fetch", async () => {
+    const { file, openUrlPayloads } = stubbedStreamingFile();
+    await file.open("gs://bucket/path/to/obj.slp");
+    expect(openUrlPayloads).toHaveLength(1);
+    expect(openUrlPayloads[0].url).toBe(
+      "https://storage.googleapis.com/bucket/path/to/obj.slp",
+    );
+  });
+
+  it("passes an http(s) URL through unchanged", async () => {
+    const { file, openUrlPayloads } = stubbedStreamingFile();
+    await file.open("https://example.com/data.slp");
+    expect(openUrlPayloads[0].url).toBe("https://example.com/data.slp");
+  });
+
+  it("fails fast with a redacted RemoteIOError for s3:// (no worker fetch)", async () => {
+    const { file, openUrlPayloads } = stubbedStreamingFile();
+    let err: unknown;
+    try {
+      await file.open("s3://bucket/obj.slp");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain("presigned https");
+    // The worker was never asked to open anything.
+    expect(openUrlPayloads).toHaveLength(0);
+  });
+
+  it("fails fast with a redacted RemoteIOError for Google Drive URLs", async () => {
+    const { file, openUrlPayloads } = stubbedStreamingFile();
+    let err: unknown;
+    try {
+      await file.open("https://drive.google.com/file/d/ABC/view?token=SECRET");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain("not supported");
+    expect((err as RemoteIOError).url).not.toContain("SECRET");
+    expect(openUrlPayloads).toHaveLength(0);
+  });
+});

--- a/tests/io/gdrive.test.ts
+++ b/tests/io/gdrive.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "../bun-test";
+import {
+  parseGdrive,
+  urlFromConfirmation,
+  checkDownloadHost,
+  openGdrive,
+} from "../../src/io/gdrive.js";
+import { RemoteIOError } from "../../src/io/remote.js";
+
+const FILE_ID = "1A2B3C4D5E6F";
+
+describe("parseGdrive", () => {
+  it("parses every supported share-link shape", () => {
+    const cases: [string, string][] = [
+      [`https://drive.google.com/file/d/${FILE_ID}/view`, FILE_ID],
+      [`https://drive.google.com/file/d/${FILE_ID}/edit`, FILE_ID],
+      [`https://drive.google.com/file/d/${FILE_ID}/preview`, FILE_ID],
+      [`https://drive.google.com/file/d/${FILE_ID}`, FILE_ID],
+      [`https://drive.google.com/file/d/${FILE_ID}/`, FILE_ID],
+      [`https://drive.google.com/file/u/0/d/${FILE_ID}/view`, FILE_ID],
+      [`https://drive.google.com/open?id=${FILE_ID}`, FILE_ID],
+      [`https://drive.google.com/uc?id=${FILE_ID}&export=download`, FILE_ID],
+      [`https://drive.google.com/uc?export=download&id=${FILE_ID}`, FILE_ID],
+    ];
+    for (const [url, expected] of cases) {
+      expect(parseGdrive(url)).toBe(expected);
+    }
+  });
+
+  it("rejects folders and trailing-segment URLs", () => {
+    const bad = [
+      `https://drive.google.com/drive/folders/${FILE_ID}`,
+      `https://drive.google.com/folders/${FILE_ID}`,
+      `https://drive.google.com/file/d/${FILE_ID}/view/extra`,
+      "https://drive.google.com/",
+    ];
+    for (const url of bad) {
+      expect(() => parseGdrive(url)).toThrow();
+    }
+  });
+
+  it("redacts tokens in thrown messages", () => {
+    let err: unknown;
+    try {
+      parseGdrive("https://drive.google.com/?token=SECRET");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toContain("SECRET");
+  });
+});
+
+describe("urlFromConfirmation", () => {
+  it("returns the small-file href with &amp; decoded", () => {
+    const html = `<a href="/uc?export=download&amp;id=${FILE_ID}&amp;confirm=t">Download</a>`;
+    const out = urlFromConfirmation(html);
+    expect(out).toBe(
+      `https://docs.google.com/uc?export=download&id=${FILE_ID}&confirm=t`,
+    );
+  });
+
+  it("parses the #download-form, hidden inputs winning", () => {
+    const html = `
+      <form id="download-form" action="https://drive.usercontent.google.com/download?foo=bar">
+        <input type="hidden" name="id" value="${FILE_ID}">
+        <input type="hidden" name="export" value="download">
+        <input type="hidden" name="confirm" value="abc123">
+        <input type="hidden" name="uuid" value="u-9999">
+        <input type="submit" value="Download">
+      </form>`;
+    const out = urlFromConfirmation(html);
+    expect(out).toContain("drive.usercontent.google.com/download");
+    expect(out).toContain(`id=${FILE_ID}`);
+    expect(out).toContain("confirm=abc123");
+    expect(out).toContain("uuid=u-9999");
+    expect(out).toContain("export=download");
+  });
+
+  it("decodes the JSON downloadUrl variant", () => {
+    const html = `{"downloadUrl":"https://x/y?a\\u003d1\\u0026b\\u003d2"}`;
+    const out = urlFromConfirmation(html);
+    expect(out).toBe("https://x/y?a=1&b=2");
+  });
+
+  it("throws RemoteIOError with the caption on an error page", () => {
+    const html =
+      '<p class="uc-error-subcaption">Too many users have viewed or downloaded this file recently.</p>';
+    let err: unknown;
+    try {
+      urlFromConfirmation(html, "https://drive.google.com/uc?id=X");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain("refused the download");
+    expect((err as Error).message).toContain("Too many users");
+  });
+
+  it("throws when nothing matches", () => {
+    expect(() => urlFromConfirmation("<html>nope</html>")).toThrow(
+      /Could not find/,
+    );
+  });
+});
+
+describe("checkDownloadHost", () => {
+  it("allows the Drive download hosts", () => {
+    for (const u of [
+      "https://drive.google.com/uc?id=X",
+      "https://docs.google.com/uc?id=X",
+      "https://drive.usercontent.google.com/download",
+      "https://abc.googleusercontent.com/x",
+    ]) {
+      expect(() => checkDownloadHost(u)).not.toThrow();
+    }
+  });
+
+  it("rejects unexpected hosts and schemes", () => {
+    for (const u of [
+      "https://evil.com/x",
+      "http://localhost/x",
+      "ftp://drive.google.com/x",
+    ]) {
+      expect(() => checkDownloadHost(u)).toThrow(RemoteIOError);
+    }
+  });
+});
+
+// --- openGdrive (stubbed fetch only) ---
+
+type StubResponse = {
+  ok: boolean;
+  status: number;
+  headers: Headers;
+  text: () => Promise<string>;
+  arrayBuffer: () => Promise<ArrayBuffer>;
+  body?: ReadableStream<Uint8Array> | null;
+};
+
+function htmlResponse(html: string): StubResponse {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "Content-Type": "text/html; charset=utf-8" }),
+    text: async () => html,
+    arrayBuffer: async () => new ArrayBuffer(0),
+    body: null,
+  };
+}
+
+function fileResponse(
+  bytes: Uint8Array,
+  extraHeaders: Record<string, string> = {},
+): StubResponse {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({
+      "Content-Type": "application/octet-stream",
+      "Content-Disposition": 'attachment; filename="data.slp"',
+      ...extraHeaders,
+    }),
+    text: async () => "",
+    arrayBuffer: async () =>
+      bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer,
+    body: null,
+  };
+}
+
+describe("openGdrive", () => {
+  let originalFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("two-hop: interstitial -> file, strips Authorization/Cookie, sends browser UA", async () => {
+    const fileBytes = new Uint8Array([1, 2, 3, 4]);
+    const form = `
+      <form id="download-form" action="https://drive.usercontent.google.com/download?confirm=t">
+        <input type="hidden" name="id" value="${FILE_ID}">
+        <input type="hidden" name="uuid" value="u-1">
+      </form>`;
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const mock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (calls.length === 1) return htmlResponse(form) as unknown as Response;
+      return fileResponse(fileBytes) as unknown as Response;
+    });
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    const out = await openGdrive(
+      `https://drive.google.com/file/d/${FILE_ID}/view`,
+      { headers: { Authorization: "Bearer T", Cookie: "c=1" } },
+    );
+    expect(Array.from(out)).toEqual([1, 2, 3, 4]);
+    expect(calls).toHaveLength(2);
+    expect(calls[1].url).toContain("drive.usercontent.google.com/download");
+    for (const c of calls) {
+      const headers = (c.init?.headers ?? {}) as Record<string, string>;
+      // Browser UA sent; Authorization/Cookie NEVER sent to Google hosts.
+      expect(headers["User-Agent"]).toContain("Mozilla/5.0");
+      expect(headers.Authorization).toBeUndefined();
+      expect(headers.Cookie).toBeUndefined();
+    }
+  });
+
+  it("cap pre-check throws when Content-Length exceeds maxBytes", async () => {
+    const mock = vi.fn(
+      async () =>
+        fileResponse(new Uint8Array(4), {
+          "Content-Length": "1000000",
+        }) as unknown as Response,
+    );
+    globalThis.fetch = mock as unknown as typeof fetch;
+    let err: unknown;
+    try {
+      await openGdrive(`https://drive.google.com/uc?id=${FILE_ID}`, {
+        maxBytes: 10,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain(
+      "exceeds the maximum in-memory download size",
+    );
+  });
+
+  it("running-check throws (no Content-Length) and discards the buffer", async () => {
+    // Chunked body with no Content-Length, exceeding a small cap.
+    const chunk = new Uint8Array(8).fill(7);
+    const makeBody = (): ReadableStream<Uint8Array> => {
+      let sent = 0;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (sent < 4) {
+            sent++;
+            controller.enqueue(chunk);
+          } else {
+            controller.close();
+          }
+        },
+      });
+    };
+    const mock = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        headers: new Headers({
+          "Content-Type": "application/octet-stream",
+          "Content-Disposition": 'attachment; filename="data.slp"',
+        }),
+        text: async () => "",
+        arrayBuffer: async () => new ArrayBuffer(0),
+        body: makeBody(),
+      } as unknown as Response;
+    });
+    globalThis.fetch = mock as unknown as typeof fetch;
+    let err: unknown;
+    try {
+      await openGdrive(`https://drive.google.com/uc?id=${FILE_ID}`, {
+        maxBytes: 10,
+      });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain(
+      "exceeds the maximum in-memory download size",
+    );
+  });
+
+  it("throws after MAX_HOPS interstitials without converging", async () => {
+    const form = `
+      <form id="download-form" action="https://drive.usercontent.google.com/download?confirm=t">
+        <input type="hidden" name="id" value="${FILE_ID}">
+      </form>`;
+    const mock = vi.fn(async () => htmlResponse(form) as unknown as Response);
+    globalThis.fetch = mock as unknown as typeof fetch;
+    let err: unknown;
+    try {
+      await openGdrive(`https://drive.google.com/uc?id=${FILE_ID}`);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain("did not converge within 4 hops");
+  });
+
+  it("SSRF: refuses to follow a form action to an unexpected host", async () => {
+    const form = `
+      <form id="download-form" action="https://evil.com/download">
+        <input type="hidden" name="id" value="${FILE_ID}">
+      </form>`;
+    let secondCalled = false;
+    const mock = vi.fn(async (_url: string) => {
+      if (!secondCalled) {
+        secondCalled = true;
+        return htmlResponse(form) as unknown as Response;
+      }
+      // Should never be reached — the host check throws first.
+      return fileResponse(new Uint8Array(1)) as unknown as Response;
+    });
+    globalThis.fetch = mock as unknown as typeof fetch;
+    let err: unknown;
+    try {
+      await openGdrive(`https://drive.google.com/uc?id=${FILE_ID}`);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect((err as Error).message).toContain("unexpected host");
+  });
+});

--- a/tests/io/remote.test.ts
+++ b/tests/io/remote.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "../bun-test";
+import {
+  isUrl,
+  isGdriveUrl,
+  resolveUrl,
+  redactUrl,
+  redactedCauseSummary,
+  RemoteIOError,
+  statusToMessage,
+  identityHeaders,
+  stripCrossOriginHeaders,
+  withRetries,
+  headOrRangeProbe,
+} from "../../src/io/remote.js";
+
+describe("isUrl", () => {
+  it("recognizes remote schemes", () => {
+    expect(isUrl("http://h/x")).toBe(true);
+    expect(isUrl("https://h/x")).toBe(true);
+    expect(isUrl("gs://b/o")).toBe(true);
+    expect(isUrl("s3://b/o")).toBe(true);
+    expect(isUrl("gcs://b/o")).toBe(true);
+    expect(isUrl("az://b/o")).toBe(true);
+    expect(isUrl("abfs://b/o")).toBe(true);
+  });
+
+  it("rejects non-URLs (drive-letter guard etc.)", () => {
+    expect(isUrl("")).toBe(false);
+    expect(isUrl(123 as unknown as string)).toBe(false);
+    expect(isUrl(null as unknown as string)).toBe(false);
+    // Single-letter scheme (Windows drive letter) must NOT be a URL.
+    expect(isUrl("C:\\path\\file.slp")).toBe(false);
+    expect(isUrl("relative/path.slp")).toBe(false);
+    expect(isUrl("/abs/path.slp")).toBe(false);
+    // Unknown scheme.
+    expect(isUrl("ftp://h/x")).toBe(false);
+  });
+});
+
+describe("isGdriveUrl", () => {
+  it("matches Drive hosts case-insensitively", () => {
+    expect(isGdriveUrl("https://drive.google.com/file/d/ABC/view")).toBe(true);
+    expect(isGdriveUrl("https://DOCS.GOOGLE.COM/uc?id=ABC")).toBe(true);
+  });
+
+  it("rejects other hosts and non-URLs", () => {
+    expect(isGdriveUrl("https://example.com/x")).toBe(false);
+    expect(isGdriveUrl("not a url")).toBe(false);
+    expect(isGdriveUrl("C:\\path")).toBe(false);
+  });
+});
+
+describe("resolveUrl", () => {
+  it("maps gs:// to storage.googleapis.com preserving nested path + query", () => {
+    expect(resolveUrl("gs://my-bucket/path/to/obj.slp")).toEqual({
+      url: "https://storage.googleapis.com/my-bucket/path/to/obj.slp",
+      gdrive: false,
+    });
+    expect(resolveUrl("gs://b/a/b/c.slp?x=1")).toEqual({
+      url: "https://storage.googleapis.com/b/a/b/c.slp?x=1",
+      gdrive: false,
+    });
+  });
+
+  it("maps gcs:// to storage.googleapis.com", () => {
+    expect(resolveUrl("gcs://b/o")).toEqual({
+      url: "https://storage.googleapis.com/b/o",
+      gdrive: false,
+    });
+  });
+
+  it("passes through http(s) and flags Drive", () => {
+    expect(resolveUrl("https://h/x.slp")).toEqual({
+      url: "https://h/x.slp",
+      gdrive: false,
+    });
+    expect(resolveUrl("https://drive.google.com/file/d/ABC/view")).toEqual({
+      url: "https://drive.google.com/file/d/ABC/view",
+      gdrive: true,
+    });
+  });
+
+  it("throws RemoteIOError pointing to presigned https for cloud schemes", () => {
+    for (const u of ["s3://b/o", "az://b/o", "abfs://c@a.dfs/x"]) {
+      let err: unknown;
+      try {
+        resolveUrl(u);
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(RemoteIOError);
+      expect((err as Error).message).toContain("presigned https");
+    }
+  });
+
+  it("throws for non-URL input", () => {
+    expect(() => resolveUrl("/local/path.slp")).toThrow(RemoteIOError);
+  });
+});
+
+// The redacted value of a sensitive param is either `***` or its percent-encoded
+// form `%2A%2A%2A` depending on the URL implementation; assert it is masked
+// (some form present) and the original secret is gone.
+function maskedTokenPresent(out: string, param: string): boolean {
+  return out.includes(`${param}=%2A%2A%2A`) || out.includes(`${param}=***`);
+}
+
+describe("redactUrl", () => {
+  it("masks userinfo and sensitive query values, keeps others", () => {
+    const out = redactUrl("https://u:p@host/x?token=secret&keep=1");
+    expect(out).toContain("***:***@host");
+    expect(maskedTokenPresent(out, "token")).toBe(true);
+    expect(out).toContain("keep=1");
+    expect(out).not.toContain("secret");
+  });
+
+  it("masks sensitive params case-insensitively", () => {
+    const out = redactUrl("https://h/x?Access_Token=abc");
+    expect(maskedTokenPresent(out, "Access_Token")).toBe(true);
+    expect(out).not.toContain("abc");
+  });
+
+  it("masks each known sensitive param", () => {
+    for (const p of [
+      "token",
+      "access_token",
+      "x-amz-security-token",
+      "sas",
+      "sig",
+    ]) {
+      const out = redactUrl(`https://h/x?${p}=zzz`);
+      expect(out).not.toContain("zzz");
+    }
+  });
+
+  it("returns malformed URLs unchanged", () => {
+    expect(redactUrl("not a url")).toBe("not a url");
+  });
+
+  it("leaves non-sensitive params untouched", () => {
+    expect(redactUrl("https://h/x?a=1&b=2")).toBe("https://h/x?a=1&b=2");
+  });
+});
+
+describe("redactedCauseSummary", () => {
+  it("scrubs URL tokens out of error text", () => {
+    const out = redactedCauseSummary(
+      new Error("fetch failed for https://h/x?token=abc"),
+    );
+    expect(out.startsWith("Error:")).toBe(true);
+    expect(out.includes("token=***") || out.includes("token=%2A%2A%2A")).toBe(
+      true,
+    );
+    expect(out).not.toContain("abc");
+  });
+});
+
+describe("RemoteIOError", () => {
+  it("redacts url, sets status, and does NOT chain the raw cause", () => {
+    const raw = new Error("boom https://h/x?token=SECRET");
+    const err = new RemoteIOError({
+      message: "file not found",
+      url: "https://u:p@h/x?token=SECRET",
+      status: 404,
+      cause: raw,
+    });
+    expect(err.status).toBe(404);
+    expect(err.url).toContain("***:***@h");
+    expect(maskedTokenPresent(err.url, "token")).toBe(true);
+    expect(err.message).toContain("status=404");
+    expect(err.message).toContain("url=");
+    // The raw transport error must NOT be chained.
+    expect((err as { cause?: unknown }).cause).toBeUndefined();
+    // No secret anywhere.
+    expect(err.message).not.toContain("SECRET");
+    expect(err.url).not.toContain("SECRET");
+  });
+});
+
+describe("statusToMessage", () => {
+  it("maps known statuses", () => {
+    expect(statusToMessage(404)).toBe("file not found");
+    expect(statusToMessage(416)).toBe("range past end of file");
+    expect(statusToMessage(412)).toBe(
+      "file changed since cached (ETag mismatch)",
+    );
+    expect(statusToMessage(503)).toBe("HTTP 503");
+  });
+});
+
+describe("identityHeaders", () => {
+  it("forces Accept-Encoding: identity and drops any case", () => {
+    const out = identityHeaders({
+      "accept-encoding": "gzip",
+      Authorization: "Bearer T",
+    });
+    expect(out["Accept-Encoding"]).toBe("identity");
+    expect(out["accept-encoding"]).toBeUndefined();
+    expect(out.Authorization).toBe("Bearer T");
+  });
+});
+
+describe("stripCrossOriginHeaders", () => {
+  it("keeps headers same-origin", () => {
+    const h = { Authorization: "Bearer T", "X-Other": "1" };
+    expect(stripCrossOriginHeaders(h, "https://a/x", "https://a/y")).toEqual(h);
+  });
+
+  it("drops sensitive headers cross-origin (any case)", () => {
+    const out = stripCrossOriginHeaders(
+      { authorization: "Bearer T", Cookie: "c", "X-Other": "1" },
+      "https://a/x",
+      "https://b/y",
+    );
+    expect(out.authorization).toBeUndefined();
+    expect(out.Cookie).toBeUndefined();
+    expect(out["X-Other"]).toBe("1");
+  });
+});
+
+describe("withRetries", () => {
+  it("retries retryable 503 then succeeds", async () => {
+    let calls = 0;
+    const result = await withRetries(
+      async () => {
+        calls++;
+        if (calls < 3) {
+          throw new RemoteIOError({
+            message: "HTTP 503",
+            url: "https://h/x",
+            status: 503,
+          });
+        }
+        return "ok";
+      },
+      { retries: 3 },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  it("does not retry a non-retryable 404", async () => {
+    let calls = 0;
+    let err: unknown;
+    try {
+      await withRetries(
+        async () => {
+          calls++;
+          throw new RemoteIOError({
+            message: "file not found",
+            url: "https://h/x",
+            status: 404,
+          });
+        },
+        { retries: 3 },
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RemoteIOError);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("headOrRangeProbe", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to Range GET on 405 and forwards Authorization on both", async () => {
+    const mock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "HEAD") {
+        return { ok: false, status: 405 } as Response;
+      }
+      return { ok: false, status: 206 } as Response;
+    });
+    globalThis.fetch = mock as unknown as typeof fetch;
+
+    const ok = await headOrRangeProbe("https://h/x", {
+      headers: { Authorization: "Bearer T" },
+    });
+    expect(ok).toBe(true);
+    const calls = (mock as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    expect(calls).toHaveLength(2);
+    for (const c of calls) {
+      const init = c[1] as RequestInit & { headers: Record<string, string> };
+      expect(init.headers.Authorization).toBe("Bearer T");
+    }
+  });
+
+  it("returns false (never throws) on a thrown TypeError", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("network down");
+    }) as unknown as typeof fetch;
+    expect(await headOrRangeProbe("https://h/x")).toBe(false);
+  });
+
+  it("returns false for unsupported cloud scheme", async () => {
+    expect(await headOrRangeProbe("s3://b/o")).toBe(false);
+  });
+});

--- a/tests/video/mp4box-backend.test.ts
+++ b/tests/video/mp4box-backend.test.ts
@@ -327,4 +327,57 @@ describe("Mp4BoxVideoBackend", () => {
     expect(await backend.getFrame(999)).toBeNull();
     backend.close();
   });
+
+  it("forwards custom headers alongside Range on range fetches", async () => {
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
+    const backend = new Mp4BoxVideoBackend("https://example.com/video.mp4", {
+      headers: { Authorization: "Bearer T" },
+    });
+    await backend.getFrameTimes();
+    const calls = (globalThis.fetch as any).mock.calls;
+    // Every fetch carries the custom header AND a Range (Range wins).
+    for (const c of calls) {
+      const headers = c[1]?.headers ?? {};
+      expect(headers.Authorization).toBe("Bearer T");
+      expect(headers.Range).toBeTruthy();
+    }
+    backend.close();
+  });
+
+  it("does not let a user-supplied Range header override the byte range", async () => {
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
+    const backend = new Mp4BoxVideoBackend("https://example.com/video.mp4", {
+      headers: { Range: "bytes=999-1000", Authorization: "Bearer T" },
+    });
+    await backend.getFrameTimes();
+    const calls = (globalThis.fetch as any).mock.calls;
+    // The probe is bytes=0-0; the user Range must not clobber it.
+    const probe = calls.find((c: any) => c[1]?.headers?.Range === "bytes=0-0");
+    expect(probe).toBeTruthy();
+    expect(probe[1].headers.Authorization).toBe("Bearer T");
+    backend.close();
+  });
+
+  it("routes a custom-header video URL through createVideoBackend", async () => {
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
+    const { createVideoBackend } = await import("../../src/video/factory.js");
+    const backend = await createVideoBackend("https://example.com/video.mp4", {
+      headers: { Authorization: "Bearer T" },
+    });
+    expect(backend).toBeInstanceOf(Mp4BoxVideoBackend);
+    if (backend instanceof Mp4BoxVideoBackend) {
+      await backend.getFrameTimes();
+      const calls = (globalThis.fetch as any).mock.calls;
+      expect(
+        calls.every((c: any) => c[1]?.headers?.Authorization === "Bearer T"),
+      ).toBe(true);
+      backend.close();
+    }
+  });
 });

--- a/tests/video/mp4box-backend.test.ts
+++ b/tests/video/mp4box-backend.test.ts
@@ -346,6 +346,30 @@ describe("Mp4BoxVideoBackend", () => {
     backend.close();
   });
 
+  it("forces Accept-Encoding: identity on every ranged fetch", async () => {
+    const { Mp4BoxVideoBackend } = await import(
+      "../../src/video/mp4box-video.js"
+    );
+    const backend = new Mp4BoxVideoBackend("https://example.com/video.mp4", {
+      // A user-supplied Accept-Encoding (any case) must be overridden, never
+      // honored, so a gzip transfer-encoding can't corrupt range semantics.
+      headers: { "accept-encoding": "gzip", Authorization: "Bearer T" },
+    });
+    await backend.getFrameTimes();
+    const calls = (globalThis.fetch as any).mock.calls;
+    // Every ranged fetch (probe + readChunk) carries identity encoding, drops
+    // the user's lowercase accept-encoding, and keeps the auth header.
+    const ranged = calls.filter((c: any) => c[1]?.headers?.Range);
+    expect(ranged.length).toBeGreaterThan(0);
+    for (const c of ranged) {
+      const headers = c[1].headers as Record<string, string>;
+      expect(headers["Accept-Encoding"]).toBe("identity");
+      expect(headers["accept-encoding"]).toBeUndefined();
+      expect(headers.Authorization).toBe("Bearer T");
+    }
+    backend.close();
+  });
+
   it("does not let a user-supplied Range header override the byte range", async () => {
     const { Mp4BoxVideoBackend } = await import(
       "../../src/video/mp4box-video.js"


### PR DESCRIPTION
Ports the realistic browser+Node subset of Python sleap-io PRs #439/#445/#441: auth headers threaded end-to-end, a URL-resolution helper, credential redaction in all errors/logs, a typed `RemoteIOError` with retry/backoff, and a non-throwing `Video.exists()` URL probe. This **extends** the existing http(s) range path — the working `createLazyFile`/worker streaming is untouched when no custom headers are present.

## New modules

- **`src/io/remote.ts`** — pure helpers:
  - `isUrl` (with the `length > 1` Windows drive-letter guard), `isGdriveUrl`, `resolveUrl`.
  - `resolveUrl`: `http(s)://` passthrough; `gs://`/`gcs://` → `https://storage.googleapis.com/<bucket>/<obj>` (path + query preserved); Google Drive flagged; `s3://`/`az://`/`abfs://` → redacted `RemoteIOError` directing to a presigned `https://` URL.
  - `redactUrl` (userinfo → `***:***@host`; sensitive query values masked), `redactedCauseSummary`, `RemoteIOError` (`url` always stored redacted; the raw transport error is **never** chained as `.cause` or re-thrown).
  - `statusToMessage`/`raiseRemote`, `identityHeaders`, `stripCrossOriginHeaders`, `withRetries` (200/400/800 ms backoff, `Retry-After` honored), `headOrRangeProbe` (HEAD → `Range: bytes=0-0`).
- **`src/io/gdrive.ts`** — Google Drive resolver:
  - `parseGdrive` (every share-link shape; folders + trailing-segment URLs rejected), `urlFromConfirmation` (href → `#download-form` → JSON → error-caption, in precedence order), `checkDownloadHost` (SSRF allowlist), `openGdrive` (two-hop buffered download capped at 8 GiB, strips `Authorization`/`Cookie`, sends a browser UA, host allowlist on every hop; Node carries the interstitial cookie on manual redirects).

## Header threading end-to-end

- `OpenH5Options.headers` (and `stream`) threaded through `loadSlp`/`loadSlpSet`/`readSlp`/`readSlpLazy`/`readSlpStreaming` → `openH5File`/`openFromUrl` download fetch, the streaming worker (`openUrl` payload), and the **Node** provider (h5wasm/node cannot stream a URL, so resolved/authenticated bytes are staged to a temp file).
- `createLazyFile` (Emscripten sync XHR) cannot carry headers: authenticated remote `.slp` downloads in full on both the main thread and in the worker; header-free range streaming is unchanged. Documented as a known limitation.
- Remote/embedded video backends receive persisted headers; `Mp4BoxVideoBackend` and `MediaBunnyVideoBackend.fromUrl` forward them (`Range` always wins over a user-supplied `Range`). `createVideoBackend` routes video URLs through `resolveUrl` (gs:// mapped; s3/az/abfs and Drive video rejected, redacted).

## `Video.exists()` + persistence

Non-throwing HEAD→`Range: bytes=0-0` probe with a 60 s per-instance TTL cache, forwarding persisted auth headers via `_backendUrlHeaders()`. Header / stream-mode / Drive-byte persistence (`_setUrlPersistence`) so embedded-`pkg.slp` reopens and probes stay authenticated and Drive is not re-resolved (per-file quota).

## Redaction

Every thrown error and log line masks userinfo + sensitive query params (`token`, `access_token`, `x-amz-security-token`, `sas`, `sig`). The fallback `console.warn` in `loadSlp` now passes `redactedCauseSummary(e)`. The raw transport error is never re-thrown or chained.

## Deferrals (documented, not faked)

- `s3://`/`az://`/`abfs://` provider SDKs — no in-browser SDK; throw a typed error pointing to presigned `https://`.
- `gs://` private buckets — only the public-object HTTPS mapping is provided (no signing).
- fsspec `cache`/`filecache` disk caching + `clear_remote_cache` — no stable browser disk cache; skipped.
- aiohttp version gate / `skip_instance_cache` — no analog; the protected guarantees (cross-origin header stripping, no unbounded per-token client memoization) are preserved.
- `_find_response_error` exception-chain walking — `response.status` is used directly.
- Authenticated **range** streaming — main thread and worker fall back to a buffered download when custom headers are present.

## Tests (zero network — `globalThis.fetch` stubbed)

- `tests/io/remote.test.ts` — pure helpers (url/scheme/redaction/error/retry/probe).
- `tests/io/gdrive.test.ts` — Drive resolver: parse, confirmation scraping, host allowlist, two-hop download (asserts no `Authorization`/`Cookie`, browser UA), cap pre-check + running-check, non-convergence, SSRF.
- `tests/codecs/slp-remote-headers.test.ts` — header forwarding on the download fetch, `stream: auto` + headers takes the download path, `gs://` → `storage.googleapis.com`, Drive two-hop SLP load (no re-resolve on reopen), 404 redaction (secret absent from message/url/stack), `s3://` rejection, `headOrRangeProbe` header forwarding, and `createVideoBackend` s3/Drive-video rejection.
- `tests/video/mp4box-backend.test.ts` — extended to assert the custom header + `Range` both appear on range fetches, `Range` is not overridden by a user `Range`, and `createVideoBackend(url, { headers })` forwards them.

## Green bar

`bun run lint`, `bun run check`, `bun run build` pass; `bun run test` → **1673 pass / 0 fail / 1 skip** (the previously-flaky mp4box WebCodecs failures pass under the `--parallel` runner the `test` script uses). No unrelated Biome format churn — every touched file is format-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm