### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump `0.4.1` → **`0.5.0`** for the next release.

**Why minor:** the 24 commits since v0.4.1 add substantial new API surface — two new format readers (COCO, DeepLabCut), a faithful lazy-native recording-session model, lazy `RangeSource` streaming, centroid rendering, SLEAP Analysis CSV export, remote-loading hardening, and read-path perf. All additive (no breaking changes), so per semver this is a minor bump.

Full categorized changelog is in the **v0.5.0 draft release**. Merge this, then publish the release (which triggers the npm publish workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9wBrgT1wZbN92mv764jKq