### PR TITLE
fix(slp): clamp embedded video frame axis to max(frame_numbers)+1

### DIFF
--- a/src/codecs/slp/frame-count.ts
+++ b/src/codecs/slp/frame-count.ts
@@ -2,16 +2,19 @@
  * Resolve the source frame count (the seekbar / navigation extent) for an
  * embedded SLP video, synchronously, from metadata that is cheap to read.
  *
- * Priority:
- *  1. The `frames` HDF5 attribute — the source video's true total frame count
- *     (written by recent sleap-io / sleap_io). Authoritative when present.
- *  2. The frame count carried in videos_json `backend.shape[0]`.
- *  3. `max(frame_numbers) + 1` — a lower bound derived from the stored frames'
- *     source indices. Used for pkg.slp files written WITHOUT a `frames` attr
- *     (e.g. older PyQt SLEAP), so the seekbar still spans the labeled-frame
- *     range. This is intentionally computed here rather than via an async
- *     per-video image-decode probe (which raced the UI and produced 0 / "?" /
- *     wrong counts on multi-video packages).
+ * The extent is `max(declared, max(frame_numbers) + 1)`, where `declared` is:
+ *  1. the `frames` HDF5 attribute — the source video's total frame count
+ *     (written by recent sleap-io / sleap_io), else
+ *  2. the frame count carried in videos_json `backend.shape[0]`.
+ *
+ * `max(frame_numbers) + 1` is a HARD LOWER BOUND, not merely a last-resort
+ * fallback: a stored image at source index N proves the source had at least
+ * N + 1 frames, so a `declared` count below it is impossible — e.g. a BOGUS
+ * `frames` attr of 424 on a video whose frame_numbers reach 173997 — and must be
+ * clamped up. Without this clamp such files collapse the seekbar to the (wrong)
+ * declared count and drop every labeled frame beyond it. It also covers pkg.slp
+ * files written WITHOUT a `frames` attr (older PyQt SLEAP), synchronously (no
+ * async per-video decode probe, which raced the UI and produced 0 / "?" counts).
  *
  * Note: this is the SOURCE extent (what the seekbar spans), NOT the number of
  * embedded images — that is `frame_numbers.length`, surfaced separately.
@@ -27,15 +30,26 @@ export function resolveSourceFrameCount(opts: {
   frameNumbers?: number[];
 }): number | undefined {
   const { framesAttr, jsonFrameCount, frameNumbers } = opts;
-  if (framesAttr !== undefined && framesAttr > 0) return framesAttr;
-  if (jsonFrameCount !== undefined && jsonFrameCount > 0) return jsonFrameCount;
+
+  // Declared source length: the `frames` attr (authoritative when correct),
+  // else the videos_json `backend.shape[0]`.
+  let declared = 0;
+  if (framesAttr !== undefined && framesAttr > 0) declared = framesAttr;
+  else if (jsonFrameCount !== undefined && jsonFrameCount > 0)
+    declared = jsonFrameCount;
+
+  // Hard lower bound from the stored source indices (see docstring): the axis
+  // can never be shorter than the largest stored frame index + 1.
+  let fromFrameNumbers = 0;
   if (frameNumbers && frameNumbers.length > 0) {
     // Loop (not Math.max(...spread)) to stay safe for large frame_numbers.
     let max = 0;
     for (const n of frameNumbers) {
       if (n > max) max = n;
     }
-    return max + 1;
+    fromFrameNumbers = max + 1;
   }
-  return undefined;
+
+  const count = Math.max(declared, fromFrameNumbers);
+  return count > 0 ? count : undefined;
 }

--- a/tests/codecs/frame-count.test.ts
+++ b/tests/codecs/frame-count.test.ts
@@ -37,6 +37,23 @@ describe("resolveSourceFrameCount", () => {
     );
   });
 
+  it("clamps up to max(frame_numbers)+1 when a declared count is impossibly small (bogus `frames` attr)", () => {
+    // Real case: /video0/video has frames=424 but frame_numbers reach 173997 —
+    // a 424-frame source cannot contain frame 173997, so the seekbar extent must
+    // span at least 173998 or every label beyond 424 falls off the axis.
+    expect(
+      resolveSourceFrameCount({
+        framesAttr: 424,
+        jsonFrameCount: 336,
+        frameNumbers: [76978, 100000, 173997],
+      }),
+    ).toBe(173998);
+    // Same guard when only videos_json shape[0] is the (too-small) declared count.
+    expect(
+      resolveSourceFrameCount({ jsonFrameCount: 336, frameNumbers: [173997] }),
+    ).toBe(173998);
+  });
+
   it("returns undefined when nothing is available", () => {
     expect(resolveSourceFrameCount({})).toBeUndefined();
     expect(resolveSourceFrameCount({ frameNumbers: [] })).toBeUndefined();


### PR DESCRIPTION
## Problem

An embedded `pkg.slp` video's **seekbar extent** (source frame count) is resolved by `resolveSourceFrameCount`, which returned the **first** available of:
1. the `frames` HDF5 attribute,
2. `videos_json` `backend.shape[0]`,
3. `max(frame_numbers) + 1`.

When the `frames` attribute is **bogus — smaller than the stored frames' own source indices** — the extent collapses below the labeled-frame range, and every labeled frame beyond it falls off the seekbar. The video looks **empty on open** even though all frames and labels parse correctly.

## Real case

A 7.1 GB, **874-video** training-split `pkg.slp`: `/video0/video` carries `frames = 424`, but its `frame_numbers` reach **173997** — impossible for a 424-frame source. sleap-io.js gave video0 a **424**-frame axis and dropped the labels at 76978…173997. PyQt shows the file fine (~173k seekbar) because it derives the extent from `frame_numbers`, not the attr.

## Fix

The extent is now `max(declared, max(frame_numbers) + 1)`, where `declared` is the `frames` attr (else `videos_json shape[0]`). A stored image at source index N proves the source had ≥ N+1 frames, so a declared count below that is impossible and gets clamped up. Behavior is **unchanged** when the declared count is already valid (≥ the frame-number bound). Robust to bad `frames` attrs and to files written without one.

## Verification

- `frame-count` unit tests: **7/7 pass** (added a regression test: `framesAttr:424` + `frameNumbers→173997` ⇒ `173998`). Build clean.
- Playwright, against the real 7.1 GB file (browser, `openVideos:true`): video0 `shape[0]` **424 → 173998**, and `getFrame(77077)` decodes a real **ImageData 1280×1024**.

## Notes

- The extent is only corrected on the `openVideos:true` path (which reads `frame_numbers`); the metadata-only `openVideos:false` path still returns the declared count. The app always loads with `openVideos:true`, so this is the effective path — but noting it for follow-up if a metadata-only correct extent is ever needed.
- Companion app-side change (separate repo/PR): open a project on its first labeled frame instead of frame 0 (embedded frames live at their original indices, so frame 0 is often an empty position).

🤖 Generated with [Claude Code](https://claude.com/claude-code)