### PR TITLE
feat(model): structural skeleton dedup in Labels.update/append/extend (Python #447)

### DIFF
--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -219,24 +219,22 @@ export class Labels {
       this.videos = Array.from(uniqueVideos.values());
     }
 
-    if (!this.skeletons.length && this.labeledFrames.length) {
-      const uniqueSkeletons = new Map<Skeleton, Skeleton>();
+    // Register instance skeletons and tracks (Python `update()` loop). Skeletons
+    // are deduplicated structurally via `_registerSkeleton`, so two
+    // structurally-equal but distinct `Skeleton` objects collapse to a single
+    // canonical entry (Python #447). Explicitly-provided `skeletons` are kept
+    // (by identity) and instance skeletons dedup against them.
+    if (!this._lazyFrameList) {
+      const existingTracks = new Set(this.tracks);
       for (const frame of this.labeledFrames) {
         for (const instance of frame.instances) {
-          uniqueSkeletons.set(instance.skeleton, instance.skeleton);
+          this._registerSkeleton(instance);
+          if (instance.track && !existingTracks.has(instance.track)) {
+            existingTracks.add(instance.track);
+            this.tracks.push(instance.track);
+          }
         }
       }
-      this.skeletons = Array.from(uniqueSkeletons.values());
-    }
-
-    if (!this.tracks.length && this.labeledFrames.length) {
-      const uniqueTracks = new Map<Track, Track>();
-      for (const frame of this.labeledFrames) {
-        for (const instance of frame.instances) {
-          if (instance.track) uniqueTracks.set(instance.track, instance.track);
-        }
-      }
-      this.tracks = Array.from(uniqueTracks.values());
     }
 
     // Collect tracks from annotations already on frames
@@ -709,12 +707,55 @@ export class Labels {
     }
   }
 
+  /**
+   * Append a labeled frame to the labels.
+   *
+   * Registers the frame's video, the skeletons and tracks of its instances, and
+   * the tracks of its nested annotations. Skeletons are registered via
+   * {@link _registerSkeleton}, so an instance referencing a structurally-equal
+   * but distinct `Skeleton` is rebound to the existing canonical one instead of
+   * growing `this.skeletons` (Python #447).
+   *
+   * Mirrors Python `Labels.append` (PR #447).
+   */
   append(frame: LabeledFrame): void {
     if (this._lazyFrameList) this.materialize();
     this.labeledFrames.push(frame);
     this._invalidateIndices();
     this.addVideo(frame.video);
+    for (const inst of frame.instances) {
+      this._registerSkeleton(inst);
+      if (inst.track != null && !this.tracks.includes(inst.track)) {
+        this.tracks.push(inst.track);
+      }
+    }
     this._collectAnnotationTracks(frame);
+  }
+
+  /**
+   * Append multiple labeled frames to the labels.
+   *
+   * Like calling {@link append} on each frame in `frames`: registers each
+   * frame's video, the skeletons and tracks of its instances (deduplicating
+   * structurally-equal skeletons via {@link _registerSkeleton}, Python #447),
+   * and the tracks of its nested annotations.
+   *
+   * Mirrors Python `Labels.extend` (PR #447).
+   */
+  extend(frames: LabeledFrame[]): void {
+    if (this._lazyFrameList) this.materialize();
+    for (const frame of frames) {
+      this.labeledFrames.push(frame);
+      this.addVideo(frame.video);
+      for (const inst of frame.instances) {
+        this._registerSkeleton(inst);
+        if (inst.track != null && !this.tracks.includes(inst.track)) {
+          this.tracks.push(inst.track);
+        }
+      }
+      this._collectAnnotationTracks(frame);
+    }
+    this._invalidateIndices();
   }
 
   /**
@@ -1459,11 +1500,60 @@ export class Labels {
   }
 
   /**
+   * Register an instance's skeleton, deduplicating structurally-equal ones.
+   *
+   * If a skeleton with the same structure *and* the same node order already
+   * exists in `this.skeletons`, the instance is rebound to that canonical object
+   * instead of leaking a duplicate. If no match exists, the instance's skeleton
+   * is appended as a new canonical skeleton.
+   *
+   * A skeleton that is already registered (by object identity) is left
+   * untouched. This deliberately preserves distinct-but-compatible skeletons a
+   * caller added explicitly (e.g. via `new Labels({ skeletons: [...] })`), so
+   * workflows that reason about them separately keep working; only
+   * newly-discovered duplicates are canonicalized.
+   *
+   * Matching uses `Skeleton.matches(..., { requireSameOrder: true })` — the same
+   * strictness as {@link dedupSkeletons} — so a newly-seen skeleton is only
+   * treated as a duplicate when its node names, edges, symmetries, *and* node
+   * order all match an existing skeleton. Because the node order is identical,
+   * the instance's positional points array is already aligned to the canonical
+   * skeleton, so rebinding `inst.skeleton` never moves any point data. Two
+   * structurally-equal skeletons with *different* node order are intentionally
+   * kept distinct, since their positional point semantics genuinely differ.
+   *
+   * Mirrors Python `Labels._register_skeleton` (PR #447).
+   *
+   * @param inst - Instance whose skeleton should be registered. Both `Instance`
+   *   and `PredictedInstance` are supported.
+   */
+  private _registerSkeleton(inst: Instance | PredictedInstance): void {
+    // Already registered (identity check) -> keep as-is.
+    if (this.skeletons.includes(inst.skeleton)) {
+      return;
+    }
+    // Newly-seen skeleton: canonicalize to a structurally-equal, same-order one
+    // already registered, otherwise register it as a new skeleton.
+    const canonical = this.skeletons.find((s) =>
+      s.matches(inst.skeleton, { requireSameOrder: true }),
+    );
+    if (canonical === undefined) {
+      this.skeletons.push(inst.skeleton);
+    } else {
+      inst.skeleton = canonical;
+    }
+  }
+
+  /**
    * Update data structures based on contents.
    *
    * Repopulates `videos`, `skeletons`, and `tracks` from the labeled frames,
    * their instances and nested annotations, and the suggestions. Existing
    * entries are preserved (in order); only missing ones are appended.
+   *
+   * Skeletons are registered via {@link _registerSkeleton}, so two
+   * structurally-equal but distinct `Skeleton` objects collapse to a single
+   * canonical entry (Python #447) instead of leaking a duplicate.
    *
    * Mirrors Python `Labels.update` (labels.py:435-457).
    */
@@ -1474,9 +1564,7 @@ export class Labels {
         this.videos.push(lf.video);
       }
       for (const inst of lf.instances) {
-        if (!this.skeletons.includes(inst.skeleton)) {
-          this.skeletons.push(inst.skeleton);
-        }
+        this._registerSkeleton(inst);
         if (inst.track != null && !this.tracks.includes(inst.track)) {
           this.tracks.push(inst.track);
         }

--- a/tests/model/labels-register-skeleton.test.ts
+++ b/tests/model/labels-register-skeleton.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from "../bun-test";
+import { Labels } from "../../src/model/labels.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { Instance, PredictedInstance } from "../../src/model/instance.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { Video } from "../../src/model/video.js";
+
+/**
+ * Port of Python sleap-io PR #447 (`Labels._register_skeleton`) regression
+ * tests: structurally-equal, same-order skeletons collapse to one canonical
+ * object automatically inside `Labels` construction / `update` / `append` /
+ * `extend`, while genuinely different (or reordered) skeletons stay distinct.
+ */
+
+function abcSkeleton(): Skeleton {
+  return new Skeleton({
+    nodes: ["A", "B", "C"],
+    edges: [
+      ["A", "B"],
+      ["B", "C"],
+    ],
+  });
+}
+
+describe("Labels._registerSkeleton (Python #447)", () => {
+  it("update() dedupes structurally-equal, same-order skeletons", () => {
+    const skel1 = abcSkeleton();
+    const skel2 = abcSkeleton();
+    expect(skel1).not.toBe(skel2);
+
+    const video = new Video({ filename: "fake.mp4" });
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel1,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel2,
+    );
+    const lf1 = new LabeledFrame({ video, frameIdx: 0, instances: [inst1] });
+    const lf2 = new LabeledFrame({ video, frameIdx: 1, instances: [inst2] });
+
+    const labels = new Labels({ labeledFrames: [lf1, lf2] });
+
+    expect(labels.skeletons).toHaveLength(1);
+    const canonical = labels.skeletons[0];
+    expect(inst1.skeleton).toBe(canonical);
+    expect(inst2.skeleton).toBe(canonical);
+  });
+
+  it("append() dedupes structurally-equal, same-order skeletons", () => {
+    const skel1 = abcSkeleton();
+    const skel2 = abcSkeleton();
+
+    const video = new Video({ filename: "fake.mp4" });
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel1,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel2,
+    );
+
+    const labels = new Labels();
+    labels.append(new LabeledFrame({ video, frameIdx: 0, instances: [inst1] }));
+    labels.append(new LabeledFrame({ video, frameIdx: 1, instances: [inst2] }));
+
+    expect(labels.skeletons).toHaveLength(1);
+    const canonical = labels.skeletons[0];
+    expect(inst1.skeleton).toBe(canonical);
+    expect(inst2.skeleton).toBe(canonical);
+  });
+
+  it("extend() dedupes structurally-equal, same-order skeletons", () => {
+    const skel1 = abcSkeleton();
+    const skel2 = abcSkeleton();
+
+    const video = new Video({ filename: "fake.mp4" });
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel1,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel2,
+    );
+
+    const labels = new Labels();
+    labels.extend([
+      new LabeledFrame({ video, frameIdx: 0, instances: [inst1] }),
+      new LabeledFrame({ video, frameIdx: 1, instances: [inst2] }),
+    ]);
+
+    expect(labels.skeletons).toHaveLength(1);
+    const canonical = labels.skeletons[0];
+    expect(inst1.skeleton).toBe(canonical);
+    expect(inst2.skeleton).toBe(canonical);
+  });
+
+  it("reassigning to a same-order canonical moves no point data", () => {
+    const skel1 = abcSkeleton();
+    const skel2 = abcSkeleton();
+
+    const video = new Video({ filename: "fake.mp4" });
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel1,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [3, 3],
+        [4, 4],
+        [5, 5],
+      ],
+      skel2,
+    );
+
+    const before: Record<string, [number, number]> = {
+      A: [...inst2.getPoint("A").xy],
+      B: [...inst2.getPoint("B").xy],
+      C: [...inst2.getPoint("C").xy],
+    };
+    const orig = inst2.numpy();
+
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [inst1] }),
+        new LabeledFrame({ video, frameIdx: 1, instances: [inst2] }),
+      ],
+    });
+
+    expect(labels.skeletons).toHaveLength(1);
+    const canonical = labels.skeletons[0];
+    expect(inst2.skeleton).toBe(canonical);
+    for (const node of ["A", "B", "C"]) {
+      expect(inst2.getPoint(node).xy).toEqual(before[node]);
+    }
+    expect(inst2.numpy()).toEqual(orig);
+    expect(inst2.points.map((p) => p.name)).toEqual(canonical.nodeNames);
+  });
+
+  it("dedup preserves xy, per-node scores and instance score for predictions", () => {
+    const skel1 = abcSkeleton();
+    const skel2 = abcSkeleton();
+
+    const video = new Video({ filename: "fake.mp4" });
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skel1,
+    );
+    // Per-node scores live in the 3rd column of the points data in JS.
+    const pred = PredictedInstance.fromNumpy({
+      pointsData: [
+        [3, 3, 0.1],
+        [4, 4, 0.2],
+        [5, 5, 0.3],
+      ],
+      skeleton: skel2,
+      score: 0.9,
+    });
+
+    const beforeXy: Record<string, [number, number]> = {
+      A: [...pred.getPoint("A").xy],
+      B: [...pred.getPoint("B").xy],
+      C: [...pred.getPoint("C").xy],
+    };
+    const beforeScore: Record<string, number> = {
+      A: pred.getPoint("A").score!,
+      B: pred.getPoint("B").score!,
+      C: pred.getPoint("C").score!,
+    };
+
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [inst1] }),
+        new LabeledFrame({ video, frameIdx: 1, instances: [pred] }),
+      ],
+    });
+
+    expect(labels.skeletons).toHaveLength(1);
+    expect(pred.skeleton).toBe(labels.skeletons[0]);
+    for (const node of ["A", "B", "C"]) {
+      expect(pred.getPoint(node).xy).toEqual(beforeXy[node]);
+      expect(pred.getPoint(node).score).toBe(beforeScore[node]);
+    }
+    expect(pred.score).toBe(0.9);
+  });
+
+  it("reordered-equal skeletons are kept distinct and safe", () => {
+    const skelAbc = new Skeleton({
+      nodes: ["A", "B", "C"],
+      edges: [
+        ["A", "B"],
+        ["B", "C"],
+      ],
+    });
+    const skelCba = new Skeleton({
+      nodes: ["C", "B", "A"],
+      edges: [
+        ["A", "B"],
+        ["B", "C"],
+      ],
+    });
+
+    // Same node SET (default match) but different ORDER (strict match fails).
+    expect(skelAbc.matches(skelCba)).toBe(true);
+    expect(skelAbc.matches(skelCba, { requireSameOrder: true })).toBe(false);
+
+    const video = new Video({ filename: "fake.mp4" });
+    const instAbc = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+      ],
+      skelAbc,
+    );
+    const instCba = Instance.fromArray(
+      [
+        [9, 9],
+        [1, 1],
+        [7, 7],
+      ],
+      skelCba,
+    );
+
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [instAbc] }),
+        new LabeledFrame({ video, frameIdx: 1, instances: [instCba] }),
+      ],
+    });
+
+    // Reordered-equal skeletons are intentionally NOT merged.
+    expect(labels.skeletons).toHaveLength(2);
+    // No silent corruption: node "A" still maps to its original positional value.
+    expect(instAbc.getPoint("A").xy).toEqual([0, 0]);
+    expect(instAbc.getPoint("A").xy).not.toEqual([2, 2]);
+  });
+
+  it("re-running update with one skeleton instance does not duplicate it", () => {
+    const skel = new Skeleton({ nodes: ["A", "B"], edges: [["A", "B"]] });
+    const video = new Video({ filename: "fake.mp4" });
+    const inst = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+      ],
+      skel,
+    );
+
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [inst] }),
+      ],
+    });
+    expect(labels.skeletons).toHaveLength(1);
+
+    labels.update();
+    expect(labels.skeletons).toHaveLength(1);
+    expect(inst.skeleton).toBe(labels.skeletons[0]);
+  });
+
+  it("distinct-but-compatible skeletons added explicitly are not auto-merged", () => {
+    const skel1 = new Skeleton({ nodes: ["A", "B"], edges: [["A", "B"]] });
+    const skel2 = new Skeleton({ nodes: ["A", "B"], edges: [["A", "B"]] });
+
+    const video = new Video({ filename: "fake.mp4" });
+    const labels = new Labels({ skeletons: [skel1, skel2], videos: [video] });
+
+    const inst1 = Instance.fromArray(
+      [
+        [0, 0],
+        [1, 1],
+      ],
+      skel1,
+    );
+    const inst2 = Instance.fromArray(
+      [
+        [2, 2],
+        [3, 3],
+      ],
+      skel2,
+    );
+    labels.append(new LabeledFrame({ video, frameIdx: 0, instances: [inst1] }));
+    labels.append(new LabeledFrame({ video, frameIdx: 1, instances: [inst2] }));
+
+    // Both skeletons were explicitly registered, so neither instance is rebound
+    // and both skeletons are preserved (compatible skeletons stay distinct).
+    expect(labels.skeletons).toHaveLength(2);
+    expect(inst1.skeleton).toBe(skel1);
+    expect(inst2.skeleton).toBe(skel2);
+  });
+});


### PR DESCRIPTION
## Summary

Ports Python sleap-io **PR #447** to the JS port: `Labels` now automatically collapses structurally-equal but distinct `Skeleton` objects into a single canonical entry when registering an instance's skeleton, instead of leaking duplicates into `labels.skeletons` until a manual `dedupSkeletons()` call.

Previously, `update()` collapsed skeletons by **object identity only** (`if (!this.skeletons.includes(inst.skeleton)) this.skeletons.push(inst.skeleton)`), so two structurally-equal-but-distinct `Skeleton` instances (e.g. created across separately-appended frames) were both kept. The structural collapse existed only as the explicit `dedupSkeletons()` method and was never applied automatically.

## Change

Adds a private `_registerSkeleton(inst)` helper mirroring Python's `Labels._register_skeleton`:

- If the instance's skeleton is **already registered** (by object identity), it is left untouched. This deliberately preserves distinct-but-compatible skeletons a caller added explicitly via `new Labels({ skeletons: [...] })`, so workflows that reason about them separately keep working.
- Otherwise it searches `this.skeletons` for a structurally-equal, **same-order** skeleton via `Skeleton.matches(..., { requireSameOrder: true })` — the same strictness used by `dedupSkeletons()` and confirmed against the Python diff (`require_same_order=True`). If found, `inst.skeleton` is rebound to the canonical object; because node order is identical, the instance's positional points stay aligned and no point data moves. If not found, the skeleton is registered as a new canonical entry.

`_registerSkeleton` is called from:
- `update()` — replacing the old identity-only `includes` check.
- `append()` — which now also registers instance skeletons and tracks (previously it only registered videos and annotation tracks), matching Python.
- a new `extend(frames)` method mirroring Python `Labels.extend`.
- the constructor's instance-collection pass (so `new Labels({ labeledFrames: [...] })` dedups too, matching Python's `__attrs_post_init__` → `update()`).

Reordered-equal skeletons (same node set, different node order) are intentionally kept distinct, since their positional point semantics genuinely differ — collapsing them would silently corrupt point data.

## Test coverage

Adds `tests/model/labels-register-skeleton.test.ts`, porting the Python regression tests:

- Structurally-equal, same-order skeletons collapse to one canonical object across `update()`, `append()`, `extend()`, and construction; instances are rebound to the canonical.
- Reassigning to a same-order canonical moves no point data (xy, numpy, node names preserved).
- Predicted instances preserve per-node scores and the instance score through dedup.
- Reordered-equal skeletons (`A,B,C` vs `C,B,A`) are **not** merged and point data is not corrupted.
- Re-running `update()` with a single skeleton instance is idempotent.
- Explicitly-provided compatible skeletons are not auto-merged.

All checks green: `bun run check`, `bun run lint`, `bun run build`, `bun run test` (1802 pass, 1 skip, 0 fail).

Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm