### PR TITLE
feat(rendering): centroid rendering — draw_centroids + renderImage auto-draw (#468/#494/#506)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -524,10 +524,25 @@ for (const mask of frame.masks) {
 }
 ```
 
-The vector overlays (`drawBboxes`, `drawRois`, `applyOverlay`) and the full
-`renderImage`/`renderVideo` pipeline draw through `skia-canvas` and remain
-Node-only (main entry). See `demo/` for a complete browser example that fills
-masks with `drawMasks` and outlines them with smoothed `contours()`.
+The vector overlays (`drawBboxes`, `drawRois`, `drawCentroids`, `applyOverlay`)
+and the full `renderImage`/`renderVideo` pipeline draw through `skia-canvas` and
+remain Node-only (main entry). See `demo/` for a complete browser example that
+fills masks with `drawMasks` and outlines them with smoothed `contours()`.
+
+`renderImage`/`renderVideo` auto-draw a frame's `centroids` (filled circle
+markers, colored by track via the pose palette, scoped to the rendered video),
+so a centroid-only frame renders without an explicit overlay. `drawCentroids`
+is also exported for standalone use:
+
+```ts
+import { drawCentroids } from "@talmolab/sleap-io.js"; // Node (skia-canvas)
+
+drawCentroids(imageData, frame.centroids, {
+  colors: frame.centroids.map(centroidColorRgb), // e.g. by track identity
+  markerSize: 5,
+  alpha: 1,
+});
+```
 
 ### `BoundingBox`
 Axis-aligned or rotated bounding box for detection/tracking workflows. `BoundingBox` is abstract; use `UserBoundingBox` or `PredictedBoundingBox` for direct construction.

--- a/src/rendering/index.ts
+++ b/src/rendering/index.ts
@@ -68,6 +68,7 @@ export {
   drawLabelImage,
   drawBboxes,
   drawRois,
+  drawCentroids,
   applyOverlay,
 } from "./overlays.js";
 export type { RawLabelImage } from "./overlays.js";

--- a/src/rendering/overlays.ts
+++ b/src/rendering/overlays.ts
@@ -19,6 +19,7 @@
 import type { SegmentationMask } from "../model/mask.js";
 import type { LabelImage } from "../model/label-image.js";
 import type { BoundingBox } from "../model/bbox.js";
+import type { Centroid } from "../model/centroid.js";
 import type { ROI, Geometry } from "../model/roi.js";
 import type { RGB, PaletteName } from "./types.js";
 import { getPalette, rgbToCSS } from "./colors.js";
@@ -159,6 +160,56 @@ export function drawRois(
     for (let i = 0; i < rois.length; i++) {
       const c = pickColor(colors, i, color);
       drawGeometry(ctx, rois[i].geometry, c, lineWidth, fillAlpha);
+    }
+  });
+}
+
+/**
+ * Draw centroids as filled circle markers on an image.
+ *
+ * Each centroid is drawn as a filled circle of radius `markerSize` at
+ * `(centroid.x - offsetX, centroid.y - offsetY)`, in a single `color` or a
+ * per-centroid `colors` list (cycled when shorter than the centroid list).
+ * Rendered through an internal skia-canvas `Canvas`. Port of `draw_centroids`
+ * (overlays.py, sleap-io PR #506).
+ *
+ * @param image - RGBA ImageData, mutated in place.
+ * @param centroids - Centroids to draw.
+ * @param opts - `color` (default [0,255,0]), per-centroid `colors`, `markerSize`
+ *   (5), `alpha` (1), `offset` ([0,0]).
+ * @returns The same ImageData.
+ */
+export function drawCentroids(
+  image: ImageData,
+  centroids: Centroid[],
+  opts?: {
+    color?: RGB;
+    colors?: RGB[];
+    markerSize?: number;
+    alpha?: number;
+    offset?: [number, number];
+  },
+): ImageData {
+  if (centroids.length === 0) return image;
+
+  const color = opts?.color ?? [0, 255, 0];
+  const colors = opts?.colors ?? null;
+  const markerSize = opts?.markerSize ?? 5;
+  const alpha = clampAlpha(opts?.alpha ?? 1);
+  const [ox, oy] = opts?.offset ?? [0, 0];
+
+  return withVectorCanvas(image, (ctx) => {
+    for (let i = 0; i < centroids.length; i++) {
+      const cx = centroids[i].x - ox;
+      const cy = centroids[i].y - oy;
+      // Skip non-finite coordinates (matches the pose-node draw loop), rather
+      // than relying on skia-canvas's handling of a NaN arc center.
+      if (!Number.isFinite(cx) || !Number.isFinite(cy)) continue;
+      const c = pickColor(colors, i, color);
+      ctx.beginPath();
+      ctx.arc(cx, cy, markerSize, 0, Math.PI * 2);
+      ctx.fillStyle = rgbToCSS(c, alpha);
+      ctx.fill();
     }
   });
 }

--- a/src/rendering/render.ts
+++ b/src/rendering/render.ts
@@ -3,6 +3,7 @@
 import type { Labels } from "../model/labels.js";
 import type { LabeledFrame } from "../model/labeled-frame.js";
 import type { Instance, PredictedInstance, Track } from "../model/instance.js";
+import type { Centroid } from "../model/centroid.js";
 import type { Skeleton } from "../model/skeleton.js";
 import type {
   RenderOptions,
@@ -27,7 +28,7 @@ import {
   collectTracks,
 } from "./trails.js";
 import { RenderContext, InstanceContext } from "./context.js";
-import { applyOverlay } from "./overlays.js";
+import { applyOverlay, drawCentroids } from "./overlays.js";
 
 // Default options
 const DEFAULT_OPTIONS: Required<
@@ -213,7 +214,31 @@ export async function renderImage(
   // replicate that equivalent: read the canvas at source resolution, blend the
   // overlay in source space, then scale-composite back onto the (possibly
   // scaled) canvas. When `scale === 1` this is an in-place read/blend/write.
-  if (effectiveOverlay !== undefined && effectiveOverlay !== null) {
+  // Centroids for the rendered frame (video-scoped by construction: a Labels
+  // source renders its first labeled frame; a LabeledFrame renders itself), so
+  // centroids never bleed across videos. Colored by track via the pose palette
+  // (untracked -> palette[0]) to match poses/trails. Mirrors Python
+  // render_image centroid scoping + coloring (core.py, PR #468).
+  const frameCentroids: Centroid[] = Array.isArray(source)
+    ? []
+    : (renderedLabeledFrame(source)?.centroids ?? []);
+  let centroidColors: RGB[] = [];
+  if (frameCentroids.length > 0) {
+    const cPal = getPalette(
+      opts.palette as PaletteName,
+      Math.max(globalTracks.length, 1),
+    );
+    centroidColors = frameCentroids.map((c) => {
+      const tidx = c.track ? globalTrackIndexMap.get(c.track) : undefined;
+      return tidx !== undefined
+        ? cPal[tidx % cPal.length]
+        : (cPal[0] ?? DEFAULT_COLOR);
+    });
+  }
+
+  const hasOverlay =
+    effectiveOverlay !== undefined && effectiveOverlay !== null;
+  if (hasOverlay || frameCentroids.length > 0) {
     // Color overlay elements (masks/ROIs/bboxes) by track identity when
     // color_by resolves to "track", matching poses/centroids/trails (same
     // `palette`). Otherwise fall through to positional `overlayPalette`
@@ -230,6 +255,7 @@ export async function renderImage(
       (!Array.isArray(source) && "labeledFrames" in source);
     let overlayColors: RGB[] | null = null;
     if (
+      hasOverlay &&
       colorScheme === "track" &&
       trackColorable &&
       globalTrackIndexMap.size > 0 &&
@@ -255,31 +281,40 @@ export async function renderImage(
       outlineColor: opts.overlayOutlineColor,
       colors: overlayColors,
     };
+    // Blend the overlay AND draw centroids in SOURCE space, then upscale once,
+    // so a centroid's final radius is `markerSize * scale` — matching pose
+    // nodes and avoiding the double-scaling of Python PR #494. Order (overlay
+    // then centroids, both below the poses drawn later) mirrors render_image.
+    const applySourceSpace = (imageData: ImageData): void => {
+      if (hasOverlay) {
+        applyOverlay(imageData, effectiveOverlay as Overlay, overlayOpts);
+      }
+      if (frameCentroids.length > 0) {
+        drawCentroids(imageData, frameCentroids, {
+          colors: centroidColors,
+          markerSize: opts.markerSize,
+          alpha: opts.alpha,
+        });
+      }
+    };
     if (opts.scale === 1) {
       // Fast path: blend directly on the scaled canvas (== source resolution).
       const imageData = ctx.getImageData(0, 0, scaledWidth, scaledHeight);
-      applyOverlay(
-        imageData as unknown as ImageData,
-        effectiveOverlay,
-        overlayOpts,
-      );
+      applySourceSpace(imageData as unknown as ImageData);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ctx.putImageData(imageData as any, 0, 0);
     } else {
       // Scaled path: render the current background at source resolution onto a
-      // temporary canvas, blend the overlay there (source-pixel coords), then
-      // draw it scaled onto the main canvas so it lines up with the poses.
+      // temporary canvas, blend the overlay + centroids there (source-pixel
+      // coords), then draw it scaled onto the main canvas so it lines up with
+      // the poses.
       const srcCanvas = new Canvas(width, height);
       const srcCtx = srcCanvas.getContext("2d");
       // Downscale the already-drawn (scaled) background into source space.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       srcCtx.drawImage(canvas as any, 0, 0, width, height);
       const imageData = srcCtx.getImageData(0, 0, width, height);
-      applyOverlay(
-        imageData as unknown as ImageData,
-        effectiveOverlay,
-        overlayOpts,
-      );
+      applySourceSpace(imageData as unknown as ImageData);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       srcCtx.putImageData(imageData as any, 0, 0);
       ctx.clearRect(0, 0, scaledWidth, scaledHeight);
@@ -514,9 +549,9 @@ function renderedLabeledFrame(
  * when there are no instances. For Labels, checks the first labeled frame.
  *
  * Mirrors Python sleap-io PR #420: renderImage(source=lf) must work on
- * segmentation-only LabeledFrames. The actual overlay rendering of these
- * annotations is tracked in issue #96 — this hook is the single place to
- * extend when that lands.
+ * segmentation- or centroid-only LabeledFrames. Masks (auto-resolved as the
+ * overlay) and centroids are drawn by renderImage; bboxes/ROIs/label images
+ * still render only when passed explicitly via `overlay`.
  */
 function hasNonInstanceAnnotations(
   source: Labels | LabeledFrame | (Instance | PredictedInstance)[],

--- a/tests/rendering/centroid-rendering.test.ts
+++ b/tests/rendering/centroid-rendering.test.ts
@@ -1,0 +1,169 @@
+// Tests for centroid rendering parity with sleap-io: draw_centroids (#506),
+// renderImage auto-drawing frame centroids scoped to the rendered video (#468),
+// and single (not double) scaling of the centroid marker (#494).
+
+import { describe, it, expect } from "../bun-test";
+import { drawCentroids } from "../../src/rendering/overlays";
+import { renderImage } from "../../src/rendering/render";
+import { UserCentroid } from "../../src/model/centroid";
+import { Track } from "../../src/model/instance";
+import { Video } from "../../src/model/video";
+import { LabeledFrame } from "../../src/model/labeled-frame";
+import { Labels } from "../../src/model/labels";
+import { getPalette } from "../../src/rendering/colors";
+
+async function makeImage(
+  w: number,
+  h: number,
+  fill: [number, number, number] = [0, 0, 0],
+): Promise<ImageData> {
+  const { Canvas } = await import("skia-canvas");
+  const canvas = new Canvas(w, h);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${fill[0]}, ${fill[1]}, ${fill[2]})`;
+  ctx.fillRect(0, 0, w, h);
+  return ctx.getImageData(0, 0, w, h) as unknown as ImageData;
+}
+
+function pixel(img: ImageData, x: number, y: number): [number, number, number] {
+  const i = (y * img.width + x) * 4;
+  return [img.data[i], img.data[i + 1], img.data[i + 2]];
+}
+
+function arrEq(
+  a: [number, number, number],
+  b: [number, number, number],
+): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+}
+
+const STANDARD = getPalette("standard", 2);
+
+describe("drawCentroids (#506)", () => {
+  it("draws a filled circle at the centroid in a single color", async () => {
+    const img = await makeImage(40, 40, [0, 0, 0]);
+    drawCentroids(img, [new UserCentroid({ x: 20, y: 20 })], {
+      color: [255, 0, 0],
+      markerSize: 5,
+      alpha: 1,
+    });
+    expect(pixel(img, 20, 20)).toEqual([255, 0, 0]);
+    expect(pixel(img, 0, 0)).toEqual([0, 0, 0]);
+  });
+
+  it("uses per-centroid colors (cycled)", async () => {
+    const img = await makeImage(40, 40, [0, 0, 0]);
+    drawCentroids(
+      img,
+      [new UserCentroid({ x: 10, y: 10 }), new UserCentroid({ x: 30, y: 30 })],
+      {
+        colors: [
+          [255, 0, 0],
+          [0, 0, 255],
+        ],
+        markerSize: 4,
+      },
+    );
+    expect(pixel(img, 10, 10)).toEqual([255, 0, 0]);
+    expect(pixel(img, 30, 30)).toEqual([0, 0, 255]);
+  });
+
+  it("honors offset", async () => {
+    const img = await makeImage(40, 40, [0, 0, 0]);
+    drawCentroids(img, [new UserCentroid({ x: 25, y: 25 })], {
+      color: [0, 255, 0],
+      markerSize: 4,
+      offset: [5, 5],
+    });
+    expect(pixel(img, 20, 20)).toEqual([0, 255, 0]); // drawn at (25-5, 25-5)
+  });
+
+  it("is a no-op for an empty list", async () => {
+    const img = await makeImage(8, 8, [9, 9, 9]);
+    drawCentroids(img, []);
+    expect(pixel(img, 0, 0)).toEqual([9, 9, 9]);
+  });
+});
+
+describe("renderImage draws frame centroids (#468/#494)", () => {
+  const video = new Video({ filename: "v.mp4" });
+
+  it("auto-draws a frame's centroids over the background", async () => {
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [new UserCentroid({ x: 32, y: 32 })],
+    });
+    const img = await renderImage(lf, {
+      width: 64,
+      height: 64,
+      background: [128, 128, 128],
+      markerSize: 5,
+    });
+    expect(arrEq(pixel(img, 32, 32), [128, 128, 128])).toBe(false); // colored
+    expect(arrEq(pixel(img, 2, 2), [128, 128, 128])).toBe(true); // bg elsewhere
+  });
+
+  it("renders a centroid-only frame without throwing", async () => {
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [new UserCentroid({ x: 10, y: 10 })],
+    });
+    await expect(
+      renderImage(lf, { width: 32, height: 32, background: "black" }),
+    ).resolves.toBeDefined();
+  });
+
+  it("colors centroids by track via the pose palette", async () => {
+    const trackA = new Track("A");
+    const trackB = new Track("B");
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [
+        new UserCentroid({ x: 16, y: 16, track: trackA }),
+        new UserCentroid({ x: 48, y: 48, track: trackB }),
+      ],
+    });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      tracks: [trackA, trackB],
+    });
+    const img = await renderImage(labels, {
+      width: 64,
+      height: 64,
+      colorBy: "track",
+      background: "black",
+      markerSize: 5,
+      alpha: 1,
+    });
+    // Track A -> index 0, track B -> index 1, using the pose ("standard") palette.
+    expect(pixel(img, 16, 16)).toEqual(STANDARD[0]);
+    expect(pixel(img, 48, 48)).toEqual(STANDARD[1]);
+  });
+
+  it("scales the centroid marker once (no double-scaling, #494)", async () => {
+    // At scale=2 a markerSize=5 centroid at source (16,16) renders at canvas
+    // (32,32) with radius ~10 (markerSize*scale) — the pose-node convention.
+    const lf = new LabeledFrame({
+      video,
+      frameIdx: 0,
+      centroids: [new UserCentroid({ x: 16, y: 16 })],
+    });
+    const img = await renderImage(lf, {
+      width: 32,
+      height: 32,
+      scale: 2,
+      background: "black",
+      markerSize: 5,
+      alpha: 1,
+      colorBy: "instance",
+    });
+    expect(img.width).toBe(64);
+    expect(arrEq(pixel(img, 32, 32), [0, 0, 0])).toBe(false); // scaled center
+    expect(arrEq(pixel(img, 38, 32), [0, 0, 0])).toBe(false); // 6px in (< r≈10)
+    expect(arrEq(pixel(img, 48, 32), [0, 0, 0])).toBe(true); // 16px out (> r≈10)
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #191. Ports sleap-io 0.8.0's **centroid rendering** — the JS renderer previously drew no centroids at all (a `lf.centroids` reference existed only in a throw-guard). This closes the last rendering-parity gap from the 0.8.0 audit.

> Stacked PR — merge #190 → #191 → this. Its own change is the single commit `feat(rendering): centroid rendering …`.

## Changes

- **#506 — `drawCentroids(image, centroids, opts)`.** Filled circle markers via skia-canvas, single `color` or per-centroid `colors` (cycled), with `markerSize` (5), `alpha` (1), `offset`. Non-finite coordinates are skipped (matches the pose-node loop). Exported from the rendering entry (Node-only, sibling of `drawBboxes`/`drawRois`).
- **#468 — auto-draw + video scoping.** `renderImage` (and thus `renderVideo`) now draw the rendered frame's `centroids`, scoped to that frame's video by construction (`renderedLabeledFrame(source).centroids`), colored by track via the **pose palette** (untracked → `palette[0]`). A centroid-only frame renders without an explicit overlay.
- **#494 — single scaling.** Centroids are drawn in the **same source-space pass** as the overlay and upscaled once, so the final marker radius is `markerSize * scale` — matching pose nodes, no double-scaling. Composite order: overlay → centroids → trails → poses (matches Python `render_image`).

## Tests
- `tests/rendering/centroid-rendering.test.ts`: `drawCentroids` pixels / per-centroid colors / offset / empty no-op; `renderImage` auto-draw over background, centroid-only frame renders without throwing, track-colored via the standard palette, and the `scale=2` single-scale radius check.
- Full scoped suite: **1881 pass / 0 fail**; `lint`, `build`, Biome clean. Full rendering suite (198) green — the restructured overlay/scale block leaves all existing overlay/mask/render tests passing.

## Review
An adversarial review of the restructured overlay/scale block verified: the overlay-only path is byte-for-byte unchanged; the centroid-only path never calls `applyOverlay` with a null overlay; scaling is single-pass; coloring is index-safe when there are no tracks; scoping is frame-correct; z-order matches Python. Verdict: ship.

## Stack
- #190 (browser-safe segmentation rendering) → base `main`
- #191 (conversion metadata / isUserLabeled / single overlay) → base #190
- **this** → base #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01869N2KkrfeKADXeX9ENwD4
