### PR TITLE
feat(video): getFrame({ prefetch: false }) to suppress read-ahead

### DIFF
--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -1,4 +1,8 @@
-import type { VideoBackend, VideoFrame } from "../video/backend.js";
+import type {
+  VideoBackend,
+  VideoFrame,
+  GetFrameOptions,
+} from "../video/backend.js";
 import { CropVideoBackend } from "../video/crop-backend.js";
 import {
   cropPoints,
@@ -238,9 +242,12 @@ export class Video {
     this._fps = value;
   }
 
-  async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+  async getFrame(
+    frameIndex: number,
+    opts?: GetFrameOptions,
+  ): Promise<VideoFrame | null> {
     if (!this.backend) return null;
-    return this.backend.getFrame(frameIndex);
+    return this.backend.getFrame(frameIndex, opts);
   }
 
   async getFrameTimes(): Promise<number[] | null> {

--- a/src/video/backend.ts
+++ b/src/video/backend.ts
@@ -3,6 +3,22 @@ import type { Fill, RawFrame } from "../transform/frame.js";
 
 export type VideoFrame = ImageData | ImageBitmap | Uint8Array | ArrayBuffer;
 
+/** Per-call options for {@link VideoBackend.getFrame}. */
+export interface GetFrameOptions {
+  /**
+   * When `false`, suppress this backend's read-ahead prefetch for this call.
+   * Read-ahead helps sequential playback but is wasted (and saturates I/O) while
+   * scrubbing, where the caller jumps past the prefetched frames. Backends with
+   * no prefetch ignore it. Defaults to `true` (prefetch enabled).
+   */
+  prefetch?: boolean;
+  /**
+   * Optional cancellation signal. Backends that decode asynchronously (e.g. the
+   * MP4 backend) bail early when it aborts; backends that don't ignore it.
+   */
+  signal?: AbortSignal;
+}
+
 export interface VideoBackend {
   filename: string | string[];
   shape?: [number, number, number, number];
@@ -14,7 +30,10 @@ export interface VideoBackend {
    * backends (mp4 / seq / image-sequence), where every frame is decodable.
    */
   frameNumbers?: number[];
-  getFrame(frameIndex: number): Promise<VideoFrame | null>;
+  getFrame(
+    frameIndex: number,
+    opts?: GetFrameOptions,
+  ): Promise<VideoFrame | null>;
   getFrameTimes?(): Promise<number[] | null>;
   /**
    * Optional crop pushdown hook (Item 1 of JS issue #153, mirroring Python

--- a/src/video/crop-backend.ts
+++ b/src/video/crop-backend.ts
@@ -14,7 +14,7 @@
 // `OffscreenCanvas` when available (browser) else a lazy dynamic
 // `import("skia-canvas")` (Node), exactly like `seq-video.ts`.
 
-import type { VideoBackend, VideoFrame } from "./backend.js";
+import type { VideoBackend, VideoFrame, GetFrameOptions } from "./backend.js";
 import { cropFrame, type Fill, type RawFrame } from "../transform/frame.js";
 import {
   cropPoints,
@@ -258,7 +258,10 @@ export class CropVideoBackend implements VideoBackend {
    * wrapping raw pixel bytes), then apply {@link cropFrame} with this wrapper's
    * crop/fill. Returns `null` when the inner returns `null` (no such frame).
    */
-  async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+  async getFrame(
+    frameIndex: number,
+    opts?: GetFrameOptions,
+  ): Promise<VideoFrame | null> {
     if (typeof this.inner.readCrop === "function") {
       const pushed = await this.inner.readCrop(
         frameIndex,
@@ -268,7 +271,7 @@ export class CropVideoBackend implements VideoBackend {
       // Non-null is already cropped/padded (byte-identical to the fallback).
       if (pushed != null) return pushed as unknown as VideoFrame;
     }
-    const src = await this.inner.getFrame(frameIndex);
+    const src = await this.inner.getFrame(frameIndex, opts);
     if (src == null) return null;
     const readable = await this.toReadable(src);
     return cropFrame(readable as ImageData, this.crop, this.fill);

--- a/src/video/image-video.ts
+++ b/src/video/image-video.ts
@@ -11,7 +11,7 @@
 // both a browser (`createImageBitmap`) and Node (`skia-canvas`). PNG/JPEG/BMP/…
 // are supported; TIFF is NOT (no web decoder) — a TIFF source throws at decode.
 
-import { VideoBackend, VideoFrame } from "./backend.js";
+import { VideoBackend, VideoFrame, GetFrameOptions } from "./backend.js";
 import { decodeEncoded } from "./image-decode.js";
 import { getImageBytesReader, type ImageBytesReader } from "./image-source.js";
 import { LruCache } from "./lru-cache.js";
@@ -171,10 +171,15 @@ export class ImageVideoBackend implements VideoBackend {
     return be;
   }
 
-  async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+  async getFrame(
+    frameIndex: number,
+    opts?: GetFrameOptions,
+  ): Promise<VideoFrame | null> {
     if (frameIndex < 0 || frameIndex >= this.filename.length) return null;
-    // Kick off read-ahead before serving (so cache hits still prefetch ahead).
-    this.triggerPrefetch(frameIndex);
+    // Kick off read-ahead before serving (so cache hits still prefetch ahead),
+    // unless the caller opted out (e.g. while scrubbing, where read-ahead frames
+    // are scrubbed past and just saturate I/O — slowing the requested frame).
+    if (opts?.prefetch !== false) this.triggerPrefetch(frameIndex);
     const decoded = this.decodedCache.get(frameIndex);
     if (decoded) return decoded;
     const bytes = await this.startRead(frameIndex);

--- a/src/video/mp4box-video.ts
+++ b/src/video/mp4box-video.ts
@@ -1,4 +1,4 @@
-import { VideoBackend, VideoFrame } from "./backend.js";
+import { VideoBackend, VideoFrame, GetFrameOptions } from "./backend.js";
 import {
   RemoteIOError,
   fetchRetrying,
@@ -120,7 +120,7 @@ export class Mp4BoxVideoBackend implements VideoBackend {
 
   async getFrame(
     frameIndex: number,
-    signal?: AbortSignal,
+    opts?: GetFrameOptions,
   ): Promise<VideoFrame | null> {
     await this.ready;
     if (frameIndex < 0 || frameIndex >= this.samples.length) return null;
@@ -138,7 +138,7 @@ export class Mp4BoxVideoBackend implements VideoBackend {
 
     this.decodeQueue = this.decodeQueue.then(async () => {
       if (this.latestRequestedFrame !== frameIndex) return;
-      if (signal?.aborted) return;
+      if (opts?.signal?.aborted) return;
 
       const keyframe = this.findKeyframeBefore(frameIndex);
       const end = Math.min(

--- a/tests/video/image-video-prefetch.test.ts
+++ b/tests/video/image-video-prefetch.test.ts
@@ -135,4 +135,22 @@ describe("ImageVideoBackend.prefetch (mechanism)", () => {
     expect(t.reads).toContain("img11.jpg");
     expect(t.reads).toContain("img12.jpg");
   });
+
+  it("getFrame({ prefetch: false }) suppresses read-ahead for that call", async () => {
+    const t = trackingReader();
+    const be = await make(t, { prefetchAhead: 4, prefetchBehind: 1 });
+    await be.getFrame(9, { prefetch: false });
+    await Promise.resolve(); // let any (erroneously) scheduled prefetch run
+    expect(t.reads).toEqual(["img9.jpg"]); // only the requested frame, no window
+    expect(t.reads).not.toContain("img10.jpg");
+  });
+
+  it("getFrame prefetches by default (enabled unless opted out)", async () => {
+    const t = trackingReader();
+    const be = await make(t, { prefetchAhead: 4, prefetchBehind: 1 });
+    await be.getFrame(9);
+    await be.getFrame(10); // forward step -> read-ahead 11,12,...
+    await be.lastPrefetch;
+    expect(t.reads).toContain("img11.jpg");
+  });
 });

--- a/tests/video/mp4box-backend.test.ts
+++ b/tests/video/mp4box-backend.test.ts
@@ -312,7 +312,7 @@ describe("Mp4BoxVideoBackend", () => {
     const backend = new Mp4BoxVideoBackend(blob);
     const controller = new AbortController();
     controller.abort();
-    const result = await backend.getFrame(0, controller.signal);
+    const result = await backend.getFrame(0, { signal: controller.signal });
     expect(result).toBeNull();
     backend.close();
   });


### PR DESCRIPTION
## Summary

Adds a per-call option to opt out of read-ahead prefetch:

```ts
video.getFrame(index, { prefetch: false });
```

`ImageVideoBackend` normally fires a read-ahead window (default 8 ahead / 2 behind, 6 concurrent) on every `getFrame`. That's a win for **playback** (you watch those frames next) but a loss for **scrubbing**: the consumer jumps past the prefetched frames (wasted reads) and those concurrent reads saturate a slow mount — measured **~3.6× slower foreground reads** (84 ms solo → 301 ms under 6 in flight) on a VAST network mount. There was no way to suppress it per call.

The data layer stays agnostic about *why* — the consumer (which knows it's scrubbing) just passes `prefetch: false`.

## Changes

- **`GetFrameOptions`** (`video/backend.ts`) — new options type: `{ prefetch?: boolean; signal?: AbortSignal }`.
- **`VideoBackend.getFrame`** — optional 2nd arg `opts?: GetFrameOptions` (optional, so every existing call is unaffected).
- **`Video.getFrame`** — passes `opts` straight through to the backend.
- **`ImageVideoBackend.getFrame`** — the gate: `if (opts?.prefetch !== false) this.triggerPrefetch(...)`. The only behavior change.
- **`CropVideoBackend.getFrame`** — forwards `opts` to the inner backend (so a cropped image-sequence honors it).
- **`Mp4BoxVideoBackend.getFrame`** — its existing `AbortSignal` 2nd param moves into `GetFrameOptions.signal` (no production caller passed it positionally; avoids colliding with the new options slot).

## Backward compatibility

Purely additive. The param is optional and **defaults to prefetch-on**, so playback, single seeks, and every existing caller behave exactly as before. Backends without prefetch (MP4, HDF5, …) ignore the flag.

## Tests

- `image-video-prefetch.test.ts`: `getFrame({ prefetch: false })` reads only the requested frame (no read-ahead); default still prefetches.
- `mp4box-backend.test.ts`: abort test updated to the `{ signal }` shape.
- typecheck + build clean; `bun run test --parallel` green (the 1 remaining fail is the known pre-existing Python-oracle skeleton test, identical on `main`).

## Downstream

Lets **sleap-app** pass `{ prefetch: false }` while the user scrubs the seekbar (it sets a transient `isScrubbing` flag → `VideoPlayer` calls `getFrame(frameIdx, { prefetch: !isScrubbing })`), eliminating the scrub I/O congestion without affecting playback. Replaces a prototype field-poke that reached into the backend's prefetch fields directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
