### PR TITLE
feat(model,rendering): 0.8.0 parity — conversion metadata, isUserLabeled, single overlay

### DIFF
--- a/src/model/bbox.ts
+++ b/src/model/bbox.ts
@@ -176,13 +176,16 @@ export class BoundingBox {
     const c = this.corners;
     // Close the ring
     const ring = [...c, c[0]];
-    return ROI.fromPolygon(ring, {
+    const roi = ROI.fromPolygon(ring, {
       name: this.name,
       category: this.category,
       source: this.source,
       track: this.track,
+      trackingScore: this.trackingScore,
       instance: this.instance,
     });
+    roi._instanceIdx = this._instanceIdx;
+    return roi;
   }
 
   /** Convert to a SegmentationMask by rasterizing the bbox polygon. */

--- a/src/model/labeled-frame.ts
+++ b/src/model/labeled-frame.ts
@@ -1,5 +1,5 @@
 import { Instance, PredictedInstance } from "./instance.js";
-import { Video } from "./video.js";
+import type { Video } from "./video.js";
 import { Centroid } from "./centroid.js";
 import { BoundingBox } from "./bbox.js";
 import { SegmentationMask, PredictedSegmentationMask } from "./mask.js";
@@ -433,6 +433,28 @@ export class LabeledFrame {
 
   get hasPredictedInstances(): boolean {
     return this.predictedInstances.length > 0;
+  }
+
+  /**
+   * Whether this frame carries any user-supplied labeling.
+   *
+   * True if it has at least one user instance, is asserted as a negative
+   * (background) frame, or holds any non-predicted frame-level annotation —
+   * a user centroid, bounding box, ROI, segmentation mask, or label image.
+   * Mirrors Python `LabeledFrame.is_user_labeled` (the ROI clause is the
+   * specific contribution of sleap-io PR #509). Predicted annotations alone do
+   * not make a frame user-labeled.
+   */
+  get isUserLabeled(): boolean {
+    return (
+      this.hasUserInstances ||
+      this.isNegative ||
+      this.centroids.some((c) => !c.isPredicted) ||
+      this.bboxes.some((b) => !b.isPredicted) ||
+      this.rois.some((r) => !r.isPredicted) ||
+      this.masks.some((m) => !m.isPredicted) ||
+      this.labelImages.some((li) => !li.isPredicted)
+    );
   }
 
   numpy(): number[][][] {

--- a/src/model/mask.ts
+++ b/src/model/mask.ts
@@ -488,11 +488,13 @@ export class SegmentationMask {
       category: this.category,
       source: this.source,
       track: this.track,
+      trackingScore: this.trackingScore,
       instance: this.instance,
       scale: [1, 1],
       offset: [0, 0],
     };
 
+    let resampled: SegmentationMask;
     if (this instanceof PredictedSegmentationMask) {
       const pm = this as PredictedSegmentationMask;
       let resampledScoreMap: Float32Array | null = null;
@@ -505,18 +507,20 @@ export class SegmentationMask {
           targetWidth,
         );
       }
-      return new PredictedSegmentationMask({
+      resampled = new PredictedSegmentationMask({
         ...baseOpts,
         score: pm.score,
         scoreMap: resampledScoreMap,
       });
+    } else {
+      resampled = new UserSegmentationMask({
+        ...baseOpts,
+        fromPredicted:
+          this instanceof UserSegmentationMask ? this.fromPredicted : null,
+      });
     }
-
-    return new UserSegmentationMask({
-      ...baseOpts,
-      fromPredicted:
-        this instanceof UserSegmentationMask ? this.fromPredicted : null,
-    });
+    resampled._instanceIdx = this._instanceIdx;
+    return resampled;
   }
 
   get bbox(): { x: number; y: number; width: number; height: number } {
@@ -563,18 +567,18 @@ export class SegmentationMask {
       x2: x + width,
       y2: y + height,
       track: this.track,
+      trackingScore: this.trackingScore,
       instance: this.instance,
       category: this.category,
       name: this.name,
       source: this.source,
     };
-    if (this instanceof PredictedSegmentationMask) {
-      return new PredictedBoundingBox({
-        ...opts,
-        score: this.score,
-      });
-    }
-    return new UserBoundingBox(opts);
+    const bb =
+      this instanceof PredictedSegmentationMask
+        ? new PredictedBoundingBox({ ...opts, score: this.score })
+        : new UserBoundingBox(opts);
+    bb._instanceIdx = this._instanceIdx;
+    return bb;
   }
 
   /**
@@ -630,12 +634,15 @@ export class SegmentationMask {
       category: this.category,
       source: this.source,
       track: this.track,
+      trackingScore: this.trackingScore,
       instance: this.instance,
     };
-    if (this instanceof PredictedSegmentationMask) {
-      return new PredictedROI({ ...options, score: this.score });
-    }
-    return new UserROI(options);
+    const roi =
+      this instanceof PredictedSegmentationMask
+        ? new PredictedROI({ ...options, score: this.score })
+        : new UserROI(options);
+    roi._instanceIdx = this._instanceIdx;
+    return roi;
   }
 }
 

--- a/src/model/roi.ts
+++ b/src/model/roi.ts
@@ -299,12 +299,15 @@ export class ROI {
       category: this.category,
       source: this.source,
       track: this.track,
+      trackingScore: this.trackingScore,
       instance: this.instance,
     };
     if (this instanceof PredictedROI) {
       options.score = this.score;
     }
-    return _maskFactory(mask, height, width, options);
+    const result = _maskFactory(mask, height, width, options);
+    result._instanceIdx = this._instanceIdx;
+    return result;
   }
 
   private _allPoints(): number[][] {

--- a/src/rendering/overlays.ts
+++ b/src/rendering/overlays.ts
@@ -367,6 +367,9 @@ export function applyOverlay(
   overlay:
     | LabelImage
     | RawLabelImage
+    | SegmentationMask
+    | ROI
+    | BoundingBox
     | SegmentationMask[]
     | ROI[]
     | BoundingBox[],
@@ -386,7 +389,10 @@ export function applyOverlay(
   const outlineColor = opts?.outlineColor ?? null;
   const explicitColors = opts?.colors ?? null;
 
-  // Single LabelImage (or raw Int32Array-backed) overlay.
+  // A single overlay object: a LabelImage takes its own raster path; a bare
+  // SegmentationMask / ROI / BoundingBox is wrapped into a one-element list and
+  // falls through to the list dispatch below (sleap-io PR #505). Anything else
+  // is a no-op.
   if (!Array.isArray(overlay)) {
     if (isLabelImageLike(overlay)) {
       drawLabelImage(image, overlay, {
@@ -396,8 +402,12 @@ export function applyOverlay(
         outlineWidth,
         outlineColor,
       });
+      return image;
     }
-    return image;
+    if (isSegmentationMask(overlay)) overlay = [overlay];
+    else if (isROI(overlay)) overlay = [overlay];
+    else if (isBoundingBox(overlay)) overlay = [overlay];
+    else return image;
   }
 
   // Empty list is a no-op.

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -21,6 +21,9 @@ import type { RawLabelImage } from "./overlays-raster.js";
 export type Overlay =
   | LabelImage
   | RawLabelImage
+  | SegmentationMask
+  | ROI
+  | BoundingBox
   | SegmentationMask[]
   | ROI[]
   | BoundingBox[];

--- a/tests/model/conversion-metadata.test.ts
+++ b/tests/model/conversion-metadata.test.ts
@@ -1,0 +1,133 @@
+// Tests for sleap-io PR #504 parity: tracking_score and _instance_idx are
+// preserved through annotation conversions (bbox<->roi<->mask, mask.resampled).
+
+import { describe, it, expect } from "../bun-test";
+import { UserBoundingBox, PredictedBoundingBox } from "../../src/model/bbox.js";
+import { UserROI, PredictedROI } from "../../src/model/roi.js";
+import {
+  SegmentationMask,
+  UserSegmentationMask,
+  PredictedSegmentationMask,
+  encodeRle,
+} from "../../src/model/mask.js";
+
+function blockRaster(h: number, w: number): Uint8Array {
+  const a = new Uint8Array(h * w);
+  for (let r = 2; r < h - 2; r++)
+    for (let c = 2; c < w - 2; c++) a[r * w + c] = 1;
+  return a;
+}
+
+describe("conversions preserve tracking_score and _instance_idx (#504)", () => {
+  it("BoundingBox.toRoi() carries trackingScore and _instanceIdx", () => {
+    const bb = new UserBoundingBox({
+      x1: 0,
+      y1: 0,
+      x2: 10,
+      y2: 10,
+      trackingScore: 0.42,
+    });
+    bb._instanceIdx = 7;
+    const roi = bb.toRoi();
+    expect(roi.trackingScore).toBeCloseTo(0.42);
+    expect(roi._instanceIdx).toBe(7);
+  });
+
+  it("SegmentationMask.toBbox() carries trackingScore, _instanceIdx, and score", () => {
+    const mask = new PredictedSegmentationMask({
+      rleCounts: encodeRle(blockRaster(16, 16), 16, 16),
+      height: 16,
+      width: 16,
+      score: 0.9,
+      trackingScore: 0.31,
+    });
+    mask._instanceIdx = 4;
+    const bb = mask.toBbox();
+    expect(bb.trackingScore).toBeCloseTo(0.31);
+    expect(bb._instanceIdx).toBe(4);
+    expect(bb).toBeInstanceOf(PredictedBoundingBox);
+    expect((bb as PredictedBoundingBox).score).toBeCloseTo(0.9);
+  });
+
+  it("SegmentationMask.toPolygon() carries trackingScore and _instanceIdx", () => {
+    const mask = SegmentationMask.fromArray(blockRaster(16, 16), 16, 16, {
+      trackingScore: 0.55,
+    });
+    mask._instanceIdx = 2;
+    const roi = mask.toPolygon();
+    expect(roi.trackingScore).toBeCloseTo(0.55);
+    expect(roi._instanceIdx).toBe(2);
+  });
+
+  it("SegmentationMask.resampled() carries trackingScore and _instanceIdx", () => {
+    const mask = SegmentationMask.fromArray(blockRaster(16, 16), 16, 16, {
+      trackingScore: 0.66,
+    });
+    mask._instanceIdx = 9;
+    const out = mask.resampled(32, 32);
+    expect(out.trackingScore).toBeCloseTo(0.66);
+    expect(out._instanceIdx).toBe(9);
+    // Predicted variant keeps its score too.
+    const pred = new PredictedSegmentationMask({
+      rleCounts: encodeRle(blockRaster(16, 16), 16, 16),
+      height: 16,
+      width: 16,
+      score: 0.8,
+      trackingScore: 0.12,
+    });
+    pred._instanceIdx = 5;
+    const outP = pred.resampled(8, 8) as PredictedSegmentationMask;
+    expect(outP.trackingScore).toBeCloseTo(0.12);
+    expect(outP._instanceIdx).toBe(5);
+    expect(outP.score).toBeCloseTo(0.8);
+  });
+
+  it("ROI.toMask() carries trackingScore and _instanceIdx", () => {
+    const roi = UserROI.fromPolygon(
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+      ],
+      { trackingScore: 0.77 },
+    );
+    roi._instanceIdx = 3;
+    const mask = roi.toMask(16, 16);
+    expect(mask.trackingScore).toBeCloseTo(0.77);
+    expect(mask._instanceIdx).toBe(3);
+  });
+
+  it("predicted ROI.toMask() preserves score alongside trackingScore", () => {
+    const roi = new PredictedROI({
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [0, 0],
+            [8, 0],
+            [8, 8],
+            [0, 8],
+            [0, 0],
+          ],
+        ],
+      },
+      score: 0.65,
+      trackingScore: 0.22,
+    });
+    roi._instanceIdx = 1;
+    const mask = roi.toMask(16, 16);
+    expect(mask).toBeInstanceOf(PredictedSegmentationMask);
+    expect((mask as PredictedSegmentationMask).score).toBeCloseTo(0.65);
+    expect(mask.trackingScore).toBeCloseTo(0.22);
+    expect(mask._instanceIdx).toBe(1);
+  });
+
+  it("user mask conversions stay user-typed", () => {
+    const mask = SegmentationMask.fromArray(blockRaster(12, 12), 12, 12);
+    expect(mask).toBeInstanceOf(UserSegmentationMask);
+    expect(mask.toBbox()).toBeInstanceOf(UserBoundingBox);
+    expect(mask.toPolygon()).toBeInstanceOf(UserROI);
+    expect(mask.resampled(6, 6)).toBeInstanceOf(UserSegmentationMask);
+  });
+});

--- a/tests/model/labeled-frame-user-labeled.test.ts
+++ b/tests/model/labeled-frame-user-labeled.test.ts
@@ -1,0 +1,132 @@
+// Tests for sleap-io PR #509 parity: LabeledFrame.isUserLabeled counts user
+// instances, negative anchors, and ANY non-predicted frame-level annotation
+// (centroids, bboxes, ROIs, masks, label images). The ROI clause is the
+// specific contribution of #509.
+
+import { describe, it, expect } from "../bun-test";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { Video } from "../../src/model/video.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { Instance, PredictedInstance } from "../../src/model/instance.js";
+import { UserROI, PredictedROI } from "../../src/model/roi.js";
+import { UserBoundingBox, PredictedBoundingBox } from "../../src/model/bbox.js";
+import {
+  SegmentationMask,
+  PredictedSegmentationMask,
+  encodeRle,
+} from "../../src/model/mask.js";
+import {
+  UserLabelImage,
+  PredictedLabelImage,
+} from "../../src/model/label-image.js";
+
+const video = new Video({ filename: "v.mp4" });
+const skel = new Skeleton({ nodes: ["a"] });
+
+const frame = (opts: Record<string, unknown>) =>
+  new LabeledFrame({ video, frameIdx: 0, ...opts });
+
+const block = (): Uint8Array => {
+  const a = new Uint8Array(64);
+  for (let i = 10; i < 20; i++) a[i] = 1;
+  return a;
+};
+const userMask = () => SegmentationMask.fromArray(block(), 8, 8);
+const predMask = () =>
+  new PredictedSegmentationMask({
+    rleCounts: encodeRle(block(), 8, 8),
+    height: 8,
+    width: 8,
+    score: 0.5,
+  });
+const userRoi = () =>
+  UserROI.fromPolygon([
+    [0, 0],
+    [5, 0],
+    [5, 5],
+    [0, 5],
+  ]);
+const predRoi = () =>
+  new PredictedROI({
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [5, 0],
+          [5, 5],
+          [0, 5],
+          [0, 0],
+        ],
+      ],
+    },
+    score: 0.5,
+  });
+
+describe("LabeledFrame.isUserLabeled (#509)", () => {
+  it("is false for an empty, non-negative frame", () => {
+    expect(frame({}).isUserLabeled).toBe(false);
+  });
+
+  it("is true with a user instance, false with only a prediction", () => {
+    expect(
+      frame({
+        instances: [new Instance({ points: { a: [1, 2] }, skeleton: skel })],
+      }).isUserLabeled,
+    ).toBe(true);
+    expect(
+      frame({ instances: [PredictedInstance.fromArray([[1, 2]], skel, 0.9)] })
+        .isUserLabeled,
+    ).toBe(false);
+  });
+
+  it("is true for a negative (background) frame", () => {
+    expect(frame({ isNegative: true }).isUserLabeled).toBe(true);
+  });
+
+  it("is true with a user ROI, false with only a predicted ROI (#509 clause)", () => {
+    expect(frame({ rois: [userRoi()] }).isUserLabeled).toBe(true);
+    expect(frame({ rois: [predRoi()] }).isUserLabeled).toBe(false);
+  });
+
+  it("is true with a user mask, false with only a predicted mask", () => {
+    expect(frame({ masks: [userMask()] }).isUserLabeled).toBe(true);
+    expect(frame({ masks: [predMask()] }).isUserLabeled).toBe(false);
+  });
+
+  it("is true with a user bbox, false with only a predicted bbox", () => {
+    expect(
+      frame({ bboxes: [UserBoundingBox.fromXyxy(0, 0, 5, 5)] }).isUserLabeled,
+    ).toBe(true);
+    expect(
+      frame({
+        bboxes: [
+          new PredictedBoundingBox({ x1: 0, y1: 0, x2: 5, y2: 5, score: 0.5 }),
+        ],
+      }).isUserLabeled,
+    ).toBe(false);
+  });
+
+  it("is true with a user label image, false with only a predicted one", () => {
+    const d = new Int32Array(16);
+    d[0] = 1;
+    expect(
+      frame({ labelImages: [UserLabelImage.fromArray(d, 4, 4)] }).isUserLabeled,
+    ).toBe(true);
+    expect(
+      frame({
+        labelImages: [
+          new PredictedLabelImage({ data: d, height: 4, width: 4, score: 0.5 }),
+        ],
+      }).isUserLabeled,
+    ).toBe(false);
+  });
+
+  it("is true with a user centroid", () => {
+    const c = new Instance({
+      points: { a: [1, 2] },
+      skeleton: skel,
+    }).toCentroid();
+    expect(frame({ centroids: [c] }).isUserLabeled).toBe(true);
+  });
+});

--- a/tests/rendering/single-overlay.test.ts
+++ b/tests/rendering/single-overlay.test.ts
@@ -1,0 +1,85 @@
+// Tests for sleap-io PR #505 parity: applyOverlay (and thus renderImage's
+// `overlay=`) accepts a SINGLE SegmentationMask / ROI / BoundingBox, not just a
+// list. Previously a bare object fell through and was silently dropped.
+
+import { describe, it, expect } from "../bun-test";
+import { applyOverlay } from "../../src/rendering/overlays";
+import { UserSegmentationMask } from "../../src/model/mask";
+import { UserROI } from "../../src/model/roi";
+import { UserBoundingBox } from "../../src/model/bbox";
+import { UserLabelImage } from "../../src/model/label-image";
+
+async function makeImage(
+  w: number,
+  h: number,
+  fill: [number, number, number] = [0, 0, 0],
+): Promise<ImageData> {
+  const { Canvas } = await import("skia-canvas");
+  const canvas = new Canvas(w, h);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${fill[0]}, ${fill[1]}, ${fill[2]})`;
+  ctx.fillRect(0, 0, w, h);
+  return ctx.getImageData(0, 0, w, h) as unknown as ImageData;
+}
+
+function pixel(img: ImageData, x: number, y: number): [number, number, number] {
+  const i = (y * img.width + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2]];
+}
+
+function anyForeground(img: ImageData): boolean {
+  for (let i = 0; i < img.data.length; i += 4) {
+    if (img.data[i] || img.data[i + 1] || img.data[i + 2]) return true;
+  }
+  return false;
+}
+
+describe("applyOverlay accepts a single overlay object (#505)", () => {
+  it("draws a single SegmentationMask (wrapped into a 1-element list)", async () => {
+    const img = await makeImage(32, 32, [0, 0, 0]);
+    const a = new Uint8Array(32 * 32);
+    for (let r = 8; r < 16; r++) for (let c = 8; c < 16; c++) a[r * 32 + c] = 1;
+    const mask = UserSegmentationMask.fromArray(a, 32, 32);
+    applyOverlay(img, mask, { alpha: 1.0, colors: [[255, 0, 0]] });
+    expect(pixel(img, 12, 12)).toEqual([255, 0, 0]);
+    expect(pixel(img, 0, 0)).toEqual([0, 0, 0]);
+  });
+
+  it("draws a single ROI", async () => {
+    const img = await makeImage(40, 40, [0, 0, 0]);
+    const roi = UserROI.fromPolygon([
+      [5, 5],
+      [35, 5],
+      [35, 35],
+      [5, 35],
+    ]);
+    applyOverlay(img, roi, { alpha: 0.8 });
+    expect(anyForeground(img)).toBe(true);
+  });
+
+  it("draws a single BoundingBox", async () => {
+    const img = await makeImage(40, 40, [0, 0, 0]);
+    const bb = UserBoundingBox.fromXyxy(5, 5, 35, 35);
+    applyOverlay(img, bb, { alpha: 0.8 });
+    expect(anyForeground(img)).toBe(true);
+  });
+
+  it("still draws a single LabelImage", async () => {
+    const img = await makeImage(16, 16, [0, 0, 0]);
+    const data = new Int32Array(16 * 16);
+    for (let r = 2; r < 8; r++)
+      for (let c = 2; c < 8; c++) data[r * 16 + c] = 1;
+    const li = UserLabelImage.fromArray(data, 16, 16);
+    applyOverlay(img, li, { alpha: 1.0 });
+    expect(pixel(img, 4, 4)).not.toEqual([0, 0, 0]);
+  });
+
+  it("is a no-op for an unrecognized single object", async () => {
+    const img = await makeImage(8, 8, [10, 20, 30]);
+    const notAnOverlay = { foo: 1 } as unknown as Parameters<
+      typeof applyOverlay
+    >[1];
+    applyOverlay(img, notAnOverlay, {});
+    expect(pixel(img, 0, 0)).toEqual([10, 20, 30]);
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #190. Fills three more **sleap-io 0.8.0 parity gaps** identified by a gap-analysis audit of the remaining 0.8.0 PRs against the JS tree. All three are data-fidelity / small-API fixes, fully headlessly testable.

> Stacked PR — review/merge #190 first. The diff against `main` will include #190's commit until that merges; this PR's own changes are the single commit `feat(model,rendering): 0.8.0 parity …`.

## Changes

- **#504 — preserve `tracking_score` / `_instance_idx` through conversions.** `BoundingBox.toRoi`, `SegmentationMask.toBbox` / `toPolygon` / `resampled`, and `ROI.toMask` now carry `trackingScore` and `_instanceIdx` (and the predicted `score` where applicable). Previously these were dropped on conversion.
- **#509 — `LabeledFrame.isUserLabeled`.** New getter: true if the frame has a user instance, is a negative (background) anchor, or holds any non-predicted frame-level annotation — centroid, bbox, **ROI** (the specific #509 contribution), mask, or label image. Predicted annotations alone don't make a frame user-labeled.
- **#505 — single-object overlays.** `applyOverlay` (and thus `renderImage`'s `overlay=`) now accept a bare `SegmentationMask` / `ROI` / `BoundingBox`, normalizing it to a one-element list; the `Overlay` type is widened to match. Previously a single object fell through and was silently dropped.

## Tests
- `tests/model/conversion-metadata.test.ts` (#504), `tests/model/labeled-frame-user-labeled.test.ts` (#509), `tests/rendering/single-overlay.test.ts` (#505).
- Full scoped suite: **1873 pass / 0 fail**; `lint`, `build`, Biome clean. Broad regression slice (mask / roi / bbox / rendering / model / SLP round-trip / COCO / Ultralytics / GeoJSON) green.

## Deferred (from the same audit)
- **#512** (skeleton-JSON isolated-node order): a genuine fidelity bug, but the JS encoder/decoder use a self-consistent, *non-jsonpickle* py/id scheme; preserving declared order means reconciling two id schemes in a core decoder that currently parses real SLEAP files. Deserves its own PR with both-format fixtures + test migration.
- **Low-value / unreachable in JS:** #483 (prefer_metadata opt-out — default already matches), #495 (channel/grayscale reconcile — no grayscale setter exists), #490 (stale metadata after relink — JS swaps whole Video objects).
- **Whole-subsystem ports (own PRs):** #480 (analysis CSV/DataFrame exporter), #503 (COCO *writer* — only the read side is small), #468/#494/#506 (centroid rendering — not implemented in the JS renderer at all).
- **Already ported (verified):** #489, #438, #496, #481, #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01869N2KkrfeKADXeX9ENwD4
