### PR TITLE
feat(io): SLEAP Analysis CSV export with full-video-span padding (#480)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ JavaScript/TypeScript utilities for reading and writing SLEAP `.slp` files with 
 - Video backends accept `string`, `File`, or `Blob` sources.
 - Browser-safe: Node.js-only dependencies (`skia-canvas`, `child_process`) are dynamically imported, so bundlers can tree-shake them.
 - Dictionary and numpy codecs for interchange.
+- SLEAP Analysis CSV export (`labelsToCsv` / `saveLabelsCsv`), with optional full-video-span padding.
 - Demo app for quick inspection.
 
 ## Quickstart

--- a/docs/api.md
+++ b/docs/api.md
@@ -951,6 +951,28 @@ group.instance3d;  // Instance3D | undefined
 group.points;      // delegates to instance3d.points if available
 ```
 
+## SLEAP Analysis CSV export
+
+Export `Labels` to the SLEAP Analysis CSV — one row per instance per frame with
+columns `track, frame_idx, instance.score, {node}.score, {node}.x, {node}.y, …`
+(node columns sorted alphabetically; missing/invisible points and user-instance
+scores are empty cells). `labelsToCsv` is browser-safe (returns the string);
+`saveLabelsCsv` writes to disk (Node).
+
+```ts
+import { labelsToCsv, saveLabelsCsv } from "@talmolab/sleap-io.js";
+
+const csv = labelsToCsv(labels);               // string (browser + Node)
+await saveLabelsCsv(labels, "out.csv");        // Node file write
+
+// Span the whole video: emit NaN rows for unlabeled frames, padded to the video
+// length when known (mirrors the Analysis-HDF5 export; sleap-io PR #480).
+await saveLabelsCsv(labels, "out.csv", { includeEmpty: true });
+
+// Other options: video (Video | index filter), includeScore (default true),
+// startFrame / endFrame (inclusive / exclusive).
+```
+
 ## GeoJSON I/O
 
 Convert ROIs to/from GeoJSON format.

--- a/src/io/csv.ts
+++ b/src/io/csv.ts
@@ -1,0 +1,224 @@
+/**
+ * SLEAP Analysis CSV export.
+ *
+ * Writes `Labels` to the "SLEAP Analysis" CSV format — one row per instance per
+ * frame with columns `track, frame_idx, instance.score, {node}.score,
+ * {node}.x, {node}.y, ...` (node columns sorted alphabetically). A faithful
+ * port of the `format="sleap"` path of Python `sleap_io.io.csv.write_labels`
+ * (`_write_sleap` + `_transform_to_sleap_format`) over the instances-DataFrame
+ * builder in `sleap_io.codecs.dataframe` (`_to_instances_df`).
+ *
+ * With `includeEmpty`, frames without instances are emitted as NaN rows and each
+ * video's range is padded up to its full length — the fix from sleap-io PR #480
+ * (matching the numpy / Analysis-HDF5 export, which already spans the whole
+ * video).
+ *
+ * {@link labelsToCsv} is pure (browser-safe) and returns the CSV text;
+ * {@link saveLabelsCsv} writes it to disk via the Node fs writer registered by
+ * `h5-node.ts`, so this module stays free of Node-only imports.
+ */
+
+import type { Labels } from "../model/labels.js";
+import type { Video } from "../model/video.js";
+import { PredictedInstance } from "../model/instance.js";
+import { nodeWriteFile } from "../codecs/slp/h5.js";
+
+export interface CsvExportOptions {
+  /** Restrict output to one video (a `Video` or its index). Default: all videos. */
+  video?: Video | number | null;
+  /** Include per-node and instance confidence scores. Default `true`. */
+  includeScore?: boolean;
+  /**
+   * Emit NaN-filled rows for frames with no instances, padding each video's
+   * range up to its full length (falling back to last labeled frame + 1 when
+   * the length is unknown). Default `false`. Mirrors sleap-io PR #480.
+   */
+  includeEmpty?: boolean;
+  /**
+   * First frame index (inclusive). Default: `0` when `includeEmpty`, else the
+   * first labeled frame.
+   */
+  startFrame?: number | null;
+  /**
+   * End frame index (exclusive). Default: the full video length when known,
+   * else last labeled frame + 1.
+   */
+  endFrame?: number | null;
+}
+
+/** Best-effort video frame count (matches Python `len(video)`; 0 if unknown). */
+function videoFrameCount(video: Video): number {
+  const shape = video.shape;
+  if (shape && shape.length > 0 && typeof shape[0] === "number") {
+    return shape[0];
+  }
+  return 0;
+}
+
+/** Format one CSV cell: `null`/`NaN` -> empty, numbers as-is, strings quoted if needed. */
+function csvCell(value: number | string | null | undefined): string {
+  if (value == null) return "";
+  if (typeof value === "number")
+    return Number.isNaN(value) ? "" : String(value);
+  if (/[",\n\r]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
+  return value;
+}
+
+type Row = { video: Video; cols: Map<string, number | string | null> };
+
+/**
+ * Build the SLEAP Analysis CSV text for `labels`.
+ *
+ * Pure and browser-safe. See {@link saveLabelsCsv} to write it to disk.
+ */
+export function labelsToCsv(
+  labels: Labels,
+  options: CsvExportOptions = {},
+): string {
+  const includeScore = options.includeScore ?? true;
+  const includeEmpty = options.includeEmpty ?? false;
+  const startFrame = options.startFrame ?? null;
+  const endFrame = options.endFrame ?? null;
+
+  // Resolve the video filter.
+  let selectedVideos: Video[];
+  if (options.video == null) {
+    selectedVideos = labels.videos;
+  } else if (typeof options.video === "number") {
+    const v = labels.videos[options.video];
+    if (!v) throw new Error(`Video index ${options.video} out of range.`);
+    selectedVideos = [v];
+  } else {
+    selectedVideos = [options.video];
+  }
+  const videoSet = new Set(selectedVideos);
+  const videoIndex = new Map(labels.videos.map((v, i) => [v, i]));
+
+  const frames = labels.labeledFrames.filter((lf) => videoSet.has(lf.video));
+
+  const rows: Row[] = [];
+  const nodeColSet = new Set<string>();
+  // Frames actually emitted (passed the range filter), per video, for padding.
+  const seen = new Set<string>();
+  const seenByVideo = new Map<Video, number[]>();
+  const seenKey = (v: Video, f: number) => `${videoIndex.get(v)}:${f}`;
+
+  for (const lf of frames) {
+    if (startFrame != null && lf.frameIdx < startFrame) continue;
+    if (endFrame != null && lf.frameIdx >= endFrame) continue;
+    seen.add(seenKey(lf.video, lf.frameIdx));
+    const byVid = seenByVideo.get(lf.video);
+    if (byVid) byVid.push(lf.frameIdx);
+    else seenByVideo.set(lf.video, [lf.frameIdx]);
+
+    const instances = [...lf.userInstances, ...lf.predictedInstances];
+    for (const inst of instances) {
+      const predicted = inst instanceof PredictedInstance;
+      const cols = new Map<string, number | string | null>();
+      cols.set("frame_idx", lf.frameIdx);
+      cols.set("track", inst.track ? inst.track.name : null);
+      cols.set(
+        "instance.score",
+        predicted ? ((inst as PredictedInstance).score ?? null) : null,
+      );
+      const nodes = inst.skeleton.nodes;
+      for (let i = 0; i < nodes.length; i++) {
+        const name = nodes[i].name;
+        const pt = inst.points[i];
+        const xKey = `${name}.x`;
+        const yKey = `${name}.y`;
+        cols.set(xKey, pt ? pt.xy[0] : Number.NaN);
+        cols.set(yKey, pt ? pt.xy[1] : Number.NaN);
+        nodeColSet.add(xKey);
+        nodeColSet.add(yKey);
+        // Per-node scores are emitted only for predicted instances (matching
+        // Python `_to_instances_df`); user rows leave the cell empty.
+        if (includeScore && predicted) {
+          const sKey = `${name}.score`;
+          cols.set(sKey, pt?.score ?? Number.NaN);
+          nodeColSet.add(sKey);
+        }
+      }
+      rows.push({ video: lf.video, cols });
+    }
+  }
+
+  // Empty-frame padding, spanning the full video length (sleap-io PR #480).
+  if (includeEmpty && frames.length) {
+    const skeleton = labels.skeletons[0];
+    for (const vid of selectedVideos) {
+      const emitted = seenByVideo.get(vid);
+      if (!emitted || !emitted.length) continue;
+
+      const first = startFrame != null ? startFrame : 0;
+      let last: number;
+      if (endFrame != null) {
+        last = endFrame;
+      } else {
+        let maxIdx = emitted[0];
+        for (const f of emitted) if (f > maxIdx) maxIdx = f;
+        last = maxIdx + 1;
+        const len = videoFrameCount(vid);
+        if (len > 0) last = Math.max(last, len);
+      }
+
+      for (let f = first; f < last; f++) {
+        if (seen.has(seenKey(vid, f))) continue;
+        const cols = new Map<string, number | string | null>();
+        cols.set("frame_idx", f);
+        cols.set("track", null);
+        cols.set("instance.score", null);
+        if (skeleton) {
+          for (const node of skeleton.nodes) {
+            cols.set(`${node.name}.x`, Number.NaN);
+            cols.set(`${node.name}.y`, Number.NaN);
+            nodeColSet.add(`${node.name}.x`);
+            nodeColSet.add(`${node.name}.y`);
+            if (includeScore) {
+              cols.set(`${node.name}.score`, Number.NaN);
+              nodeColSet.add(`${node.name}.score`);
+            }
+          }
+        }
+        rows.push({ video: vid, cols });
+      }
+    }
+    // Sort by (video index, frame_idx), matching Python's all_frames output.
+    rows.sort((a, b) => {
+      const va = videoIndex.get(a.video) ?? 0;
+      const vb = videoIndex.get(b.video) ?? 0;
+      if (va !== vb) return va - vb;
+      return (
+        (a.cols.get("frame_idx") as number) -
+        (b.cols.get("frame_idx") as number)
+      );
+    });
+  }
+
+  // Header: base columns then alphabetically-sorted node columns (matching
+  // `_transform_to_sleap_format`; `video_path`/`track_score` are not emitted).
+  const nodeCols = [...nodeColSet].sort();
+  const header = ["track", "frame_idx", "instance.score", ...nodeCols];
+
+  const lines: string[] = [header.join(",")];
+  for (const row of rows) {
+    lines.push(
+      header.map((col) => csvCell(row.cols.get(col) ?? null)).join(","),
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Write `labels` to a SLEAP Analysis CSV file. Node-only (disk I/O); use
+ * {@link labelsToCsv} for the browser-safe string.
+ */
+export async function saveLabelsCsv(
+  labels: Labels,
+  filename: string,
+  options: CsvExportOptions = {},
+): Promise<void> {
+  const text = labelsToCsv(labels, options);
+  const bytes = new TextEncoder().encode(text);
+  await nodeWriteFile(filename, bytes);
+}

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -219,6 +219,13 @@ export async function saveAnalysisH5(
 /** Re-export the Analysis HDF5 format detector for public use. */
 export { isAnalysisH5File } from "./analysis-h5.js";
 
+/** SLEAP Analysis CSV export (browser-safe string + Node file write). */
+export {
+  labelsToCsv,
+  saveLabelsCsv,
+  type CsvExportOptions,
+} from "./csv.js";
+
 /**
  * Load multiple SLP files in parallel.
  *

--- a/tests/io/csv.test.ts
+++ b/tests/io/csv.test.ts
@@ -1,0 +1,323 @@
+// Tests for the SLEAP Analysis CSV export (sleap-io PR #480 parity): one row per
+// instance, alphabetically-sorted node columns, and full-video-span empty-frame
+// padding under includeEmpty.
+
+import { describe, it, expect } from "../bun-test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFileSync, rmSync } from "node:fs";
+import { labelsToCsv, saveLabelsCsv } from "../../src/io/csv.js";
+import { Labels } from "../../src/model/labels.js";
+import { Video } from "../../src/model/video.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+} from "../../src/model/instance.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+
+/** Split CSV text into [header[], rows[][]] (no quoted-comma handling). */
+function parse(csv: string): { header: string[]; rows: string[][] } {
+  const lines = csv.split("\n").filter((l) => l.length > 0);
+  const header = lines[0].split(",");
+  const rows = lines.slice(1).map((l) => l.split(","));
+  return { header, rows };
+}
+
+const skel = () => new Skeleton({ nodes: ["thorax", "head"] });
+
+describe("labelsToCsv — SLEAP Analysis format", () => {
+  it("writes one row per predicted instance with sorted node columns", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    const track0 = new Track("track0");
+    const inst = PredictedInstance.fromArray(
+      [
+        [10, 20, 0.9],
+        [30, 40, 0.8],
+      ],
+      s,
+      0.95,
+    );
+    inst.track = track0;
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [s],
+      tracks: [track0],
+    });
+
+    const { header, rows } = parse(labelsToCsv(labels));
+    // Base cols then alphabetical node cols (score < x < y; head < thorax).
+    expect(header).toEqual([
+      "track",
+      "frame_idx",
+      "instance.score",
+      "head.score",
+      "head.x",
+      "head.y",
+      "thorax.score",
+      "thorax.x",
+      "thorax.y",
+    ]);
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toEqual([
+      "track0",
+      "0",
+      "0.95",
+      "0.8", // head.score
+      "30", // head.x
+      "40", // head.y
+      "0.9", // thorax.score
+      "10", // thorax.x
+      "20", // thorax.y
+    ]);
+  });
+
+  it("leaves instance.score and node scores empty for user instances", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    const inst = new Instance({
+      points: { thorax: [1, 2], head: [3, 4] },
+      skeleton: s,
+    });
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [s],
+    });
+
+    const { header, rows } = parse(labelsToCsv(labels));
+    // No .score columns at all for a user-only project.
+    expect(header).toEqual([
+      "track",
+      "frame_idx",
+      "instance.score",
+      "head.x",
+      "head.y",
+      "thorax.x",
+      "thorax.y",
+    ]);
+    expect(rows[0][0]).toBe(""); // track (untracked)
+    expect(rows[0][2]).toBe(""); // instance.score (user)
+  });
+
+  it("omits score columns when includeScore=false", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    const inst = PredictedInstance.fromArray(
+      [
+        [1, 2, 0.5],
+        [3, 4, 0.6],
+      ],
+      s,
+      0.7,
+    );
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [s],
+    });
+    const { header } = parse(labelsToCsv(labels, { includeScore: false }));
+    // No NODE score columns; the base instance.score column always remains.
+    expect(
+      header.some((c) => c.endsWith(".score") && c !== "instance.score"),
+    ).toBe(false);
+    expect(header).toContain("instance.score");
+  });
+
+  it("writes empty cells for invisible / NaN points", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    // head invisible -> NaN coords.
+    const inst = new Instance({
+      points: { thorax: [1, 2], head: [Number.NaN, Number.NaN] },
+      skeleton: s,
+    });
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [s],
+    });
+    const { header, rows } = parse(labelsToCsv(labels));
+    const hx = header.indexOf("head.x");
+    const tx = header.indexOf("thorax.x");
+    expect(rows[0][hx]).toBe(""); // invisible head
+    expect(rows[0][tx]).toBe("1"); // visible thorax
+  });
+
+  it("pads empty frames to the full video length under includeEmpty (#480)", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    video.shape = [10, 4, 4, 1]; // 10 frames total
+    const mk = (f: number) => {
+      const inst = PredictedInstance.fromArray(
+        [
+          [1, 2, 0.5],
+          [3, 4, 0.6],
+        ],
+        s,
+        0.9,
+      );
+      return new LabeledFrame({ video, frameIdx: f, instances: [inst] });
+    };
+    // Labeled only at frames 2 and 5.
+    const labels = new Labels({
+      labeledFrames: [mk(2), mk(5)],
+      videos: [video],
+      skeletons: [s],
+    });
+
+    const { rows } = parse(labelsToCsv(labels, { includeEmpty: true }));
+    // 2 instance rows + 8 empty rows = 10, one per frame 0..9, sorted by frame.
+    expect(rows.length).toBe(10);
+    const frameCol = 1; // frame_idx
+    expect(rows.map((r) => Number(r[frameCol]))).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ]);
+    // Empty frame 0 has blank track + coords; frame 2 (labeled) has coords.
+    expect(rows[0][0]).toBe(""); // frame 0 track empty
+    expect(parse(labelsToCsv(labels, { includeEmpty: true })).header).toContain(
+      "thorax.x",
+    );
+  });
+
+  it("falls back to last labeled frame + 1 when the video length is unknown", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" }); // no shape
+    const inst = () =>
+      PredictedInstance.fromArray(
+        [
+          [1, 2, 0.5],
+          [3, 4, 0.6],
+        ],
+        s,
+        0.9,
+      );
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 1, instances: [inst()] }),
+        new LabeledFrame({ video, frameIdx: 3, instances: [inst()] }),
+      ],
+      videos: [video],
+      skeletons: [s],
+    });
+    const { rows } = parse(labelsToCsv(labels, { includeEmpty: true }));
+    // Range 0..(3+1) exclusive -> frames 0,1,2,3.
+    expect(rows.map((r) => Number(r[1]))).toEqual([0, 1, 2, 3]);
+  });
+
+  it("respects startFrame / endFrame", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    const mk = (f: number) =>
+      new LabeledFrame({
+        video,
+        frameIdx: f,
+        instances: [
+          PredictedInstance.fromArray(
+            [
+              [1, 2, 0.5],
+              [3, 4, 0.6],
+            ],
+            s,
+            0.9,
+          ),
+        ],
+      });
+    const labels = new Labels({
+      labeledFrames: [mk(0), mk(1), mk(2), mk(3)],
+      videos: [video],
+      skeletons: [s],
+    });
+    const { rows } = parse(labelsToCsv(labels, { startFrame: 1, endFrame: 3 }));
+    // endFrame exclusive -> frames 1, 2 only.
+    expect(rows.map((r) => Number(r[1]))).toEqual([1, 2]);
+  });
+
+  it("filters to a single video by index", () => {
+    const s = skel();
+    const v0 = new Video({ filename: "a.mp4" });
+    const v1 = new Video({ filename: "b.mp4" });
+    const mk = (video: Video, f: number) =>
+      new LabeledFrame({
+        video,
+        frameIdx: f,
+        instances: [
+          PredictedInstance.fromArray(
+            [
+              [1, 2, 0.5],
+              [3, 4, 0.6],
+            ],
+            s,
+            0.9,
+          ),
+        ],
+      });
+    const labels = new Labels({
+      labeledFrames: [mk(v0, 0), mk(v1, 0), mk(v1, 1)],
+      videos: [v0, v1],
+      skeletons: [s],
+    });
+    expect(parse(labelsToCsv(labels, { video: 1 })).rows.length).toBe(2);
+    expect(parse(labelsToCsv(labels, { video: v0 })).rows.length).toBe(1);
+    expect(parse(labelsToCsv(labels)).rows.length).toBe(3); // all videos
+  });
+
+  it("quotes track names containing commas", () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    const inst = PredictedInstance.fromArray(
+      [
+        [1, 2, 0.5],
+        [3, 4, 0.6],
+      ],
+      s,
+      0.9,
+    );
+    inst.track = new Track("a,b");
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [s],
+    });
+    const csv = labelsToCsv(labels);
+    expect(csv.split("\n")[1].startsWith('"a,b",0,')).toBe(true);
+  });
+
+  it("saveLabelsCsv writes the same text to disk", async () => {
+    const s = skel();
+    const video = new Video({ filename: "v.mp4" });
+    const inst = PredictedInstance.fromArray(
+      [
+        [1, 2, 0.5],
+        [3, 4, 0.6],
+      ],
+      s,
+      0.9,
+    );
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [s],
+    });
+    const path = join(
+      tmpdir(),
+      `sleapio_csv_${Date.now()}_${Math.floor(Math.random() * 1e6)}.csv`,
+    );
+    try {
+      await saveLabelsCsv(labels, path);
+      const onDisk = readFileSync(path, "utf8");
+      expect(onDisk).toBe(labelsToCsv(labels));
+    } finally {
+      rmSync(path, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #194. Ports the **SLEAP Analysis CSV exporter** (absent from the JS port) and bakes in the full-video-span behavior of sleap-io PR #480. The equivalent span logic already exists in the JS Analysis-HDF5 export (`toAnalysisArrays`); this brings the CSV path to parity.

> Stacked PR — merge #190 → #191 → #194 → this. Its own change is the single commit `feat(io): SLEAP Analysis CSV export …`.

## Changes

**`src/io/csv.ts`** (new)
- `labelsToCsv(labels, opts): string` — builds the SLEAP Analysis CSV: one row per instance per frame, columns `track, frame_idx, instance.score, {node}.score, {node}.x, {node}.y, …` (node columns sorted **alphabetically**). Missing/invisible points and user-instance scores are empty cells; track names with commas are quoted. **Pure / browser-safe.**
- `saveLabelsCsv(labels, filename, opts): Promise<void>` — writes it to disk via the Node fs writer registered by `h5-node.ts` (Node-only; same pattern as `saveAnalysisH5`, so the browser bundle stays node-free).
- **`includeEmpty` (#480):** emit NaN rows for unlabeled frames and pad each video's range to its **full length** when known (falling back to last labeled + 1) — mirroring the numpy / Analysis-HDF5 export. Other options: `video` (Video or index filter), `includeScore`, `startFrame` / `endFrame`.

Faithful port of Python `io/csv.py` (`_write_sleap` + `_transform_to_sleap_format`) over `codecs/dataframe.py` (`_to_instances_df`).

## Tests (`tests/io/csv.test.ts`)
Column ordering (alphabetical node cols), user vs predicted scores, `includeScore=false`, invisible/NaN points → empty cells, **full-video-span padding**, unknown-video-length fallback, `startFrame`/`endFrame`, video filtering, comma quoting, and the `saveLabelsCsv` disk round-trip.

Full scoped suite: **1891 pass / 0 fail** (+10); `lint`, `build`, Biome clean; browser build verified node-free with `labelsToCsv` exported.

## Stack
- #190 (browser-safe segmentation rendering) → `main`
- #191 (conversion metadata / isUserLabeled / single overlay) → #190
- #194 (centroid rendering) → #191
- **this** → #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01869N2KkrfeKADXeX9ENwD4
