### PR TITLE
fix(video): evaluate Mp4BoxVideoBackend WebCodecs/browser probes lazily (#159)

### DIFF
--- a/src/video/mp4box-video.ts
+++ b/src/video/mp4box-video.ts
@@ -6,12 +6,24 @@ import {
   statusToMessage,
 } from "../io/remote.js";
 
-const isBrowser =
-  typeof window !== "undefined" && typeof document !== "undefined";
-const hasWebCodecs =
-  isBrowser &&
-  typeof window.VideoDecoder !== "undefined" &&
-  typeof window.EncodedVideoChunk !== "undefined";
+// Environment/capability probes, evaluated at call time rather than captured in
+// module-level consts. A module-level capture is frozen at first import, which
+// breaks under a shared module registry (e.g. bare `bun test`, where all files
+// share one process): if any earlier file imports this module before a test
+// installs its `window`/WebCodecs globals, the captured value is wrong and can
+// never refresh, because ESM caches the evaluated module body. Probing per call
+// keeps backend selection correct whenever the globals change after load — the
+// browser runtime never mutates them, but the tests do. See issue #159.
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof document !== "undefined";
+}
+function hasWebCodecs(): boolean {
+  return (
+    isBrowser() &&
+    typeof window.VideoDecoder !== "undefined" &&
+    typeof window.EncodedVideoChunk !== "undefined"
+  );
+}
 const MP4BOX_CDN = "https://unpkg.com/mp4box@0.5.4/dist/mp4box.all.min.js";
 
 async function loadMp4box(): Promise<any> {
@@ -22,7 +34,7 @@ async function loadMp4box(): Promise<any> {
     const module = await import("mp4box");
     return module.default ?? module;
   } catch {
-    if (!isBrowser || typeof document === "undefined") {
+    if (!isBrowser()) {
       throw new Error("Failed to load mp4box");
     }
     await new Promise<void>((resolve, reject) => {
@@ -86,10 +98,10 @@ export class Mp4BoxVideoBackend implements VideoBackend {
       headers?: Record<string, string>;
     },
   ) {
-    if (!hasWebCodecs) {
+    if (!hasWebCodecs()) {
       throw new Error("Mp4BoxVideoBackend requires WebCodecs support.");
     }
-    if (!isBrowser) {
+    if (!isBrowser()) {
       throw new Error("Mp4BoxVideoBackend requires a browser environment.");
     }
     this.filename =

--- a/tests/bun-test.ts
+++ b/tests/bun-test.ts
@@ -21,10 +21,11 @@
  *     does not revert it), so the real-WebM integration test would otherwise
  *     pick up the mocked `mediabunny`.
  *   - It makes `vi.resetModules()` a safe no-op: each file already starts from
- *     a clean registry, and the few tests that re-import a module per case set
- *     their globals in `beforeEach` before the first dynamic `import()`, so
- *     module-level environment captures (e.g. mp4box-video.ts's
- *     `isBrowser`/`hasWebCodecs`) are evaluated correctly.
+ *     a clean registry. Runtime capability probes that a test toggles via
+ *     globals (e.g. mp4box-video.ts's WebCodecs/`isBrowser` check) are evaluated
+ *     lazily at call time rather than captured in a module-level const, so they
+ *     read the current globals regardless of import order — keeping those tests
+ *     correct even under a shared registry (bare `bun test`). See issue #159.
  *   - Per-worker teardown also avoids a cumulative native-module teardown crash
  *     (skia-canvas + many h5wasm instances) seen when the whole suite shares a
  *     single process under plain `--isolate`.


### PR DESCRIPTION
## Summary

Fixes the test-isolation bug in #159: the 11 `Mp4BoxVideoBackend` tests failed in the full **bare** `bun test` suite (`error: Mp4BoxVideoBackend requires WebCodecs support.`) while passing in isolation.

**Root cause.** `src/video/mp4box-video.ts` captured `isBrowser`/`hasWebCodecs` in **module-level consts**, frozen at first import. Under a shared module registry (bare `bun test`, all files in one process), any file that imports this module before a test installs its fake `window`/WebCodecs globals freezes the value to `false`. ESM module caching then means the later per-test `await import()` returns the cached module body without re-evaluating it, so the constructor throws.

**Fix.** Make the probes lazy functions (`isBrowser()` / `hasWebCodecs()`) evaluated at call time, so backend selection reads the *current* globals regardless of import order. This is the issue's recommended option 1 — strictly more correct at runtime (the browser never mutates these, but the tests do), and it removes the fragility entirely. The now-stale explanatory comment in `tests/bun-test.ts` is updated to match.

`src/video/factory.ts` already computes its WebCodecs check locally per call, so no change was needed there.

## Verification

| Scenario | Before | After |
|---|---|---|
| bare `bun test ./tests/video/` | 11 mp4box "WebCodecs" failures | **0** mp4box failures |
| `bun test --parallel ./tests/` (CI command) | green | **1920 pass / 1 skip / 0 fail, exit 0** |
| `tsc -p tsconfig.json --noEmit` | — | clean |

The 3 remaining failures under *bare* `bun test ./tests/video/` are the pre-existing, separate `mediabunny` `mock.module` cross-file leak (confirmed by `mediabunny-integration.test.ts` passing 4/4 in isolation) — unrelated to this change and already prevented by `--parallel`/`--isolate`.

Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQDXxA9TYiC3aCtKWD7Eqn
