### PR TITLE
chore(release): bump version to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release **v0.5.2** — one lazy-reader correctness fix since v0.5.1.

- **#205** (closes #204) — lazy readers now apply the `buildVideoIdMap` remap, so non-contiguous / sparse video group ids resolve to the correct video (previously frames could attach to the wrong video or be dropped in lazy mode).

Bumps `package.json` 0.5.1 → 0.5.2. On merge I'll cut the `v0.5.2` GitHub release (triggers the npm publish workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQDXxA9TYiC3aCtKWD7Eqn