### PR TITLE
fix(io): helpful error when SLP metadata JSON attribute is missing (Python #446)

### DIFF
--- a/src/codecs/slp/parsers.ts
+++ b/src/codecs/slp/parsers.ts
@@ -35,6 +35,73 @@ export function parseJsonAttr(attr: unknown): unknown {
 }
 
 /**
+ * Determine whether a `/metadata` `json` HDF5 attribute holds usable content.
+ *
+ * Mirrors the precondition for which Python's `read_metadata` raises (an absent
+ * `json` attribute surfaces as a `KeyError`). An attribute is considered absent
+ * when it is `undefined`/`null`, an empty string (including a `{ value }`
+ * wrapper around one), or an empty byte buffer. A non-empty value -- even one
+ * that is malformed JSON -- is treated as present so that downstream parsing can
+ * surface the real decode error rather than masking it as corruption (see
+ * Python #446's `test_read_metadata_malformed_json_not_remasked`).
+ */
+function hasMetadataJsonAttr(attr: unknown): boolean {
+  if (attr === undefined || attr === null) return false;
+  const value = (attr as { value?: unknown }).value ?? attr;
+  if (typeof value === "string") return value.length > 0;
+  if (value instanceof Uint8Array) return value.length > 0;
+  if (value && typeof value === "object" && "buffer" in value) {
+    return new Uint8Array((value as { buffer: ArrayBuffer }).buffer).length > 0;
+  }
+  // Already-parsed objects (e.g. from the streaming worker) are usable as-is.
+  return true;
+}
+
+/**
+ * Build the helpful error message for a corrupt `.slp` whose `/metadata` group
+ * is missing its required `json` attribute. Mirrors the wording/intent of
+ * Python sleap-io PR #446 (`read_metadata` raising `ValueError`).
+ */
+export function missingMetadataJsonError(labelsPath: string): Error {
+  return new Error(
+    `The SLEAP labels file '${labelsPath}' is missing its required ` +
+      "metadata JSON blob (the 'metadata' HDF5 group has no readable 'json' " +
+      "attribute) and is likely corrupt. If you have a working .slp file " +
+      "with the same skeleton, you can copy the attribute into a BACKUP " +
+      "COPY of the corrupt file with h5py (back up first):\n" +
+      "    import h5py\n" +
+      "    with h5py.File('working.slp', 'r') as src, " +
+      "h5py.File('corrupt_copy.slp', 'a') as dst:\n" +
+      "        dst['metadata'].attrs['json'] = src['metadata'].attrs['json']\n" +
+      "Only do this if the skeletons match exactly, otherwise the loaded " +
+      "data will be wrong.",
+  );
+}
+
+/**
+ * Parse the `/metadata` group's `json` HDF5 attribute, raising a helpful error
+ * when it is absent.
+ *
+ * The `.slp` reader needs the JSON-encoded metadata blob to recover skeletons,
+ * provenance, etc. When the `metadata` group exists but the `json` attribute is
+ * missing/empty (a truncated, foreign, or otherwise corrupt file), the legacy
+ * code silently parsed it as `null` and failed later with an opaque error. This
+ * mirrors Python sleap-io PR #446: surface a clear, actionable error naming the
+ * file and the missing attribute instead. Malformed-but-present JSON still
+ * surfaces as the underlying parse error.
+ *
+ * @param attr The raw `json` attribute value as read from the HDF5 file.
+ * @param labelsPath Path/identifier of the `.slp` file (used in the message).
+ * @throws {Error} If the `json` attribute is absent or empty.
+ */
+export function parseMetadataJson(attr: unknown, labelsPath: string): unknown {
+  if (!hasMetadataJsonAttr(attr)) {
+    throw missingMetadataJsonError(labelsPath);
+  }
+  return parseJsonAttr(attr);
+}
+
+/**
  * Trim trailing nulls and whitespace from a string (for fixed-width HDF5 strings).
  */
 function trimHdf5String(str: string): string {

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -18,6 +18,7 @@ import {
   attrToNumber,
   attrToString,
   parseMetadataJson,
+  missingMetadataJsonError,
   parseJsonEntry,
   parseSkeletons,
   parseTracks,
@@ -156,8 +157,13 @@ export async function readSlpStreaming(
 
 /**
  * Read Labels from an already-opened StreamingH5File.
+ *
+ * Exported for direct testing of the streaming metadata-error path: the full
+ * streaming reader (`readSlpStreaming`) is browser/Worker-gated and unreachable
+ * from the all-Node test suite, so the error-routing here is exercised by
+ * driving this function with a minimal `getAttrs`-providing stub.
  */
-async function readFromStreamingFile(
+export async function readFromStreamingFile(
   file: StreamingH5File,
   url: string,
   filenameHint?: string,
@@ -189,17 +195,28 @@ async function readFromStreamingFile(
     onProgress?.(n, total, message ?? STAGES[n]);
 
   report(0);
-  const metadataAttrs = await file.getAttrs("metadata");
+  const labelsPath =
+    filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
+  // A missing `metadata` group surfaces from the worker as a thrown
+  // "Path not found: metadata"; treat that the same as a missing `json`
+  // attribute (both indicate a truncated/corrupt file) and route it through
+  // the same helpful error. Mirrors Python sleap-io PR #446, where
+  // `read_metadata` catches the `KeyError` from BOTH cases and maps them to
+  // the same `ValueError`, and matches the eager/lazy readers in read.ts.
+  let metadataAttrs: Record<string, unknown>;
+  try {
+    metadataAttrs = await file.getAttrs("metadata");
+  } catch {
+    throw missingMetadataJsonError(labelsPath);
+  }
   const formatId = Number(
     (metadataAttrs["format_id"] as { value?: number })?.value ??
       metadataAttrs["format_id"] ??
       1.0,
   );
-  const labelsPath =
-    filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
-  // Throws a helpful error if the `metadata` group exists but its required
-  // `json` attribute is missing/empty (truncated/corrupt file); mirrors Python
-  // sleap-io PR #446 and matches the eager/lazy readers in read.ts.
+  // Throws the same helpful error if the `metadata` group exists but its
+  // required `json` attribute is missing/empty (truncated/corrupt file);
+  // mirrors Python sleap-io PR #446 and matches the eager/lazy readers.
   const metadataJson = parseMetadataJson(
     metadataAttrs["json"],
     labelsPath,

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -17,7 +17,7 @@ import {
 import {
   attrToNumber,
   attrToString,
-  parseJsonAttr,
+  parseMetadataJson,
   parseJsonEntry,
   parseSkeletons,
   parseTracks,
@@ -195,13 +195,16 @@ async function readFromStreamingFile(
       metadataAttrs["format_id"] ??
       1.0,
   );
-  const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<
-    string,
-    unknown
-  > | null;
-
   const labelsPath =
     filenameHint ?? url.split("/").pop()?.split("?")[0] ?? "slp-data.slp";
+  // Throws a helpful error if the `metadata` group exists but its required
+  // `json` attribute is missing/empty (truncated/corrupt file); mirrors Python
+  // sleap-io PR #446 and matches the eager/lazy readers in read.ts.
+  const metadataJson = parseMetadataJson(
+    metadataAttrs["json"],
+    labelsPath,
+  ) as Record<string, unknown> | null;
+
   const skeletons = parseSkeletons(metadataJson);
 
   report(1);

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -2,7 +2,7 @@ import { openH5File, OpenH5Options, SlpSource } from "./h5.js";
 import {
   attrToNumber,
   attrToString,
-  parseJsonAttr,
+  parseMetadataJson,
   parseSkeletons,
   resolveCameraKey,
   reconstructInstance3D,
@@ -131,15 +131,18 @@ export async function readSlp(
     const formatId = Number(
       metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0,
     );
-    const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<
-      string,
-      unknown
-    > | null;
-
     const labelsPath =
       typeof source === "string"
         ? source
         : (options?.h5?.filenameHint ?? "slp-data.slp");
+    // Throws a helpful error if the `metadata` group exists but its required
+    // `json` attribute is missing/empty (truncated/corrupt file); mirrors
+    // Python sleap-io PR #446.
+    const metadataJson = parseMetadataJson(
+      metadataAttrs["json"],
+      labelsPath,
+    ) as Record<string, unknown> | null;
+
     const skeletons = parseSkeletons(metadataJson);
     report(1); // Reading tracks
     const tracks = readTracks(file.get("tracks_json"));
@@ -386,15 +389,18 @@ export async function readSlpLazy(
     const formatId = Number(
       metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0,
     );
-    const metadataJson = parseJsonAttr(metadataAttrs["json"]) as Record<
-      string,
-      unknown
-    > | null;
-
     const labelsPath =
       typeof source === "string"
         ? source
         : (options?.h5?.filenameHint ?? "slp-data.slp");
+    // Throws a helpful error if the `metadata` group exists but its required
+    // `json` attribute is missing/empty (truncated/corrupt file); mirrors
+    // Python sleap-io PR #446.
+    const metadataJson = parseMetadataJson(
+      metadataAttrs["json"],
+      labelsPath,
+    ) as Record<string, unknown> | null;
+
     const skeletons = parseSkeletons(metadataJson);
     report(1); // Reading tracks
     const tracks = readTracks(file.get("tracks_json"));

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -3,6 +3,7 @@ import {
   attrToNumber,
   attrToString,
   parseMetadataJson,
+  missingMetadataJsonError,
   parseSkeletons,
   resolveCameraKey,
   reconstructInstance3D,
@@ -121,9 +122,17 @@ export async function readSlp(
   };
   try {
     report(0); // Reading metadata
+    const labelsPath =
+      typeof source === "string"
+        ? source
+        : (options?.h5?.filenameHint ?? "slp-data.slp");
     const metadataGroup = file.get("metadata");
+    // A missing `metadata` group is treated the same as a missing `json`
+    // attribute: both indicate a truncated/corrupt file. Mirrors Python
+    // sleap-io PR #446, where `read_metadata` catches the `KeyError` from
+    // BOTH cases and maps them to the same helpful `ValueError`.
     if (!metadataGroup) {
-      throw new Error("Missing /metadata group in SLP file");
+      throw missingMetadataJsonError(labelsPath);
     }
 
     const metadataAttrs =
@@ -131,13 +140,9 @@ export async function readSlp(
     const formatId = Number(
       metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0,
     );
-    const labelsPath =
-      typeof source === "string"
-        ? source
-        : (options?.h5?.filenameHint ?? "slp-data.slp");
-    // Throws a helpful error if the `metadata` group exists but its required
-    // `json` attribute is missing/empty (truncated/corrupt file); mirrors
-    // Python sleap-io PR #446.
+    // Throws the same helpful error if the `metadata` group exists but its
+    // required `json` attribute is missing/empty (truncated/corrupt file);
+    // mirrors Python sleap-io PR #446.
     const metadataJson = parseMetadataJson(
       metadataAttrs["json"],
       labelsPath,
@@ -379,9 +384,16 @@ export async function readSlpLazy(
   };
   try {
     report(0); // Reading metadata
+    const labelsPath =
+      typeof source === "string"
+        ? source
+        : (options?.h5?.filenameHint ?? "slp-data.slp");
     const metadataGroup = file.get("metadata");
+    // A missing `metadata` group is treated the same as a missing `json`
+    // attribute: both indicate a truncated/corrupt file. Mirrors Python
+    // sleap-io PR #446 (and the eager/streaming readers).
     if (!metadataGroup) {
-      throw new Error("Missing /metadata group in SLP file");
+      throw missingMetadataJsonError(labelsPath);
     }
 
     const metadataAttrs =
@@ -389,13 +401,9 @@ export async function readSlpLazy(
     const formatId = Number(
       metadataAttrs["format_id"]?.value ?? metadataAttrs["format_id"] ?? 1.0,
     );
-    const labelsPath =
-      typeof source === "string"
-        ? source
-        : (options?.h5?.filenameHint ?? "slp-data.slp");
-    // Throws a helpful error if the `metadata` group exists but its required
-    // `json` attribute is missing/empty (truncated/corrupt file); mirrors
-    // Python sleap-io PR #446.
+    // Throws the same helpful error if the `metadata` group exists but its
+    // required `json` attribute is missing/empty (truncated/corrupt file);
+    // mirrors Python sleap-io PR #446.
     const metadataJson = parseMetadataJson(
       metadataAttrs["json"],
       labelsPath,

--- a/tests/slp-metadata-error.test.ts
+++ b/tests/slp-metadata-error.test.ts
@@ -16,6 +16,8 @@
  */
 import { describe, it, expect } from "./bun-test";
 import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
+import { readFromStreamingFile } from "../src/codecs/slp/read-streaming.js";
+import type { StreamingH5File } from "../src/codecs/slp/h5-streaming.js";
 import {
   parseMetadataJson,
   missingMetadataJsonError,
@@ -69,6 +71,39 @@ async function buildFixture(opts: {
   // The reader touches these datasets after metadata; include empties so that,
   // absent the metadata error, reads would proceed (proving the throw is what
   // stops them) rather than tripping over a missing dataset first.
+  f.create_dataset({ name: "tracks_json", data: [], shape: [0], dtype: "S" });
+  f.create_dataset({
+    name: "suggestions_json",
+    data: [],
+    shape: [0],
+    dtype: "S",
+  });
+  f.create_dataset({ name: "videos_json", data: [], shape: [0], dtype: "S" });
+  f.close();
+
+  const out = FS.readFile(p);
+  FS.unlink(p);
+  return new Uint8Array(out).buffer;
+}
+
+/**
+ * Build a minimal in-memory `.slp` buffer with NO `metadata` group at all,
+ * reproducing the case Python's
+ * `test_read_metadata_missing_metadata_group_raises_valueerror` exercises
+ * (`f.require_group("other")` with no `metadata`). The non-metadata datasets
+ * are still present so that, absent the metadata error, the reader could
+ * otherwise proceed — proving the throw is specifically about the absent group.
+ */
+async function buildNoMetadataGroupFixture(): Promise<ArrayBuffer> {
+  const h5 = await import("h5wasm");
+  await h5.ready;
+  const FS = h5.FS;
+  const p = memPath();
+  FS.writeFile(p, new Uint8Array(0));
+  const f = new h5.File(p, "w");
+
+  // An unrelated group, but deliberately NO `metadata` group.
+  f.create_group("other");
   f.create_dataset({ name: "tracks_json", data: [], shape: [0], dtype: "S" });
   f.create_dataset({
     name: "suggestions_json",
@@ -164,6 +199,102 @@ describe("missing /metadata json attribute raises a helpful error", () => {
     const labels = await readSlp(buf, { openVideos: false });
     expect(labels).toBeDefined();
     expect(labels.skeletons.length).toBe(0);
+  });
+});
+
+describe("a missing /metadata GROUP raises the same helpful error", () => {
+  // Mirrors Python's test_read_metadata_missing_metadata_group_raises_valueerror.
+  // Python catches the KeyError from BOTH a missing `metadata` group AND a
+  // missing `json` attr and maps both to the same ValueError; the JS readers
+  // unify these through `missingMetadataJsonError` too.
+  it("readSlp (eager) throws the corruption error when the group is absent", async () => {
+    const buf = await buildNoMetadataGroupFixture();
+    await expect(
+      readSlp(buf, { openVideos: false, h5: { filenameHint: "nogroup.slp" } }),
+    ).rejects.toThrow(CORRUPT_MESSAGE);
+    await expect(
+      readSlp(buf, { openVideos: false, h5: { filenameHint: "nogroup.slp" } }),
+    ).rejects.toThrow("nogroup.slp");
+  });
+
+  it("readSlpLazy throws the same error when the group is absent", async () => {
+    const buf = await buildNoMetadataGroupFixture();
+    await expect(
+      readSlpLazy(buf, {
+        openVideos: false,
+        h5: { filenameHint: "nogroup.slp" },
+      }),
+    ).rejects.toThrow(CORRUPT_MESSAGE);
+  });
+});
+
+describe("the streaming reader funnels through the same helpful error", () => {
+  // The full streaming reader (`readSlpStreaming`) is browser/Worker-gated and
+  // unreachable from the all-Node suite (see streaming-field-names.test.ts), so
+  // we drive `readFromStreamingFile` directly with a minimal `getAttrs`-only
+  // stub. The metadata read is the first thing the function does, so no other
+  // `file` method is reached before the error is thrown.
+
+  /** A StreamingH5File stub exposing only `getAttrs` (all the reader needs to
+   * reach the metadata error). `getAttrs` either returns the serialized attrs
+   * or throws, mirroring the real worker's behavior. */
+  function stubFile(
+    getAttrs: (path: string) => Promise<Record<string, unknown>>,
+  ): StreamingH5File {
+    return { getAttrs } as unknown as StreamingH5File;
+  }
+
+  it("throws when the worker reports a missing /metadata group", async () => {
+    // The worker's getAttrs throws "Path not found: metadata" for an absent
+    // group; the reader maps that to the helpful corruption error.
+    const file = stubFile(async (path) => {
+      throw new Error(`Path not found: ${path}`);
+    });
+    await expect(
+      readFromStreamingFile(file, "https://example.com/stream.slp"),
+    ).rejects.toThrow(CORRUPT_MESSAGE);
+    await expect(
+      readFromStreamingFile(file, "https://example.com/stream.slp"),
+    ).rejects.toThrow("stream.slp");
+  });
+
+  it("throws when the /metadata group is present but `json` is missing", async () => {
+    // Group present (only an unrelated attr), json attr deleted — the corrupt
+    // fixture scenario, but driven through the streaming code path.
+    const file = stubFile(async () => ({
+      format_id: { value: 1.1 },
+    }));
+    await expect(
+      readFromStreamingFile(
+        file,
+        "https://example.com/x.slp",
+        "corrupt-stream.slp",
+      ),
+    ).rejects.toThrow(CORRUPT_MESSAGE);
+    await expect(
+      readFromStreamingFile(
+        file,
+        "https://example.com/x.slp",
+        "corrupt-stream.slp",
+      ),
+    ).rejects.toThrow("corrupt-stream.slp");
+  });
+
+  it("does NOT mask malformed-but-present json as corruption (streaming)", async () => {
+    // A present (non-empty) but invalid json attr must fail at the parse step,
+    // not be re-reported as missing/corrupt — Python's
+    // test_read_metadata_malformed_json_not_remasked, via the streaming path.
+    const file = stubFile(async () => ({
+      json: { value: "{not valid json" },
+    }));
+    let caught: unknown;
+    try {
+      await readFromStreamingFile(file, "https://example.com/x.slp");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).not.toContain(CORRUPT_MESSAGE);
   });
 });
 

--- a/tests/slp-metadata-error.test.ts
+++ b/tests/slp-metadata-error.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Regression tests for the helpful error raised when an `.slp` file's
+ * `/metadata` group exists but is missing its required `json` attribute (the
+ * JSON-encoded metadata blob the reader needs to recover skeletons, provenance,
+ * etc.). Such files are typically truncated, foreign, or otherwise corrupt.
+ *
+ * Ports Python sleap-io PR #446 (closes JS #149). Before the fix, the reader
+ * silently parsed the missing attribute as `null` and failed later with an
+ * opaque error; now it throws a clear, actionable message naming the file and
+ * the missing attribute. The eager (`readSlp`), lazy (`readSlpLazy`), and
+ * streaming readers all funnel through the shared `parseMetadataJson` helper, so
+ * they produce the same error.
+ *
+ * Fixtures are constructed in-test with h5wasm (mirroring
+ * tests/h5-attrs-and-cleanup.test.ts) so no checked-in corrupt file is needed.
+ */
+import { describe, it, expect } from "./bun-test";
+import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
+import {
+  parseMetadataJson,
+  missingMetadataJsonError,
+} from "../src/codecs/slp/parsers.js";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
+
+const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
+
+/** A unique MEMFS path so concurrent fixtures never collide. */
+function memPath(): string {
+  return (
+    "/slp-metadata-error-" +
+    Date.now() +
+    "-" +
+    Math.random().toString(36).slice(2) +
+    ".slp"
+  );
+}
+
+/**
+ * Build a minimal in-memory `.slp` buffer. When `includeJson` is false the
+ * `metadata` group is created (with an unrelated `format_id` attr) but its
+ * `json` attribute is omitted, reproducing the corrupt-file scenario. When a
+ * `json` string is provided verbatim (e.g. malformed), it is written as-is.
+ */
+async function buildFixture(opts: {
+  includeJson: boolean;
+  rawJson?: string;
+}): Promise<ArrayBuffer> {
+  const h5 = await import("h5wasm");
+  await h5.ready;
+  const FS = h5.FS;
+  const p = memPath();
+  FS.writeFile(p, new Uint8Array(0));
+  const f = new h5.File(p, "w");
+
+  const meta = f.create_group("metadata") as {
+    create_attribute: (n: string, v: unknown) => void;
+  };
+  // Group exists but (when includeJson is false) carries only an unrelated attr,
+  // mirroring Python's test that sets `format_id` without `json`.
+  meta.create_attribute("format_id", 1.1);
+  if (opts.rawJson !== undefined) {
+    meta.create_attribute("json", opts.rawJson);
+  } else if (opts.includeJson) {
+    meta.create_attribute("json", JSON.stringify({ skeletons: [], nodes: [] }));
+  }
+
+  // The reader touches these datasets after metadata; include empties so that,
+  // absent the metadata error, reads would proceed (proving the throw is what
+  // stops them) rather than tripping over a missing dataset first.
+  f.create_dataset({ name: "tracks_json", data: [], shape: [0], dtype: "S" });
+  f.create_dataset({
+    name: "suggestions_json",
+    data: [],
+    shape: [0],
+    dtype: "S",
+  });
+  f.create_dataset({ name: "videos_json", data: [], shape: [0], dtype: "S" });
+  f.close();
+
+  const out = FS.readFile(p);
+  FS.unlink(p);
+  return new Uint8Array(out).buffer;
+}
+
+/**
+ * Copy a real `.slp` fixture into MEMFS, delete only the `metadata/json`
+ * attribute, and re-serialize. Mirrors Python's
+ * `test_read_labels_missing_json_attr_raises_valueerror`, which corrupts a copy
+ * of a working file so every other dataset is genuinely present.
+ */
+async function corruptRealFixture(filename: string): Promise<ArrayBuffer> {
+  const h5 = await import("h5wasm");
+  await h5.ready;
+  const FS = h5.FS;
+  const p = memPath();
+  const data = new Uint8Array(
+    fs.readFileSync(path.join(fixtureRoot, "slp", filename)),
+  );
+  FS.writeFile(p, data);
+  const f = new h5.File(p, "a");
+  const meta = f.get("metadata") as { delete_attribute: (n: string) => void };
+  meta.delete_attribute("json");
+  f.close();
+
+  const out = FS.readFile(p);
+  FS.unlink(p);
+  return new Uint8Array(out).buffer;
+}
+
+const CORRUPT_MESSAGE = "missing its required metadata JSON blob";
+
+describe("missing /metadata json attribute raises a helpful error", () => {
+  it("readSlp (eager) throws naming the file and missing attribute", async () => {
+    const buf = await buildFixture({ includeJson: false });
+    await expect(
+      readSlp(buf, { openVideos: false, h5: { filenameHint: "broken.slp" } }),
+    ).rejects.toThrow(CORRUPT_MESSAGE);
+    await expect(
+      readSlp(buf, { openVideos: false, h5: { filenameHint: "broken.slp" } }),
+    ).rejects.toThrow("broken.slp");
+  });
+
+  it("readSlpLazy throws the same helpful error", async () => {
+    const buf = await buildFixture({ includeJson: false });
+    await expect(
+      readSlpLazy(buf, {
+        openVideos: false,
+        h5: { filenameHint: "broken.slp" },
+      }),
+    ).rejects.toThrow(CORRUPT_MESSAGE);
+  });
+
+  it("the message is actionable (mentions corruption and the h5py recovery)", async () => {
+    const buf = await buildFixture({ includeJson: false });
+    let caught: unknown;
+    try {
+      await readSlp(buf, { openVideos: false });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const msg = (caught as Error).message;
+    expect(msg).toContain("likely corrupt");
+    expect(msg).toContain("metadata");
+    expect(msg).toContain("h5py");
+  });
+
+  it("a corrupted copy of a real fixture (json attr deleted) throws", async () => {
+    // Every other dataset is present, so the throw is specifically about the
+    // missing json attribute, not an unrelated missing group.
+    const buf = await corruptRealFixture("minimal_instance.slp");
+    await expect(
+      readSlp(buf, {
+        openVideos: false,
+        h5: { filenameHint: "minimal_instance.slp" },
+      }),
+    ).rejects.toThrow(CORRUPT_MESSAGE);
+  });
+
+  it("a healthy fixture still loads (no false positive)", async () => {
+    const buf = await buildFixture({ includeJson: true });
+    const labels = await readSlp(buf, { openVideos: false });
+    expect(labels).toBeDefined();
+    expect(labels.skeletons.length).toBe(0);
+  });
+});
+
+describe("malformed-but-present json is not masked as corruption", () => {
+  it("readSlp surfaces a JSON parse error, not the corruption message", async () => {
+    // Mirrors Python's test_read_metadata_malformed_json_not_remasked: a present
+    // (non-empty) json attribute that is invalid JSON must fail at the parse
+    // step, NOT be re-reported as a missing/corrupt attribute.
+    const buf = await buildFixture({
+      includeJson: false,
+      rawJson: "{not valid json",
+    });
+    let caught: unknown;
+    try {
+      await readSlp(buf, { openVideos: false });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).not.toContain(CORRUPT_MESSAGE);
+  });
+});
+
+describe("parseMetadataJson helper (shared by all readers)", () => {
+  it("throws the helpful error for an undefined attribute", () => {
+    expect(() => parseMetadataJson(undefined, "ghost.slp")).toThrow(
+      CORRUPT_MESSAGE,
+    );
+    expect(() => parseMetadataJson(undefined, "ghost.slp")).toThrow(
+      "ghost.slp",
+    );
+  });
+
+  it("treats an empty string / empty buffer as missing", () => {
+    expect(() => parseMetadataJson("", "empty.slp")).toThrow(CORRUPT_MESSAGE);
+    expect(() => parseMetadataJson({ value: "" }, "empty.slp")).toThrow(
+      CORRUPT_MESSAGE,
+    );
+    expect(() => parseMetadataJson(new Uint8Array(0), "empty.slp")).toThrow(
+      CORRUPT_MESSAGE,
+    );
+  });
+
+  it("parses present JSON (string and { value } wrapper)", () => {
+    expect(parseMetadataJson('{"a":1}', "ok.slp")).toEqual({ a: 1 });
+    expect(parseMetadataJson({ value: '{"b":2}' }, "ok.slp")).toEqual({ b: 2 });
+  });
+
+  it("lets malformed-but-present JSON throw the underlying parse error", () => {
+    expect(() => parseMetadataJson("{bad", "ok.slp")).toThrow();
+    expect(() => parseMetadataJson("{bad", "ok.slp")).not.toThrow(
+      CORRUPT_MESSAGE,
+    );
+  });
+
+  it("missingMetadataJsonError embeds the labels path", () => {
+    const err = missingMetadataJsonError("/data/foo.slp");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("/data/foo.slp");
+    expect(err.message).toContain("likely corrupt");
+  });
+});


### PR DESCRIPTION
Closes #149 (ports Python sleap-io PR #446).

## Problem

When a `.slp` file's `/metadata` HDF5 group exists but is missing its required `json` attribute (the JSON-encoded metadata blob the reader needs to recover skeletons, provenance, etc.), the readers previously parsed the absent attribute as `null` via `parseJsonAttr` and silently continued. The load then failed later with a confusing, opaque error far from the real cause. Such files are typically truncated, foreign, or otherwise corrupt.

## Change

Adds a shared `parseMetadataJson(attr, labelsPath)` helper in `src/codecs/slp/parsers.ts` that throws a clear, actionable `Error` -- naming the file and the missing attribute and pointing at the h5py-based recovery -- mirroring the wording and intent of Python #446's `read_metadata` `ValueError`:

> The SLEAP labels file '<path>' is missing its required metadata JSON blob (the 'metadata' HDF5 group has no readable 'json' attribute) and is likely corrupt. ...

An attribute is treated as absent when it is `undefined`/`null`, an empty string (including a `{ value }` wrapper), or an empty byte buffer. A non-empty but **malformed** JSON value is treated as present, so the underlying JSON parse error still surfaces rather than being masked as corruption (mirrors Python's `test_read_metadata_malformed_json_not_remasked`).

All three reader paths now funnel through the helper so they emit the same error:
- eager `readSlp` (`src/codecs/slp/read.ts`)
- lazy `readSlpLazy` (`src/codecs/slp/read.ts`)
- streaming `readFromStreamingFile` (`src/codecs/slp/read-streaming.ts`)

(The `labelsPath` computation was hoisted above the metadata parse in each so it can be embedded in the message.) The jsfive-based `lite.ts` reader already raised an explicit typed error for this case and was left unchanged.

## Test coverage

New `tests/slp-metadata-error.test.ts` builds minimal in-memory fixtures with h5wasm (no checked-in corrupt file needed):
- `metadata` group with no `json` attribute -> eager and lazy readers throw the helpful error (asserts file name + "likely corrupt" + h5py guidance).
- A corrupted **copy of a real fixture** (`minimal_instance.slp`) with the `json` attribute deleted -> readers throw (every other dataset is genuinely present, so the throw is specifically about the missing attribute).
- A healthy fixture still loads (no false positive).
- A malformed-but-present `json` value surfaces a JSON parse error, NOT the corruption message.
- Direct unit coverage of `parseMetadataJson` and `missingMetadataJsonError` (undefined, empty string/`{value}`/empty buffer, valid JSON, malformed JSON).

All checks pass locally: `bun run check`, `bun run lint`, `bun run build`, `bun run test` (1805 pass, 1 skip, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm
