### PR TITLE
perf(video): shared-decode mosaic reuse for cropped videos on SLP read (JS#153 item 2)

### DIFF
--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -530,10 +530,23 @@ async function readVideosStreaming(
       if (cropEntry) {
         const [cx1, cy1, cx2, cy2] = cropEntry.crop;
         if (openVideos && videoBackend) {
+          // Each reloaded tile owns its freshly-reconstructed inner (ownsInner
+          // defaults to true). We do NOT share one inner across sibling mosaic
+          // tiles here: on read each video entry rebuilds a private inner, so
+          // sharing would leave the inner unowned (leaked — never closed) for no
+          // decode savings. The streaming inner already shares the single
+          // StreamingH5File worker across all backends and never closes it
+          // (streaming-hdf5-video.ts), so the per-tile wrapper is cheap and its
+          // ownsInner=true is harmless (close() only clears the wrapper's tiny
+          // legacy cache; it cannot tear down the shared worker file). Live
+          // mosaic decode-sharing is opt-in and in-memory only, via
+          // Video.crop({ shareDecode: true }). Mirrors Python slp.py make_video
+          // (slp.py:393-401).
           videoBackend = CropVideoBackend.wrap({
             inner: videoBackend,
             crop: cropEntry.crop,
             fill: cropEntry.fill,
+            // ownsInner: true (default) — see comment above.
           });
         }
         if (shape && shape.length === 4) {

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -847,10 +847,20 @@ async function readVideos(
     if (cropEntry) {
       const [cx1, cy1, cx2, cy2] = cropEntry.crop;
       if (openVideos && backend) {
+        // Each reloaded tile owns its freshly-reconstructed inner (ownsInner
+        // defaults to true). We do NOT share one inner across sibling mosaic
+        // tiles here: on read each video entry rebuilds a private inner, so
+        // sharing would leave the inner unowned (leaked — never closed) for no
+        // decode savings. The Hdf5VideoBackend is a thin per-frame slicer over
+        // the already-shared open h5 `file`, so duplicating it per tile is
+        // cheap. Live mosaic decode-sharing is opt-in and in-memory only, via
+        // Video.crop({ shareDecode: true }). Mirrors Python slp.py make_video
+        // (slp.py:393-401).
         backend = CropVideoBackend.wrap({
           inner: backend,
           crop: cropEntry.crop,
           fill: cropEntry.fill,
+          // ownsInner: true (default) — see comment above.
         });
       }
       // Copy before overwriting so a shared metadata dict is never mutated.

--- a/src/video/backend.ts
+++ b/src/video/backend.ts
@@ -1,3 +1,6 @@
+import type { CropRect } from "../transform/points.js";
+import type { Fill, RawFrame } from "../transform/frame.js";
+
 export type VideoFrame = ImageData | ImageBitmap | Uint8Array | ArrayBuffer;
 
 export interface VideoBackend {
@@ -13,5 +16,28 @@ export interface VideoBackend {
   frameNumbers?: number[];
   getFrame(frameIndex: number): Promise<VideoFrame | null>;
   getFrameTimes?(): Promise<number[] | null>;
+  /**
+   * Optional crop pushdown hook (Item 1 of JS issue #153, mirroring Python
+   * `read_crop`, `video_reading.py:1647`).
+   *
+   * When a backend can read *only* the requested crop region directly from
+   * storage — e.g. a raw rank-4 chunked HDF5 pixel array via an N-D hyperslab —
+   * it implements this to return a `(y2-y1) x (x2-x1) x C` {@link RawFrame}
+   * that is **byte-identical** to `cropFrame(fullFrame, crop, fill)` (same pad
+   * value, same clamp arithmetic). Returning `null` signals "I cannot push this
+   * down — fall back to a full decode + `cropFrame`". It must never throw for
+   * out-of-bounds crops.
+   *
+   * Backends that store opaque encoded blobs (PNG/JPEG) or per-frame-indexed
+   * rows (the embedded `pkg.slp` case) cannot spatially hyperslab a frame and
+   * always return `null`. The JS port ships no raw rank-4 HDF5 video backend
+   * today, so this is a no-op on every current fixture; the hook keeps the
+   * architecture aligned with Python and leaves the fast path open.
+   */
+  readCrop?(
+    frameIndex: number,
+    crop: CropRect,
+    fill: Fill,
+  ): Promise<RawFrame | null>;
   close(): void;
 }

--- a/src/video/crop-backend.ts
+++ b/src/video/crop-backend.ts
@@ -14,7 +14,7 @@
 // `OffscreenCanvas` when available (browser) else a lazy dynamic
 // `import("skia-canvas")` (Node), exactly like `seq-video.ts`.
 
-import { VideoBackend, VideoFrame } from "./backend.js";
+import type { VideoBackend, VideoFrame } from "./backend.js";
 import { cropFrame, type Fill, type RawFrame } from "../transform/frame.js";
 import {
   cropPoints,
@@ -245,12 +245,29 @@ export class CropVideoBackend implements VideoBackend {
   /**
    * Read a single cropped frame.
    *
-   * Decodes the inner full frame, normalizes it to readable pixels (rasterizing
-   * an opaque `ImageBitmap`, decoding undecoded encoded bytes, or wrapping raw
-   * pixel bytes), then applies {@link cropFrame} with this wrapper's crop/fill.
-   * Returns `null` when the inner returns `null` (no such frame).
+   * First attempts crop pushdown: if the inner backend implements the optional
+   * {@link VideoBackend.readCrop} hook (Item 1 of JS issue #153, mirroring
+   * Python `_source_frame`, `video_reading.py:2392`) it is given the chance to
+   * read only the crop region directly from storage. A non-null result is
+   * already cropped/padded and is byte-identical to the fallback, so it is
+   * returned as-is. `null` (the default for every shipping backend — encoded
+   * blobs / per-frame rows cannot be spatially hyperslabbed) means fall back.
+   *
+   * Fallback: decode the inner full frame, normalize it to readable pixels
+   * (rasterizing an opaque `ImageBitmap`, decoding undecoded encoded bytes, or
+   * wrapping raw pixel bytes), then apply {@link cropFrame} with this wrapper's
+   * crop/fill. Returns `null` when the inner returns `null` (no such frame).
    */
   async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+    if (typeof this.inner.readCrop === "function") {
+      const pushed = await this.inner.readCrop(
+        frameIndex,
+        this.crop,
+        this.fill,
+      );
+      // Non-null is already cropped/padded (byte-identical to the fallback).
+      if (pushed != null) return pushed as unknown as VideoFrame;
+    }
     const src = await this.inner.getFrame(frameIndex);
     if (src == null) return null;
     const readable = await this.toReadable(src);

--- a/src/video/hdf5-video.ts
+++ b/src/video/hdf5-video.ts
@@ -1,4 +1,4 @@
-import { VideoBackend, VideoFrame } from "./backend.js";
+import type { VideoBackend, VideoFrame } from "./backend.js";
 import { getH5EmscriptenModule } from "../codecs/slp/h5.js";
 import {
   type EmbeddedFrameReader,
@@ -93,6 +93,20 @@ export class Hdf5VideoBackend implements VideoBackend {
 
     const image = decodeRawFrame(rawBytes, this.shape, this.channelOrder);
     return image ?? rawBytes;
+  }
+
+  /**
+   * Crop pushdown hook (Item 1 of JS issue #153). Always returns `null`: this
+   * embedded backend stores opaque encoded blobs (PNG/JPEG) or per-frame-indexed
+   * raw rows, neither of which can be spatially hyperslabbed without first
+   * decoding the whole frame. Pushdown is structurally impossible here, so the
+   * crop wrapper falls back to full-decode + `cropFrame`. (A raw rank-4 chunked
+   * HDF5 pixel-array backend, which COULD push down, does not exist in the JS
+   * port yet; see backend.ts `readCrop` doc.) Short-circuits before touching the
+   * dataset.
+   */
+  async readCrop(): Promise<null> {
+    return null;
   }
 
   /** Build a single-frame reader bound to an open h5wasm dataset object. */

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -1,4 +1,4 @@
-import { VideoBackend, VideoFrame } from "./backend.js";
+import type { VideoBackend, VideoFrame } from "./backend.js";
 import type { StreamingH5File } from "../codecs/slp/h5-streaming.js";
 import {
   type EmbeddedFrameReader,
@@ -133,6 +133,20 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     } catch {
       /* probe failed, shape stays undefined */
     }
+  }
+
+  /**
+   * Crop pushdown hook (Item 1 of JS issue #153). Always returns `null`: this
+   * streaming embedded backend stores opaque encoded blobs (PNG/JPEG) or
+   * per-frame-indexed raw rows, neither of which can be spatially hyperslabbed
+   * without first decoding the whole frame. Pushdown is structurally impossible
+   * here, so the crop wrapper falls back to full-decode + `cropFrame`. (A raw
+   * rank-4 chunked HDF5 pixel-array backend, which COULD push down over the
+   * worker's `dataset.slice`, does not exist in the JS port yet; see backend.ts
+   * `readCrop` doc.) Short-circuits before any network read.
+   */
+  async readCrop(): Promise<null> {
+    return null;
   }
 
   /** Build a single-frame reader bound to the streaming worker file. */

--- a/tests/codecs/slp-crop.test.ts
+++ b/tests/codecs/slp-crop.test.ts
@@ -124,6 +124,16 @@ describe("PYTHON -> JS: committed format-2.3 cropped fixture", () => {
     expect(gray(frame, 74, 94)).not.toBe(0);
   });
 
+  it("reloaded crop tile OWNS its inner (per-tile ownership, no auto-share on read — JS#153 item 2)", async () => {
+    const labels = await readSlp(FIXTURE, { openVideos: true });
+    const v = labels.videos[0];
+    expect(v.backend instanceof CropVideoBackend).toBe(true);
+    // On read each video entry rebuilds a private inner, so the tile owns it
+    // (ownsInner defaults to true). Sharing is opt-in/in-memory only via
+    // Video.crop({ shareDecode: true }). Mirrors Python slp.py:393-401.
+    expect((v.backend as CropVideoBackend).ownsInner).toBe(true);
+  });
+
   it("closed read (openVideos=false): cropped shape + crop metadata, null backend", async () => {
     const labels = await readSlp(FIXTURE, { openVideos: false });
     const v = labels.videos[0];

--- a/tests/model/video-crop-share-decode.test.ts
+++ b/tests/model/video-crop-share-decode.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared-decode mosaic tests (Item 2 of JS issue #153).
+ *
+ * Locks in the decision (mirroring Python `slp.py:393-401`):
+ *  - In-memory `Video.crop({ shareDecode: true })` (the default) reuses ONE
+ *    inner decoder across sibling tiles (ownsInner=false), so closing one tile
+ *    does NOT tear down its siblings — the caller owns the shared inner.
+ *  - `Video.crop({ shareDecode: false })` gives the tile its OWN inner
+ *    (ownsInner=true), whose close() cascades to the inner.
+ *
+ * No real decode / network: the inner is an in-memory spy backend.
+ */
+import { describe, it, expect } from "../bun-test";
+import { Video } from "../../src/model/video.js";
+import type { CropVideoBackend } from "../../src/video/crop-backend.js";
+import type { VideoBackend, VideoFrame } from "../../src/video/backend.js";
+
+/**
+ * A spy source backend: counts `getFrame` calls (decode sites) and records
+ * whether `close()` was called. Returns a tiny readable RGBA `ImageData`-shaped
+ * frame so the crop wrapper can crop it synchronously on Node (no decode).
+ */
+interface SpyBackend extends VideoBackend {
+  decodeCount: number;
+  closed: boolean;
+}
+
+function makeSpy(width = 8, height = 4): SpyBackend {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < data.length; i++) data[i] = i % 256;
+  return {
+    filename: "/data/mosaic.mp4",
+    shape: [1, height, width, 1],
+    dataset: null,
+    decodeCount: 0,
+    closed: false,
+    async getFrame(): Promise<VideoFrame | null> {
+      this.decodeCount++;
+      return {
+        data,
+        width,
+        height,
+        colorSpace: "srgb",
+      } as unknown as ImageData;
+    },
+    close() {
+      this.closed = true;
+    },
+  };
+}
+
+describe("Video.crop shared-decode (Item 2)", () => {
+  it("tiles of one source share ONE inner (the shared inner is the single decode site)", async () => {
+    const spy = makeSpy(8, 4);
+    const src = new Video({ backend: spy });
+
+    const tileA = src.crop([0, 0, 4, 4], { shareDecode: true });
+    const tileB = src.crop([4, 0, 8, 4], { shareDecode: true });
+
+    const innerA = (tileA.backend as CropVideoBackend).inner;
+    const innerB = (tileB.backend as CropVideoBackend).inner;
+    // Same object, and that object is literally the source spy.
+    expect(innerA).toBe(spy);
+    expect(innerB).toBe(spy);
+    expect(innerA).toBe(innerB);
+
+    // Reading one frame from each tile decodes the shared inner once per read.
+    await tileA.getFrame(0);
+    await tileB.getFrame(0);
+    expect(spy.decodeCount).toBe(2);
+  });
+
+  it("closing one tile does NOT tear down siblings sharing the inner", async () => {
+    const spy = makeSpy(8, 4);
+    const src = new Video({ backend: spy });
+    const tileA = src.crop([0, 0, 4, 4], { shareDecode: true });
+    const tileB = src.crop([4, 0, 8, 4], { shareDecode: true });
+
+    tileA.close();
+    // Shared inner untouched (ownsInner=false on the tile).
+    expect(spy.closed).toBe(false);
+    // Sibling still reads.
+    const frame = (await tileB.getFrame(0)) as ImageData;
+    expect(frame.width).toBe(4);
+    expect(frame.height).toBe(4);
+
+    tileB.close();
+    // No tile owns the shared inner — the caller does, by design.
+    expect(spy.closed).toBe(false);
+  });
+
+  it("default shareDecode (no opt-in) shares the inner", () => {
+    const spy = makeSpy(8, 4);
+    const src = new Video({ backend: spy });
+    const tile = src.crop([0, 0, 4, 4]); // shareDecode defaults to true
+    const cb = tile.backend as CropVideoBackend;
+    expect(cb.inner).toBe(spy);
+    expect(cb.ownsInner).toBe(false);
+  });
+
+  it("shareDecode:false gives the tile its OWN inner whose close() cascades", () => {
+    const spy = makeSpy(8, 4);
+    const src = new Video({ backend: spy });
+    const tile = src.crop([0, 0, 4, 4], { shareDecode: false });
+    const cb = tile.backend as CropVideoBackend;
+    expect(cb.ownsInner).toBe(true);
+    expect(spy.closed).toBe(false);
+    tile.close();
+    expect(spy.closed).toBe(true);
+  });
+});

--- a/tests/video/crop-pushdown.test.ts
+++ b/tests/video/crop-pushdown.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Crop pushdown protocol tests (Item 1 of JS issue #153).
+ *
+ * The optional `VideoBackend.readCrop` hook lets a backend read only the crop
+ * region directly from storage. These tests prove it is a CORRECT no-op:
+ *  - When present and non-null, its result is returned as-is and is
+ *    byte-identical to the full-decode + `cropFrame` fallback (in-bounds AND
+ *    out-of-bounds / padded crops).
+ *  - When it returns `null`, the wrapper falls back to a single full decode +
+ *    `cropFrame`, yielding the identical cropped frame.
+ *  - The shipping embedded HDF5 backends (sync + streaming) return `null`
+ *    unconditionally (encoded blobs / per-frame rows can't be hyperslabbed),
+ *    short-circuiting before touching any dataset.
+ *
+ * No real decode / h5 file: in-memory `RawFrame`s and trivial backend stubs.
+ */
+import { describe, it, expect } from "../bun-test";
+import { CropVideoBackend } from "../../src/video/crop-backend.js";
+import {
+  cropFrame,
+  type Fill,
+  type RawFrame,
+} from "../../src/transform/frame.js";
+import type { CropRect } from "../../src/transform/points.js";
+import type { VideoBackend, VideoFrame } from "../../src/video/backend.js";
+import { Hdf5VideoBackend } from "../../src/video/hdf5-video.js";
+import { StreamingHdf5VideoBackend } from "../../src/video/streaming-hdf5-video.js";
+
+/** A known raw single-channel frame with deterministic pixel values. */
+function makeFullFrame(width = 6, height = 5): RawFrame {
+  const data = new Uint8Array(width * height);
+  for (let i = 0; i < data.length; i++) data[i] = (i * 7 + 3) % 256;
+  return { data, width, height, channels: 1 };
+}
+
+/**
+ * An inner backend that returns the full raw frame from `getFrame` (counting
+ * calls) and, optionally, the correctly cropped frame from `readCrop`.
+ */
+function makeInner(
+  full: RawFrame,
+  readCropImpl:
+    | ((frameIndex: number, crop: CropRect, fill: Fill) => RawFrame | null)
+    | null,
+): VideoBackend & { getFrameCalls: number } {
+  return {
+    filename: "/data/raw.h5",
+    shape: [1, full.height, full.width, full.channels ?? 1],
+    dataset: null,
+    getFrameCalls: 0,
+    async getFrame(): Promise<VideoFrame | null> {
+      this.getFrameCalls++;
+      return full as unknown as VideoFrame;
+    },
+    ...(readCropImpl
+      ? {
+          async readCrop(
+            frameIndex: number,
+            crop: CropRect,
+            fill: Fill,
+          ): Promise<RawFrame | null> {
+            return readCropImpl(frameIndex, crop, fill);
+          },
+        }
+      : {}),
+    close() {},
+  };
+}
+
+function expectRawEqual(a: RawFrame, b: RawFrame): void {
+  expect(a.width).toBe(b.width);
+  expect(a.height).toBe(b.height);
+  expect(a.channels ?? 1).toBe(b.channels ?? 1);
+  expect(Array.from(a.data)).toEqual(Array.from(b.data));
+}
+
+describe("crop pushdown protocol (Item 1)", () => {
+  it("getFrame uses readCrop and the result is byte-identical to full-decode+crop (in-bounds)", async () => {
+    const full = makeFullFrame(6, 5);
+    const crop: CropRect = [1, 1, 4, 4];
+    const fill: Fill = 0;
+    const expected = cropFrame(full, crop, fill);
+
+    const inner = makeInner(full, (_f, c, fl) => cropFrame(full, c, fl));
+    const cb = CropVideoBackend.wrap({ inner, crop, fill });
+    const out = (await cb.getFrame(0)) as unknown as RawFrame;
+
+    expectRawEqual(out, expected);
+    // Pushdown short-circuits the full decode.
+    expect(inner.getFrameCalls).toBe(0);
+  });
+
+  it("getFrame uses readCrop for an OOB crop and pads identically (pad parity)", async () => {
+    const full = makeFullFrame(6, 5);
+    // Crop extends past the right/bottom edges and starts off the top-left.
+    const crop: CropRect = [-2, -1, 5, 6];
+    const fill: Fill = 99;
+    const expected = cropFrame(full, crop, fill);
+
+    const inner = makeInner(full, (_f, c, fl) => cropFrame(full, c, fl));
+    const cb = CropVideoBackend.wrap({ inner, crop, fill });
+    const out = (await cb.getFrame(0)) as unknown as RawFrame;
+
+    expectRawEqual(out, expected);
+    expect(inner.getFrameCalls).toBe(0);
+  });
+
+  it("readCrop returning null falls back to a single full-decode+crop", async () => {
+    const full = makeFullFrame(6, 5);
+    const crop: CropRect = [1, 1, 4, 4];
+    const fill: Fill = 0;
+    const expected = cropFrame(full, crop, fill);
+
+    const inner = makeInner(full, () => null);
+    const cb = CropVideoBackend.wrap({ inner, crop, fill });
+    const out = (await cb.getFrame(0)) as unknown as RawFrame;
+
+    expectRawEqual(out, expected);
+    // Fell back to exactly one full decode.
+    expect(inner.getFrameCalls).toBe(1);
+  });
+
+  it("no readCrop at all still produces the identical cropped frame", async () => {
+    const full = makeFullFrame(6, 5);
+    const crop: CropRect = [0, 0, 3, 2];
+    const fill: Fill = 5;
+    const expected = cropFrame(full, crop, fill);
+
+    const inner = makeInner(full, null);
+    expect("readCrop" in inner).toBe(false);
+    const cb = CropVideoBackend.wrap({ inner, crop, fill });
+    const out = (await cb.getFrame(0)) as unknown as RawFrame;
+
+    expectRawEqual(out, expected);
+    expect(inner.getFrameCalls).toBe(1);
+  });
+
+  it("Hdf5VideoBackend.readCrop returns null (embedded blobs can't be hyperslabbed)", async () => {
+    const backend = new Hdf5VideoBackend({
+      filename: "/data/embedded.pkg.slp",
+      // No dataset is touched: readCrop short-circuits to null.
+      file: null,
+      datasetPath: "video0/video",
+      frameNumbers: [0],
+      format: "png",
+    });
+    expect(await backend.readCrop(0, [0, 0, 1, 1], 0)).toBeNull();
+  });
+
+  it("StreamingHdf5VideoBackend.readCrop returns null (embedded blobs can't be hyperslabbed)", async () => {
+    const backend = new StreamingHdf5VideoBackend({
+      filename: "/data/embedded.pkg.slp",
+      // No worker call is made: readCrop short-circuits to null.
+      h5file: null as never,
+      datasetPath: "video0/video",
+      frameNumbers: [0],
+      format: "png",
+    });
+    expect(await backend.readCrop(0, [0, 0, 1, 1], 0)).toBeNull();
+  });
+});


### PR DESCRIPTION
Implements JS issue #153 (virtual-crop perf follow-ups, deferred from PR #147). Two independent items.

## Item 2 — shared-decode mosaic reuse on SLP read (DONE)

Locks in the **correct** behavior (mirroring Python `slp.py:393-401`), rather than the leaky auto-share the issue's headline implies:

- **No auto-share on read.** On the SLP read path each video entry rebuilds a *private* inner backend (`read.ts`, `read-streaming.ts`). Auto-sharing one inner across sibling mosaic tiles would leave the shared inner **unowned** (leaked — never closed) for **no decode savings**: the embedded `Hdf5VideoBackend` is a thin per-frame slicer over the already-shared open h5 `file`, and the streaming backend shares one `StreamingH5File` worker it never closes. So per-tile `ownsInner=true` is both cheap and correct. Added clarifying comments at both reconstruction sites (no functional change).
- **Opt-in shared decode stays in-memory.** `Video.crop(rect, { shareDecode: true })` (the default for in-memory crops) already wires `ownsInner=false`, so tiles built by repeatedly cropping one source `Video` share the single inner, and **closing one tile does not tear down siblings** (the caller owns the shared inner).
- **Dedup + round-trip unaffected:** crop-aware dedup keys off the crop rect (`Video._cropTuple()`), never backend identity, and `/video_crops` is keyed by rect — so sharing-or-not has zero effect.

Tests (`tests/model/video-crop-share-decode.test.ts`): tiles of one source share **one** inner (the single decode site), closing one tile does **not** close the shared inner or break siblings, and `shareDecode:false` gives a tile its own inner whose `close()` cascades. `tests/codecs/slp-crop.test.ts` now asserts a reloaded crop tile has `ownsInner===true`; the existing JS→JS crop round-trip and crop-dedup suites stay green.

## Item 1 — HDF5 hyperslab crop pushdown (architecturally stubbed; fast path remains deferred / blocked)

Added an optional, all-additive pushdown protocol and wired it as a **correct no-op**:

- `VideoBackend.readCrop?(frameIndex, crop, fill): Promise<RawFrame | null>` (mirrors Python `read_crop`). Contract: return a crop that is **byte-identical** to `cropFrame(fullFrame, crop, fill)`, or `null` to fall back to full-decode + crop; never throws on OOB.
- `CropVideoBackend.getFrame` tries `inner.readCrop` first and falls back on `null` (mirrors Python `_source_frame`). Pure no-op until a backend implements it.
- `Hdf5VideoBackend.readCrop` and `StreamingHdf5VideoBackend.readCrop` return `null` unconditionally.

**Why the fast path remains deferred:** pushdown is byte-meaningful only for a **raw rank-4 chunked HDF5 pixel array** `(F,H,W,C)` with sub-frame spatial chunking. The embedded `pkg.slp` backends store **opaque encoded blobs (PNG/JPEG)** or per-frame-indexed rows — a hyperslab cannot sub-crop a PNG without decoding the whole image. Although h5wasm `0.10.2` *does* now expose N-D hyperslab slicing (`Dataset.slice` → `H5Sselect_hyperslab` + `H5Dread`, filter pipeline applied transparently), so the original "BLOCKED: h5wasm exposes no slicing API" note is stale, **the JS port ships no raw rank-4 HDF5 video backend at all** — there is no structure to attach a real pushdown to. So this is a no-op on every current fixture; the hook keeps the architecture aligned with Python and leaves the door open. Implementing the raw-dataset fast path (and a backend to hang it on) is the remaining deferred work.

Tests (`tests/video/crop-pushdown.test.ts`): `getFrame` uses `readCrop` when present and the result is byte-identical to full-decode + crop (in-bounds **and** OOB/padded — pad parity); `readCrop` returning `null` falls back to exactly one full decode producing the identical frame; both embedded backends return `null`.

## Checks

`bun run format` (unrelated reformatting reverted), `bun run check` (biome, exit 0), `bun run lint` (tsc, exit 0), `bun run build`, `bun run test` — all green (1829 pass / 1 skip / 0 fail; the mp4box WebCodecs tests also passed in this environment).

Refs #153 — Item 2 is complete; Item 1's raw-dataset hyperslab fast path remains deferred (no raw rank-4 HDF5 video backend exists in the JS port yet to attach it to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XExMxcwxeoR4vs67nm84Zm
