### PR TITLE
fix(slp): apply the video-id remap in the lazy readers (#204)

### DIFF
--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -32,6 +32,7 @@ import { buildSourceVideoFromDict } from "./source-video.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
 import { LazyDataStore, LazyFrameList } from "../../model/lazy.js";
+import { buildVideoIdMap } from "../../model/video-id-map.js";
 import {
   Instance,
   PredictedInstance,
@@ -1402,44 +1403,4 @@ function buildLabeledFrames(options: {
   }
 
   return frames;
-}
-
-function buildVideoIdMap(
-  framesData: Record<string, unknown[]>,
-  videos: Video[],
-): Map<number, number> {
-  const videoIds = new Set<number>();
-  for (const value of (framesData.video ?? []) as number[]) {
-    videoIds.add(Number(value));
-  }
-  if (!videoIds.size) return new Map();
-
-  const maxId = Math.max(...Array.from(videoIds));
-  if (videoIds.size === videos.length && maxId === videos.length - 1) {
-    const identity = new Map<number, number>();
-    for (let i = 0; i < videos.length; i += 1) {
-      identity.set(i, i);
-    }
-    return identity;
-  }
-
-  const map = new Map<number, number>();
-  for (let index = 0; index < videos.length; index += 1) {
-    const video = videos[index];
-    const dataset =
-      (video.backendMetadata?.dataset as string | undefined) ?? "";
-    const parsedId = parseVideoIdFromDataset(dataset);
-    if (parsedId != null) {
-      map.set(parsedId, index);
-    }
-  }
-  return map;
-}
-
-function parseVideoIdFromDataset(dataset: string): number | null {
-  if (!dataset) return null;
-  const group = dataset.split("/")[0];
-  if (!group.startsWith("video")) return null;
-  const id = Number(group.slice(5));
-  return Number.isNaN(id) ? null : id;
 }

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -42,6 +42,7 @@ import {
 } from "../../model/camera.js";
 import { Identity } from "../../model/identity.js";
 import { LazyDataStore, LazyFrameList } from "../../model/lazy.js";
+import { buildVideoIdMap } from "../../model/video-id-map.js";
 import {
   type ROI,
   UserROI,
@@ -2310,48 +2311,6 @@ function buildLabeledFrames(options: {
   }
 
   return frames;
-}
-
-function buildVideoIdMap(
-  framesData: Record<string, any[]>,
-  videos: Video[],
-): Map<number, number> {
-  const videoIds = new Set<number>();
-  for (const value of framesData.video ?? []) {
-    videoIds.add(Number(value));
-  }
-  if (!videoIds.size) return new Map();
-
-  const maxId = Math.max(...Array.from(videoIds));
-  if (videoIds.size === videos.length && maxId === videos.length - 1) {
-    const identity = new Map<number, number>();
-    for (let i = 0; i < videos.length; i += 1) {
-      identity.set(i, i);
-    }
-    return identity;
-  }
-
-  const map = new Map<number, number>();
-  for (let index = 0; index < videos.length; index += 1) {
-    const video = videos[index];
-    const dataset =
-      video.backend?.dataset ??
-      (video.backendMetadata?.dataset as string | undefined) ??
-      "";
-    const parsedId = parseVideoIdFromDataset(dataset);
-    if (parsedId != null) {
-      map.set(parsedId, index);
-    }
-  }
-  return map;
-}
-
-function parseVideoIdFromDataset(dataset: string): number | null {
-  if (!dataset) return null;
-  const group = dataset.split("/")[0];
-  if (!group.startsWith("video")) return null;
-  const id = Number(group.slice(5));
-  return Number.isNaN(id) ? null : id;
 }
 
 function readCentroids(

--- a/src/model/lazy.ts
+++ b/src/model/lazy.ts
@@ -8,6 +8,7 @@ import {
 } from "./instance.js";
 import { Skeleton } from "./skeleton.js";
 import { Video } from "./video.js";
+import { buildVideoIdMap } from "./video-id-map.js";
 import type { Centroid } from "./centroid.js";
 import type { BoundingBox } from "./bbox.js";
 import type { SegmentationMask } from "./mask.js";
@@ -29,6 +30,13 @@ export class LazyDataStore {
   videos: Video[];
   formatId: number;
   negativeFrames: Set<string>;
+
+  /**
+   * Memoized raw-`frames.video`-id -> `videos` index map (see
+   * {@link buildVideoIdMap}). Lazily built on first frame access; rebuilt from
+   * scratch by a copied store since `copy()` does not carry it over.
+   */
+  private _videoIdToIndex?: Map<number, number>;
 
   // Per-frame annotation lookups: "videoIdx:frameIdx" -> annotation[]
   _centroidByFrame: Map<string, Centroid[]> = new Map();
@@ -123,6 +131,17 @@ export class LazyDataStore {
   }
 
   /**
+   * Resolve a raw `frames.video` id to its `videos` array index, applying the
+   * same remap the eager readers use so sparse / non-contiguous group ids
+   * (e.g. `video0`, `video2`) resolve to the correct video. Falls back to the
+   * raw id when unmapped — identical to `buildLabeledFrames`.
+   */
+  private videoIndexFor(rawVideoId: number): number {
+    this._videoIdToIndex ??= buildVideoIdMap(this.framesData, this.videos);
+    return this._videoIdToIndex.get(rawVideoId) ?? rawVideoId;
+  }
+
+  /**
    * Materialize a single LabeledFrame by index.
    */
   materializeFrame(frameIdx: number): LabeledFrame | null {
@@ -130,7 +149,7 @@ export class LazyDataStore {
     if (frameIdx < 0 || frameIdx >= frameIds.length) return null;
 
     const rawVideoId = Number(this.framesData.video?.[frameIdx] ?? 0);
-    const videoIndex = rawVideoId;
+    const videoIndex = this.videoIndexFor(rawVideoId);
     const frameIndex = Number(this.framesData.frame_idx?.[frameIdx] ?? 0);
     const instStart = Number(
       this.framesData.instance_id_start?.[frameIdx] ?? 0,
@@ -285,7 +304,8 @@ export class LazyDataStore {
       : (() => {
           let maxInst = 1;
           for (let i = 0; i < frameIds.length; i++) {
-            if (Number(frameVideos[i]) !== targetVideoIdx) continue;
+            if (this.videoIndexFor(Number(frameVideos[i])) !== targetVideoIdx)
+              continue;
             const count = Number(instEnds[i]) - Number(instStarts[i]);
             if (count > maxInst) maxInst = count;
           }
@@ -295,7 +315,8 @@ export class LazyDataStore {
     // Collect matching frame indices
     const matchingFrames: number[] = [];
     for (let i = 0; i < frameIds.length; i++) {
-      if (Number(frameVideos[i]) !== targetVideoIdx) continue;
+      if (this.videoIndexFor(Number(frameVideos[i])) !== targetVideoIdx)
+        continue;
       const fi = Number(frameIndices[i]);
       if (fi > maxFrameIdx) maxFrameIdx = fi;
       matchingFrames.push(i);

--- a/src/model/video-id-map.ts
+++ b/src/model/video-id-map.ts
@@ -1,0 +1,60 @@
+import type { Video } from "./video.js";
+
+/**
+ * Map each raw `frames.video` id to the index of its `Video` in the `videos`
+ * array. SLP stores a frame's video as the integer id of its `videoN` HDF5
+ * group, which is NOT necessarily the video's position in `videos` — after a
+ * remove-video / merge / export the group ids can be sparse or non-contiguous
+ * (e.g. `video0`, `video2` → array indices 0, 1). Callers resolve a frame's
+ * video with `videos[map.get(rawId) ?? rawId]`.
+ *
+ * Fast path: when the ids are exactly `0..videos.length-1` (the common case) an
+ * identity map is returned. Otherwise each video's group id is parsed from its
+ * `dataset` ("videoN/video" → N), preferring the live backend's dataset and
+ * falling back to `backendMetadata.dataset`.
+ *
+ * Single source of truth for the eager readers (`buildLabeledFrames`) and the
+ * lazy store ({@link LazyDataStore}), which previously carried drifting copies.
+ */
+export function buildVideoIdMap(
+  framesData: Record<string, unknown[]>,
+  videos: Video[],
+): Map<number, number> {
+  const videoIds = new Set<number>();
+  for (const value of framesData.video ?? []) {
+    videoIds.add(Number(value));
+  }
+  if (!videoIds.size) return new Map();
+
+  const maxId = Math.max(...Array.from(videoIds));
+  if (videoIds.size === videos.length && maxId === videos.length - 1) {
+    const identity = new Map<number, number>();
+    for (let i = 0; i < videos.length; i += 1) {
+      identity.set(i, i);
+    }
+    return identity;
+  }
+
+  const map = new Map<number, number>();
+  for (let index = 0; index < videos.length; index += 1) {
+    const video = videos[index];
+    const dataset =
+      video.backend?.dataset ??
+      (video.backendMetadata?.dataset as string | undefined) ??
+      "";
+    const parsedId = parseVideoIdFromDataset(dataset);
+    if (parsedId != null) {
+      map.set(parsedId, index);
+    }
+  }
+  return map;
+}
+
+/** Parse the integer id from a `"videoN/..."` HDF5 dataset path, or `null`. */
+export function parseVideoIdFromDataset(dataset: string): number | null {
+  if (!dataset) return null;
+  const group = dataset.split("/")[0];
+  if (!group.startsWith("video")) return null;
+  const id = Number(group.slice(5));
+  return Number.isNaN(id) ? null : id;
+}

--- a/tests/model/lazy-video-id-map.test.ts
+++ b/tests/model/lazy-video-id-map.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Lazy readers must apply the same raw-`frames.video`-id -> `videos`-index remap
+ * the eager readers use (issue #204). Before the fix, `LazyDataStore` indexed
+ * `videos[rawId]` directly, so a file with non-contiguous group ids
+ * (`video0`, `video2`) attached frames to the wrong video or dropped them
+ * (`videos[2] === undefined`). These tests pin the remap in `materializeFrame`,
+ * `toNumpy`, and the shared `buildVideoIdMap`.
+ */
+import { describe, it, expect } from "../bun-test";
+import { LazyDataStore } from "../../src/model/lazy.js";
+import { buildVideoIdMap } from "../../src/model/video-id-map.js";
+import { Video } from "../../src/model/video.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+
+function video(dataset: string): Video {
+  return new Video({ filename: ".", backendMetadata: { dataset } });
+}
+
+/**
+ * A 2-frame store: frame 0 -> raw video id `ids[0]`, frame 1 -> raw video id
+ * `ids[1]`; one 1-point user instance per frame.
+ */
+function makeStore(videos: Video[], ids: [number, number]): LazyDataStore {
+  return new LazyDataStore({
+    framesData: {
+      frame_id: [0, 1],
+      video: ids,
+      frame_idx: [5, 7],
+      instance_id_start: [0, 1],
+      instance_id_end: [1, 2],
+    },
+    instancesData: {
+      instance_type: [0, 0],
+      skeleton: [0, 0],
+      track: [-1, -1],
+      point_id_start: [0, 1],
+      point_id_end: [1, 2],
+      score: [0, 0],
+      tracking_score: [0, 0],
+      from_predicted: [-1, -1],
+    },
+    pointsData: {
+      x: [10, 30],
+      y: [20, 40],
+      visible: [1, 1],
+      complete: [1, 1],
+      score: [0, 0],
+    },
+    predPointsData: { x: [], y: [], visible: [], complete: [], score: [] },
+    skeletons: [new Skeleton({ nodes: ["A"] })],
+    tracks: [],
+    videos,
+    formatId: 1.2,
+  });
+}
+
+describe("buildVideoIdMap", () => {
+  it("returns an identity map for contiguous 0-based ids", () => {
+    const videos = [video("video0/video"), video("video1/video")];
+    const map = buildVideoIdMap({ video: [0, 1, 0, 1] }, videos);
+    expect(map.get(0)).toBe(0);
+    expect(map.get(1)).toBe(1);
+  });
+
+  it("maps non-contiguous group ids to array indices", () => {
+    const videos = [video("video0/video"), video("video2/video")];
+    const map = buildVideoIdMap({ video: [0, 2] }, videos);
+    expect(map.get(0)).toBe(0);
+    expect(map.get(2)).toBe(1); // raw id 2 -> array index 1
+  });
+
+  it("returns an empty map when there are no frames", () => {
+    expect(buildVideoIdMap({ video: [] }, [video("video0/video")]).size).toBe(
+      0,
+    );
+  });
+});
+
+describe("LazyDataStore.materializeFrame — video id remap (#204)", () => {
+  it("attaches frames to the correct video for non-contiguous ids", () => {
+    const videos = [video("video0/video"), video("video2/video")];
+    const store = makeStore(videos, [0, 2]);
+
+    const f0 = store.materializeFrame(0);
+    const f1 = store.materializeFrame(1);
+
+    expect(f0).not.toBeNull();
+    expect(f0!.video).toBe(videos[0]);
+    expect(f0!.frameIdx).toBe(5);
+
+    // Before the fix this was `videos[2]` (undefined) -> frame dropped (null).
+    expect(f1).not.toBeNull();
+    expect(f1!.video).toBe(videos[1]);
+    expect(f1!.frameIdx).toBe(7);
+    expect(f1!.instances.length).toBe(1);
+  });
+
+  it("still resolves the contiguous (identity) case", () => {
+    const videos = [video("video0/video"), video("video1/video")];
+    const store = makeStore(videos, [0, 1]);
+    expect(store.materializeFrame(0)!.video).toBe(videos[0]);
+    expect(store.materializeFrame(1)!.video).toBe(videos[1]);
+  });
+});
+
+describe("LazyDataStore.toNumpy — video id remap (#204)", () => {
+  it("selects the requested video's frames under non-contiguous ids", () => {
+    const videos = [video("video0/video"), video("video2/video")];
+    const store = makeStore(videos, [0, 2]);
+
+    // videos[1] owns only frame 1 (frame_idx 7, point (30,40)).
+    const arr = store.toNumpy({ video: videos[1] });
+    // Frame dimension spans 0..maxFrameIdx (7) -> length 8; row 7 is populated.
+    expect(arr.length).toBe(8);
+    expect(arr[7][0][0]).toEqual([30, 40]);
+    // A frame this video does NOT own (index 5, which belongs to videos[0]) is NaN.
+    expect(Number.isNaN(arr[5][0][0][0])).toBe(true);
+
+    // videos[0] owns only frame 0 (frame_idx 5, point (10,20)).
+    const arr0 = store.toNumpy({ video: videos[0] });
+    expect(arr0[5][0][0]).toEqual([10, 20]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #204 (surfaced by the adversarial review of #203). The **lazy** SLP readers indexed videos by the raw `frames.video` id, while the **eager** readers remap it through `buildVideoIdMap`. For a file whose frame video ids are non-contiguous / don't match their `videos` position — e.g. `video0`, `video2` after a remove-video / merge / export — the lazy path attached frames to the wrong video or dropped them (`videos[2] === undefined` → `materializeFrame` returns `null`), diverging from the eager readers.

Applies to both lazy entry points: `readSlpLazy` (main thread) and the streaming lazy mode added in #203.

## Changes

- **`src/model/video-id-map.ts`** (new) — single canonical `buildVideoIdMap` / `parseVideoIdFromDataset`. The two eager copies had **already drifted** (`read.ts` preferred the live backend's `dataset`; `read-streaming.ts` used only `backendMetadata.dataset`); this unifies them on the superset (`backend?.dataset ?? backendMetadata?.dataset`). `read.ts`, `read-streaming.ts`, and `lazy.ts` all import it now.
- **`src/model/lazy.ts`** — `LazyDataStore` memoizes the map and applies it in `materializeFrame` **and** `toNumpy` (both previously assumed `rawId === array index`).

## Compatibility

The common contiguous case is unchanged — `buildVideoIdMap` returns an identity map for `0..n-1` ids, so single-video and normally-ordered multi-video files behave exactly as before. Unmapped ids fall back to the raw id, identical to eager `buildLabeledFrames`.

## Tests

`tests/model/lazy-video-id-map.test.ts` (6 tests) covers `buildVideoIdMap` (identity / non-contiguous / empty), `materializeFrame` (correct video for non-contiguous ids; before the fix frame 1 dropped to `null`), and `toNumpy` (per-video selection under non-contiguous ids). Full suite green (1943 pass / 1 skip / 0 fail); `tsc` + `biome check` clean.

Closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQDXxA9TYiC3aCtKWD7Eqn