### PR TITLE
fix(slp): round-trip source_video lineage with shape (#160)

### DIFF
--- a/src/codecs/slp/parsers.ts
+++ b/src/codecs/slp/parsers.ts
@@ -363,8 +363,14 @@ export interface VideoMetadata {
   channelOrder?: string;
   /** Whether video is embedded in the SLP file */
   embedded: boolean;
-  /** Source video metadata if this is derived */
-  sourceVideo?: { filename: string };
+  /**
+   * Full serialized `source_video` lineage dict (`{ filename?, backend?,
+   * source_video? }`) when present in `videos_json` — reconstructed with its
+   * recorded shape via {@link buildSourceVideoFromDict}. Not the authoritative
+   * source for embedded videos (that lives in the `{group}/source_video` HDF5
+   * group); see the readers.
+   */
+  sourceVideo?: Record<string, unknown>;
 }
 
 /**
@@ -439,7 +445,7 @@ export function parseVideosMetadata(
       fps: backendMeta.fps as number | undefined,
       channelOrder: backendMeta.channel_order as string | undefined,
       embedded,
-      sourceVideo: parsed.source_video as { filename: string } | undefined,
+      sourceVideo: parsed.source_video as Record<string, unknown> | undefined,
     });
   }
 

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -28,6 +28,7 @@ import {
   reconstructInstance3D,
   resolveIdentity,
 } from "./parsers.js";
+import { buildSourceVideoFromDict } from "./source-video.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
 import {
@@ -390,6 +391,45 @@ export async function readVideoCropsStreaming(
 }
 
 /**
+ * Read a video's `source_video` metadata JSON from its `{group}/source_video`
+ * HDF5 group over the streaming worker, or `null` when absent. Checks a `json`
+ * *dataset* first (oversized metadata) then the `json` *attribute* (normal
+ * case), mirroring the sync reader and Python `_read_source_video_json`.
+ */
+export async function readSourceVideoGroupJsonStreaming(
+  file: Pick<StreamingH5File, "getKeys" | "getAttrs" | "getDatasetValue">,
+  groupPath: string,
+): Promise<Record<string, unknown> | null> {
+  const svPath = `${groupPath}/source_video`;
+  let raw: string | undefined;
+  try {
+    const keys = await file.getKeys(svPath);
+    if (keys.includes("json")) {
+      const { value } = await file.getDatasetValue(`${svPath}/json`);
+      if (typeof value === "string") raw = value;
+      else if (value instanceof Uint8Array)
+        raw = new TextDecoder().decode(value);
+      else if (Array.isArray(value) && value.length > 0) raw = String(value[0]);
+    }
+    if (raw === undefined) {
+      const attrs = await file.getAttrs(svPath);
+      raw = attrToString(attrs.json);
+    }
+  } catch {
+    return null;
+  }
+  if (raw === undefined) return null;
+  try {
+    return JSON.parse(raw.trim().replace(/\0+$/, "")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read video metadata from videos_json dataset.
  * When openVideos is true, creates StreamingHdf5VideoBackend for embedded videos.
  */
@@ -569,14 +609,28 @@ async function readVideosStreaming(
         backendMetadata.crop_fill = cropEntry.fill;
       }
 
+      // Reconstruct the source_video lineage WITH its recorded shape (and any
+      // deeper chain), preferring the authoritative `{group}/source_video` HDF5
+      // group for embedded videos and falling back to the nested videos_json
+      // dict — parity with the eager reader (read.ts) for #160.
+      let sourceVideo: Video | null = null;
+      if (meta.embedded && datasetPath) {
+        const groupPath = datasetPath.endsWith("/video")
+          ? datasetPath.slice(0, -6)
+          : datasetPath;
+        const svDict = await readSourceVideoGroupJsonStreaming(file, groupPath);
+        if (svDict) sourceVideo = buildSourceVideoFromDict(svDict, labelsPath);
+      }
+      if (!sourceVideo && meta.sourceVideo) {
+        sourceVideo = buildSourceVideoFromDict(meta.sourceVideo, labelsPath);
+      }
+
       videos.push(
         new Video({
           filename: meta.filename,
           backend: videoBackend,
           backendMetadata,
-          sourceVideo: meta.sourceVideo
-            ? new Video({ filename: meta.sourceVideo.filename })
-            : null,
+          sourceVideo,
           openBackend: openVideos && meta.embedded,
           embedded: meta.embedded,
         }),

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -16,6 +16,7 @@ import {
   resolveIdentity,
   resolveVideoFilename,
 } from "./parsers.js";
+import { buildSourceVideoFromDict } from "./source-video.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
 import { Instance, PredictedInstance, Track } from "../../model/instance.js";
@@ -719,6 +720,40 @@ function readVideoCrops(file: any): Map<number, VideoCropEntry> {
   return out;
 }
 
+/**
+ * Read a video's `source_video` metadata JSON from its `{group}/source_video`
+ * HDF5 group, or `null` when the group is absent. Checks a `json` *dataset*
+ * first (where oversized metadata is stored) then the `json` *attribute* (the
+ * normal case), mirroring Python `_read_source_video_json`. h5wasm sync path.
+ */
+function readSourceVideoGroupJson(
+  file: any,
+  groupPath: string,
+): Record<string, unknown> | null {
+  const grp = file.get(`${groupPath}/source_video`);
+  if (!grp) return null;
+  let raw: string | undefined;
+  const ds = file.get(`${groupPath}/source_video/json`);
+  if (ds) {
+    const v = (ds as { value?: unknown }).value;
+    if (typeof v === "string") raw = v;
+    else if (v instanceof Uint8Array) raw = textDecoder.decode(v);
+    else if (Array.isArray(v) && v.length > 0) raw = String(v[0]);
+  }
+  if (raw === undefined) {
+    raw = attrToString((grp.attrs ?? {}).json);
+  }
+  if (raw === undefined) return null;
+  try {
+    return JSON.parse(raw.trim().replace(/\0+$/, "")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return null;
+  }
+}
+
 async function readVideos(
   dataset: any,
   labelsPath: string,
@@ -868,14 +903,28 @@ async function readVideos(
       }
     }
 
-    // NOTE: source_video is reconstructed filename-only, so the source's shape
-    // is dropped on reload. This leaves _getEffectiveShape() with no source
-    // shape for a reloaded embedded subset, keeping the embedded-subset ->
-    // restore-original matching workflow broken across save/load. Tracked in
-    // #160 (a follow-up to the in-memory #476 source-chain fix).
-    const sourceVideo = parsed.source_video
-      ? new Video({ filename: parsed.source_video.filename ?? "" })
-      : null;
+    // Reconstruct the source_video lineage WITH its recorded shape (and any
+    // deeper chain) so a reloaded embedded subset can resolve its source's full
+    // frame extent via _getEffectiveShape — the prerequisite for the
+    // embedded-subset -> restore-original matching workflow (#160). Embedded
+    // videos store their source in the authoritative `{group}/source_video`
+    // HDF5 group (older `.pkg.slp` omit it from videos_json entirely); prefer it
+    // and fall back to a nested videos_json `source_video` (non-embedded videos,
+    // and newer files that carry both).
+    let sourceVideo: Video | null = null;
+    if (embedded && datasetPath) {
+      const groupPath = datasetPath.endsWith("/video")
+        ? datasetPath.slice(0, -6)
+        : datasetPath;
+      const svDict = readSourceVideoGroupJson(file, groupPath);
+      if (svDict) sourceVideo = buildSourceVideoFromDict(svDict, labelsPath);
+    }
+    if (!sourceVideo && parsed.source_video) {
+      sourceVideo = buildSourceVideoFromDict(
+        parsed.source_video as Record<string, unknown>,
+        labelsPath,
+      );
+    }
 
     // Crop reconstruction (SLP 2.3): the backend just built from videos_json is
     // the UNCROPPED inner. If a /video_crops entry exists for this index, wrap it

--- a/src/codecs/slp/source-video.ts
+++ b/src/codecs/slp/source-video.ts
@@ -1,0 +1,59 @@
+/**
+ * Reconstruction of a video's `source_video` lineage from its serialized SLP
+ * form, shared by the eager ({@link ../read}) and streaming
+ * ({@link ../read-streaming}) readers.
+ *
+ * A `source_video` is serialized as a full video dict — the same shape
+ * `video_to_dict` produces — either nested inside a `videos_json` entry
+ * (non-embedded videos) or as JSON in the `{group}/source_video` HDF5 group
+ * (embedded videos; the authoritative location Python reads for `.pkg.slp`).
+ * Historically the JS codec reconstructed it filename-only, dropping the
+ * source's shape and any deeper chain, which left `_getEffectiveShape` unable to
+ * resolve an embedded subset's full frame extent across a save/reload and broke
+ * the embedded-subset -> restore-original matching workflow (#160).
+ */
+import { Video } from "../../model/video.js";
+import { resolveVideoFilename } from "./parsers.js";
+
+/**
+ * Reconstruct a lineage `Video` from its serialized dict.
+ *
+ * The result is METADATA-ONLY: `backend` is left `null` (a lineage video's file
+ * is often unavailable, and opening it is unnecessary — matching only needs its
+ * recorded shape), while `backendMetadata` carries the recorded `shape` (and the
+ * rest of the backend dict) so `Video.shape` and `_getEffectiveShape` resolve
+ * the source's full frame extent. Recurses so a multi-level chain
+ * (e.g. crop -> embedded subset -> original mp4) is preserved end to end.
+ * Mirrors the `source_video` branch of Python `make_video`.
+ *
+ * @param dict Parsed source-video dict: `{ filename?, backend?, source_video? }`.
+ * @param labelsPath Path of the `.slp` being read, used to resolve a `"."`
+ *   self-reference back to the containing file.
+ */
+export function buildSourceVideoFromDict(
+  dict: Record<string, unknown>,
+  labelsPath?: string,
+): Video {
+  const backend = (dict.backend ?? {}) as Record<string, unknown>;
+  let filename = resolveVideoFilename(backend, dict);
+  let embedded = false;
+  if (filename === ".") {
+    embedded = true;
+    filename = labelsPath ?? ".";
+  }
+
+  const nested = dict.source_video as Record<string, unknown> | undefined;
+  const sourceVideo = nested
+    ? buildSourceVideoFromDict(nested, labelsPath)
+    : null;
+
+  return new Video({
+    filename,
+    backend: null,
+    // Copy so a shared parsed object is never mutated by later crop seeding etc.
+    backendMetadata: { ...backend },
+    sourceVideo,
+    openBackend: false,
+    embedded,
+  });
+}

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -878,11 +878,52 @@ function serializeVideo(video: Video): Record<string, unknown> {
     backend,
   };
 
+  // Serialize the full source_video lineage (filename + backend incl. shape +
+  // any deeper chain), not just its filename, so a reload can recover the
+  // source's frame extent. Mirrors Python `video_to_dict` (recursive). See #160.
   if (video.sourceVideo) {
-    entry.source_video = { filename: video.sourceVideo.filename };
+    entry.source_video = serializeVideo(video.sourceVideo);
   }
 
   return entry;
+}
+
+/**
+ * The full source-video dict to persist for a video that is being embedded, or
+ * `null` when there is nothing to record. Prefers an explicit `sourceVideo`
+ * (its lineage, incl. shape); otherwise, for a not-yet-embedded video, records
+ * the video itself as its own source (mirrors Python `process_and_embed_frames`,
+ * where `source_video = video.source_video or video`). An already-embedded video
+ * with no known source contributes nothing.
+ */
+function sourceVideoDict(video: Video): Record<string, unknown> | null {
+  if (video.sourceVideo) return serializeVideo(video.sourceVideo);
+  if (!video.hasEmbeddedImages) return serializeVideo(video);
+  return null;
+}
+
+/** Python `METADATA_ATTR_SIZE_LIMIT`: the HDF5 64 KB attribute ceiling. */
+const SOURCE_VIDEO_ATTR_LIMIT = 64000;
+
+/**
+ * Write a source video's metadata JSON into its `{group}/source_video` HDF5
+ * group, the authoritative location an embedded video's source is read from
+ * (Python `_write_source_video_json`). Normally a `json` string *attribute*;
+ * if the blob would exceed the 64 KB attribute ceiling it goes to a `json`
+ * *dataset* in the same group instead (readers check the dataset first).
+ */
+function writeSourceVideoJson(
+  file: any,
+  groupPath: string,
+  sourceDict: Record<string, unknown>,
+): void {
+  const blob = JSON.stringify(sourceDict);
+  file.create_group(`${groupPath}/source_video`);
+  if (new TextEncoder().encode(blob).length <= SOURCE_VIDEO_ATTR_LIMIT) {
+    setStringAttr(file.get(`${groupPath}/source_video`), "json", blob);
+    return;
+  }
+  file.create_dataset({ name: `${groupPath}/source_video/json`, data: [blob] });
 }
 
 /**
@@ -1477,17 +1518,11 @@ function writeEmbeddedVideos(
         filename: ".",
         backend,
       };
-      // Preserve source_video reference to original
-      if (video.sourceVideo) {
-        entry.source_video = { filename: video.sourceVideo.filename };
-      } else if (!video.hasEmbeddedImages) {
-        // If this video wasn't already embedded, save original path as source
-        entry.source_video = {
-          filename: Array.isArray(video.filename)
-            ? video.filename[0]
-            : video.filename,
-        };
-      }
+      // Preserve the full source_video lineage (filename + backend incl. shape
+      // + deeper chain), mirroring newer Python which nests it in videos_json as
+      // well as the authoritative HDF5 group written below. See #160.
+      const srcDict = sourceVideoDict(video);
+      if (srcDict) entry.source_video = srcDict;
       return JSON.stringify(entry);
     } else {
       return JSON.stringify(serializeVideo(video));
@@ -1499,6 +1534,13 @@ function writeEmbeddedVideos(
   for (const [videoIndex, embedData] of embeddedVideoData) {
     const groupName = `video${videoIndex}`;
     file.create_group(groupName);
+
+    // Write the source video lineage into the authoritative
+    // `{group}/source_video` HDF5 group — the location Python reads for an
+    // embedded `.pkg.slp` (it ignores videos_json's source_video for embedded
+    // videos). Mirrors Python `write_videos`' lineage pass. See #160.
+    const srcDict = sourceVideoDict(labels.videos[videoIndex]);
+    if (srcDict) writeSourceVideoJson(file, groupName, srcDict);
 
     // Write frame data as vlen array
     const frameBytes: Uint8Array[] = [];

--- a/tests/codecs/source-video-fidelity.test.ts
+++ b/tests/codecs/source-video-fidelity.test.ts
@@ -1,0 +1,224 @@
+/**
+ * `source_video` lineage fidelity across a save/reload (issue #160).
+ *
+ * A video's `source_video` must round-trip with its recorded shape (and any
+ * deeper chain), not filename-only, so `_getEffectiveShape` can resolve an
+ * embedded subset's full frame extent after a real reload — the prerequisite
+ * for the embedded-subset -> restore-original matching workflow. These tests
+ * exercise the shared reconstruction helper, the eager reader against real
+ * Python-written `.pkg.slp` fixtures (source in the HDF5 group and/or nested in
+ * videos_json), the streaming group reader, and a full JS -> JS round-trip.
+ */
+import { describe, it, expect } from "../bun-test";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { loadSlp } from "../../src/io/main.js";
+import { saveSlpToBytes } from "../../src/codecs/slp/write.js";
+import { readSlp } from "../../src/codecs/slp/read.js";
+import { Video } from "../../src/model/video.js";
+import { Instance } from "../../src/model/instance.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { Labels } from "../../src/model/labels.js";
+import {
+  _getEffectiveShape,
+  shapesCompatible,
+} from "../../src/model/matching.js";
+import { buildSourceVideoFromDict } from "../../src/codecs/slp/source-video.js";
+import { readSourceVideoGroupJsonStreaming } from "../../src/codecs/slp/read-streaming.js";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+const slp = (name: string) => path.join(fixtureRoot, "slp", name);
+
+describe("buildSourceVideoFromDict", () => {
+  it("recovers shape and a multi-level chain, backend left unopened", () => {
+    const dict = {
+      filename: "subset.pkg.slp",
+      backend: { shape: [27, 384, 384, 1], filename: "subset.pkg.slp" },
+      source_video: {
+        filename: "original.mp4",
+        backend: {
+          type: "MediaVideo",
+          shape: [80, 384, 384, 1],
+          filename: "original.mp4",
+        },
+      },
+    };
+    const v = buildSourceVideoFromDict(dict);
+    expect(v.backend).toBeNull(); // metadata-only; never opens the lineage file
+    expect(v.shape).toEqual([27, 384, 384, 1]);
+    expect(v.sourceVideo).not.toBeNull();
+    expect(v.sourceVideo?.shape).toEqual([80, 384, 384, 1]);
+    // The video's OWN shape is the subset extent...
+    expect(v.shape).toEqual([27, 384, 384, 1]);
+    // ...but _getEffectiveShape walks source-first, resolving to the source's
+    // full extent (the point of the source chain for matching).
+    expect(_getEffectiveShape(v)).toEqual([80, 384, 384, 1]);
+  });
+
+  it("resolves a '.' self-reference to the labels path", () => {
+    const v = buildSourceVideoFromDict(
+      { backend: { filename: ".", dataset: "video0/video" } },
+      "/data/project.pkg.slp",
+    );
+    expect(v.filename).toBe("/data/project.pkg.slp");
+    expect(v.hasEmbeddedImages).toBe(true);
+  });
+
+  it("falls back to the top-level filename when backend.filename is absent", () => {
+    const v = buildSourceVideoFromDict({ filename: "bare.mp4", backend: {} });
+    expect(v.filename).toBe("bare.mp4");
+    expect(v.shape).toBeNull();
+  });
+});
+
+describe("readSourceVideoGroupJsonStreaming", () => {
+  const blob =
+    '{"filename":"o.mp4","backend":{"shape":[80,384,384,1],"filename":"o.mp4"}}';
+
+  it("reads the json attribute (normal case)", async () => {
+    const file = {
+      getKeys: async () => [],
+      getAttrs: async (p: string) =>
+        p === "video0/source_video" ? { json: blob } : {},
+      getDatasetValue: async () => {
+        throw new Error("no dataset");
+      },
+    };
+    const dict = await readSourceVideoGroupJsonStreaming(file, "video0");
+    expect(dict).not.toBeNull();
+    expect((dict?.backend as any).shape).toEqual([80, 384, 384, 1]);
+  });
+
+  it("prefers the json dataset when present (oversized metadata)", async () => {
+    const file = {
+      getKeys: async () => ["json"],
+      getAttrs: async () => ({}),
+      getDatasetValue: async () => ({ value: blob, shape: [1], dtype: "S" }),
+    };
+    const dict = await readSourceVideoGroupJsonStreaming(file, "video0");
+    expect((dict?.backend as any).shape).toEqual([80, 384, 384, 1]);
+  });
+
+  it("returns null when the group is absent", async () => {
+    const file = {
+      getKeys: async () => [],
+      getAttrs: async () => ({}),
+      getDatasetValue: async () => {
+        throw new Error("no dataset");
+      },
+    };
+    expect(await readSourceVideoGroupJsonStreaming(file, "video0")).toBeNull();
+  });
+});
+
+describe("eager reader recovers source_video lineage from fixtures", () => {
+  it("cropped_format_2_3.pkg.slp: source shape + chain from the nested videos_json dict", async () => {
+    const labels = await readSlp(slp("cropped_format_2_3.pkg.slp"), {
+      openVideos: false,
+    });
+    const v = labels.videos[0];
+    // The video itself is a 192x256 crop of a 384x384 source.
+    expect(v.shape).toEqual([1, 192, 256, 1]);
+    expect(v.sourceVideo).not.toBeNull();
+    expect(v.sourceVideo?.shape).toEqual([1, 384, 384, 1]);
+    // Two-level chain: crop -> embedded subset -> original mp4.
+    expect(v.sourceVideo?.sourceVideo).not.toBeNull();
+    // Effective shape resolves to the uncropped source, not the cropped facade.
+    expect(_getEffectiveShape(v)).toEqual([1, 384, 384, 1]);
+  });
+
+  it("minimal_instance.pkg.slp: source recovered from the {group}/source_video HDF5 group", async () => {
+    const labels = await readSlp(slp("minimal_instance.pkg.slp"), {
+      openVideos: false,
+    });
+    const v = labels.videos[0];
+    // videos_json for this older file carries NO source_video; it lives only in
+    // the HDF5 group. Before the fix, sourceVideo was dropped entirely.
+    expect(v.sourceVideo).not.toBeNull();
+    expect(String(v.sourceVideo?.filename)).toContain(".mp4");
+  });
+});
+
+describe("#160 end-to-end: embedded subset -> restore-original matching survives a reload", () => {
+  it("recovers the source's full shape and pairs the subset with the restored original", async () => {
+    // An embedded pkg whose frames we can re-embed.
+    const labels = await loadSlp(slp("minimal_instance.pkg.slp"), {
+      openVideos: true,
+    });
+    const subset = labels.videos[0];
+
+    // Model the workflow: this embedded video is a SUBSET of a larger (80-frame)
+    // original. Attach the original as its source (full extent in metadata).
+    subset.sourceVideo = new Video({
+      filename: "the_original.mp4",
+      backendMetadata: { shape: [80, 384, 384, 1] },
+    });
+    expect(_getEffectiveShape(subset)).toEqual([80, 384, 384, 1]);
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sleap-160-"));
+    try {
+      const tmpFile = path.join(tmpDir, "subset.pkg.slp");
+      fs.writeFileSync(tmpFile, await saveSlpToBytes(labels, { embed: true }));
+
+      const reloaded = await readSlp(tmpFile, { openVideos: false });
+      const rv = reloaded.videos[0];
+      expect(rv.hasEmbeddedImages).toBe(true);
+      expect(rv.sourceVideo).not.toBeNull();
+      // The source's full frame extent survives the round-trip...
+      expect(rv.sourceVideo?.shape).toEqual([80, 384, 384, 1]);
+      expect(_getEffectiveShape(rv)).toEqual([80, 384, 384, 1]);
+
+      // ...so the restored original (80 frames) is judged compatible with the
+      // subset instead of being rejected on the subset's own frame count.
+      const restoredOriginal = new Video({
+        filename: "the_original.mp4",
+        backendMetadata: { shape: [80, 384, 384, 1] },
+      });
+      expect(shapesCompatible(rv, restoredOriginal)).toBe(true);
+
+      // The authoritative HDF5 group (what Python reads for embedded videos) is
+      // written, not only the videos_json nested dict.
+      const { openH5File } = await import("../../src/codecs/slp/h5.js");
+      const { file, close } = await openH5File(tmpFile);
+      try {
+        expect(file.get("video0/source_video")).not.toBeNull();
+      } finally {
+        close();
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("non-embedded videos_json source_video round-trip", () => {
+  it("serializes and recovers a source with shape via the nested videos_json dict", async () => {
+    const source = new Video({
+      filename: "original.mp4",
+      backendMetadata: { shape: [80, 384, 384, 1] },
+    });
+    const video = new Video({ filename: "derived.mp4", sourceVideo: source });
+    const skeleton = new Skeleton({ nodes: ["A", "B"] });
+    const inst = new Instance({ points: { A: [1, 2], B: [3, 4] }, skeleton });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({ video, frameIdx: 0, instances: [inst] }),
+      ],
+      videos: [video],
+      skeletons: [skeleton],
+    });
+
+    const bytes = await saveSlpToBytes(labels); // no embedding
+    const reloaded = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
+    const rv = reloaded.videos[0];
+    expect(rv.hasEmbeddedImages).toBe(false);
+    expect(rv.sourceVideo).not.toBeNull();
+    expect(rv.sourceVideo?.shape).toEqual([80, 384, 384, 1]);
+    expect(_getEffectiveShape(rv)).toEqual([80, 384, 384, 1]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #160: `source_video` was serialized/reconstructed **filename-only**, so the source's shape (and any deeper lineage) was dropped on reload. After a real save/reload, `_getEffectiveShape()` had no source shape for a reloaded embedded subset and fell back to the subset's own (small) frame count — so the AUTO video-match cascade rejected the same-file pair on frame count, keeping the **embedded-subset → restore-original matching workflow broken across the round-trip**. This is the follow-up the in-memory #476 source-chain fix was gated on.

This ports Python `sleap-io`'s full `video_to_dict` / `make_video` source_video handling.

## What Python does (confirmed against real fixtures)

- Non-embedded videos: `source_video` is a **full nested video dict** inside the `videos_json` entry.
- Embedded videos (`.pkg.slp`): the authoritative `source_video` lives in the **`{group}/source_video` HDF5 group** (`json` attribute, or `json` dataset when >64 KB). On read, Python reads *only* the group for embedded videos and *only* the nested `videos_json` dict for non-embedded — it never cross-reads. Older `.pkg.slp` (e.g. `minimal_instance.pkg.slp`) omit `source_video` from `videos_json` entirely, so reading the group is required, not optional.

## Changes

**Write** (`write.ts`)
- `serializeVideo` now emits the full nested `source_video` dict (filename + backend incl. `shape` + recursive chain) instead of `{ filename }`.
- Embedded videos additionally write the `{group}/source_video` HDF5 group, mirroring `_write_source_video_json` (attr, with a dataset fallback past the 64 KB ceiling).

**Read** (`read.ts` eager + `read-streaming.ts` streaming, at parity)
- New shared `buildSourceVideoFromDict` (`source-video.ts`) reconstructs the lineage **with its recorded shape** and full chain. It is **metadata-only** — a lineage video's file is never opened (it may be missing; matching only needs its shape).
- Embedded videos prefer the HDF5 group; non-embedded use the nested `videos_json` dict.

**Types** (`parsers.ts`): `VideoMetadata.sourceVideo` widened from `{ filename }` to the full dict.

## Verification

New `tests/codecs/source-video-fidelity.test.ts` (10 tests) plus manual end-to-end checks:

| Check | Result |
|---|---|
| `cropped_format_2_3.pkg.slp` load | `sourceVideo.shape = [1,384,384,1]`, 2-level chain, `_getEffectiveShape → [1,384,384,1]` (was the cropped `[1,192,256,1]`) |
| `minimal_instance.pkg.slp` load | source recovered from the HDF5 group (was dropped entirely) |
| **JS→JS embed round-trip** | attach an 80-frame source, `embed:true`, reload → `sourceVideo.shape = [80,384,384,1]`, `shapesCompatible(subset, original) = true` |
| **JS→Python** | `sleap-io` reads the JS-written file: `source_video.shape = [80,384,384,1]` ✓ |
| Full `bun test --parallel ./tests/` | **1930 pass / 1 skip / 0 fail** |
| `tsc --noEmit`, `biome check .` | clean |

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQDXxA9TYiC3aCtKWD7Eqn
