### PR TITLE
Faithful lazy-native recording-session model (lossless grouping, Python-canonical shape) — #197

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -951,15 +951,53 @@ group.instance3d;  // Instance3D | undefined
 group.points;      // delegates to instance3d.points if available
 ```
 
-### Raw `sessions_json` access (`rawJson` / `rawSessionsJson`)
+### Lossless, lazy-native session grouping
 
-When reading a `.slp`, the verbatim parsed `sessions_json` dict for each session
-is surfaced so 3D consumers (e.g. luc3d/LUCID) can read app-specific state
-without re-opening the HDF5. This is populated on **eager, lazy, and streaming**
-reads.
+Cross-camera grouping (`FrameGroup` / `InstanceGroup`) round-trips losslessly
+through read → object model → write **without** materializing frames, on all
+three read paths (eager, lazy, streaming). Instead of resolving the grouping
+against a materialized frame table at read time, the model stores the as-read
+index refs (`camcorder_to_lf_and_inst_idx_map` and `labeled_frame_by_camera`)
+and resolves them lazily:
 
 ```ts
-// Per-session: the untouched JSON.parse of that session's sessions_json entry
+// Typed access — same public API as before, now lazy under the hood.
+const fg = labels.sessions[0].frameGroups.get(0)!;
+fg.instanceGroups[0].instanceByCamera; // Map<Camera, Instance> (resolved on demand)
+fg.labeledFrameByCamera;               // Map<Camera, LabeledFrame> (resolved on demand)
+```
+
+Under the lazy reader, resolving one cross-camera ref materializes only that one
+frame (via `Labels.frameAt(i)`); an untouched session serializes straight from
+the stored refs with **zero** frame materialization. Mutating a group (accessing
+its map, then editing/reordering instances) re-derives indices from the live
+objects on write, so edits are reflected correctly.
+
+On write, the `sessions_json` shape matches Python `sleap-io`'s `session_to_dict`
+byte-for-byte: `calibration` is keyed `cam_0`, `cam_1`, … (with each camera's
+`name` kept as a field inside its dict), while `camcorder_to_video_idx_map`,
+`camcorder_to_lf_and_inst_idx_map`, and `labeled_frame_by_camera` are keyed by the
+bare integer camera index (`"0"`, `"1"`, …). These are two different key spaces on
+purpose — both Python and sleap-io.js resolve cameras by their **order** in
+`calibration` / positional index, so the calibration key string is cosmetic. This
+is a convergence to Python's existing format, **not** a new on-disk feature, so it
+does **not** bump `format_id` (that namespace is shared with Python, which already
+defines 2.5+). Reading stays tolerant of legacy name-keyed calibration, so loading
+an older file and re-saving upgrades the sessions to the canonical shape in place.
+
+### Raw `sessions_json` access (`rawJson` / `rawSessionsJson`) — deprecated
+
+> **Deprecated / transitional, opt-in only.** The typed session model above is
+> now a faithful projection of `sessions_json`, so consumers should read typed
+> objects rather than this raw dict. `rawJson` is a temporary bridge that will be
+> removed once LUCID migrates. It is **`undefined` by default** — pass
+> `{ rawSessions: true }` to a read entrypoint to capture it. Capturing it
+> deep-clones the whole session payload (doubling session memory in
+> `Labels.copy()`), which is why it is off by default.
+
+```ts
+// OPT-IN: capture the verbatim parsed sessions_json dict per session.
+const labels = await readSlp(path, { rawSessions: true });
 labels.sessions[0].rawJson;
 //   -> { calibration, camcorder_to_video_idx_map,
 //        camcorder_to_lf_and_inst_idx_map, frame_group_dicts, metadata, ... }
@@ -967,13 +1005,17 @@ labels.sessions[0].rawJson;
 // Index-aligned convenience getter (derived from sessions, no stored field)
 labels.rawSessionsJson;         // Array<Record<string, unknown> | undefined>
 labels.rawSessionsJson[0];      // === labels.sessions[0].rawJson
+
+// Default (no option): rawJson is undefined, no clone, no copy() bloat.
+const lean = await readSlp(path);
+lean.sessions[0].rawJson;       // undefined
 ```
 
-`rawJson` exposes every key, including ones sleap-io.js does not itself model
-(`camcorder_to_lf_and_inst_idx_map`, LUCID's per-session `metadata.lucid` blob,
-`frame_group_dicts` with inline `points3d`, etc.).
+`rawSessions` is accepted by `readSlp`, `readSlpLazy`, and `readSlpStreaming`.
+When captured, `rawJson` exposes every key, including ones sleap-io.js does not
+itself model.
 
-Caveats:
+Caveats (when captured):
 
 - **Read-time snapshot.** `rawJson` is captured at read time and is NOT updated
   when you mutate the object model afterwards.
@@ -982,7 +1024,8 @@ Caveats:
   already-existing `sessions_json` dataset. It is not stored in `provenance` or
   the `/metadata` blob, so saving does not bloat those.
 - **Index-aligned.** `rawSessionsJson[i]` corresponds to `sessions[i]`; entries
-  are `undefined` for sessions constructed in-memory (never read from disk).
+  are `undefined` for sessions constructed in-memory or read without
+  `rawSessions`.
 
 #### Metadata round-trip (Option 1)
 
@@ -999,24 +1042,24 @@ write at every level — `RecordingSession.metadata` (including nested
 The write path (`serializeSession`) rebuilds `sessions_json` from a fixed field
 set, so it is lossless for everything sleap-io.js structurally models —
 per-camera intrinsics/extrinsics (`name`, `rotation`, `translation`, `matrix`,
-`distortions`, `size`), stringified-integer calibration keys (`"0"`, `"1"`, …)
-when cameras have no distinct name, `camcorder_to_video_idx_map` keys (always
-normalized to decimal index strings), `frame_group_dicts` structural fields, and
-all `metadata` dicts. The following are recoverable **only via `rawJson`**, not
-via an object-model write round-trip:
+`distortions`, `size`), `cam_N`-keyed `calibration` with `name` kept as a field,
+integer-index-keyed `camcorder_to_video_idx_map` /
+`camcorder_to_lf_and_inst_idx_map` / `labeled_frame_by_camera`, and all `metadata`
+dicts. `camcorder_to_lf_and_inst_idx_map`
+now survives losslessly — it is derived from live objects when the group was
+mutated, and otherwise falls back to the as-read index refs (so it is preserved
+even in lazy mode). The following remain recoverable only via `rawSessions`:
 
-1. `camcorder_to_lf_and_inst_idx_map` is re-derived from live frame/instance
-   indices on write (not echoed); it can differ from the source ordering and is
-   empty in lazy mode (empty `labeledFrames`).
-2. A camera carrying both a numeric key and a differing explicit `name` is
-   re-keyed by `name` on write. This is exactly the Python `make_session` shape
-   (`calibration = {"0": {name: "camA"}, "1": {name: "camB"}, …}`): on write the
-   `calibration` keys become `"camA"`/`"camB"` while `camcorder_to_video_idx_map`
-   stays integer-keyed (`"0"`/`"1"`), so the two key spaces diverge. Read `rawJson`
-   for the original integer-keyed calibration.
-3. Any unmodeled top-level key NOT under a `metadata` sub-dict (at session /
+1. Any unmodeled top-level key NOT under a `metadata` sub-dict (at session /
    per-camera / frame-group / instance-group level) is dropped.
-4. Frame groups with zero instance groups are skipped entirely on write.
+2. Frame groups with zero instance groups are skipped entirely on write.
+3. Frame groups are keyed by `frame_idx`; groups sharing (or missing) a
+   `frame_idx` collapse to one entry on read (a pre-existing fidelity gap).
+
+> Legacy note: older sleap-io.js builds keyed `calibration` by camera `name`
+> when a camera had a distinct name, diverging from Python's `cam_N` convention.
+> Reading tolerates both (cameras resolve by order); re-saving canonicalizes to
+> `cam_N`.
 
 ## SLEAP Analysis CSV export
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -951,6 +951,73 @@ group.instance3d;  // Instance3D | undefined
 group.points;      // delegates to instance3d.points if available
 ```
 
+### Raw `sessions_json` access (`rawJson` / `rawSessionsJson`)
+
+When reading a `.slp`, the verbatim parsed `sessions_json` dict for each session
+is surfaced so 3D consumers (e.g. luc3d/LUCID) can read app-specific state
+without re-opening the HDF5. This is populated on **eager, lazy, and streaming**
+reads.
+
+```ts
+// Per-session: the untouched JSON.parse of that session's sessions_json entry
+labels.sessions[0].rawJson;
+//   -> { calibration, camcorder_to_video_idx_map,
+//        camcorder_to_lf_and_inst_idx_map, frame_group_dicts, metadata, ... }
+
+// Index-aligned convenience getter (derived from sessions, no stored field)
+labels.rawSessionsJson;         // Array<Record<string, unknown> | undefined>
+labels.rawSessionsJson[0];      // === labels.sessions[0].rawJson
+```
+
+`rawJson` exposes every key, including ones sleap-io.js does not itself model
+(`camcorder_to_lf_and_inst_idx_map`, LUCID's per-session `metadata.lucid` blob,
+`frame_group_dicts` with inline `points3d`, etc.).
+
+Caveats:
+
+- **Read-time snapshot.** `rawJson` is captured at read time and is NOT updated
+  when you mutate the object model afterwards.
+- **Never re-written to disk.** Writes are rebuilt from the object model (the
+  single source of truth); `rawJson` is a pure in-memory read surface over the
+  already-existing `sessions_json` dataset. It is not stored in `provenance` or
+  the `/metadata` blob, so saving does not bloat those.
+- **Index-aligned.** `rawSessionsJson[i]` corresponds to `sessions[i]`; entries
+  are `undefined` for sessions constructed in-memory (never read from disk).
+
+#### Metadata round-trip (Option 1)
+
+Opaque `metadata` dicts round-trip losslessly through read → object model →
+write at every level — `RecordingSession.metadata` (including nested
+`metadata.lucid`), `FrameGroup.metadata`, `InstanceGroup.metadata`, and
+`CameraGroup.metadata`. Arbitrary unknown keys survive by JSON-equality.
+
+> Note: `CameraGroup.metadata` previously read back as `{}` (silently dropped on
+> read); it is now populated from `calibration.metadata`.
+
+#### Object-model write limitations (Option 3)
+
+The write path (`serializeSession`) rebuilds `sessions_json` from a fixed field
+set, so it is lossless for everything sleap-io.js structurally models —
+per-camera intrinsics/extrinsics (`name`, `rotation`, `translation`, `matrix`,
+`distortions`, `size`), stringified-integer calibration keys (`"0"`, `"1"`, …)
+when cameras have no distinct name, `camcorder_to_video_idx_map` keys (always
+normalized to decimal index strings), `frame_group_dicts` structural fields, and
+all `metadata` dicts. The following are recoverable **only via `rawJson`**, not
+via an object-model write round-trip:
+
+1. `camcorder_to_lf_and_inst_idx_map` is re-derived from live frame/instance
+   indices on write (not echoed); it can differ from the source ordering and is
+   empty in lazy mode (empty `labeledFrames`).
+2. A camera carrying both a numeric key and a differing explicit `name` is
+   re-keyed by `name` on write. This is exactly the Python `make_session` shape
+   (`calibration = {"0": {name: "camA"}, "1": {name: "camB"}, …}`): on write the
+   `calibration` keys become `"camA"`/`"camB"` while `camcorder_to_video_idx_map`
+   stays integer-keyed (`"0"`/`"1"`), so the two key spaces diverge. Read `rawJson`
+   for the original integer-keyed calibration.
+3. Any unmodeled top-level key NOT under a `metadata` sub-dict (at session /
+   per-camera / frame-group / instance-group level) is dropped.
+4. Frame groups with zero instance groups are skipped entirely on write.
+
 ## SLEAP Analysis CSV export
 
 Export `Labels` to the SLEAP Analysis CSV — one row per instance per frame with

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -44,6 +44,7 @@ import {
   CameraGroup,
   FrameGroup,
   InstanceGroup,
+  injectSessionFrameResolver,
   RecordingSession,
 } from "../../model/camera.js";
 import { Identity } from "../../model/identity.js";
@@ -69,6 +70,12 @@ export interface StreamingSlpOptions {
   headers?: Record<string, string>;
   /** Whether to open video backends for embedded videos (default: false) */
   openVideos?: boolean;
+  /**
+   * Capture the verbatim, deep-cloned `sessions_json` dict onto each
+   * `RecordingSession.rawJson` (deprecated, transitional). Default `false`. See
+   * `RecordingSession.rawJson`.
+   */
+  rawSessions?: boolean;
   /**
    * Optional progress callback fired as loading advances through its stages.
    * `current` counts completed stages out of `total`; `message` labels the
@@ -144,6 +151,7 @@ export async function readSlpStreaming(
       options?.filenameHint,
       openVideos,
       options?.onProgress,
+      options?.rawSessions ?? false,
     );
   } finally {
     // Only close the file if we're NOT opening video backends.
@@ -168,6 +176,7 @@ export async function readFromStreamingFile(
   filenameHint?: string,
   openVideos: boolean = false,
   onProgress?: (current: number, total: number, message?: string) => void,
+  rawSessions: boolean = false,
 ): Promise<Labels> {
   // Stage-level progress. The orchestration in this function runs on the MAIN
   // thread — only the low-level HDF5 byte reads are delegated to the worker via
@@ -271,18 +280,18 @@ export async function readFromStreamingFile(
   report(8);
   const identities = await readIdentitiesStreaming(file);
 
-  // Read sessions
+  // Read sessions — grouping captured as index refs (no frame materialization).
   report(9);
   const sessions = await readSessionsStreaming(
     file,
     videos,
     skeletons,
-    labeledFrames,
     identities,
+    rawSessions,
   );
 
   onProgress?.(total, total, "Finalizing");
-  return new Labels({
+  const labels = new Labels({
     labeledFrames,
     videos,
     skeletons,
@@ -292,6 +301,10 @@ export async function readFromStreamingFile(
     identities,
     provenance: (metadataJson?.provenance as Record<string, unknown>) ?? {},
   });
+  // Sessions are read before the frame store exists; wire the lazy frame
+  // resolver now so ref-backed grouping resolves against labels.labeledFrames.
+  injectSessionFrameResolver(labels);
+  return labels;
 }
 
 /**
@@ -774,8 +787,8 @@ export async function readSessionsStreaming(
   file: StreamingH5File,
   videos: Video[],
   skeletons: Skeleton[],
-  labeledFrames: LabeledFrame[],
   identities?: Identity[],
+  captureRaw: boolean = false,
 ): Promise<RecordingSession[]> {
   try {
     const keys = file.keys();
@@ -814,11 +827,12 @@ export async function readSessionsStreaming(
         metadata:
           (parsed.metadata as Record<string, unknown> | undefined) ?? {},
       });
-      // Retain the verbatim parsed sessions_json dict (Option 2). Deep-cloned
-      // so it is an INDEPENDENT snapshot (the object model reuses `parsed`'s
-      // nested metadata/calibration objects by reference). Never re-written to
-      // disk; see RecordingSession.rawJson. Mirrors readSessions in read.ts.
-      session.rawJson = structuredClone(parsed);
+      // Optionally retain the verbatim parsed sessions_json dict (deprecated,
+      // opt-in via `rawSessions`). Deep-cloned so it is an INDEPENDENT snapshot
+      // (the object model reuses `parsed`'s nested metadata/calibration objects
+      // by reference). Never re-written to disk; see RecordingSession.rawJson.
+      // Mirrors readSessions in read.ts.
+      if (captureRaw) session.rawJson = structuredClone(parsed);
 
       const map = (parsed.camcorder_to_video_idx_map ?? {}) as Record<
         string,
@@ -851,9 +865,10 @@ export async function readSessionsStreaming(
           : [];
         for (const instanceGroup of instanceGroupList) {
           const instanceGroupRecord = instanceGroup as Record<string, unknown>;
-          const instanceByCamera = new Map<Camera, Instance>();
-
-          // Read JS-format instances (camera key -> point data)
+          // Concrete instances only for the JS-inline format; the Python/
+          // camcorder format is stored as index refs and resolved lazily via the
+          // injected frame resolver (no frame materialization at read time).
+          let instanceByCamera: Map<Camera, Instance> | undefined;
           const instancesRecord = (instanceGroupRecord.instances ??
             {}) as Record<string, unknown>;
           for (const [cameraKey, points] of Object.entries(instancesRecord)) {
@@ -869,6 +884,8 @@ export async function readSessionsStreaming(
               continue;
             }
             const skeleton = skeletons[0] ?? new Skeleton({ nodes: [] });
+            if (!instanceByCamera)
+              instanceByCamera = new Map<Camera, Instance>();
             instanceByCamera.set(
               camera,
               new Instance({
@@ -878,25 +895,25 @@ export async function readSessionsStreaming(
             );
           }
 
-          // Fall back to Python-format camcorder_to_lf_and_inst_idx_map
-          if (instanceByCamera.size === 0) {
-            const lfInstMap =
-              (instanceGroupRecord.camcorder_to_lf_and_inst_idx_map ??
-                {}) as Record<string, unknown>;
-            for (const [camIdx, value] of Object.entries(lfInstMap)) {
-              const camera = resolveCameraKey(
-                camIdx,
-                cameraMap,
-                cameraGroup.cameras,
-              );
-              if (!camera) continue;
-              const pair = value as unknown as [number, number];
-              const lf = labeledFrames[Number(pair[0])];
-              if (lf) {
-                const inst = lf.instances[Number(pair[1])];
-                if (inst) instanceByCamera.set(camera, inst as Instance);
-              }
-            }
+          // Capture verbatim index refs (camera -> [lfIdx, instIdx]) as NUMBERS.
+          let instanceRefsByCamera: Map<Camera, [number, number]> | undefined;
+          const lfInstMap =
+            (instanceGroupRecord.camcorder_to_lf_and_inst_idx_map ??
+              {}) as Record<string, unknown>;
+          for (const [camIdx, value] of Object.entries(lfInstMap)) {
+            const camera = resolveCameraKey(
+              camIdx,
+              cameraMap,
+              cameraGroup.cameras,
+            );
+            if (!camera) continue;
+            const pair = value as unknown as [unknown, unknown];
+            if (!instanceRefsByCamera)
+              instanceRefsByCamera = new Map<Camera, [number, number]>();
+            instanceRefsByCamera.set(camera, [
+              Number(pair[0]),
+              Number(pair[1]),
+            ]);
           }
 
           const instance3d = reconstructInstance3D(
@@ -908,6 +925,7 @@ export async function readSessionsStreaming(
           instanceGroups.push(
             new InstanceGroup({
               instanceByCamera,
+              instanceRefsByCamera,
               score: instanceGroupRecord.score as number | undefined,
               instance3d,
               identity,
@@ -919,7 +937,8 @@ export async function readSessionsStreaming(
           );
         }
 
-        const labeledFrameByCamera = new Map<Camera, LabeledFrame>();
+        // Capture labeled-frame index refs (camera -> lfIdx) verbatim.
+        let labeledFrameRefsByCamera: Map<Camera, number> | undefined;
         const labeledFrameMap = (groupRecord.labeled_frame_by_camera ??
           {}) as Record<string, unknown>;
         for (const [cameraKey, labeledFrameIdx] of Object.entries(
@@ -936,14 +955,14 @@ export async function readSessionsStreaming(
             );
             continue;
           }
-          const labeledFrame = labeledFrames[Number(labeledFrameIdx)];
-          if (labeledFrame) {
-            labeledFrameByCamera.set(camera, labeledFrame);
-          }
+          if (!labeledFrameRefsByCamera)
+            labeledFrameRefsByCamera = new Map<Camera, number>();
+          labeledFrameRefsByCamera.set(camera, Number(labeledFrameIdx));
         }
 
-        // If no labeled_frame_by_camera, reconstruct from camcorder_to_lf_and_inst_idx_map
-        if (labeledFrameByCamera.size === 0) {
+        // If no labeled_frame_by_camera, reconstruct refs from
+        // camcorder_to_lf_and_inst_idx_map.
+        if (!labeledFrameRefsByCamera) {
           for (const instanceGroup of instanceGroupList) {
             const igRecord = instanceGroup as Record<string, unknown>;
             const lfInstMap = (igRecord.camcorder_to_lf_and_inst_idx_map ??
@@ -955,9 +974,10 @@ export async function readSessionsStreaming(
                 cameraGroup.cameras,
               );
               if (!camera) continue;
-              const pair = value as unknown as [number, number];
-              const lf = labeledFrames[Number(pair[0])];
-              if (lf) labeledFrameByCamera.set(camera, lf);
+              const pair = value as unknown as [unknown, unknown];
+              if (!labeledFrameRefsByCamera)
+                labeledFrameRefsByCamera = new Map<Camera, number>();
+              labeledFrameRefsByCamera.set(camera, Number(pair[0]));
             }
           }
         }
@@ -967,7 +987,7 @@ export async function readSessionsStreaming(
           new FrameGroup({
             frameIdx: Number(frameIdx),
             instanceGroups,
-            labeledFrameByCamera,
+            labeledFrameRefsByCamera,
             metadata:
               (groupRecord.metadata as Record<string, unknown> | undefined) ??
               {},

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -766,7 +766,11 @@ async function readIdentitiesStreaming(
 /**
  * Read recording sessions from sessions_json dataset.
  */
-async function readSessionsStreaming(
+// Exported for a Worker-free unit test of the streaming session-read wiring:
+// the full streaming reader (`readSlpStreaming`) is browser/Worker-gated and
+// unreachable in the Node test runner, so tests drive this directly with a fake
+// `StreamingH5File`. Not re-exported from the package barrel (see src/index.ts).
+export async function readSessionsStreaming(
   file: StreamingH5File,
   videos: Video[],
   skeletons: Skeleton[],
@@ -802,12 +806,19 @@ async function readSessionsStreaming(
         cameraGroup.cameras.push(camera);
         cameraMap.set(String(key), camera);
       }
+      cameraGroup.metadata =
+        (calibration.metadata as Record<string, unknown> | undefined) ?? {};
 
       const session = new RecordingSession({
         cameraGroup,
         metadata:
           (parsed.metadata as Record<string, unknown> | undefined) ?? {},
       });
+      // Retain the verbatim parsed sessions_json dict (Option 2). Deep-cloned
+      // so it is an INDEPENDENT snapshot (the object model reuses `parsed`'s
+      // nested metadata/calibration objects by reference). Never re-written to
+      // disk; see RecordingSession.rawJson. Mirrors readSessions in read.ts.
+      session.rawJson = structuredClone(parsed);
 
       const map = (parsed.camcorder_to_video_idx_map ?? {}) as Record<
         string,

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -36,6 +36,7 @@ import {
   CameraGroup,
   FrameGroup,
   InstanceGroup,
+  injectSessionFrameResolver,
   RecordingSession,
 } from "../../model/camera.js";
 import { Identity } from "../../model/identity.js";
@@ -96,6 +97,14 @@ export async function readSlp(
   options?: {
     openVideos?: boolean;
     h5?: OpenH5Options;
+    /**
+     * Capture the verbatim, deep-cloned `sessions_json` dict onto each
+     * `RecordingSession.rawJson` (deprecated, transitional). Default `false`:
+     * the faithful typed session model is the source of truth, and skipping the
+     * clone avoids doubling session memory in `Labels.copy()`. See
+     * `RecordingSession.rawJson`.
+     */
+    rawSessions?: boolean;
     /**
      * Optional progress callback fired as loading advances through its stages.
      * `current` counts completed stages out of `total`; `message` labels the
@@ -224,8 +233,8 @@ export async function readSlp(
       file.get("sessions_json"),
       videos,
       skeletons,
-      labeledFrames,
       identities,
+      options?.rawSessions ?? false,
     );
     report(7); // Reading annotations
     const allInstances = labeledFrames.flatMap((f) => f.instances);
@@ -327,7 +336,7 @@ export async function readSlp(
     }
 
     onProgress?.(total, total, "Finalizing");
-    return new Labels({
+    const labels = new Labels({
       labeledFrames,
       videos,
       skeletons,
@@ -338,6 +347,10 @@ export async function readSlp(
       provenance: (metadataJson?.provenance as Record<string, unknown>) ?? {},
       rois: staticRois,
     });
+    // Sessions are read before the frame store exists; wire the lazy frame
+    // resolver now so ref-backed grouping resolves against labels.labeledFrames.
+    injectSessionFrameResolver(labels);
+    return labels;
   } finally {
     close();
   }
@@ -371,6 +384,12 @@ export async function readSlpLazy(
   options?: {
     openVideos?: boolean;
     h5?: OpenH5Options;
+    /**
+     * Capture the verbatim, deep-cloned `sessions_json` dict onto each
+     * `RecordingSession.rawJson` (deprecated, transitional). Default `false`.
+     * See `readSlp` and `RecordingSession.rawJson`.
+     */
+    rawSessions?: boolean;
     /**
      * Optional progress callback fired as loading advances through its stages.
      * `current` counts completed stages out of `total`; `message` labels the
@@ -484,8 +503,8 @@ export async function readSlpLazy(
 
     const lazyFrames = new LazyFrameList(store);
 
-    // Read sessions eagerly - they don't depend on frame data.
-    // Pass empty labeledFrames since frames aren't materialized yet.
+    // Read sessions — grouping is captured as index refs only (no frame
+    // materialization); refs resolve lazily via the injected frame resolver.
     report(5); // Reading identities
     const identities = readIdentities(file.get("identities_json"));
     report(6); // Reading sessions
@@ -493,8 +512,8 @@ export async function readSlpLazy(
       file.get("sessions_json"),
       videos,
       skeletons,
-      [],
       identities,
+      options?.rawSessions ?? false,
     );
     report(7); // Reading annotations
     const { rois: roiTuples, bboxes: bboxTuples } = readRoisAndBboxes(
@@ -597,6 +616,10 @@ export async function readSlpLazy(
     // Replace the eager labeledFrames with lazy proxy
     labels._lazyFrameList = lazyFrames;
     labels._lazyDataStore = store;
+
+    // Wire the lazy frame resolver AFTER _lazyFrameList is attached so ref-backed
+    // grouping resolves a single frame on demand (never the full table).
+    injectSessionFrameResolver(labels);
 
     onProgress?.(total, total, "Finalizing");
     return labels;
@@ -1026,8 +1049,8 @@ function readSessions(
   dataset: any,
   videos: Video[],
   skeletons: Skeleton[],
-  labeledFrames: LabeledFrame[],
   identities?: Identity[],
+  captureRaw: boolean = false,
 ): RecordingSession[] {
   if (!dataset) return [];
   const values = dataset.value ?? [];
@@ -1061,13 +1084,13 @@ function readSessions(
       cameraGroup,
       metadata: (parsed.metadata as Record<string, unknown> | undefined) ?? {},
     });
-    // Retain the verbatim parsed sessions_json dict for lossless read-side
-    // access (Option 2). Deep-cloned so it is an INDEPENDENT snapshot: the
-    // object model reuses `parsed`'s nested metadata/calibration objects by
+    // Optionally retain the verbatim parsed sessions_json dict (deprecated,
+    // opt-in via `rawSessions`). Deep-cloned so it is an INDEPENDENT snapshot:
+    // the object model reuses `parsed`'s nested metadata/calibration objects by
     // reference, so without the clone a consumer mutating `rawJson` would
     // silently alter what `serializeSession` writes to disk (and vice versa).
     // Never re-written to disk; see RecordingSession.rawJson.
-    session.rawJson = structuredClone(parsed);
+    if (captureRaw) session.rawJson = structuredClone(parsed);
     const map = asRecord(parsed.camcorder_to_video_idx_map);
     for (const [cameraKey, videoIdx] of Object.entries(map)) {
       const camera = resolveCameraKey(
@@ -1096,9 +1119,11 @@ function readSessions(
         : [];
       for (const instanceGroup of instanceGroupList) {
         const instanceGroupRecord = asRecord(instanceGroup);
-        const instanceByCamera = new Map<Camera, Instance>();
-
-        // Read JS-format instances (camera key -> point data)
+        // Concrete instances are built ONLY for the JS-inline format (camera key
+        // -> point dict). The Python/camcorder format is stored as index refs and
+        // resolved lazily via the injected frame resolver — no frame
+        // materialization at read time.
+        let instanceByCamera: Map<Camera, Instance> | undefined;
         const instancesRecord = asRecord(instanceGroupRecord.instances);
         for (const [cameraKey, points] of Object.entries(instancesRecord)) {
           const camera = resolveCameraKey(
@@ -1113,6 +1138,7 @@ function readSessions(
             continue;
           }
           const skeleton = skeletons[0] ?? new Skeleton({ nodes: [] });
+          if (!instanceByCamera) instanceByCamera = new Map<Camera, Instance>();
           instanceByCamera.set(
             camera,
             new Instance({
@@ -1122,25 +1148,25 @@ function readSessions(
           );
         }
 
-        // Fall back to Python-format camcorder_to_lf_and_inst_idx_map
-        if (instanceByCamera.size === 0) {
-          const lfInstMap = asRecord(
-            instanceGroupRecord.camcorder_to_lf_and_inst_idx_map,
+        // Capture verbatim index refs (camera -> [lfIdx, instIdx]) from the
+        // Python-canonical camcorder map, as NUMBERS (the fixture stores them as
+        // strings). Kept even when concrete instances exist so an untouched
+        // round-trip re-derives / falls back to them losslessly on write.
+        let instanceRefsByCamera: Map<Camera, [number, number]> | undefined;
+        const lfInstMap = asRecord(
+          instanceGroupRecord.camcorder_to_lf_and_inst_idx_map,
+        );
+        for (const [camIdx, value] of Object.entries(lfInstMap)) {
+          const camera = resolveCameraKey(
+            camIdx,
+            cameraMap,
+            cameraGroup.cameras,
           );
-          for (const [camIdx, value] of Object.entries(lfInstMap)) {
-            const camera = resolveCameraKey(
-              camIdx,
-              cameraMap,
-              cameraGroup.cameras,
-            );
-            if (!camera) continue;
-            const pair = value as unknown as [number, number];
-            const lf = labeledFrames[Number(pair[0])];
-            if (lf) {
-              const inst = lf.instances[Number(pair[1])];
-              if (inst) instanceByCamera.set(camera, inst as Instance);
-            }
-          }
+          if (!camera) continue;
+          const pair = value as unknown as [unknown, unknown];
+          if (!instanceRefsByCamera)
+            instanceRefsByCamera = new Map<Camera, [number, number]>();
+          instanceRefsByCamera.set(camera, [Number(pair[0]), Number(pair[1])]);
         }
 
         const instance3d = reconstructInstance3D(
@@ -1152,6 +1178,7 @@ function readSessions(
         instanceGroups.push(
           new InstanceGroup({
             instanceByCamera,
+            instanceRefsByCamera,
             score: instanceGroupRecord.score as number | undefined,
             instance3d,
             identity,
@@ -1163,7 +1190,9 @@ function readSessions(
         );
       }
 
-      const labeledFrameByCamera = new Map<Camera, LabeledFrame>();
+      // Capture labeled-frame index refs (camera -> lfIdx) verbatim; resolved
+      // lazily on access. No frame materialization at read time.
+      let labeledFrameRefsByCamera: Map<Camera, number> | undefined;
       const labeledFrameMap = asRecord(groupRecord.labeled_frame_by_camera);
       for (const [cameraKey, labeledFrameIdx] of Object.entries(
         labeledFrameMap,
@@ -1179,14 +1208,14 @@ function readSessions(
           );
           continue;
         }
-        const labeledFrame = labeledFrames[Number(labeledFrameIdx)];
-        if (labeledFrame) {
-          labeledFrameByCamera.set(camera, labeledFrame);
-        }
+        if (!labeledFrameRefsByCamera)
+          labeledFrameRefsByCamera = new Map<Camera, number>();
+        labeledFrameRefsByCamera.set(camera, Number(labeledFrameIdx));
       }
 
-      // If no labeled_frame_by_camera, reconstruct from camcorder_to_lf_and_inst_idx_map
-      if (labeledFrameByCamera.size === 0) {
+      // If no labeled_frame_by_camera, reconstruct refs from
+      // camcorder_to_lf_and_inst_idx_map.
+      if (!labeledFrameRefsByCamera) {
         for (const instanceGroup of instanceGroupList) {
           const igRecord = asRecord(instanceGroup);
           const lfInstMap = asRecord(igRecord.camcorder_to_lf_and_inst_idx_map);
@@ -1197,9 +1226,10 @@ function readSessions(
               cameraGroup.cameras,
             );
             if (!camera) continue;
-            const pair = value as unknown as [number, number];
-            const lf = labeledFrames[Number(pair[0])];
-            if (lf) labeledFrameByCamera.set(camera, lf);
+            const pair = value as unknown as [unknown, unknown];
+            if (!labeledFrameRefsByCamera)
+              labeledFrameRefsByCamera = new Map<Camera, number>();
+            labeledFrameRefsByCamera.set(camera, Number(pair[0]));
           }
         }
       }
@@ -1209,7 +1239,7 @@ function readSessions(
         new FrameGroup({
           frameIdx: Number(frameIdx),
           instanceGroups,
-          labeledFrameByCamera,
+          labeledFrameRefsByCamera,
           metadata:
             (groupRecord.metadata as Record<string, unknown> | undefined) ?? {},
         }),

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -1054,11 +1054,20 @@ function readSessions(
       cameraGroup.cameras.push(camera);
       cameraMap.set(String(key), camera);
     }
+    cameraGroup.metadata =
+      (calibration.metadata as Record<string, unknown> | undefined) ?? {};
 
     const session = new RecordingSession({
       cameraGroup,
       metadata: (parsed.metadata as Record<string, unknown> | undefined) ?? {},
     });
+    // Retain the verbatim parsed sessions_json dict for lossless read-side
+    // access (Option 2). Deep-cloned so it is an INDEPENDENT snapshot: the
+    // object model reuses `parsed`'s nested metadata/calibration objects by
+    // reference, so without the clone a consumer mutating `rawJson` would
+    // silently alter what `serializeSession` writes to disk (and vice versa).
+    // Never re-written to disk; see RecordingSession.rawJson.
+    session.rawJson = structuredClone(parsed);
     const map = asRecord(parsed.camcorder_to_video_idx_map);
     for (const [cameraKey, videoIdx] of Object.entries(map)) {
       const camera = resolveCameraKey(

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -1,29 +1,32 @@
 import { Labels } from "../../model/labels.js";
-import { Instance, PredictedInstance } from "../../model/instance.js";
+import { type Instance, PredictedInstance } from "../../model/instance.js";
 import type { Track } from "../../model/instance.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
-import {
+import type {
   RecordingSession,
   Camera,
   InstanceGroup,
   FrameGroup,
 } from "../../model/camera.js";
-import { Skeleton } from "../../model/skeleton.js";
+import type { Skeleton } from "../../model/skeleton.js";
 import { SuggestionFrame } from "../../model/suggestions.js";
-import { Video } from "../../model/video.js";
+import type { Video } from "../../model/video.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
 import { getH5Module, getH5FileSystem, ensureH5StagingDir } from "./h5.js";
-import { ROI, PredictedROI, encodeWkb } from "../../model/roi.js";
-import {
+import { type ROI, type PredictedROI, encodeWkb } from "../../model/roi.js";
+import type {
   SegmentationMask,
   UserSegmentationMask,
   PredictedSegmentationMask,
 } from "../../model/mask.js";
-import { BoundingBox, PredictedBoundingBox } from "../../model/bbox.js";
-import { Centroid, PredictedCentroid } from "../../model/centroid.js";
-import { LabelImage, PredictedLabelImage } from "../../model/label-image.js";
+import type { BoundingBox, PredictedBoundingBox } from "../../model/bbox.js";
+import type { Centroid, PredictedCentroid } from "../../model/centroid.js";
+import type {
+  LabelImage,
+  PredictedLabelImage,
+} from "../../model/label-image.js";
 import { deflate } from "pako";
-import { Identity } from "../../model/identity.js";
+import type { Identity } from "../../model/identity.js";
 import { Instance3D, PredictedInstance3D } from "../../model/instance3d.js";
 import type { LazyDataStore } from "../../model/lazy.js";
 
@@ -709,6 +712,16 @@ function writeMetadata(file: any, labels: Labels): void {
     formatId = Math.max(formatId, 2.4);
   }
 
+  // NOTE (sessions): the canonical `sessions_json` shape written here
+  // (calibration keyed `cam_<i>`, camcorder/labeled_frame maps keyed by integer
+  // index) is a CONVERGENCE to Python `sleap-io`'s existing format — not a new
+  // on-disk feature — so it deliberately does NOT bump format_id. `format_id` is
+  // a namespace shared with Python, which already defines 2.5 (/identity_links),
+  // 2.6 (/embeddings) and 2.7 (categories); minting a value here would collide
+  // and mislabel the file. Reading stays tolerant of the legacy name-keyed shape,
+  // so re-saving a legacy file upgrades its sessions to the canonical shape with
+  // no version change required.
+
   file.create_group("metadata");
   const metadataGroup = file.get("metadata");
   metadataGroup.create_attribute("format_id", formatId);
@@ -964,8 +977,15 @@ function serializeSession(
   const calibration: Record<string, unknown> = {
     metadata: session.cameraGroup.metadata ?? {},
   };
+  // Key calibration by `cam_<index>` to match Python `sleap-io`'s
+  // `camera_group_to_dict` byte-for-byte (keeps our on-disk shape a clean subset
+  // of the Python format, per the "upstreamable" goal). The calibration key is
+  // cosmetic on read — both readers resolve cameras by dict ORDER / positional
+  // index, and the camcorder maps below key by bare integer index
+  // (cameraKeyForSession = String(index)), exactly as Python does. `name` is
+  // kept as a field inside each camera dict.
   session.cameraGroup.cameras.forEach((camera, idx) => {
-    const key = camera.name ?? String(idx);
+    const key = `cam_${idx}`;
     const camData: Record<string, unknown> = {
       name: camera.name ?? key,
       rotation: camera.rvec,
@@ -1017,13 +1037,27 @@ function serializeFrameGroup(
       labeledFrameIndex,
     ),
   );
+  // Derive-then-ref-fallback (hybrid write-back), reading RAW backing fields so
+  // an untouched (lazy) group serializes from its stored refs with ZERO frame
+  // materialization, while a mutated/in-memory group re-derives indices from the
+  // concrete map (reflecting any reorder/edit). Never touches the caching getter
+  // (that would materialize + cache between the two saves of the round-trip
+  // equality test).
+  const concreteLfByCamera = frameGroup._labeledFrameByCamera;
+  const lfRefsByCamera = frameGroup._labeledFrameRefsByCamera;
   const labeled_frame_by_camera: Record<string, number> = {};
-  for (const [
-    camera,
-    labeledFrame,
-  ] of frameGroup.labeledFrameByCamera.entries()) {
+  const frameCameras = new Set<Camera>([
+    ...(concreteLfByCamera?.keys() ?? []),
+    ...(lfRefsByCamera?.keys() ?? []),
+  ]);
+  for (const camera of frameCameras) {
     const cameraKey = cameraKeyForSession(camera, session);
-    const index = labeledFrameIndex.get(labeledFrame);
+    const labeledFrame = concreteLfByCamera?.get(camera);
+    let index =
+      labeledFrame !== undefined
+        ? labeledFrameIndex.get(labeledFrame)
+        : undefined;
+    if (index === undefined) index = lfRefsByCamera?.get(camera);
     if (index !== undefined) {
       labeled_frame_by_camera[cameraKey] = index;
     }
@@ -1044,31 +1078,59 @@ function serializeInstanceGroup(
   frameGroup?: FrameGroup,
   labeledFrameIndex?: Map<LabeledFrame, number>,
 ): Record<string, unknown> {
+  // Hybrid write-back: read RAW backing fields (never the caching getter, which
+  // would materialize + cache concrete maps between the two saves of the
+  // round-trip equality test). Per camera: try OBJECT DERIVATION first
+  // (labeledFrameIndex.get(lf) + lf.instances.indexOf(inst)) so any
+  // mutation/reorder is reflected; FALL BACK to the stored index refs when the
+  // group was never materialized (lazy pure-ref group). `instances` points are
+  // emitted ONLY for concrete groups (pure-ref groups omit `instances`, matching
+  // Python-canonical shape) — zero frame materialization for untouched groups.
+  const concreteInst = group._instanceByCamera;
+  const instRefs = group._instanceRefsByCamera;
+  // Resolve the frame group's labeled-frame map ONLY when this instance group is
+  // concrete (materialized/in-memory) — via the GETTER, not the raw field, so
+  // derivation works even when the consumer reached the mutation through
+  // `instanceByCamera` alone (which does NOT populate the frame group's raw map).
+  // For a concrete instance group the frames are already materialized, so the
+  // getter resolves from cache with no NEW materialization; for an untouched
+  // pure-ref group `concreteInst` is undefined, so we never touch the getter and
+  // the zero-materialization guarantee holds.
+  const lfByCamera =
+    concreteInst && frameGroup ? frameGroup.labeledFrameByCamera : undefined;
+
   const instances: Record<string, Record<string, number[]>> = {};
-  for (const [camera, instance] of group.instanceByCamera.entries()) {
-    const cameraKey = cameraKeyForSession(camera, session);
-    instances[cameraKey] = pointsToDict(instance);
-  }
-
-  // Build Python-compatible camcorder_to_lf_and_inst_idx_map
   const camcorder_to_lf_and_inst_idx_map: Record<string, [number, number]> = {};
-  if (frameGroup && labeledFrameIndex) {
-    for (const [camera, instance] of group.instanceByCamera.entries()) {
-      const cameraKey = cameraKeyForSession(camera, session);
-      const labeledFrame = frameGroup.labeledFrameByCamera.get(camera);
-      if (labeledFrame) {
-        const lfIdx = labeledFrameIndex.get(labeledFrame);
-        const instIdx = labeledFrame.instances.indexOf(instance as Instance);
-        if (lfIdx !== undefined && instIdx >= 0) {
-          camcorder_to_lf_and_inst_idx_map[cameraKey] = [lfIdx, instIdx];
-        }
+  const instCameras = new Set<Camera>([
+    ...(concreteInst?.keys() ?? []),
+    ...(instRefs?.keys() ?? []),
+  ]);
+  for (const camera of instCameras) {
+    const cameraKey = cameraKeyForSession(camera, session);
+    const instance = concreteInst?.get(camera);
+    let pair: [number, number] | undefined;
+    if (instance) {
+      if (labeledFrameIndex) {
+        const labeledFrame = lfByCamera?.get(camera);
+        const lfIdx =
+          labeledFrame !== undefined
+            ? labeledFrameIndex.get(labeledFrame)
+            : undefined;
+        const instIdx = labeledFrame
+          ? labeledFrame.instances.indexOf(instance as Instance)
+          : -1;
+        if (lfIdx !== undefined && instIdx >= 0) pair = [lfIdx, instIdx];
       }
+      instances[cameraKey] = pointsToDict(instance);
     }
+    if (!pair && instRefs?.has(camera)) pair = instRefs.get(camera);
+    if (pair) camcorder_to_lf_and_inst_idx_map[cameraKey] = pair;
   }
 
-  const payload: Record<string, unknown> = {
-    instances,
-  };
+  const payload: Record<string, unknown> = {};
+  if (Object.keys(instances).length > 0) {
+    payload.instances = instances;
+  }
   if (Object.keys(camcorder_to_lf_and_inst_idx_map).length > 0) {
     payload.camcorder_to_lf_and_inst_idx_map = camcorder_to_lf_and_inst_idx_map;
   }
@@ -1160,7 +1222,7 @@ function writeLabeledFrames(file: any, labels: Labels): void {
         ? labels.tracks.indexOf(instance.track)
         : -1;
       const trackingScore = instance.trackingScore ?? 0;
-      let fromPredicted = -1;
+      const fromPredicted = -1;
       let score = 0;
       let pointStart = 0;
       let pointEnd = 0;

--- a/src/model/camera.ts
+++ b/src/model/camera.ts
@@ -1,8 +1,8 @@
-import { Instance } from "./instance.js";
-import { LabeledFrame } from "./labeled-frame.js";
-import { Video } from "./video.js";
-import { Identity } from "./identity.js";
-import { Instance3D } from "./instance3d.js";
+import type { Instance } from "./instance.js";
+import type { LabeledFrame } from "./labeled-frame.js";
+import type { Video } from "./video.js";
+import type { Identity } from "./identity.js";
+import type { Instance3D } from "./instance3d.js";
 
 export function rodriguesTransformation(input: number[][] | number[]): {
   matrix: number[][];
@@ -210,18 +210,42 @@ export class RecordingSession {
   cameraByVideo: Map<Video, Camera>;
   metadata: Record<string, unknown>;
 
+  /**
+   * The verbatim, as-read `sessions_json` dict for this session.
+   *
+   * This is a deep-cloned copy of the `JSON.parse` result of the session's
+   * `sessions_json` entry, populated on read (eager, lazy, and streaming). It
+   * lets 3D consumers (e.g. luc3d/LUCID) read app-specific state —
+   * `calibration`, `camcorder_to_video_idx_map`,
+   * `camcorder_to_lf_and_inst_idx_map`, `frame_group_dicts`, and any nested
+   * `metadata.lucid` blob — without re-opening the HDF5, including keys
+   * sleap-io.js does not itself model.
+   *
+   * Caveats:
+   * - It is a READ-TIME SNAPSHOT: it is deep-cloned from the parsed dict and
+   *   holds NO shared references with the object model, so mutating `rawJson`
+   *   never affects the model (or what is written to disk) and mutating the
+   *   model never affects `rawJson`.
+   * - It is NEVER itself re-written to disk. The object model is the single
+   *   source of truth on write; `rawJson` is a pure in-memory read surface.
+   * - `undefined` for sessions constructed in-memory (never read from disk).
+   */
+  rawJson?: Record<string, unknown>;
+
   constructor(options?: {
     cameraGroup?: CameraGroup;
     frameGroupByFrameIdx?: Map<number, FrameGroup>;
     videoByCamera?: Map<Camera, Video>;
     cameraByVideo?: Map<Video, Camera>;
     metadata?: Record<string, unknown>;
+    rawJson?: Record<string, unknown>;
   }) {
     this.cameraGroup = options?.cameraGroup ?? new CameraGroup();
     this.frameGroupByFrameIdx = options?.frameGroupByFrameIdx ?? new Map();
     this.videoByCamera = options?.videoByCamera ?? new Map();
     this.cameraByVideo = options?.cameraByVideo ?? new Map();
     this.metadata = options?.metadata ?? {};
+    this.rawJson = options?.rawJson;
   }
 
   get frameGroups(): Map<number, FrameGroup> {

--- a/src/model/camera.ts
+++ b/src/model/camera.ts
@@ -3,6 +3,7 @@ import type { LabeledFrame } from "./labeled-frame.js";
 import type { Video } from "./video.js";
 import type { Identity } from "./identity.js";
 import type { Instance3D } from "./instance3d.js";
+import type { Labels } from "./labels.js";
 
 export function rodriguesTransformation(input: number[][] | number[]): {
   matrix: number[][];
@@ -110,31 +111,61 @@ export class CameraGroup {
 }
 
 export class InstanceGroup {
-  instanceByCamera: Map<Camera, Instance>;
   score?: number;
   identity?: Identity;
   instance3d?: Instance3D;
   metadata: Record<string, unknown>;
   private _points?: number[][];
 
+  /**
+   * The CONCRETE camera→instance map. Set for in-memory construction and for the
+   * JS-inline read path (point-dict instances). `undefined` for a pure-ref group
+   * read from a camcorder-format file until first access resolves the refs. Read
+   * directly (not via the caching getter) by the write path.
+   * @internal
+   */
+  _instanceByCamera?: Map<Camera, Instance>;
+
+  /**
+   * Verbatim as-read index refs from `camcorder_to_lf_and_inst_idx_map`:
+   * camera → [globalLabeledFrameIdx, instanceIdx]. Captured on read WITHOUT
+   * materializing any frames, so an untouched group can be written back
+   * losslessly (see hybrid write-back). `undefined` for in-memory groups.
+   * @internal
+   */
+  _instanceRefsByCamera?: Map<Camera, [number, number]>;
+
+  /**
+   * Injected lazy frame resolver (`(globalLfIdx) => LabeledFrame | undefined`).
+   * Declared (no runtime slot) so it is NEVER an own-enumerable property — it is
+   * installed non-enumerably via `injectSessionFrameResolver` after Labels is
+   * built. Enumerability matters: `structuredClone(labels.sessions)` in
+   * `Labels.copy()` throws `DataCloneError` on an enumerable function property.
+   * @internal
+   */
+  declare _frameResolver?: (globalLfIdx: number) => LabeledFrame | undefined;
+
   constructor(options: {
-    instanceByCamera: Map<Camera, Instance> | Record<string, Instance>;
+    instanceByCamera?: Map<Camera, Instance> | Record<string, Instance>;
+    instanceRefsByCamera?: Map<Camera, [number, number]>;
     score?: number;
     points?: number[][];
     identity?: Identity;
     instance3d?: Instance3D;
     metadata?: Record<string, unknown>;
   }) {
-    this.instanceByCamera =
-      options.instanceByCamera instanceof Map
-        ? options.instanceByCamera
-        : new Map();
-    if (!(options.instanceByCamera instanceof Map)) {
-      for (const [key, value] of Object.entries(options.instanceByCamera)) {
-        const camera = key as unknown as Camera;
-        this.instanceByCamera.set(camera, value);
+    if (options.instanceByCamera !== undefined) {
+      if (options.instanceByCamera instanceof Map) {
+        this._instanceByCamera = options.instanceByCamera;
+      } else {
+        const map = new Map<Camera, Instance>();
+        for (const [key, value] of Object.entries(options.instanceByCamera)) {
+          map.set(key as unknown as Camera, value);
+        }
+        this._instanceByCamera = map;
       }
     }
+    this._instanceRefsByCamera = options.instanceRefsByCamera;
     this.score = options.score;
     this.identity = options.identity;
     this.instance3d = options.instance3d;
@@ -156,6 +187,33 @@ export class InstanceGroup {
     this._points = value;
   }
 
+  /**
+   * Camera→Instance map. Concrete when the group was built in memory (or via the
+   * JS-inline read path); otherwise resolved lazily from `_instanceRefsByCamera`
+   * on first access via the injected `_frameResolver` and cached. In-place
+   * `.set()`/`.delete()` mutations therefore act on the resolved concrete map.
+   */
+  get instanceByCamera(): Map<Camera, Instance> {
+    if (this._instanceByCamera) return this._instanceByCamera;
+    const refs = this._instanceRefsByCamera;
+    const resolver = this._frameResolver;
+    if (refs && resolver) {
+      const map = new Map<Camera, Instance>();
+      for (const [camera, [lfIdx, instIdx]] of refs) {
+        const lf = resolver(lfIdx);
+        const inst = lf?.instances[instIdx];
+        if (inst) map.set(camera, inst as Instance);
+      }
+      this._instanceByCamera = map;
+      return map;
+    }
+    return new Map();
+  }
+
+  set instanceByCamera(value: Map<Camera, Instance>) {
+    this._instanceByCamera = value;
+  }
+
   get instances(): Instance[] {
     return Array.from(this.instanceByCamera.values());
   }
@@ -164,34 +222,95 @@ export class InstanceGroup {
 export class FrameGroup {
   frameIdx: number;
   instanceGroups: InstanceGroup[];
-  labeledFrameByCamera: Map<Camera, LabeledFrame>;
   metadata: Record<string, unknown>;
+
+  /**
+   * The CONCRETE camera→labeledFrame map. Set for in-memory construction;
+   * `undefined` for a pure-ref group read from a camcorder-format file until
+   * first access resolves the refs. Read directly (not via the caching getter)
+   * by the write path.
+   * @internal
+   */
+  _labeledFrameByCamera?: Map<Camera, LabeledFrame>;
+
+  /**
+   * Verbatim as-read index refs from `labeled_frame_by_camera` (or reconstructed
+   * from `camcorder_to_lf_and_inst_idx_map`): camera → globalLabeledFrameIdx.
+   * Captured on read WITHOUT materializing any frames. `undefined` for in-memory
+   * groups.
+   * @internal
+   */
+  _labeledFrameRefsByCamera?: Map<Camera, number>;
+
+  /** @see InstanceGroup._frameResolver @internal */
+  declare _frameResolver?: (globalLfIdx: number) => LabeledFrame | undefined;
 
   constructor(options: {
     frameIdx: number;
     instanceGroups: InstanceGroup[];
-    labeledFrameByCamera:
+    labeledFrameByCamera?:
       | Map<Camera, LabeledFrame>
       | Record<string, LabeledFrame>;
+    labeledFrameRefsByCamera?: Map<Camera, number>;
     metadata?: Record<string, unknown>;
   }) {
     this.frameIdx = options.frameIdx;
     this.instanceGroups = options.instanceGroups;
-    this.labeledFrameByCamera =
-      options.labeledFrameByCamera instanceof Map
-        ? options.labeledFrameByCamera
-        : new Map();
-    if (!(options.labeledFrameByCamera instanceof Map)) {
-      for (const [key, value] of Object.entries(options.labeledFrameByCamera)) {
-        const camera = key as unknown as Camera;
-        this.labeledFrameByCamera.set(camera, value);
+    if (options.labeledFrameByCamera !== undefined) {
+      if (options.labeledFrameByCamera instanceof Map) {
+        this._labeledFrameByCamera = options.labeledFrameByCamera;
+      } else {
+        const map = new Map<Camera, LabeledFrame>();
+        for (const [key, value] of Object.entries(
+          options.labeledFrameByCamera,
+        )) {
+          map.set(key as unknown as Camera, value);
+        }
+        this._labeledFrameByCamera = map;
       }
     }
+    this._labeledFrameRefsByCamera = options.labeledFrameRefsByCamera;
     this.metadata = options.metadata ?? {};
   }
 
+  /**
+   * Camera→LabeledFrame map. Concrete when the group was built in memory;
+   * otherwise resolved lazily from `_labeledFrameRefsByCamera` on first access
+   * via the injected `_frameResolver` and cached.
+   */
+  get labeledFrameByCamera(): Map<Camera, LabeledFrame> {
+    if (this._labeledFrameByCamera) return this._labeledFrameByCamera;
+    const refs = this._labeledFrameRefsByCamera;
+    const resolver = this._frameResolver;
+    if (refs && resolver) {
+      const map = new Map<Camera, LabeledFrame>();
+      for (const [camera, lfIdx] of refs) {
+        const lf = resolver(lfIdx);
+        if (lf) map.set(camera, lf);
+      }
+      this._labeledFrameByCamera = map;
+      return map;
+    }
+    return new Map();
+  }
+
+  set labeledFrameByCamera(value: Map<Camera, LabeledFrame>) {
+    this._labeledFrameByCamera = value;
+  }
+
+  /**
+   * Cameras participating in this frame group. Reads keys from whichever backing
+   * map exists WITHOUT resolving refs, so listing cameras never materializes a
+   * frame (crucial for the lazy/zero-materialization write path).
+   */
   get cameras(): Camera[] {
-    return Array.from(this.labeledFrameByCamera.keys());
+    return Array.from(
+      (
+        this._labeledFrameByCamera ??
+        this._labeledFrameRefsByCamera ??
+        new Map()
+      ).keys(),
+    );
   }
 
   get labeledFrames(): LabeledFrame[] {
@@ -211,12 +330,21 @@ export class RecordingSession {
   metadata: Record<string, unknown>;
 
   /**
-   * The verbatim, as-read `sessions_json` dict for this session.
+   * @deprecated Transitional bridge, OPT-IN only. Pass `{ rawSessions: true }`
+   * to a read entrypoint (`readSlp`/`readSlpLazy`/`readSlpStreaming`) to capture
+   * it; it is `undefined` by default. The object model is now a faithful, lossless
+   * projection of `sessions_json` (typed grouping via `InstanceGroup`/`FrameGroup`
+   * refs), so consumers should read typed objects rather than this raw dict. It
+   * will be removed once LUCID migrates off it. Capturing it deep-clones the whole
+   * session payload, so leaving it off avoids doubling session memory in
+   * `Labels.copy()`.
+   *
+   * The verbatim, as-read `sessions_json` dict for this session (when captured).
    *
    * This is a deep-cloned copy of the `JSON.parse` result of the session's
-   * `sessions_json` entry, populated on read (eager, lazy, and streaming). It
-   * lets 3D consumers (e.g. luc3d/LUCID) read app-specific state —
-   * `calibration`, `camcorder_to_video_idx_map`,
+   * `sessions_json` entry, populated on read (eager, lazy, and streaming) ONLY
+   * when `rawSessions` is requested. It lets 3D consumers (e.g. luc3d/LUCID) read
+   * app-specific state — `calibration`, `camcorder_to_video_idx_map`,
    * `camcorder_to_lf_and_inst_idx_map`, `frame_group_dicts`, and any nested
    * `metadata.lucid` blob — without re-opening the HDF5, including keys
    * sleap-io.js does not itself model.
@@ -275,6 +403,169 @@ export class RecordingSession {
   getVideo(camera: Camera): Video | undefined {
     return this.videoByCamera.get(camera);
   }
+}
+
+/**
+ * Install a lazy frame resolver onto every FrameGroup and InstanceGroup reachable
+ * from `labels.sessions`. Session grouping is read BEFORE the frame store exists
+ * in all readers, so this is called AFTER the `Labels` is constructed (and, for
+ * the lazy reader, after `_lazyFrameList` is attached). The resolver routes
+ * through `labels.frameAt(i)`, which materializes only frame `i` under the lazy
+ * reader — so ref-backed groups resolve their instances/frames on first access
+ * without forcing a full-table materialization.
+ *
+ * The resolver is installed NON-ENUMERABLE via `Object.defineProperty`: an
+ * enumerable function property would make `structuredClone(labels.sessions)` in
+ * `Labels.copy()` throw `DataCloneError`.
+ */
+export function injectSessionFrameResolver(labels: Labels): void {
+  const resolver = (i: number): LabeledFrame | undefined => labels.frameAt(i);
+  const install = (target: FrameGroup | InstanceGroup): void => {
+    Object.defineProperty(target, "_frameResolver", {
+      value: resolver,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  };
+  for (const session of labels.sessions) {
+    for (const frameGroup of session.frameGroupByFrameIdx.values()) {
+      install(frameGroup);
+      for (const instanceGroup of frameGroup.instanceGroups) {
+        install(instanceGroup);
+      }
+    }
+  }
+}
+
+function cloneInstanceGroup(
+  ig: InstanceGroup,
+  remapCam: (c: Camera) => Camera,
+  instanceMap?: Map<Instance, Instance>,
+): InstanceGroup {
+  let instanceByCamera: Map<Camera, Instance> | undefined;
+  let instanceRefsByCamera: Map<Camera, [number, number]> | undefined;
+  if (ig._instanceRefsByCamera) {
+    // Ref-backed (disk-read): carry the index refs (remapping only the Camera
+    // keys). The concrete cache is intentionally dropped so the getter
+    // re-resolves against the COPY's frames via the re-injected resolver.
+    instanceRefsByCamera = new Map();
+    for (const [c, pair] of ig._instanceRefsByCamera)
+      instanceRefsByCamera.set(remapCam(c), [pair[0], pair[1]]);
+  } else if (ig._instanceByCamera) {
+    // Concrete in-memory group: remap Camera keys and (when available) Instance
+    // values onto the copied objects.
+    instanceByCamera = new Map();
+    for (const [c, inst] of ig._instanceByCamera)
+      instanceByCamera.set(remapCam(c), instanceMap?.get(inst) ?? inst);
+  }
+  // Carry the standalone 3D points array only when there is no `instance3d`
+  // (the `points` getter returns `instance3d.points` otherwise) — avoids
+  // touching the private `_points` field.
+  const points =
+    ig.instance3d || !ig.points ? undefined : ig.points.map((p) => [...p]);
+  return new InstanceGroup({
+    instanceByCamera,
+    instanceRefsByCamera,
+    score: ig.score,
+    points,
+    identity: ig.identity,
+    instance3d: ig.instance3d,
+    metadata: structuredClone(ig.metadata),
+  });
+}
+
+/**
+ * Deep-clone a {@link RecordingSession} preserving class prototypes (so the lazy
+ * grouping getters survive — unlike `structuredClone`, which strips prototypes
+ * and the non-enumerable frame resolver) and the as-read index refs.
+ *
+ * Camera keys are remapped to freshly-cloned cameras; `Video` references are
+ * remapped via `videoMap`. Ref-backed (disk-read) grouping is carried as refs
+ * and re-resolves against the COPY once {@link injectSessionFrameResolver} runs
+ * on it — the copied `labeledFrames` preserve the original's global ordering, so
+ * the same indices resolve correctly. Concrete in-memory maps are carried with
+ * Camera keys remapped and Instance/LabeledFrame values remapped via
+ * `frameMap`/`instanceMap` when supplied (eager copy).
+ *
+ * NOTE: `identity` and `instance3d` are carried by reference — deep-copying those
+ * across a `Labels.copy()` (and relinking to the copy's identities/skeletons) is
+ * a separate, pre-existing concern outside the session-grouping model.
+ */
+export function cloneRecordingSession(
+  session: RecordingSession,
+  opts: {
+    videoMap?: Map<Video, Video>;
+    frameMap?: Map<LabeledFrame, LabeledFrame>;
+    instanceMap?: Map<Instance, Instance>;
+  } = {},
+): RecordingSession {
+  const { videoMap, frameMap, instanceMap } = opts;
+  const cameraMap = new Map<Camera, Camera>();
+  const newCameras = session.cameraGroup.cameras.map((cam) => {
+    const nc = new Camera({
+      name: cam.name,
+      rvec: [...cam.rvec],
+      tvec: [...cam.tvec],
+      matrix: cam.matrix?.map((r) => [...r]),
+      distortions: cam.distortions ? [...cam.distortions] : undefined,
+      size: cam.size ? [cam.size[0], cam.size[1]] : undefined,
+    });
+    cameraMap.set(cam, nc);
+    return nc;
+  });
+  const remapCam = (c: Camera): Camera => cameraMap.get(c) ?? c;
+
+  const cameraGroup = new CameraGroup({
+    cameras: newCameras,
+    metadata: structuredClone(session.cameraGroup.metadata),
+  });
+
+  const videoByCamera = new Map<Camera, Video>();
+  const cameraByVideo = new Map<Video, Camera>();
+  for (const [cam, vid] of session.videoByCamera) {
+    const nc = remapCam(cam);
+    const nv = videoMap?.get(vid) ?? vid;
+    videoByCamera.set(nc, nv);
+    cameraByVideo.set(nv, nc);
+  }
+
+  const frameGroupByFrameIdx = new Map<number, FrameGroup>();
+  for (const [fidx, fg] of session.frameGroupByFrameIdx) {
+    const instanceGroups = fg.instanceGroups.map((ig) =>
+      cloneInstanceGroup(ig, remapCam, instanceMap),
+    );
+    let labeledFrameByCamera: Map<Camera, LabeledFrame> | undefined;
+    let labeledFrameRefsByCamera: Map<Camera, number> | undefined;
+    if (fg._labeledFrameRefsByCamera) {
+      labeledFrameRefsByCamera = new Map();
+      for (const [c, i] of fg._labeledFrameRefsByCamera)
+        labeledFrameRefsByCamera.set(remapCam(c), i);
+    } else if (fg._labeledFrameByCamera) {
+      labeledFrameByCamera = new Map();
+      for (const [c, lf] of fg._labeledFrameByCamera)
+        labeledFrameByCamera.set(remapCam(c), frameMap?.get(lf) ?? lf);
+    }
+    frameGroupByFrameIdx.set(
+      fidx,
+      new FrameGroup({
+        frameIdx: fg.frameIdx,
+        instanceGroups,
+        labeledFrameByCamera,
+        labeledFrameRefsByCamera,
+        metadata: structuredClone(fg.metadata),
+      }),
+    );
+  }
+
+  return new RecordingSession({
+    cameraGroup,
+    frameGroupByFrameIdx,
+    videoByCamera,
+    cameraByVideo,
+    metadata: structuredClone(session.metadata),
+    rawJson: session.rawJson ? structuredClone(session.rawJson) : undefined,
+  });
 }
 
 export function makeCameraFromDict(data: Record<string, unknown>): Camera {

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -13,7 +13,11 @@ import type {
 import { Skeleton, Node, Edge, Symmetry } from "./skeleton.js";
 import { SuggestionFrame } from "./suggestions.js";
 import { Video } from "./video.js";
-import type { RecordingSession } from "./camera.js";
+import {
+  type RecordingSession,
+  cloneRecordingSession,
+  injectSessionFrameResolver,
+} from "./camera.js";
 import type { Identity } from "./identity.js";
 import { toDict } from "../codecs/dictionary.js";
 import { labelsFromNumpy } from "../codecs/numpy.js";
@@ -253,17 +257,34 @@ export class Labels {
   }
 
   /**
+   * @deprecated Transitional. Only populated when a read entrypoint is called
+   * with `{ rawSessions: true }`; `undefined` per entry otherwise. Prefer the
+   * faithful typed session model. See `RecordingSession.rawJson`.
+   *
    * The verbatim, as-read `sessions_json` dicts, index-aligned with `sessions`.
    *
    * Derived (no stored field) so it cannot desync in length from `sessions`.
    * `rawSessionsJson[i]` corresponds to `sessions[i]`, and is `undefined` for
-   * sessions constructed in-memory (never read from disk). Each entry is the
-   * untouched `JSON.parse` result of that session's `sessions_json` entry — a
-   * read-time snapshot, never itself re-written to disk. See
+   * sessions constructed in-memory (or read without `rawSessions`). Each entry
+   * is the untouched `JSON.parse` result of that session's `sessions_json`
+   * entry — a read-time snapshot, never itself re-written to disk. See
    * `RecordingSession.rawJson`.
    */
   get rawSessionsJson(): Array<Record<string, unknown> | undefined> {
     return this.sessions.map((s) => s.rawJson);
+  }
+
+  /**
+   * Get the labeled frame at global index `i`, materializing only that frame
+   * under the lazy reader. Backs the session grouping's lazy frame resolver
+   * (`injectSessionFrameResolver`): resolving one cross-camera ref materializes
+   * a single frame via `LazyFrameList.at(i)` rather than the whole table, so an
+   * untouched session round-trips with zero frame materialization.
+   */
+  frameAt(i: number): LabeledFrame | undefined {
+    return this._lazyFrameList
+      ? this._lazyFrameList.at(i)
+      : this.labeledFrames[i];
   }
 
   /**
@@ -1347,18 +1368,32 @@ export class Labels {
             metadata: { ...s.metadata },
           });
         }),
-        sessions: structuredClone(this.sessions),
+        // Rebuild sessions via constructors (NOT structuredClone, which strips
+        // class prototypes/getters and the non-enumerable frame resolver). In
+        // lazy mode frames are not materialized here, so ref-backed grouping is
+        // carried as refs and re-resolves against the copy's lazy frame list
+        // once injectSessionFrameResolver runs below.
+        sessions: this.sessions.map((s) =>
+          cloneRecordingSession(s, { videoMap }),
+        ),
         provenance: { ...this.provenance },
         identities: structuredClone(this.identities),
       });
 
       labelsCopy._lazyDataStore = newStore;
       labelsCopy._lazyFrameList = newLazyFrames;
+      injectSessionFrameResolver(labelsCopy);
     } else {
       // Eager deep copy: rebuild from constructors, including per-frame annotations
+      const frameMap = new Map<LabeledFrame, LabeledFrame>();
+      const instanceMap = new Map<Instance, Instance>();
       const newFrames = this.labeledFrames.map((f) => {
-        const newInstances = f.instances.map(cloneInstance);
-        return new LabeledFrame({
+        const newInstances = f.instances.map((inst) => {
+          const ni = cloneInstance(inst);
+          instanceMap.set(inst, ni);
+          return ni;
+        });
+        const nf = new LabeledFrame({
           video: videoMap.get(f.video) ?? f.video,
           frameIdx: f.frameIdx,
           instances: newInstances,
@@ -1369,6 +1404,8 @@ export class Labels {
           labelImages: cloneAncillary(f.labelImages) as LabelImage[],
           rois: cloneAncillary(f.rois) as ROI[],
         });
+        frameMap.set(f, nf);
+        return nf;
       });
 
       labelsCopy = new Labels({
@@ -1385,11 +1422,17 @@ export class Labels {
             metadata: { ...s.metadata },
           });
         }),
-        sessions: structuredClone(this.sessions),
+        // Rebuild sessions via constructors, remapping Camera keys and
+        // Instance/LabeledFrame references onto the copied objects; ref-backed
+        // grouping re-resolves via the resolver injected below.
+        sessions: this.sessions.map((s) =>
+          cloneRecordingSession(s, { videoMap, frameMap, instanceMap }),
+        ),
         provenance: { ...this.provenance },
         rois: cloneAncillary(this._staticRois),
         identities: structuredClone(this.identities),
       });
+      injectSessionFrameResolver(labelsCopy);
     }
 
     if (options?.openVideos !== undefined) {

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -253,6 +253,20 @@ export class Labels {
   }
 
   /**
+   * The verbatim, as-read `sessions_json` dicts, index-aligned with `sessions`.
+   *
+   * Derived (no stored field) so it cannot desync in length from `sessions`.
+   * `rawSessionsJson[i]` corresponds to `sessions[i]`, and is `undefined` for
+   * sessions constructed in-memory (never read from disk). Each entry is the
+   * untouched `JSON.parse` result of that session's `sessions_json` entry — a
+   * read-time snapshot, never itself re-written to disk. See
+   * `RecordingSession.rawJson`.
+   */
+  get rawSessionsJson(): Array<Record<string, unknown> | undefined> {
+    return this.sessions.map((s) => s.rawJson);
+  }
+
+  /**
    * Collect tracks from annotations on a frame into this.tracks.
    *
    * `seen` lets a caller iterating many frames share one membership set instead

--- a/tests/slp-raw-sessions.test.ts
+++ b/tests/slp-raw-sessions.test.ts
@@ -72,7 +72,10 @@ async function streamingWorks(): Promise<boolean> {
 
 describe("Raw sessions_json surface (#197)", () => {
   it("exposes verbatim rawJson on eager read", async () => {
-    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const labels = await readSlp(MULTIVIEW, {
+      openVideos: false,
+      rawSessions: true,
+    });
     expect(labels.sessions.length).toBeGreaterThan(0);
 
     // Derived getter is index-aligned with sessions and fully populated.
@@ -95,8 +98,14 @@ describe("Raw sessions_json surface (#197)", () => {
   });
 
   it("lazy read populates identical rawJson (full fidelity even when model is sparse)", async () => {
-    const eager = await readSlp(MULTIVIEW, { openVideos: false });
-    const lazy = await readSlpLazy(MULTIVIEW, { openVideos: false });
+    const eager = await readSlp(MULTIVIEW, {
+      openVideos: false,
+      rawSessions: true,
+    });
+    const lazy = await readSlpLazy(MULTIVIEW, {
+      openVideos: false,
+      rawSessions: true,
+    });
 
     expect(lazy.rawSessionsJson).toEqual(eager.rawSessionsJson);
 
@@ -108,7 +117,10 @@ describe("Raw sessions_json surface (#197)", () => {
   });
 
   it("streaming read populates identical rawJson (or documents Worker gating)", async () => {
-    const eager = await readSlp(MULTIVIEW, { openVideos: false });
+    const eager = await readSlp(MULTIVIEW, {
+      openVideos: false,
+      rawSessions: true,
+    });
     if (!(await streamingWorks())) {
       // Worker path unreachable in this Node runtime (importScripts absent).
       // The eager/lazy assertions above pin the contract the streaming loop
@@ -117,7 +129,7 @@ describe("Raw sessions_json surface (#197)", () => {
     }
     const streamed = await readSlpStreaming(
       new Uint8Array(readFileSync(MULTIVIEW)).buffer as ArrayBuffer,
-      { openVideos: false, filenameHint: "multiview.slp" },
+      { openVideos: false, filenameHint: "multiview.slp", rawSessions: true },
     );
     expect(streamed.sessions.length).toBe(eager.sessions.length);
     for (let i = 0; i < streamed.sessions.length; i++) {
@@ -152,8 +164,8 @@ describe("Raw sessions_json surface (#197)", () => {
       fakeFile,
       [],
       [],
-      [],
       undefined,
+      true, // captureRaw
     );
     expect(sessions).toHaveLength(1);
     const s = sessions[0];
@@ -166,6 +178,44 @@ describe("Raw sessions_json surface (#197)", () => {
     // Deep-cloned snapshot: no shared refs with the object model.
     expect(s.rawJson).not.toBe(source);
     expect(s.metadata).not.toBe(s.rawJson!.metadata);
+  });
+
+  it("rawJson is undefined by DEFAULT (opt-in only) across eager/lazy/streaming", async () => {
+    const eager = await readSlp(MULTIVIEW, { openVideos: false });
+    expect(eager.sessions.length).toBeGreaterThan(0);
+    for (const s of eager.sessions) expect(s.rawJson).toBeUndefined();
+    for (const entry of eager.rawSessionsJson) expect(entry).toBeUndefined();
+
+    const lazy = await readSlpLazy(MULTIVIEW, { openVideos: false });
+    for (const s of lazy.sessions) expect(s.rawJson).toBeUndefined();
+
+    // Worker-free streaming session read: captureRaw defaults to false.
+    const fakeFile = {
+      keys: () => ["sessions_json"],
+      getDatasetValue: async (name: string) =>
+        name === "sessions_json"
+          ? {
+              value: [
+                JSON.stringify({
+                  calibration: { "0": { name: "c0" } },
+                  camcorder_to_video_idx_map: { "0": 0 },
+                }),
+              ],
+            }
+          : { value: [] },
+    } as unknown as Parameters<typeof readSessionsStreaming>[0];
+    const streamed = await readSessionsStreaming(fakeFile, [], [], undefined);
+    expect(streamed[0].rawJson).toBeUndefined();
+  });
+
+  it("Labels.copy() does NOT clone a raw payload by default (no double-clone)", async () => {
+    // Default read: rawJson undefined. copy() must not throw (guards the
+    // non-enumerable _frameResolver against structuredClone DataCloneError) and
+    // must not resurrect a raw payload.
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const copy = labels.copy();
+    expect(copy.sessions.length).toBe(labels.sessions.length);
+    for (const s of copy.sessions) expect(s.rawJson).toBeUndefined();
   });
 
   it("rawJson is an independent snapshot of the object model (no shared refs)", async () => {
@@ -214,6 +264,7 @@ describe("Raw sessions_json surface (#197)", () => {
     const bytes = new Uint8Array(await saveSlpToBytes(labels));
     const reloaded = await readSlp(bytes.buffer as ArrayBuffer, {
       openVideos: false,
+      rawSessions: true,
     });
     const s = reloaded.sessions[0];
     const raw = s.rawJson as Record<string, unknown>;
@@ -263,7 +314,10 @@ describe("Raw sessions_json surface (#197)", () => {
   });
 
   it("rawJson deep-copies on Labels.copy() and getter stays index-aligned", async () => {
-    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const labels = await readSlp(MULTIVIEW, {
+      openVideos: false,
+      rawSessions: true,
+    });
     const copy = labels.copy();
 
     // Mutating the original's rawJson must not affect the copy (structuredClone,
@@ -279,7 +333,7 @@ describe("Raw sessions_json surface (#197)", () => {
     expect(synthetic.rawSessionsJson.length).toBe(synthetic.sessions.length);
   });
 
-  it("Option 3 lossless: stringified-int camera keys survive when cameras are unnamed", async () => {
+  it("writes Python-canonical cam_N calibration + integer camcorder keys when cameras are unnamed", async () => {
     const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } =
       await import("../src/model/camera.js");
     const { Instance } = await import("../src/model/instance.js");
@@ -291,7 +345,8 @@ describe("Raw sessions_json surface (#197)", () => {
     const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
     const v0 = new Video({ filename: "v0.mp4" });
     const v1 = new Video({ filename: "v1.mp4" });
-    // Cameras with NO explicit name -> keys should serialize as "0","1".
+    // Cameras with NO explicit name -> calibration keyed cam_0/cam_1 (Python
+    // parity), camcorder_to_video_idx_map keyed by bare integer index.
     const c0 = new Camera({ rvec: [0, 0, 0], tvec: [0, 0, 0] });
     const c1 = new Camera({ rvec: [0, 0, 0], tvec: [1, 0, 0] });
     const i0 = Instance.fromArray([[1, 2]], skeleton);
@@ -330,7 +385,7 @@ describe("Raw sessions_json surface (#197)", () => {
     const calibKeys = Object.keys(
       s0.calibration as Record<string, unknown>,
     ).filter((k) => k !== "metadata");
-    expect(calibKeys.sort()).toEqual(["0", "1"]);
+    expect(calibKeys.sort()).toEqual(["cam_0", "cam_1"]);
     expect(
       Object.keys(
         s0.camcorder_to_video_idx_map as Record<string, unknown>,

--- a/tests/slp-raw-sessions.test.ts
+++ b/tests/slp-raw-sessions.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Raw sessions_json surface (issue #197).
+ *
+ * Verifies the verbatim parsed sessions_json dict is surfaced on read via
+ * `RecordingSession.rawJson` and the derived `Labels.rawSessionsJson` getter,
+ * across eager / lazy / streaming read paths, WITHOUT introducing any new
+ * on-disk storage (the write path is byte-for-byte unchanged and never
+ * references rawJson).
+ */
+import { describe, it, expect } from "./bun-test";
+import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
+import {
+  readSlpStreaming,
+  readSessionsStreaming,
+} from "../src/codecs/slp/read-streaming.js";
+import { saveSlpToBytes } from "../src/codecs/slp/write.js";
+import { ready, File as H5File } from "h5wasm/node";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
+const MULTIVIEW = path.join(fixtureRoot, "slp", "multiview.slp");
+
+/** Read the raw sessions_json entries and /metadata `json` attr via h5wasm. */
+async function inspectSessions(bytes: Uint8Array): Promise<{
+  sessionsJson: Array<Record<string, unknown>>;
+  metadataJson: string;
+}> {
+  const module = await ready;
+  const p = `/tmp/raw_sessions_${Date.now()}_${Math.random()
+    .toString(16)
+    .slice(2)}.slp`;
+  module.FS.writeFile(p, bytes);
+  const file = new H5File(p, "r");
+  try {
+    const keys = file.keys() as string[];
+    const sessionsJson = keys.includes("sessions_json")
+      ? (file.get("sessions_json") as { value: string[] }).value.map((s) =>
+          JSON.parse(s),
+        )
+      : [];
+    const meta = file.get("metadata") as {
+      attrs: Record<string, { value?: unknown }>;
+    };
+    const rawAttr = meta.attrs.json?.value ?? meta.attrs.json;
+    const metadataJson =
+      typeof rawAttr === "string"
+        ? rawAttr
+        : rawAttr instanceof Uint8Array
+          ? new TextDecoder().decode(rawAttr)
+          : String(rawAttr ?? "");
+    return { sessionsJson, metadataJson };
+  } finally {
+    file.close();
+    module.FS.unlink(p);
+  }
+}
+
+/** Whether the in-Worker streaming reader is usable in this runtime. */
+async function streamingWorks(): Promise<boolean> {
+  try {
+    await readSlpStreaming(
+      new Uint8Array(readFileSync(MULTIVIEW)).buffer as ArrayBuffer,
+      { openVideos: false, filenameHint: "multiview.slp" },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("Raw sessions_json surface (#197)", () => {
+  it("exposes verbatim rawJson on eager read", async () => {
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    expect(labels.sessions.length).toBeGreaterThan(0);
+
+    // Derived getter is index-aligned with sessions and fully populated.
+    expect(labels.rawSessionsJson.length).toBe(labels.sessions.length);
+    for (const entry of labels.rawSessionsJson) {
+      expect(entry).toBeDefined();
+    }
+    expect(labels.rawSessionsJson[0]).toBe(labels.sessions[0].rawJson);
+
+    const raw = labels.sessions[0].rawJson!;
+    expect(Object.hasOwn(raw, "calibration")).toBe(true);
+    expect(Object.hasOwn(raw, "camcorder_to_video_idx_map")).toBe(true);
+
+    // Byte-verbatim vs the on-disk dataset (second h5wasm open).
+    const { sessionsJson } = await inspectSessions(readFileSync(MULTIVIEW));
+    expect(labels.rawSessionsJson.length).toBe(sessionsJson.length);
+    for (let i = 0; i < sessionsJson.length; i++) {
+      expect(labels.rawSessionsJson[i]).toEqual(sessionsJson[i]);
+    }
+  });
+
+  it("lazy read populates identical rawJson (full fidelity even when model is sparse)", async () => {
+    const eager = await readSlp(MULTIVIEW, { openVideos: false });
+    const lazy = await readSlpLazy(MULTIVIEW, { openVideos: false });
+
+    expect(lazy.rawSessionsJson).toEqual(eager.rawSessionsJson);
+
+    // frame_group_dicts is fully present under rawJson even though the lazy
+    // object model reconstructs instance maps from empty labeledFrames.
+    const raw = lazy.sessions[0].rawJson!;
+    expect(Array.isArray(raw.frame_group_dicts)).toBe(true);
+    expect((raw.frame_group_dicts as unknown[]).length).toBeGreaterThan(0);
+  });
+
+  it("streaming read populates identical rawJson (or documents Worker gating)", async () => {
+    const eager = await readSlp(MULTIVIEW, { openVideos: false });
+    if (!(await streamingWorks())) {
+      // Worker path unreachable in this Node runtime (importScripts absent).
+      // The eager/lazy assertions above pin the contract the streaming loop
+      // (readSessionsStreaming, wired identically) is written to reproduce.
+      return;
+    }
+    const streamed = await readSlpStreaming(
+      new Uint8Array(readFileSync(MULTIVIEW)).buffer as ArrayBuffer,
+      { openVideos: false, filenameHint: "multiview.slp" },
+    );
+    expect(streamed.sessions.length).toBe(eager.sessions.length);
+    for (let i = 0; i < streamed.sessions.length; i++) {
+      expect(streamed.sessions[i].rawJson).toEqual(eager.rawSessionsJson[i]);
+    }
+  });
+
+  it("streaming session-read wiring is exercised Worker-free (readSessionsStreaming)", async () => {
+    // `readSlpStreaming` is Worker-gated and unreachable in Node, so drive the
+    // internal session-read loop directly with a fake StreamingH5File. This
+    // pins the exact lines LUCID's streaming import (issue #197) depends on.
+    const source = {
+      calibration: {
+        metadata: { rig: "A" },
+        "0": { name: "c0", rotation: [0, 0, 0], translation: [0, 0, 0] },
+        "1": { name: "c1", rotation: [0, 0, 0], translation: [1, 0, 0] },
+      },
+      camcorder_to_video_idx_map: { "0": 0, "1": 1 },
+      camcorder_to_lf_and_inst_idx_map: { "0": [3, 1] },
+      frame_group_dicts: [{ frame_idx: 0, instance_groups: [] }],
+      metadata: { lucid: { sessionName: "s", trustTracks: true } },
+    };
+    const fakeFile = {
+      keys: () => ["sessions_json"],
+      getDatasetValue: async (name: string) =>
+        name === "sessions_json"
+          ? { value: [JSON.stringify(source)] }
+          : { value: [] },
+    } as unknown as Parameters<typeof readSessionsStreaming>[0];
+
+    const sessions = await readSessionsStreaming(
+      fakeFile,
+      [],
+      [],
+      [],
+      undefined,
+    );
+    expect(sessions).toHaveLength(1);
+    const s = sessions[0];
+
+    // rawJson is the verbatim, full-fidelity parsed dict (incl. the unmodeled
+    // camcorder_to_lf_and_inst_idx_map key), matching the eager contract.
+    expect(s.rawJson).toEqual(source);
+    // Option-1 gap fix mirrored on the streaming path: cameraGroup.metadata.
+    expect(s.cameraGroup.metadata).toEqual({ rig: "A" });
+    // Deep-cloned snapshot: no shared refs with the object model.
+    expect(s.rawJson).not.toBe(source);
+    expect(s.metadata).not.toBe(s.rawJson!.metadata);
+  });
+
+  it("rawJson is an independent snapshot of the object model (no shared refs)", async () => {
+    // Build a session carrying nested metadata at every level, save, and re-read
+    // so rawJson is populated from disk — the LUCID round-trip scenario.
+    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } =
+      await import("../src/model/camera.js");
+    const { Instance } = await import("../src/model/instance.js");
+    const { Skeleton } = await import("../src/model/skeleton.js");
+    const { Video } = await import("../src/model/video.js");
+    const { Labels } = await import("../src/model/labels.js");
+    const { LabeledFrame } = await import("../src/model/labeled-frame.js");
+
+    const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
+    const video = new Video({ filename: "v.mp4" });
+    const cam = new Camera({ name: "cam", rvec: [0, 0, 0], tvec: [0, 0, 0] });
+    const inst = Instance.fromArray([[1, 2]], skeleton);
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const ig = new InstanceGroup({
+      instanceByCamera: new Map([[cam, inst]]),
+      metadata: { note: { deep: 1 } },
+    });
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [ig],
+      labeledFrameByCamera: new Map([[cam, lf]]),
+      metadata: { fgKey: { deep: 2 } },
+    });
+    const cameraGroup = new CameraGroup({
+      cameras: [cam],
+      metadata: { rig: "A" },
+    });
+    const session = new RecordingSession({
+      cameraGroup,
+      metadata: { lucid: { trustTracks: true } },
+    });
+    session.addVideo(video, cam);
+    session.frameGroups.set(0, fg);
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
+
+    const bytes = new Uint8Array(await saveSlpToBytes(labels));
+    const reloaded = await readSlp(bytes.buffer as ArrayBuffer, {
+      openVideos: false,
+    });
+    const s = reloaded.sessions[0];
+    const raw = s.rawJson as Record<string, unknown>;
+    const rawMeta = raw.metadata as { lucid: { trustTracks: unknown } };
+
+    // Distinct object identities between model and the raw snapshot.
+    expect(s.metadata).not.toBe(raw.metadata);
+    expect((s.metadata as { lucid: unknown }).lucid).not.toBe(rawMeta.lucid);
+
+    // Mutating rawJson does NOT change what the model writes to disk.
+    rawMeta.lucid.trustTracks = false;
+    expect(
+      (s.metadata as { lucid: { trustTracks: unknown } }).lucid.trustTracks,
+    ).toBe(true);
+
+    // Mutating the model does NOT change the as-read rawJson snapshot.
+    (s.metadata as { lucid: { trustTracks: unknown } }).lucid.trustTracks =
+      "edited";
+    expect(rawMeta.lucid.trustTracks).toBe(false);
+  });
+
+  it("rawJson never leaks into provenance and is not double-written", async () => {
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+
+    // Baseline write (before touching rawJson).
+    const before = await inspectSessions(
+      new Uint8Array(await saveSlpToBytes(labels)),
+    );
+
+    // Poison rawJson with a marker; leave provenance untouched.
+    labels.sessions[0].rawJson = {
+      __marker__: true,
+      huge: "x".repeat(1000),
+    };
+
+    const after = await inspectSessions(
+      new Uint8Array(await saveSlpToBytes(labels)),
+    );
+
+    // serializeSession ignores rawJson: the marker never reaches sessions_json.
+    expect(JSON.stringify(after.sessionsJson)).not.toContain("__marker__");
+    // writeMetadata serializes only provenance: no bloat, byte-unchanged.
+    expect(after.metadataJson).not.toContain("__marker__");
+    expect(after.metadataJson).toBe(before.metadataJson);
+    // The rebuilt sessions_json payload is identical before/after.
+    expect(after.sessionsJson).toEqual(before.sessionsJson);
+  });
+
+  it("rawJson deep-copies on Labels.copy() and getter stays index-aligned", async () => {
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const copy = labels.copy();
+
+    // Mutating the original's rawJson must not affect the copy (structuredClone,
+    // no aliasing).
+    (labels.sessions[0].rawJson as Record<string, unknown>).__mutated__ = true;
+    expect(Object.hasOwn(copy.sessions[0].rawJson!, "__mutated__")).toBe(false);
+
+    // In-memory sessions (no rawJson) yield undefined, index-aligned.
+    const { RecordingSession } = await import("../src/model/camera.js");
+    const { Labels } = await import("../src/model/labels.js");
+    const synthetic = new Labels({ sessions: [new RecordingSession()] });
+    expect(synthetic.rawSessionsJson).toEqual([undefined]);
+    expect(synthetic.rawSessionsJson.length).toBe(synthetic.sessions.length);
+  });
+
+  it("Option 3 lossless: stringified-int camera keys survive when cameras are unnamed", async () => {
+    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } =
+      await import("../src/model/camera.js");
+    const { Instance } = await import("../src/model/instance.js");
+    const { Skeleton } = await import("../src/model/skeleton.js");
+    const { Video } = await import("../src/model/video.js");
+    const { Labels } = await import("../src/model/labels.js");
+    const { LabeledFrame } = await import("../src/model/labeled-frame.js");
+
+    const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
+    const v0 = new Video({ filename: "v0.mp4" });
+    const v1 = new Video({ filename: "v1.mp4" });
+    // Cameras with NO explicit name -> keys should serialize as "0","1".
+    const c0 = new Camera({ rvec: [0, 0, 0], tvec: [0, 0, 0] });
+    const c1 = new Camera({ rvec: [0, 0, 0], tvec: [1, 0, 0] });
+    const i0 = Instance.fromArray([[1, 2]], skeleton);
+    const i1 = Instance.fromArray([[3, 4]], skeleton);
+    const lf0 = new LabeledFrame({ video: v0, frameIdx: 0, instances: [i0] });
+    const lf1 = new LabeledFrame({ video: v1, frameIdx: 0, instances: [i1] });
+    const ibc = new Map([
+      [c0, i0],
+      [c1, i1],
+    ]);
+    const lfbc = new Map([
+      [c0, lf0],
+      [c1, lf1],
+    ]);
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera: ibc })],
+      labeledFrameByCamera: lfbc,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [c0, c1] }),
+    });
+    session.addVideo(v0, c0);
+    session.addVideo(v1, c1);
+    session.frameGroups.set(0, fg);
+    const labels = new Labels({
+      labeledFrames: [lf0, lf1],
+      videos: [v0, v1],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
+
+    const bytes = new Uint8Array(await saveSlpToBytes(labels));
+    const { sessionsJson } = await inspectSessions(bytes);
+    const s0 = sessionsJson[0];
+    const calibKeys = Object.keys(
+      s0.calibration as Record<string, unknown>,
+    ).filter((k) => k !== "metadata");
+    expect(calibKeys.sort()).toEqual(["0", "1"]);
+    expect(
+      Object.keys(
+        s0.camcorder_to_video_idx_map as Record<string, unknown>,
+      ).sort(),
+    ).toEqual(["0", "1"]);
+
+    // resolveCameraKey semantics: re-read maps decimal keys back to cameras.
+    const reloaded = await readSlp(bytes.buffer as ArrayBuffer, {
+      openVideos: false,
+    });
+    expect(reloaded.sessions[0].videoByCamera.size).toBe(2);
+  });
+
+  it("Option 3 known-limitation: unmodeled structural keys dropped on write, recoverable via rawJson", async () => {
+    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } =
+      await import("../src/model/camera.js");
+    const { Instance } = await import("../src/model/instance.js");
+    const { Skeleton } = await import("../src/model/skeleton.js");
+    const { Video } = await import("../src/model/video.js");
+    const { Labels } = await import("../src/model/labels.js");
+    const { LabeledFrame } = await import("../src/model/labeled-frame.js");
+
+    const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
+    const video = new Video({ filename: "v.mp4" });
+    const cam = new Camera({ name: "cam", rvec: [0, 0, 0], tvec: [0, 0, 0] });
+    const inst = Instance.fromArray([[1, 2]], skeleton);
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const ibc = new Map([[cam, inst]]);
+    const lfbc = new Map([[cam, lf]]);
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera: ibc })],
+      labeledFrameByCamera: lfbc,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam] }),
+    });
+    session.addVideo(video, cam);
+    session.frameGroups.set(0, fg);
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
+
+    // Simulate an as-read raw dict carrying an unmodeled top-level structural
+    // key that is NOT under a `metadata` sub-dict.
+    session.rawJson = {
+      calibration: { cam: { name: "cam" } },
+      camcorder_to_video_idx_map: { cam: 0 },
+      camcorder_to_lf_and_inst_idx_map: { "0": [7, 3] }, // re-derived on write
+      frame_group_dicts: [{ frame_idx: 0, instance_groups: [] }],
+      unmodeled_top_level_key: { app: "lucid", answer: 42 },
+    };
+
+    const bytes = new Uint8Array(await saveSlpToBytes(labels));
+    const { sessionsJson } = await inspectSessions(bytes);
+    const written = sessionsJson[0];
+
+    // KNOWN LIMITATION (documented, not fixed): the fixed-shape serializer drops
+    // unmodeled top-level keys and re-derives camcorder_to_lf_and_inst_idx_map.
+    expect(Object.hasOwn(written, "unmodeled_top_level_key")).toBe(false);
+    // The write emits its own top-level shape (no verbatim echo of the source).
+    expect(Object.keys(written).sort()).toEqual([
+      "calibration",
+      "camcorder_to_video_idx_map",
+      "frame_group_dicts",
+      "metadata",
+    ]);
+
+    // FIDELITY GUARANTEE is Option 2 (rawJson), not the object-model write:
+    // the ORIGINAL dict is still fully recoverable in-memory.
+    expect(session.rawJson.unmodeled_top_level_key).toEqual({
+      app: "lucid",
+      answer: 42,
+    });
+    expect(session.rawJson.camcorder_to_lf_and_inst_idx_map).toEqual({
+      "0": [7, 3],
+    });
+  });
+});

--- a/tests/slp-sessions-lazy-lossless.test.ts
+++ b/tests/slp-sessions-lazy-lossless.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Lossless, lazy-native recording sessions (issue #197).
+ *
+ * Verifies the model faithfully round-trips cross-camera grouping via as-read
+ * index refs (no rawJson needed), that the lazy reader serializes grouping with
+ * ZERO frame materialization, that the written shape matches Python `sleap-io`
+ * (calibration keyed `cam_N`, camcorder maps keyed by integer index, no
+ * format_id bump), that legacy files re-save to that canonical shape, that a
+ * mutation reached via `instanceByCamera` alone still derives correct indices,
+ * that `Labels.copy()` preserves the typed session model, and that eager / lazy
+ * / (Worker-free) streaming reads all produce the same sessions_json.
+ */
+import { describe, it, expect } from "./bun-test";
+import { readSlp, readSlpLazy } from "../src/codecs/slp/read.js";
+import { readSessionsStreaming } from "../src/codecs/slp/read-streaming.js";
+import { saveSlpToBytes } from "../src/codecs/slp/write.js";
+import { Labels } from "../src/model/labels.js";
+import { injectSessionFrameResolver } from "../src/model/camera.js";
+import { ready, File as H5File } from "h5wasm/node";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
+const MULTIVIEW = path.join(fixtureRoot, "slp", "multiview.slp");
+
+/** Read the raw sessions_json entries and format_id via a fresh h5wasm open. */
+async function inspect(bytes: Uint8Array): Promise<{
+  sessionsJson: Array<Record<string, unknown>>;
+  formatId: number;
+}> {
+  const module = await ready;
+  const p = `/tmp/lossless_${Date.now()}_${Math.random()
+    .toString(16)
+    .slice(2)}.slp`;
+  module.FS.writeFile(p, bytes);
+  const file = new H5File(p, "r");
+  try {
+    const keys = file.keys() as string[];
+    const sessionsJson = keys.includes("sessions_json")
+      ? (file.get("sessions_json") as { value: string[] }).value.map((s) =>
+          JSON.parse(s),
+        )
+      : [];
+    const meta = file.get("metadata") as {
+      attrs: Record<string, { value?: unknown }>;
+    };
+    const formatId = Number(
+      (meta.attrs.format_id as { value?: unknown })?.value ??
+        meta.attrs.format_id,
+    );
+    return { sessionsJson, formatId };
+  } finally {
+    file.close();
+    module.FS.unlink(p);
+  }
+}
+
+/** The verbatim on-disk sessions_json string of the multiview fixture. */
+async function fixtureSessionsJson(): Promise<string> {
+  const module = await ready;
+  const p = `/tmp/mvsrc_${Date.now()}.slp`;
+  module.FS.writeFile(p, readFileSync(MULTIVIEW));
+  const file = new H5File(p, "r");
+  try {
+    return (file.get("sessions_json") as { value: string[] }).value[0];
+  } finally {
+    file.close();
+    module.FS.unlink(p);
+  }
+}
+
+describe("Lossless lazy-native sessions (#197)", () => {
+  it("byte-stable canonical grouping round-trip (eager)", async () => {
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const firstBytes = new Uint8Array(await saveSlpToBytes(labels));
+    const first = await inspect(firstBytes);
+
+    // Re-read the canonical bytes and save again — must be byte-stable.
+    const reloaded = await readSlp(firstBytes.buffer as ArrayBuffer, {
+      openVideos: false,
+    });
+    const second = await inspect(
+      new Uint8Array(await saveSlpToBytes(reloaded)),
+    );
+
+    expect(second.sessionsJson).toEqual(first.sessionsJson);
+    // Grouping survived: a non-empty camcorder map is present.
+    const fg = (first.sessionsJson[0].frame_group_dicts as any[])[0];
+    const ig = fg.instance_groups[0];
+    expect(Object.keys(ig.camcorder_to_lf_and_inst_idx_map).length).toBe(8);
+  });
+
+  it("eager, lazy, and streaming reads produce identical canonical sessions_json", async () => {
+    const eager = await readSlp(MULTIVIEW, { openVideos: false });
+    const eagerJson = (
+      await inspect(new Uint8Array(await saveSlpToBytes(eager)))
+    ).sessionsJson;
+
+    const lazy = await readSlpLazy(MULTIVIEW, { openVideos: false });
+    const lazyJson = (await inspect(new Uint8Array(await saveSlpToBytes(lazy))))
+      .sessionsJson;
+    expect(lazyJson).toEqual(eagerJson);
+
+    // Worker-free streaming: drive readSessionsStreaming with the fixture's raw
+    // sessions_json, wrap the parsed sessions in a Labels with the eager frame
+    // table, inject the resolver, and serialize.
+    const rawSessions = await fixtureSessionsJson();
+    const fakeFile = {
+      keys: () => ["sessions_json"],
+      getDatasetValue: async (name: string) =>
+        name === "sessions_json" ? { value: [rawSessions] } : { value: [] },
+    } as unknown as Parameters<typeof readSessionsStreaming>[0];
+    const streamedSessions = await readSessionsStreaming(
+      fakeFile,
+      eager.videos,
+      eager.skeletons,
+      undefined,
+    );
+    const streamedLabels = new Labels({
+      labeledFrames: eager.labeledFrames,
+      videos: eager.videos,
+      skeletons: eager.skeletons,
+      sessions: streamedSessions,
+    });
+    injectSessionFrameResolver(streamedLabels);
+    const streamedJson = (
+      await inspect(new Uint8Array(await saveSlpToBytes(streamedLabels)))
+    ).sessionsJson;
+    expect(streamedJson).toEqual(eagerJson);
+  });
+
+  it("NO frame materialization when serializing lazy sessions", async () => {
+    const labels = await readSlpLazy(MULTIVIEW, { openVideos: false });
+    expect(labels._lazyFrameList).not.toBeNull();
+    expect(labels._lazyFrameList!.materializedCount).toBe(0);
+
+    const bytes = new Uint8Array(await saveSlpToBytes(labels));
+
+    // Grouping never forced a single frame to materialize.
+    expect(labels._lazyFrameList!.materializedCount).toBe(0);
+
+    // ...yet the full camcorder grouping map survived to disk.
+    const { sessionsJson } = await inspect(bytes);
+    const fg = (sessionsJson[0].frame_group_dicts as any[])[0];
+    const ig = fg.instance_groups[0];
+    expect(Object.keys(ig.camcorder_to_lf_and_inst_idx_map).length).toBe(8);
+    // Pure-ref group: no inline `instances` (Python-canonical shape).
+    expect(Object.hasOwn(ig, "instances")).toBe(false);
+  });
+
+  it("writes Python-canonical cam_N calibration keys + integer camcorder maps", async () => {
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const { sessionsJson, formatId } = await inspect(
+      new Uint8Array(await saveSlpToBytes(labels)),
+    );
+    // Sessions do NOT bump format_id — the canonical shape is a convergence to
+    // Python's existing format, not a new on-disk feature (Python already owns
+    // 2.5+).
+    expect(formatId).toBeLessThan(2.5);
+
+    const s0 = sessionsJson[0];
+    const calib = s0.calibration as Record<string, Record<string, unknown>>;
+    const calibKeys = Object.keys(calib).filter((k) => k !== "metadata");
+    // Calibration keyed `cam_0`..`cam_7` (Python `camera_group_to_dict` parity),
+    // each camera dict keeping its `name`.
+    expect(
+      calibKeys.sort((a, b) => Number(a.slice(4)) - Number(b.slice(4))),
+    ).toEqual([
+      "cam_0",
+      "cam_1",
+      "cam_2",
+      "cam_3",
+      "cam_4",
+      "cam_5",
+      "cam_6",
+      "cam_7",
+    ]);
+    for (const k of calibKeys) {
+      expect(k).toMatch(/^cam_\d+$/);
+      expect(typeof calib[k].name).toBe("string");
+    }
+    // camcorder_to_video_idx_map keys are bare integer indices (Python parity),
+    // a DIFFERENT key space than calibration — both resolve by camera order.
+    for (const k of Object.keys(
+      s0.camcorder_to_video_idx_map as Record<string, unknown>,
+    )) {
+      expect(k).toMatch(/^\d+$/);
+    }
+    // camcorder pairs are NUMBERS (upgraded from the legacy string pairs).
+    const fg = (s0.frame_group_dicts as any[])[0];
+    const pair = Object.values(
+      fg.instance_groups[0].camcorder_to_lf_and_inst_idx_map,
+    )[0] as unknown[];
+    expect(typeof pair[0]).toBe("number");
+    expect(typeof pair[1]).toBe("number");
+  });
+
+  it("legacy file re-saves to the canonical Python shape (converter)", async () => {
+    // The fixture is format 1.2 with cam_N-keyed calibration and STRING ref
+    // pairs and no labeled_frame_by_camera.
+    const src = await inspect(readFileSync(MULTIVIEW));
+    expect(src.formatId).toBeCloseTo(1.2);
+    const srcCalibKeys = Object.keys(
+      src.sessionsJson[0].calibration as Record<string, unknown>,
+    ).filter((k) => k !== "metadata");
+    expect(srcCalibKeys[0]).toBe("cam_0");
+    // Source stores ref pairs as STRINGS (legacy shape).
+    const srcPair = Object.values(
+      (src.sessionsJson[0].frame_group_dicts as any[])[0].instance_groups[0]
+        .camcorder_to_lf_and_inst_idx_map,
+    )[0] as unknown[];
+    expect(typeof srcPair[0]).toBe("string");
+
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const bytes = new Uint8Array(await saveSlpToBytes(labels));
+    const out = await inspect(bytes);
+
+    // No format bump (convergence to Python's shape, not a new feature)...
+    expect(out.formatId).toBeLessThan(2.5);
+    // ...calibration stays cam_N (Python parity, unchanged from source)...
+    const calibKeys = Object.keys(
+      out.sessionsJson[0].calibration as Record<string, unknown>,
+    ).filter((k) => k !== "metadata");
+    expect(calibKeys.every((k) => /^cam_\d+$/.test(k))).toBe(true);
+    // ...and the legacy STRING ref pairs are normalized to NUMBERS.
+    const outPair = Object.values(
+      (out.sessionsJson[0].frame_group_dicts as any[])[0].instance_groups[0]
+        .camcorder_to_lf_and_inst_idx_map,
+    )[0] as unknown[];
+    expect(typeof outPair[0]).toBe("number");
+
+    // Reloading the upgraded file yields the same grouping sizes as the source.
+    const reloaded = await readSlp(bytes.buffer as ArrayBuffer, {
+      openVideos: false,
+    });
+    const srcFg = labels.sessions[0].frameGroups.get(0)!;
+    const outFg = reloaded.sessions[0].frameGroups.get(0)!;
+    expect(outFg.instanceGroups.length).toBe(srcFg.instanceGroups.length);
+    expect(outFg.instanceGroups[0].instanceByCamera.size).toBe(
+      srcFg.instanceGroups[0].instanceByCamera.size,
+    );
+    expect(outFg.labeledFrameByCamera.size).toBe(
+      srcFg.labeledFrameByCamera.size,
+    );
+  });
+
+  it("mutation is reflected: accessing + editing a group emits concrete points", async () => {
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const fg = labels.sessions[0].frameGroups.get(0)!;
+    const ig = fg.instanceGroups[0];
+
+    // Force concrete resolution (caches _instanceByCamera and, via the frame
+    // group, _labeledFrameByCamera) so the write takes the object-derivation path.
+    const [[camera, instance]] = fg.labeledFrameByCamera; // materialize frame map
+    void camera;
+    void instance;
+    const [firstCam, firstInst] = [...ig.instanceByCamera][0];
+    // Mutate a point coordinate to a sentinel value.
+    firstInst.points[0].xy = [12345, 67890];
+
+    const { sessionsJson } = await inspect(
+      new Uint8Array(await saveSlpToBytes(labels)),
+    );
+    const outIg = (sessionsJson[0].frame_group_dicts as any[])[0]
+      .instance_groups[0];
+    // Concrete group now emits inline `instances` points including the mutation.
+    expect(outIg.instances).toBeDefined();
+    const flat = JSON.stringify(outIg.instances);
+    expect(flat).toContain("12345");
+    expect(flat).toContain("67890");
+    // A camcorder pair still exists for the mutated camera (derive-first).
+    expect(
+      Object.keys(outIg.camcorder_to_lf_and_inst_idx_map).length,
+    ).toBeGreaterThan(0);
+    void firstCam;
+  });
+
+  it("mutation via instanceByCamera alone (no frame-map access) derives the correct index", async () => {
+    // Reviewer repro: reach the mutation through ONLY the instance group's map —
+    // never touching fg.labeledFrameByCamera — then shift the instance's index.
+    // The written camcorder pair must reflect the NEW index (derive-first via the
+    // frame-group GETTER), not the stale as-read ref.
+    const { Instance } = await import("../src/model/instance.js");
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const session = labels.sessions[0];
+    const fg = session.frameGroups.get(0)!;
+    const ig = fg.instanceGroups[0];
+
+    const [camera, instance] = [...ig.instanceByCamera][0];
+    const lf = labels.labeledFrames.find((f) =>
+      f.instances.includes(instance),
+    )!;
+    const nodeCount = instance.skeleton.nodeNames.length;
+    const sentinel = Instance.fromArray(
+      Array.from({ length: nodeCount }, () => [0, 0]),
+      instance.skeleton,
+    );
+    lf.instances.unshift(sentinel); // shifts `instance` one slot later
+    const expectedLfIdx = labels.labeledFrames.indexOf(lf);
+    const expectedInstIdx = lf.instances.indexOf(instance);
+
+    const { sessionsJson } = await inspect(
+      new Uint8Array(await saveSlpToBytes(labels)),
+    );
+    const outIg = (sessionsJson[0].frame_group_dicts as any[])[0]
+      .instance_groups[0];
+    const cameraKey = String(session.cameraGroup.cameras.indexOf(camera));
+    expect(outIg.camcorder_to_lf_and_inst_idx_map[cameraKey]).toEqual([
+      expectedLfIdx,
+      expectedInstIdx,
+    ]);
+  });
+
+  it("Labels.copy() preserves the typed session model and re-saves byte-identically", async () => {
+    const labels = await readSlp(MULTIVIEW, { openVideos: false });
+    const copy = labels.copy();
+
+    // Prototypes survived: the grouping getters work on the copy.
+    const cfg = copy.sessions[0].frameGroups.get(0)!;
+    expect(cfg.instanceGroups.length).toBeGreaterThan(0);
+    const origSize =
+      labels.sessions[0].frameGroups.get(0)!.instanceGroups[0].instanceByCamera
+        .size;
+    expect(cfg.instanceGroups[0].instanceByCamera.size).toBe(origSize);
+    expect(origSize).toBeGreaterThan(0);
+
+    // The copy re-saves to the same sessions_json as the original (ref-backed
+    // grouping re-resolved against the copy's own frames).
+    const origBytes = new Uint8Array(await saveSlpToBytes(labels));
+    const copyBytes = new Uint8Array(await saveSlpToBytes(copy));
+    const orig = await inspect(origBytes);
+    const out = await inspect(copyBytes);
+    expect(out.sessionsJson).toEqual(orig.sessionsJson);
+  });
+
+  it("in-memory construction still exposes concrete maps (no refs needed)", async () => {
+    const { Camera, CameraGroup, InstanceGroup, FrameGroup } = await import(
+      "../src/model/camera.js"
+    );
+    const { Instance } = await import("../src/model/instance.js");
+    const { Skeleton } = await import("../src/model/skeleton.js");
+    const { LabeledFrame } = await import("../src/model/labeled-frame.js");
+    const { Video } = await import("../src/model/video.js");
+
+    const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
+    const video = new Video({ filename: "v.mp4" });
+    const cam = new Camera({ name: "cam", rvec: [0, 0, 0], tvec: [0, 0, 0] });
+    const inst = Instance.fromArray([[1, 2]], skeleton);
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    void CameraGroup;
+
+    const ig = new InstanceGroup({
+      instanceByCamera: new Map([[cam, inst]]),
+    });
+    expect(ig.instanceByCamera.size).toBe(1);
+    expect(ig.instances).toHaveLength(1);
+
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [ig],
+      labeledFrameByCamera: new Map([[cam, lf]]),
+    });
+    expect(fg.labeledFrameByCamera.size).toBe(1);
+    expect(fg.cameras).toHaveLength(1);
+    expect(fg.getFrame(cam)).toBe(lf);
+  });
+});

--- a/tests/slp-write-3d.test.ts
+++ b/tests/slp-write-3d.test.ts
@@ -316,4 +316,59 @@ describe("SLP write with identity and 3D data", () => {
 
     expect(loaded.sessions[0].cameraGroup.cameras[0].size).toEqual([640, 480]);
   });
+
+  it("Option 1 gap fix: cameraGroup.metadata now round-trips (eager + streaming)", async () => {
+    const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
+    const video = new Video({ filename: "v.mp4" });
+    const cam = new Camera({ name: "cam", rvec: [0, 0, 0], tvec: [0, 0, 0] });
+    const inst = Instance.fromArray([[1, 2]], skeleton);
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const instanceByCamera = new Map<Camera, Instance>();
+    instanceByCamera.set(cam, inst);
+    const lfByCamera = new Map<Camera, LabeledFrame>();
+    lfByCamera.set(cam, lf);
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [new InstanceGroup({ instanceByCamera })],
+      labeledFrameByCamera: lfByCamera,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam] }),
+    });
+    // Previously dropped on read (read back as {}); now preserved.
+    session.cameraGroup.metadata = { foo: 1, nested: { a: [2, 3] } };
+    session.addVideo(video, cam);
+    session.frameGroups.set(0, fg);
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
+
+    const bytes = new Uint8Array(await saveSlpToBytes(labels));
+
+    const eager = await readSlp(bytes.buffer, { openVideos: false });
+    expect(eager.sessions[0].cameraGroup.metadata).toEqual({
+      foo: 1,
+      nested: { a: [2, 3] },
+    });
+
+    // Streaming path (guarded: Worker unavailable in the Node suite).
+    const { readSlpStreaming } = await import(
+      "../src/codecs/slp/read-streaming.js"
+    );
+    try {
+      const streamed = await readSlpStreaming(bytes.buffer as ArrayBuffer, {
+        openVideos: false,
+        filenameHint: "cam-group-meta.slp",
+      });
+      expect(streamed.sessions[0].cameraGroup.metadata).toEqual({
+        foo: 1,
+        nested: { a: [2, 3] },
+      });
+    } catch {
+      // In-Worker streaming path unreachable here; eager assertion holds.
+    }
+  });
 });

--- a/tests/slp-write-3d.test.ts
+++ b/tests/slp-write-3d.test.ts
@@ -169,17 +169,23 @@ describe("SLP write with identity and 3D data", () => {
     expect(pred.pointScores).toEqual([0.95, 0.88]);
   });
 
-  it("sets format version to 1.9 when identities are present", async () => {
+  it("does not bump format_id for sessions (converges to the Python shape, no new version)", async () => {
+    // The canonical sessions_json shape is a convergence to Python `sleap-io`'s
+    // existing format, not a new on-disk feature, so writing sessions must NOT
+    // mint a format_id. `format_id` is a namespace shared with Python, which
+    // already defines 2.5 (/identity_links), 2.6 (/embeddings), 2.7 (categories).
     const labels = makeTestLabels({ withIdentity: true });
+    expect(labels.sessions.length).toBeGreaterThan(0);
     const bytes = await saveSlpToBytes(labels);
-    // Read back and check format_id in metadata
     const { openH5File } = await import("../src/codecs/slp/h5.js");
     const { file, close } = await openH5File(new Uint8Array(bytes).buffer);
     try {
       const metadataGroup = file.get("metadata");
       const attrs = (metadataGroup as any).attrs ?? {};
       const formatId = Number(attrs["format_id"]?.value ?? attrs["format_id"]);
+      // Identities present -> 1.9 bump; sessions add nothing on top of that.
       expect(formatId).toBeCloseTo(1.9);
+      expect(formatId).toBeLessThan(2.5);
     } finally {
       close();
     }

--- a/tests/streaming-sessions.test.ts
+++ b/tests/streaming-sessions.test.ts
@@ -164,4 +164,93 @@ describe("Streaming Sessions", () => {
     expect(loadedFg.instanceGroups[0].instanceByCamera.size).toBe(2);
     expect(loadedFg.labeledFrameByCamera.size).toBe(2);
   });
+
+  it("Option 1: nested metadata.lucid round-trips losslessly (session/frameGroup/instanceGroup)", async () => {
+    const { Camera, CameraGroup, InstanceGroup, FrameGroup, RecordingSession } =
+      await import("../src/model/camera.js");
+    const { Instance } = await import("../src/model/instance.js");
+    const { Skeleton } = await import("../src/model/skeleton.js");
+    const { Video } = await import("../src/model/video.js");
+    const { Labels } = await import("../src/model/labels.js");
+    const { LabeledFrame } = await import("../src/model/labeled-frame.js");
+    const { saveSlpToBytes } = await import("../src/codecs/slp/write.js");
+
+    const sessionMeta = {
+      lucid: {
+        sessionName: "s",
+        trustTracks: true,
+        frameIdentityMap: { "0": [1, 2] },
+        nested: { deep: [1, { a: "b" }] },
+        points3d: [[0, 1, 2]],
+      },
+    };
+    const frameGroupMeta = { lucid: { x: 1 } };
+    const instanceGroupMeta = { lucid: { y: 2 } };
+
+    const skeleton = new Skeleton({ nodes: ["A"], edges: [] });
+    const video = new Video({ filename: "v.mp4" });
+    const cam = new Camera({ name: "cam", rvec: [0, 0, 0], tvec: [0, 0, 0] });
+    const inst = Instance.fromArray([[1, 2]], skeleton);
+    const lf = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    const ibc = new Map([[cam, inst]]);
+    const lfbc = new Map([[cam, lf]]);
+    // One group carries metadata, a second carries empty {} (must be tolerated).
+    const fg = new FrameGroup({
+      frameIdx: 0,
+      instanceGroups: [
+        new InstanceGroup({
+          instanceByCamera: ibc,
+          metadata: instanceGroupMeta,
+        }),
+        new InstanceGroup({ instanceByCamera: new Map([[cam, inst]]) }),
+      ],
+      labeledFrameByCamera: lfbc,
+      metadata: frameGroupMeta,
+    });
+    const session = new RecordingSession({
+      cameraGroup: new CameraGroup({ cameras: [cam] }),
+      metadata: sessionMeta,
+    });
+    session.addVideo(video, cam);
+    session.frameGroups.set(0, fg);
+    const labels = new Labels({
+      labeledFrames: [lf],
+      videos: [video],
+      skeletons: [skeleton],
+      sessions: [session],
+    });
+
+    const bytes = new Uint8Array(await saveSlpToBytes(labels));
+
+    const assertRoundTrip = (loaded: InstanceType<typeof Labels>) => {
+      const s = loaded.sessions[0];
+      expect(s.metadata.lucid).toEqual(sessionMeta.lucid);
+      const loadedFg = s.frameGroups.get(0)!;
+      expect(loadedFg.metadata).toEqual(frameGroupMeta);
+      expect(loadedFg.instanceGroups[0].metadata).toEqual(instanceGroupMeta);
+      // Empty {} instanceGroup metadata is tolerated (read back as {}).
+      expect(loadedFg.instanceGroups[1].metadata).toEqual({});
+    };
+
+    // Eager path.
+    assertRoundTrip(
+      await readSlp(bytes.buffer as ArrayBuffer, {
+        openVideos: false,
+      }),
+    );
+
+    // Streaming path (guarded: Worker unavailable in the Node suite).
+    const { readSlpStreaming } = await import(
+      "../src/codecs/slp/read-streaming.js"
+    );
+    try {
+      const streamed = await readSlpStreaming(bytes.buffer as ArrayBuffer, {
+        openVideos: false,
+        filenameHint: "roundtrip.slp",
+      });
+      assertRoundTrip(streamed);
+    } catch {
+      // In-Worker streaming path unreachable here; eager assertion above holds.
+    }
+  });
 });


### PR DESCRIPTION
Closes #197.

## Why

luc3d/LUCID stores its multi-view/3D state inside the SLP `sessions_json` dataset and today **hand-parses it with raw h5wasm**, because sleap-io.js's object model was a *lossy, normalizing projection* of that data — most importantly, the cross-camera grouping came back **empty on the lazy/streaming reader** (the exact fast path LUCID wants for the #196 perf win). This PR makes the **model** faithful so consumers read typed objects and never touch raw dicts.

The first commit (`0dc8603`) added a verbatim `rawJson` escape hatch as an interim bridge. This was a smell (the model admitting it can't represent the data) and it doubled session memory in `Labels.copy()`. The second commit (`9fc33fa`) replaces it with a real fix and demotes `rawJson` to an opt-in transitional bridge.

## What changed

**Lossless, lazy-native grouping.** `InstanceGroup`/`FrameGroup` retain the as-read index refs (`camcorder_to_lf_and_inst_idx_map` / `labeled_frame_by_camera`) captured with **no frame materialization**. `instanceByCamera` / `labeledFrameByCamera` are now lazy getters that resolve refs on first access via an injected `_frameResolver` (`Labels.frameAt(i)` materializes only the touched frame) and cache. The resolver is injected into all three read paths after `Labels` is built.

**Hybrid write-back** (per the agreed fork): derive indices from live objects when a group was materialized/mutated (reflects reorders/edits), else fall back to the as-read refs. Result: an untouched lazy save is **byte-exact with zero frame materialization**, and the full grouping now survives a lazy save — previously it was silently lost.

**Python-canonical on-disk shape.** `sessions_json` now matches Python `sleap-io`'s `session_to_dict` byte-for-byte: `calibration` keyed `cam_0`, `cam_1`, …; `camcorder_to_video_idx_map` / `camcorder_to_lf_and_inst_idx_map` / `labeled_frame_by_camera` keyed by bare integer index. Both are resolved by camera **order** / positional index (the calibration key string is cosmetic), exactly as Python does.

**No `format_id` bump** (this reverses the "bump" half of the earlier plan — see Design decisions). Reading stays tolerant of legacy name-keyed calibration; re-saving upgrades in place (the "converter"). Also fixes `cameraGroup.metadata` being dropped on read.

**`Labels.copy()`** rebuilds sessions via constructors (+ re-injects the resolver) instead of `structuredClone`, which stripped class prototypes/getters and the resolver — a copied `Labels` now exposes working typed grouping and re-saves byte-identically. (This was pre-existing breakage, surfaced by the review.)

**`rawJson` → opt-in.** Gated behind `{ rawSessions: true }` (default off): no per-session clone and no `copy()` doubling by default. Deprecated; to be removed once LUCID migrates.

## Design decisions

- **Why no `format_id` bump?** `format_id` is a namespace shared with Python `sleap-io`, which is already at **2.7** (2.5 = `/identity_links`, 2.6 = `/embeddings`, 2.7 = categories) while sleap-io.js only implements through 2.4. Our change adds **no new on-disk construct** — it converges to Python's *existing* session shape — so minting a value here would collide and mislabel files. Verified directly against `sleap_io/io/slp.py` (`session_to_dict` / `make_session`).
- **Why `cam_N` keys?** Python keys `calibration` by `cam_<idx>` (`camera_group_to_dict`), not the camera name and not bare integers; the camcorder maps use bare integer index. We match both exactly. This is the "keep it upstreamable" goal.
- **Nothing to upstream to Python** for this change — it moves *toward* Python's format. (Separately: sleap-io.js is behind Python on format 2.5–2.7 read support — tracked out of band.)

## Testing

- New `tests/slp-sessions-lazy-lossless.test.ts`: byte-stable canonical round-trip (eager/lazy/Worker-free streaming produce identical `sessions_json`); **zero-materialization proof** (`_lazyFrameList.materializedCount === 0` across a lazy read+save while the full 8-entry camcorder map still reaches disk); `cam_N` calibration + integer camcorder keys; no `format_id` bump; legacy→canonical re-save (converter); **mutation via `instanceByCamera` alone derives the correct index** (adversarial-review repro); **`Labels.copy()` preserves the typed model + re-saves byte-identically**.
- Updated `slp-raw-sessions` / `slp-write-3d` for the canonical shape and opt-in `rawJson`.
- Full suite: **1880 pass, 0 new failures** (the 18 failures are pre-existing WebCodecs/Mp4Box env failures on `main`; the `tests/codecs/slp-crop*` Bun+h5wasm segfault is also pre-existing on `main`). Typecheck clean.

A companion handoff issue for LUCID's migration (drop raw-h5wasm; use `instance3d`/`Identity`/typed grouping) will be filed in `talmolab/luc3d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9wBrgT1wZbN92mv764jKq