### PR TITLE
feat(slp): streaming/incremental SLP writer + multi-store merge (#207)

### DIFF
--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -636,6 +636,9 @@ export class SlpStreamWriter {
   private file: any;
   private module: any;
   private memPath: string;
+  private videos: Video[];
+  private skeletons: Skeleton[];
+  private tracks: Track[];
   private frameRows = 0;
   private instRows = 0;
   private pointRows = 0;
@@ -644,10 +647,18 @@ export class SlpStreamWriter {
   private closed = false;
 
   /** @internal — use {@link openSlpWriter}. */
-  constructor(module: any, file: any, memPath: string) {
+  constructor(
+    module: any,
+    file: any,
+    memPath: string,
+    header: { videos: Video[]; skeletons: Skeleton[]; tracks: Track[] },
+  ) {
     this.module = module;
     this.file = file;
     this.memPath = memPath;
+    this.videos = header.videos;
+    this.skeletons = header.skeletons;
+    this.tracks = header.tracks;
   }
 
   /**
@@ -693,126 +704,315 @@ export class SlpStreamWriter {
       qc = store.predPointsData.complete,
       qs = store.predPointsData.score;
 
-    for (let wStart = 0; wStart < nFrames; wStart += windowFrames) {
-      const wEnd = Math.min(wStart + windowFrames, nFrames);
-      const wFrames = wEnd - wStart;
+    // Running counts of user / predicted points emitted for THIS store, across
+    // all its windows. Points are re-packed into frame-iteration order, so an
+    // instance's new point range is its position in that packed stream — NOT the
+    // store's original `point_id_start` (which need not be monotonic in frame
+    // order for a reader-valid store, and would then misattribute points). #208.
+    let userWritten = 0;
+    let predWritten = 0;
 
-      // Pass 1: size the window's instance / user-point / pred-point buffers.
-      let nInst = 0;
-      let nUserPts = 0;
-      let nPredPts = 0;
-      for (let r = wStart; r < wEnd; r++) {
-        const iStart = numAt(fd.instance_id_start, r);
-        const iEnd = numAt(fd.instance_id_end, r);
-        nInst += iEnd - iStart;
-        for (let j = iStart; j < iEnd; j++) {
-          const cnt = numAt(idn.point_id_end, j) - numAt(idn.point_id_start, j);
-          if (numAt(idn.instance_type, j) === 1) nPredPts += cnt;
-          else nUserPts += cnt;
-        }
-      }
+    try {
+      for (let wStart = 0; wStart < nFrames; wStart += windowFrames) {
+        const wEnd = Math.min(wStart + windowFrames, nFrames);
+        const wFrames = wEnd - wStart;
 
-      const framesFlat = new Float64Array(wFrames * 5);
-      const instFlat = new Float64Array(nInst * 10);
-      const userPtsFlat = new Float64Array(nUserPts * 4);
-      const predPtsFlat = new Float64Array(nPredPts * 5);
-      let fi = 0;
-      let ii = 0;
-      let upi = 0;
-      let ppi = 0;
-
-      // Pass 2: emit rows, rebasing every cross-reference onto the store bases.
-      for (let r = wStart; r < wEnd; r++) {
-        const newFrameId = frameBase + r;
-        const combinedVideo = remapVideo(numAt(fd.video, r));
-        const frameIdx = numAt(fd.frame_idx, r);
-        const iStart = numAt(fd.instance_id_start, r);
-        const iEnd = numAt(fd.instance_id_end, r);
-
-        framesFlat[fi++] = newFrameId;
-        framesFlat[fi++] = combinedVideo;
-        framesFlat[fi++] = frameIdx;
-        framesFlat[fi++] = instBase + iStart;
-        framesFlat[fi++] = instBase + iEnd;
-
-        if (store.negativeFrames.has(`${numAt(fd.video, r)}:${frameIdx}`)) {
-          this.negativeFrames.add(`${combinedVideo}:${frameIdx}`);
-        }
-
-        for (let j = iStart; j < iEnd; j++) {
-          const type = numAt(idn.instance_type, j);
-          const ptStart = numAt(idn.point_id_start, j);
-          const ptEnd = numAt(idn.point_id_end, j);
-          const trk = numAt(idn.track, j, -1);
-          const fp = numAt(idn.from_predicted, j, -1);
-
-          instFlat[ii++] = instBase + j; // instance_id
-          instFlat[ii++] = type; // instance_type
-          instFlat[ii++] = newFrameId; // frame_id
-          instFlat[ii++] = numAt(idn.skeleton, j) + kOff; // skeleton
-          instFlat[ii++] = trk >= 0 ? trk + tOff : -1; // track
-          instFlat[ii++] = fp >= 0 ? instBase + fp : -1; // from_predicted
-          instFlat[ii++] = numAt(idn.score, j); // score
-          if (type === 1) {
-            instFlat[ii++] = predBase + ptStart; // point_id_start
-            instFlat[ii++] = predBase + ptEnd; // point_id_end
-            for (let p = ptStart; p < ptEnd; p++) {
-              predPtsFlat[ppi++] = numAt(qx, p);
-              predPtsFlat[ppi++] = numAt(qy, p);
-              predPtsFlat[ppi++] = numAt(qv, p);
-              predPtsFlat[ppi++] = numAt(qc, p);
-              predPtsFlat[ppi++] = numAt(qs, p);
-            }
-          } else {
-            instFlat[ii++] = pointBase + ptStart; // point_id_start
-            instFlat[ii++] = pointBase + ptEnd; // point_id_end
-            for (let p = ptStart; p < ptEnd; p++) {
-              userPtsFlat[upi++] = numAt(px, p);
-              userPtsFlat[upi++] = numAt(py, p);
-              userPtsFlat[upi++] = numAt(pv, p);
-              userPtsFlat[upi++] = numAt(pc, p);
-            }
+        // Pass 1: size the window's instance / user-point / pred-point buffers.
+        let nInst = 0;
+        let nUserPts = 0;
+        let nPredPts = 0;
+        for (let r = wStart; r < wEnd; r++) {
+          const iStart = numAt(fd.instance_id_start, r);
+          const iEnd = numAt(fd.instance_id_end, r);
+          nInst += iEnd - iStart;
+          for (let j = iStart; j < iEnd; j++) {
+            const cnt =
+              numAt(idn.point_id_end, j) - numAt(idn.point_id_start, j);
+            if (numAt(idn.instance_type, j) === 1) nPredPts += cnt;
+            else nUserPts += cnt;
           }
-          instFlat[ii++] = numAt(idn.tracking_score, j); // tracking_score
+        }
+
+        const framesFlat = new Float64Array(wFrames * 5);
+        const instFlat = new Float64Array(nInst * 10);
+        const userPtsFlat = new Float64Array(nUserPts * 4);
+        const predPtsFlat = new Float64Array(nPredPts * 5);
+        let fi = 0;
+        let ii = 0;
+        let upi = 0;
+        let ppi = 0;
+
+        // Pass 2: emit rows, rebasing every cross-reference onto the store bases.
+        for (let r = wStart; r < wEnd; r++) {
+          const newFrameId = frameBase + r;
+          const combinedVideo = remapVideo(numAt(fd.video, r));
+          const frameIdx = numAt(fd.frame_idx, r);
+          const iStart = numAt(fd.instance_id_start, r);
+          const iEnd = numAt(fd.instance_id_end, r);
+
+          framesFlat[fi++] = newFrameId;
+          framesFlat[fi++] = combinedVideo;
+          framesFlat[fi++] = frameIdx;
+          framesFlat[fi++] = instBase + iStart;
+          framesFlat[fi++] = instBase + iEnd;
+
+          if (store.negativeFrames.has(`${numAt(fd.video, r)}:${frameIdx}`)) {
+            this.negativeFrames.add(`${combinedVideo}:${frameIdx}`);
+          }
+
+          for (let j = iStart; j < iEnd; j++) {
+            const type = numAt(idn.instance_type, j);
+            const ptStart = numAt(idn.point_id_start, j);
+            const ptEnd = numAt(idn.point_id_end, j);
+            const trk = numAt(idn.track, j, -1);
+            const fp = numAt(idn.from_predicted, j, -1);
+
+            instFlat[ii++] = instBase + j; // instance_id
+            instFlat[ii++] = type; // instance_type
+            instFlat[ii++] = newFrameId; // frame_id
+            instFlat[ii++] = numAt(idn.skeleton, j) + kOff; // skeleton
+            instFlat[ii++] = trk >= 0 ? trk + tOff : -1; // track
+            instFlat[ii++] = fp >= 0 ? instBase + fp : -1; // from_predicted
+            instFlat[ii++] = numAt(idn.score, j); // score
+            if (type === 1) {
+              // point_id range = position in the re-packed pred-point stream.
+              instFlat[ii++] = predBase + predWritten;
+              instFlat[ii++] = predBase + predWritten + (ptEnd - ptStart);
+              for (let p = ptStart; p < ptEnd; p++) {
+                predPtsFlat[ppi++] = numAt(qx, p);
+                predPtsFlat[ppi++] = numAt(qy, p);
+                predPtsFlat[ppi++] = numAt(qv, p);
+                predPtsFlat[ppi++] = numAt(qc, p);
+                predPtsFlat[ppi++] = numAt(qs, p);
+              }
+              predWritten += ptEnd - ptStart;
+            } else {
+              instFlat[ii++] = pointBase + userWritten;
+              instFlat[ii++] = pointBase + userWritten + (ptEnd - ptStart);
+              for (let p = ptStart; p < ptEnd; p++) {
+                userPtsFlat[upi++] = numAt(px, p);
+                userPtsFlat[upi++] = numAt(py, p);
+                userPtsFlat[upi++] = numAt(pv, p);
+                userPtsFlat[upi++] = numAt(pc, p);
+              }
+              userWritten += ptEnd - ptStart;
+            }
+            instFlat[ii++] = numAt(idn.tracking_score, j); // tracking_score
+          }
+        }
+
+        appendMatrixRows(
+          this.file,
+          "frames",
+          framesFlat,
+          wFrames,
+          5,
+          this.frameRows,
+        );
+        this.frameRows += wFrames;
+        appendMatrixRows(
+          this.file,
+          "instances",
+          instFlat,
+          nInst,
+          10,
+          this.instRows,
+        );
+        this.instRows += nInst;
+        appendMatrixRows(
+          this.file,
+          "points",
+          userPtsFlat,
+          nUserPts,
+          4,
+          this.pointRows,
+        );
+        this.pointRows += nUserPts;
+        appendMatrixRows(
+          this.file,
+          "pred_points",
+          predPtsFlat,
+          nPredPts,
+          5,
+          this.predPointRows,
+        );
+        this.predPointRows += nPredPts;
+      }
+    } catch (e) {
+      // A mid-write failure leaves a partial file — release it rather than leak.
+      this.dispose();
+      throw e;
+    }
+  }
+
+  /**
+   * Append a batch of already-materialized `LabeledFrame`s — the write-side of
+   * an edit overlay: user-corrected or newly-added frames layered onto a lazy
+   * stream. Each frame's `video`/`skeleton`/`track` is resolved against this
+   * writer's header (by identity); `from_predicted` links are resolved among the
+   * batch. Intended for a bounded batch (the corrected subset), so it is not
+   * windowed. Interleave freely with {@link appendStore}.
+   */
+  appendFrames(frames: LabeledFrame[]): void {
+    if (this.closed) throw new Error("SlpStreamWriter is closed");
+    if (frames.length === 0) return;
+    try {
+      const frameBase = this.frameRows;
+      const instBase = this.instRows;
+      const pointBase = this.pointRows;
+      const predBase = this.predPointRows;
+
+      // Build the batch with LOCAL 0-based ids, then offset onto the file.
+      const framesRows: number[][] = [];
+      const instRows: number[][] = [];
+      const userPts: number[][] = [];
+      const predPts: number[][] = [];
+      const localId = new Map<Instance, number>();
+      const links: Array<[number, PredictedInstance]> = [];
+
+      for (const frame of frames) {
+        const localFrameId = framesRows.length;
+        const instanceStart = instRows.length;
+        const videoIndex = Math.max(0, this.videos.indexOf(frame.video));
+        for (const inst of frame.instances) {
+          const localInstId = instRows.length;
+          localId.set(inst as Instance, localInstId);
+          const skeletonId = Math.max(0, this.skeletons.indexOf(inst.skeleton));
+          const trackId = inst.track ? this.tracks.indexOf(inst.track) : -1;
+          const trackingScore = inst.trackingScore ?? 0;
+          let type = 0;
+          let score = 0;
+          let ptStart = 0;
+          let ptEnd = 0;
+          if (inst instanceof PredictedInstance) {
+            type = 1;
+            score = inst.score ?? 0;
+            ptStart = predPts.length;
+            for (const p of inst.points) {
+              predPts.push([
+                p.xy[0],
+                p.xy[1],
+                p.visible ? 1 : 0,
+                p.complete ? 1 : 0,
+                (p as { score?: number }).score ?? 0,
+              ]);
+            }
+            ptEnd = predPts.length;
+          } else {
+            ptStart = userPts.length;
+            for (const p of inst.points) {
+              userPts.push([
+                p.xy[0],
+                p.xy[1],
+                p.visible ? 1 : 0,
+                p.complete ? 1 : 0,
+              ]);
+            }
+            ptEnd = userPts.length;
+            if (inst.fromPredicted)
+              links.push([localInstId, inst.fromPredicted]);
+          }
+          instRows.push([
+            localInstId,
+            type,
+            localFrameId,
+            skeletonId,
+            trackId,
+            -1, // from_predicted (patched below)
+            score,
+            ptStart,
+            ptEnd,
+            trackingScore,
+          ]);
+        }
+        framesRows.push([
+          localFrameId,
+          videoIndex,
+          frame.frameIdx,
+          instanceStart,
+          instRows.length,
+        ]);
+        if (frame.isNegative) {
+          this.negativeFrames.add(`${videoIndex}:${frame.frameIdx}`);
         }
       }
 
-      appendMatrixRows(
-        this.file,
-        "frames",
-        framesFlat,
-        wFrames,
-        5,
-        this.frameRows,
-      );
-      this.frameRows += wFrames;
-      appendMatrixRows(
-        this.file,
-        "instances",
-        instFlat,
-        nInst,
-        10,
-        this.instRows,
-      );
-      this.instRows += nInst;
-      appendMatrixRows(
-        this.file,
-        "points",
-        userPtsFlat,
-        nUserPts,
-        4,
-        this.pointRows,
-      );
-      this.pointRows += nUserPts;
+      // Resolve from_predicted to a GLOBAL instance id (or -1 if the source is
+      // not in this batch — a dangling link, matching the eager writer).
+      for (const [local, src] of links) {
+        const srcLocal = localId.get(src as unknown as Instance);
+        instRows[local][5] = srcLocal != null ? instBase + srcLocal : -1;
+      }
+
+      const nF = framesRows.length;
+      const nI = instRows.length;
+      const nU = userPts.length;
+      const nP = predPts.length;
+
+      const framesFlat = new Float64Array(nF * 5);
+      for (let i = 0; i < nF; i++) {
+        const r = framesRows[i];
+        const o = i * 5;
+        framesFlat[o] = frameBase + r[0];
+        framesFlat[o + 1] = r[1];
+        framesFlat[o + 2] = r[2];
+        framesFlat[o + 3] = instBase + r[3];
+        framesFlat[o + 4] = instBase + r[4];
+      }
+      const instFlat = new Float64Array(nI * 10);
+      for (let i = 0; i < nI; i++) {
+        const r = instRows[i];
+        const o = i * 10;
+        const ptBase = r[1] === 1 ? predBase : pointBase;
+        instFlat[o] = instBase + r[0];
+        instFlat[o + 1] = r[1];
+        instFlat[o + 2] = frameBase + r[2];
+        instFlat[o + 3] = r[3];
+        instFlat[o + 4] = r[4];
+        instFlat[o + 5] = r[5]; // already global (or -1)
+        instFlat[o + 6] = r[6];
+        instFlat[o + 7] = ptBase + r[7];
+        instFlat[o + 8] = ptBase + r[8];
+        instFlat[o + 9] = r[9];
+      }
+      const userFlat = new Float64Array(nU * 4);
+      for (let i = 0; i < nU; i++) {
+        const r = userPts[i];
+        const o = i * 4;
+        userFlat[o] = r[0];
+        userFlat[o + 1] = r[1];
+        userFlat[o + 2] = r[2];
+        userFlat[o + 3] = r[3];
+      }
+      const predFlat = new Float64Array(nP * 5);
+      for (let i = 0; i < nP; i++) {
+        const r = predPts[i];
+        const o = i * 5;
+        predFlat[o] = r[0];
+        predFlat[o + 1] = r[1];
+        predFlat[o + 2] = r[2];
+        predFlat[o + 3] = r[3];
+        predFlat[o + 4] = r[4];
+      }
+
+      appendMatrixRows(this.file, "frames", framesFlat, nF, 5, this.frameRows);
+      this.frameRows += nF;
+      appendMatrixRows(this.file, "instances", instFlat, nI, 10, this.instRows);
+      this.instRows += nI;
+      appendMatrixRows(this.file, "points", userFlat, nU, 4, this.pointRows);
+      this.pointRows += nU;
       appendMatrixRows(
         this.file,
         "pred_points",
-        predPtsFlat,
-        nPredPts,
+        predFlat,
+        nP,
         5,
         this.predPointRows,
       );
-      this.predPointRows += nPredPts;
+      this.predPointRows += nP;
+    } catch (e) {
+      this.dispose();
+      throw e;
     }
   }
 
@@ -843,6 +1043,26 @@ export class SlpStreamWriter {
     fs.unlink!(this.memPath);
     return bytes;
   }
+
+  /**
+   * Release the underlying HDF5 file WITHOUT producing bytes — call to clean up
+   * a writer that will not be finished (e.g. after an error). Idempotent and
+   * best-effort (never throws); the file/MEMFS path are closed and unlinked.
+   */
+  dispose(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.file.close();
+    } catch {
+      // best-effort
+    }
+    try {
+      getH5FileSystem(this.module).unlink?.(this.memPath);
+    } catch {
+      // best-effort
+    }
+  }
 }
 
 /**
@@ -859,46 +1079,80 @@ export async function openSlpWriter(
   const memPath = `/tmp/sleap_stream_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
   const file = new module.File(memPath, "w");
 
-  // Reuse the eager metadata writers via a frameless header `Labels` (they read
-  // only header fields). Sessions are written with an empty labeled-frame list,
-  // so frame-group refs that resolve by labeled-frame index are dropped — matches
-  // the lazy fast-path (`writeSlpToFileLazy`).
-  const headerLabels = new Labels({
-    labeledFrames: [],
+  try {
+    // Reuse the eager metadata writers via a frameless header `Labels` (they read
+    // only header fields). Sessions are written with an empty labeled-frame list,
+    // so frame-group refs that resolve by labeled-frame index are dropped — matches
+    // the lazy fast-path (`writeSlpToFileLazy`).
+    const headerLabels = new Labels({
+      labeledFrames: [],
+      videos: header.videos,
+      skeletons: header.skeletons,
+      tracks: header.tracks ?? [],
+      suggestions: header.suggestions ?? [],
+      sessions: header.sessions ?? [],
+      identities: header.identities ?? [],
+      provenance: header.provenance ?? {},
+    });
+
+    writeMetadata(file, headerLabels);
+    writeVideos(file, headerLabels.videos);
+    writeVideoCrops(file, headerLabels.videos);
+    writeTracks(file, headerLabels.tracks);
+    writeSuggestions(file, headerLabels.suggestions, headerLabels.videos);
+    writeIdentities(file, headerLabels.identities);
+    writeSessions(
+      file,
+      headerLabels.sessions,
+      headerLabels.videos,
+      [],
+      headerLabels.identities,
+    );
+
+    createAppendableMatrixDataset(file, "frames", FRAMES_FIELDS, "<i8");
+    createAppendableMatrixDataset(file, "instances", INSTANCES_FIELDS, "<f8");
+    createAppendableMatrixDataset(file, "points", POINTS_FIELDS, "<f8");
+    createAppendableMatrixDataset(
+      file,
+      "pred_points",
+      PRED_POINTS_FIELDS,
+      "<f8",
+    );
+  } catch (e) {
+    // Don't leak the MEMFS file if header setup fails before a writer exists.
+    try {
+      file.close();
+    } catch {
+      // best-effort
+    }
+    try {
+      getH5FileSystem(module).unlink?.(memPath);
+    } catch {
+      // best-effort
+    }
+    throw e;
+  }
+
+  return new SlpStreamWriter(module, file, memPath, {
     videos: header.videos,
     skeletons: header.skeletons,
     tracks: header.tracks ?? [],
-    suggestions: header.suggestions ?? [],
-    sessions: header.sessions ?? [],
-    identities: header.identities ?? [],
-    provenance: header.provenance ?? {},
   });
-
-  writeMetadata(file, headerLabels);
-  writeVideos(file, headerLabels.videos);
-  writeVideoCrops(file, headerLabels.videos);
-  writeTracks(file, headerLabels.tracks);
-  writeSuggestions(file, headerLabels.suggestions, headerLabels.videos);
-  writeIdentities(file, headerLabels.identities);
-  writeSessions(
-    file,
-    headerLabels.sessions,
-    headerLabels.videos,
-    [],
-    headerLabels.identities,
-  );
-
-  createAppendableMatrixDataset(file, "frames", FRAMES_FIELDS, "<i8");
-  createAppendableMatrixDataset(file, "instances", INSTANCES_FIELDS, "<f8");
-  createAppendableMatrixDataset(file, "points", POINTS_FIELDS, "<f8");
-  createAppendableMatrixDataset(file, "pred_points", PRED_POINTS_FIELDS, "<f8");
-
-  return new SlpStreamWriter(module, file, memPath);
 }
 
-/** Structural node-name signature of a skeleton list, for cross-store equality. */
+/**
+ * Structural signature of a skeleton list — node names, edges, and symmetries —
+ * for cross-store equality. Instances from every store are read back against the
+ * combined (store 0's) skeleton, so topology must match, not just node names.
+ */
 function skeletonSignature(skeletons: Skeleton[]): string {
-  return JSON.stringify(skeletons.map((s) => s.nodeNames));
+  return JSON.stringify(
+    skeletons.map((s) => ({
+      nodes: s.nodeNames,
+      edges: s.edges.map((e) => [e.source.name, e.destination.name]),
+      symmetries: s.symmetryNames,
+    })),
+  );
 }
 
 /**

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -29,6 +29,7 @@ import { deflate } from "pako";
 import type { Identity } from "../../model/identity.js";
 import { Instance3D, PredictedInstance3D } from "../../model/instance3d.js";
 import type { LazyDataStore } from "../../model/lazy.js";
+import { buildVideoIdMap } from "../../model/video-id-map.js";
 
 // File writer hook — registered by h5-node.ts (imported as side-effect from Node entry point).
 let _writeToFile:
@@ -506,6 +507,463 @@ function writeSlpToFileLazy(file: any, labels: Labels): void {
  * - `"user+suggestions"` - Embed user instance frames and suggestion frames
  * - `"source"` - Restore original video paths (no embedding)
  */
+// ===========================================================================
+// Streaming / incremental SLP writer (issue #207)
+//
+// A write-side companion to `readSlpStreaming({ lazy })`: build an SLP file by
+// appending pose frames/instances/points in bounded windows to *resizable* HDF5
+// datasets (create-empty → `resize` + `write_slice` per window), rather than
+// materializing the whole `Labels` graph or a full row matrix. Also supports
+// MERGING N per-camera `LazyDataStore`s into one combined multi-video `.slp`,
+// remapping video/instance/point/track ids as each store is appended — the
+// downstream LUCID export path (one combined multi-camera file, memory-bounded).
+//
+// Scope (v1): pose tables only (frames/instances/points/pred_points) +
+// negative_frames + all header metadata (videos/tracks/skeletons/suggestions/
+// identities/sessions/provenance). Per-frame annotation overlays (masks/rois/
+// bboxes/centroids/label-images), an edit overlay of corrected frames, and a
+// `FileSystemWritableFileStream` sink are follow-ups.
+// ===========================================================================
+
+/** Frames per append window — bounds the per-window typed-array allocation. */
+const DEFAULT_WRITE_WINDOW_FRAMES = 5000;
+/** HDF5 chunk row count for the appendable pose datasets. */
+const WRITE_CHUNK_ROWS = 8192;
+
+const FRAMES_FIELDS = [
+  "frame_id",
+  "video",
+  "frame_idx",
+  "instance_id_start",
+  "instance_id_end",
+];
+const INSTANCES_FIELDS = [
+  "instance_id",
+  "instance_type",
+  "frame_id",
+  "skeleton",
+  "track",
+  "from_predicted",
+  "score",
+  "point_id_start",
+  "point_id_end",
+  "tracking_score",
+];
+const POINTS_FIELDS = ["x", "y", "visible", "complete"];
+const PRED_POINTS_FIELDS = ["x", "y", "visible", "complete", "score"];
+
+/** Read a numeric column cell with a default (mirrors the lazy reader). */
+function numAt(col: any[] | undefined, i: number, def = 0): number {
+  const v = col?.[i];
+  return v === undefined || v === null ? def : Number(v);
+}
+
+/**
+ * Create an empty, row-resizable 2D dataset (`[0, cols]`, maxshape
+ * `[null, cols]`, chunked) and stamp its `field_names` attribute — the
+ * append-mode analog of {@link createMatrixDataset}.
+ */
+function createAppendableMatrixDataset(
+  file: any,
+  name: string,
+  fieldNames: string[],
+  dtype: string,
+): void {
+  const colCount = fieldNames.length;
+  file.create_dataset({
+    name,
+    data: new Float64Array(0),
+    shape: [0, colCount],
+    maxshape: [null, colCount],
+    chunks: [WRITE_CHUNK_ROWS, colCount],
+    dtype,
+  });
+  setStringAttr(file.get(name), "field_names", JSON.stringify(fieldNames));
+}
+
+/** Resize a matrix dataset by `rowCount` rows and write `flat` into the tail. */
+function appendMatrixRows(
+  file: any,
+  name: string,
+  flat: Float64Array,
+  rowCount: number,
+  colCount: number,
+  currentRows: number,
+): void {
+  if (rowCount === 0) return;
+  const ds = file.get(name);
+  ds.resize([currentRows + rowCount, colCount]);
+  ds.write_slice(
+    [
+      [currentRows, currentRows + rowCount],
+      [0, colCount],
+    ],
+    flat,
+  );
+}
+
+/** Static header (everything except the pose frames) for {@link openSlpWriter}. */
+export interface SlpWriteHeader {
+  skeletons: Skeleton[];
+  videos: Video[];
+  tracks?: Track[];
+  suggestions?: SuggestionFrame[];
+  identities?: Identity[];
+  sessions?: RecordingSession[];
+  provenance?: Record<string, unknown>;
+}
+
+/** Per-store id offsets applied while appending (see {@link SlpStreamWriter.appendStore}). */
+export interface AppendStoreOptions {
+  /** Added to each frame's (remapped) video index. */
+  videoIndexOffset?: number;
+  /** Added to each instance's non-null track index. */
+  trackOffset?: number;
+  /** Added to each instance's skeleton index. */
+  skeletonOffset?: number;
+  /** Frames per append window (defaults to {@link DEFAULT_WRITE_WINDOW_FRAMES}). */
+  windowFrames?: number;
+}
+
+/**
+ * Incremental SLP writer. Open with {@link openSlpWriter} (which writes the
+ * header and creates the resizable pose datasets), append one or more
+ * {@link LazyDataStore}s with {@link appendStore}, then {@link close} to get the
+ * file bytes. Ids are rebased per store so multiple stores concatenate into one
+ * consistent multi-video file.
+ */
+export class SlpStreamWriter {
+  private file: any;
+  private module: any;
+  private memPath: string;
+  private frameRows = 0;
+  private instRows = 0;
+  private pointRows = 0;
+  private predPointRows = 0;
+  private negativeFrames = new Set<string>();
+  private closed = false;
+
+  /** @internal — use {@link openSlpWriter}. */
+  constructor(module: any, file: any, memPath: string) {
+    this.module = module;
+    this.file = file;
+    this.memPath = memPath;
+  }
+
+  /**
+   * Append every frame of `store` (in windows), rebasing its ids onto the
+   * running file so the store's videos/instances/points/tracks land at the
+   * offsets given in `opts`. Point coordinates and all per-instance fields are
+   * copied verbatim from the store's columns — no `Instance`/`LabeledFrame`
+   * object is constructed. The store's frame/instance/point tables are assumed
+   * ordered by frame (the SLP on-disk invariant).
+   */
+  appendStore(store: LazyDataStore, opts?: AppendStoreOptions): void {
+    if (this.closed) throw new Error("SlpStreamWriter is closed");
+    const windowFrames = opts?.windowFrames ?? DEFAULT_WRITE_WINDOW_FRAMES;
+    const vOff = opts?.videoIndexOffset ?? 0;
+    const tOff = opts?.trackOffset ?? 0;
+    const kOff = opts?.skeletonOffset ?? 0;
+
+    const fd = store.framesData;
+    const idn = store.instancesData;
+    const nFrames = (fd.frame_id ?? fd.video ?? []).length;
+    if (nFrames === 0) return;
+
+    // Remap this store's raw `frames.video` ids to its own video indices (#204)
+    // before offsetting into the combined `videos` array.
+    const videoIdMap = buildVideoIdMap(fd, store.videos);
+    const remapVideo = (raw: number) => vOff + (videoIdMap.get(raw) ?? raw);
+
+    // Per-store bases: within the store, tables are 0-based, so a store row `r`
+    // maps to global `base + r`. Appends advance the running counters in lock-step
+    // with these bases, so instance/point ranges stay consistent across windows.
+    const frameBase = this.frameRows;
+    const instBase = this.instRows;
+    const pointBase = this.pointRows;
+    const predBase = this.predPointRows;
+
+    const px = store.pointsData.x,
+      py = store.pointsData.y,
+      pv = store.pointsData.visible,
+      pc = store.pointsData.complete;
+    const qx = store.predPointsData.x,
+      qy = store.predPointsData.y,
+      qv = store.predPointsData.visible,
+      qc = store.predPointsData.complete,
+      qs = store.predPointsData.score;
+
+    for (let wStart = 0; wStart < nFrames; wStart += windowFrames) {
+      const wEnd = Math.min(wStart + windowFrames, nFrames);
+      const wFrames = wEnd - wStart;
+
+      // Pass 1: size the window's instance / user-point / pred-point buffers.
+      let nInst = 0;
+      let nUserPts = 0;
+      let nPredPts = 0;
+      for (let r = wStart; r < wEnd; r++) {
+        const iStart = numAt(fd.instance_id_start, r);
+        const iEnd = numAt(fd.instance_id_end, r);
+        nInst += iEnd - iStart;
+        for (let j = iStart; j < iEnd; j++) {
+          const cnt = numAt(idn.point_id_end, j) - numAt(idn.point_id_start, j);
+          if (numAt(idn.instance_type, j) === 1) nPredPts += cnt;
+          else nUserPts += cnt;
+        }
+      }
+
+      const framesFlat = new Float64Array(wFrames * 5);
+      const instFlat = new Float64Array(nInst * 10);
+      const userPtsFlat = new Float64Array(nUserPts * 4);
+      const predPtsFlat = new Float64Array(nPredPts * 5);
+      let fi = 0;
+      let ii = 0;
+      let upi = 0;
+      let ppi = 0;
+
+      // Pass 2: emit rows, rebasing every cross-reference onto the store bases.
+      for (let r = wStart; r < wEnd; r++) {
+        const newFrameId = frameBase + r;
+        const combinedVideo = remapVideo(numAt(fd.video, r));
+        const frameIdx = numAt(fd.frame_idx, r);
+        const iStart = numAt(fd.instance_id_start, r);
+        const iEnd = numAt(fd.instance_id_end, r);
+
+        framesFlat[fi++] = newFrameId;
+        framesFlat[fi++] = combinedVideo;
+        framesFlat[fi++] = frameIdx;
+        framesFlat[fi++] = instBase + iStart;
+        framesFlat[fi++] = instBase + iEnd;
+
+        if (store.negativeFrames.has(`${numAt(fd.video, r)}:${frameIdx}`)) {
+          this.negativeFrames.add(`${combinedVideo}:${frameIdx}`);
+        }
+
+        for (let j = iStart; j < iEnd; j++) {
+          const type = numAt(idn.instance_type, j);
+          const ptStart = numAt(idn.point_id_start, j);
+          const ptEnd = numAt(idn.point_id_end, j);
+          const trk = numAt(idn.track, j, -1);
+          const fp = numAt(idn.from_predicted, j, -1);
+
+          instFlat[ii++] = instBase + j; // instance_id
+          instFlat[ii++] = type; // instance_type
+          instFlat[ii++] = newFrameId; // frame_id
+          instFlat[ii++] = numAt(idn.skeleton, j) + kOff; // skeleton
+          instFlat[ii++] = trk >= 0 ? trk + tOff : -1; // track
+          instFlat[ii++] = fp >= 0 ? instBase + fp : -1; // from_predicted
+          instFlat[ii++] = numAt(idn.score, j); // score
+          if (type === 1) {
+            instFlat[ii++] = predBase + ptStart; // point_id_start
+            instFlat[ii++] = predBase + ptEnd; // point_id_end
+            for (let p = ptStart; p < ptEnd; p++) {
+              predPtsFlat[ppi++] = numAt(qx, p);
+              predPtsFlat[ppi++] = numAt(qy, p);
+              predPtsFlat[ppi++] = numAt(qv, p);
+              predPtsFlat[ppi++] = numAt(qc, p);
+              predPtsFlat[ppi++] = numAt(qs, p);
+            }
+          } else {
+            instFlat[ii++] = pointBase + ptStart; // point_id_start
+            instFlat[ii++] = pointBase + ptEnd; // point_id_end
+            for (let p = ptStart; p < ptEnd; p++) {
+              userPtsFlat[upi++] = numAt(px, p);
+              userPtsFlat[upi++] = numAt(py, p);
+              userPtsFlat[upi++] = numAt(pv, p);
+              userPtsFlat[upi++] = numAt(pc, p);
+            }
+          }
+          instFlat[ii++] = numAt(idn.tracking_score, j); // tracking_score
+        }
+      }
+
+      appendMatrixRows(
+        this.file,
+        "frames",
+        framesFlat,
+        wFrames,
+        5,
+        this.frameRows,
+      );
+      this.frameRows += wFrames;
+      appendMatrixRows(
+        this.file,
+        "instances",
+        instFlat,
+        nInst,
+        10,
+        this.instRows,
+      );
+      this.instRows += nInst;
+      appendMatrixRows(
+        this.file,
+        "points",
+        userPtsFlat,
+        nUserPts,
+        4,
+        this.pointRows,
+      );
+      this.pointRows += nUserPts;
+      appendMatrixRows(
+        this.file,
+        "pred_points",
+        predPtsFlat,
+        nPredPts,
+        5,
+        this.predPointRows,
+      );
+      this.predPointRows += nPredPts;
+    }
+  }
+
+  /** Finalize the file (writes `negative_frames` if any) and return its bytes. */
+  close(): Uint8Array {
+    if (this.closed) throw new Error("SlpStreamWriter is already closed");
+    this.closed = true;
+
+    if (this.negativeFrames.size > 0) {
+      const rows: number[][] = [];
+      for (const key of this.negativeFrames) {
+        const [v, f] = key.split(":");
+        rows.push([Number(v), Number(f)]);
+      }
+      rows.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+      createMatrixDataset(
+        this.file,
+        "negative_frames",
+        rows,
+        ["video_id", "frame_idx"],
+        "<i8",
+      );
+    }
+
+    this.file.close();
+    const fs = getH5FileSystem(this.module);
+    const bytes = fs.readFile!(this.memPath);
+    fs.unlink!(this.memPath);
+    return bytes;
+  }
+}
+
+/**
+ * Open a streaming SLP writer: create the in-memory HDF5 file, write the header
+ * (skeletons/videos/tracks/suggestions/identities/sessions/provenance), and
+ * create the resizable `frames`/`instances`/`points`/`pred_points` datasets.
+ * Frame data is appended later via {@link SlpStreamWriter.appendStore}.
+ */
+export async function openSlpWriter(
+  header: SlpWriteHeader,
+): Promise<SlpStreamWriter> {
+  const module = await getH5Module();
+  ensureH5StagingDir(module);
+  const memPath = `/tmp/sleap_stream_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
+  const file = new module.File(memPath, "w");
+
+  // Reuse the eager metadata writers via a frameless header `Labels` (they read
+  // only header fields). Sessions are written with an empty labeled-frame list,
+  // so frame-group refs that resolve by labeled-frame index are dropped — matches
+  // the lazy fast-path (`writeSlpToFileLazy`).
+  const headerLabels = new Labels({
+    labeledFrames: [],
+    videos: header.videos,
+    skeletons: header.skeletons,
+    tracks: header.tracks ?? [],
+    suggestions: header.suggestions ?? [],
+    sessions: header.sessions ?? [],
+    identities: header.identities ?? [],
+    provenance: header.provenance ?? {},
+  });
+
+  writeMetadata(file, headerLabels);
+  writeVideos(file, headerLabels.videos);
+  writeVideoCrops(file, headerLabels.videos);
+  writeTracks(file, headerLabels.tracks);
+  writeSuggestions(file, headerLabels.suggestions, headerLabels.videos);
+  writeIdentities(file, headerLabels.identities);
+  writeSessions(
+    file,
+    headerLabels.sessions,
+    headerLabels.videos,
+    [],
+    headerLabels.identities,
+  );
+
+  createAppendableMatrixDataset(file, "frames", FRAMES_FIELDS, "<i8");
+  createAppendableMatrixDataset(file, "instances", INSTANCES_FIELDS, "<f8");
+  createAppendableMatrixDataset(file, "points", POINTS_FIELDS, "<f8");
+  createAppendableMatrixDataset(file, "pred_points", PRED_POINTS_FIELDS, "<f8");
+
+  return new SlpStreamWriter(module, file, memPath);
+}
+
+/** Structural node-name signature of a skeleton list, for cross-store equality. */
+function skeletonSignature(skeletons: Skeleton[]): string {
+  return JSON.stringify(skeletons.map((s) => s.nodeNames));
+}
+
+/**
+ * Merge N per-camera {@link LazyDataStore}s into one combined multi-video
+ * `.slp`, streaming each store's frames in bounded windows (peak memory ≪ the
+ * whole graph). The combined `videos` and `tracks` are the concatenation of the
+ * stores' (video index and track index remapped accordingly); all stores must
+ * share a structurally-identical skeleton list (the multi-camera case), which
+ * becomes the combined skeleton set. Session graph / identities / suggestions /
+ * provenance for the combined file are supplied via `options`.
+ *
+ * @returns the SLP file bytes (round-trips via `readSlpStreaming` / `readSlp`).
+ */
+export async function saveSlpMergedFromStores(
+  stores: LazyDataStore[],
+  options?: {
+    sessions?: RecordingSession[];
+    identities?: Identity[];
+    suggestions?: SuggestionFrame[];
+    provenance?: Record<string, unknown>;
+    windowFrames?: number;
+  },
+): Promise<Uint8Array> {
+  if (stores.length === 0) {
+    throw new Error("saveSlpMergedFromStores requires at least one store");
+  }
+  const sig = skeletonSignature(stores[0].skeletons);
+  for (let i = 1; i < stores.length; i++) {
+    if (skeletonSignature(stores[i].skeletons) !== sig) {
+      throw new Error(
+        `saveSlpMergedFromStores: store ${i} has a different skeleton than store 0; ` +
+          "all stores must share the same skeletons to merge into one file.",
+      );
+    }
+  }
+
+  const videos: Video[] = stores.flatMap((s) => s.videos);
+  const tracks: Track[] = stores.flatMap((s) => s.tracks);
+
+  const writer = await openSlpWriter({
+    skeletons: stores[0].skeletons,
+    videos,
+    tracks,
+    suggestions: options?.suggestions,
+    identities: options?.identities,
+    sessions: options?.sessions,
+    provenance: options?.provenance,
+  });
+
+  let videoOffset = 0;
+  let trackOffset = 0;
+  for (const store of stores) {
+    writer.appendStore(store, {
+      videoIndexOffset: videoOffset,
+      trackOffset,
+      skeletonOffset: 0, // shared skeletons (validated)
+      windowFrames: options?.windowFrames,
+    });
+    videoOffset += store.videos.length;
+    trackOffset += store.tracks.length;
+  }
+
+  return writer.close();
+}
+
 export async function saveSlpToBytes(
   labels: Labels,
   options?: SlpWriteOptions,

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -626,6 +626,44 @@ export interface AppendStoreOptions {
 }
 
 /**
+ * A chunked byte sink for {@link SlpStreamWriter.writeToSink} — the output-side
+ * companion to the append writer. Satisfied by a browser
+ * `FileSystemWritableFileStream` (OPFS / save-file-picker) and by Node's
+ * `fs.WriteStream`, so the finished file need not be resident as one big
+ * `Uint8Array`.
+ */
+export interface SlpWriteSink {
+  write(chunk: Uint8Array): unknown | Promise<unknown>;
+  close?(): unknown | Promise<unknown>;
+}
+
+/** Emscripten-FS methods used for chunked reads (present on h5wasm's `module.FS`). */
+interface ChunkedFs {
+  open?: (path: string, flags: string) => unknown;
+  read?: (
+    stream: unknown,
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: number,
+  ) => number;
+  close?: (stream: unknown) => void;
+  stat?: (path: string) => { size: number };
+}
+
+/** An annotation with the instance link the writers read via fallback. */
+type AnnLinked = { instance: Instance | null; _instanceIdx: number | null };
+/** Accumulated annotations of one type: objects + `[vid,frame]` ctx + global inst idx. */
+interface AnnBucket<T> {
+  anns: T[];
+  ctx: [number, number][];
+  inst: number[];
+}
+function newAnnBucket<T>(): AnnBucket<T> {
+  return { anns: [], ctx: [], inst: [] };
+}
+
+/**
  * Incremental SLP writer. Open with {@link openSlpWriter} (which writes the
  * header and creates the resizable pose datasets), append one or more
  * {@link LazyDataStore}s with {@link appendStore}, then {@link close} to get the
@@ -645,6 +683,23 @@ export class SlpStreamWriter {
   private predPointRows = 0;
   private negativeFrames = new Set<string>();
   private closed = false;
+
+  // Per-frame annotations (masks/rois/bboxes/centroids/label-images) accumulated
+  // across appends and written once at finalize — they're far fewer than pose
+  // points, so they are not windowed. `ctx` is `[videoIndex, frameIdx]`; `inst`
+  // is the resolved GLOBAL instance index (or -1) for the annotation's link.
+  private pendingRois = newAnnBucket<ROI>();
+  private pendingMasks = newAnnBucket<SegmentationMask>();
+  private pendingBboxes = newAnnBucket<BoundingBox>();
+  private pendingCentroids = newAnnBucket<Centroid>();
+  // Label images carry instance links PER OBJECT (not on the top-level object),
+  // so only their video/frame context is remapped here; each object's
+  // `_instanceIdx` passes through (correct single-store; may be off in a
+  // multi-store merge — a niche edge, tracked on #207).
+  private pendingLabelImages: {
+    anns: LabelImage[];
+    ctx: [number, number][];
+  } = { anns: [], ctx: [] };
 
   /** @internal — use {@link openSlpWriter}. */
   constructor(
@@ -838,6 +893,9 @@ export class SlpStreamWriter {
         );
         this.predPointRows += nPredPts;
       }
+      // Per-frame + undistributed annotations (masks/rois/…), video + instance
+      // remapped, written once at finalize.
+      this.collectStoreAnnotations(store, vOff, instBase);
     } catch (e) {
       // A mid-write failure leaves a partial file — release it rather than leak.
       this.dispose();
@@ -935,6 +993,7 @@ export class SlpStreamWriter {
         if (frame.isNegative) {
           this.negativeFrames.add(`${videoIndex}:${frame.frameIdx}`);
         }
+        this.collectFrameAnnotations(frame, videoIndex, instBase, localId);
       }
 
       // Resolve from_predicted to a GLOBAL instance id (or -1 if the source is
@@ -1016,11 +1075,161 @@ export class SlpStreamWriter {
     }
   }
 
-  /** Finalize the file (writes `negative_frames` if any) and return its bytes. */
-  close(): Uint8Array {
-    if (this.closed) throw new Error("SlpStreamWriter is already closed");
-    this.closed = true;
+  /**
+   * Collect a store's per-frame + undistributed annotations, remapping the
+   * video index (`+vOff`) and the instance link (`+instBase`) onto the combined
+   * file. The store's map keys are `"videoIndex:frameIdx"` (array-index video).
+   */
+  private collectStoreAnnotations(
+    store: LazyDataStore,
+    vOff: number,
+    instBase: number,
+  ): void {
+    const resolve = (idx: number | null | undefined): number =>
+      idx != null && idx >= 0 ? instBase + idx : -1;
+    const fromMap = <T extends AnnLinked>(
+      map: Map<string, T[]>,
+      bucket: AnnBucket<T>,
+    ): void => {
+      for (const [key, list] of map) {
+        const sep = key.indexOf(":");
+        const vid = vOff + Number(key.slice(0, sep));
+        const fidx = Number(key.slice(sep + 1));
+        for (const ann of list) {
+          bucket.anns.push(ann);
+          bucket.ctx.push([vid, fidx]);
+          bucket.inst.push(resolve(ann._instanceIdx));
+        }
+      }
+    };
+    fromMap(store._roiByFrame, this.pendingRois);
+    fromMap(store._maskByFrame, this.pendingMasks);
+    fromMap(store._bboxByFrame, this.pendingBboxes);
+    fromMap(store._centroidByFrame, this.pendingCentroids);
+    for (const [key, list] of store._labelImageByFrame) {
+      const sep = key.indexOf(":");
+      const vid = vOff + Number(key.slice(0, sep));
+      const fidx = Number(key.slice(sep + 1));
+      for (const li of list) {
+        this.pendingLabelImages.anns.push(li);
+        this.pendingLabelImages.ctx.push([vid, fidx]);
+      }
+    }
 
+    const undist = <T extends AnnLinked>(
+      list: T[],
+      bucket: AnnBucket<T>,
+      vidFor: (ann: T) => number,
+    ): void => {
+      for (const ann of list) {
+        bucket.anns.push(ann);
+        bucket.ctx.push([vidFor(ann), -1]);
+        bucket.inst.push(resolve(ann._instanceIdx));
+      }
+    };
+    // Static ROIs keep their video association (via the combined videos array).
+    undist(store._undistributedRois, this.pendingRois, (roi) =>
+      (roi as ROI).video ? this.videos.indexOf((roi as ROI).video!) : -1,
+    );
+    undist(store._undistributedMasks, this.pendingMasks, () => -1);
+    undist(store._undistributedBboxes, this.pendingBboxes, () => -1);
+    undist(store._undistributedCentroids, this.pendingCentroids, () => -1);
+    for (const li of store._undistributedLabelImages) {
+      this.pendingLabelImages.anns.push(li);
+      this.pendingLabelImages.ctx.push([-1, -1]);
+    }
+  }
+
+  /**
+   * Collect a materialized frame's annotations, resolving each annotation's live
+   * `instance` to its GLOBAL index via the batch's local map (`+instBase`).
+   * Annotations without a live `instance` in the batch drop their link (-1).
+   */
+  private collectFrameAnnotations(
+    frame: LabeledFrame,
+    vid: number,
+    instBase: number,
+    localId: Map<Instance, number>,
+  ): void {
+    const resolve = (inst: Instance | null | undefined): number => {
+      if (!inst) return -1;
+      const l = localId.get(inst);
+      return l != null ? instBase + l : -1;
+    };
+    const push = <T extends AnnLinked>(
+      list: T[],
+      bucket: AnnBucket<T>,
+    ): void => {
+      for (const ann of list) {
+        bucket.anns.push(ann);
+        bucket.ctx.push([vid, frame.frameIdx]);
+        bucket.inst.push(resolve(ann.instance));
+      }
+    };
+    push(frame.rois, this.pendingRois);
+    push(frame.masks, this.pendingMasks);
+    push(frame.bboxes, this.pendingBboxes);
+    push(frame.centroids, this.pendingCentroids);
+    for (const li of frame.labelImages) {
+      this.pendingLabelImages.anns.push(li);
+      this.pendingLabelImages.ctx.push([vid, frame.frameIdx]);
+    }
+  }
+
+  /**
+   * Write all accumulated annotation datasets. The per-type writers read the
+   * instance link off each object, so the resolved GLOBAL index is applied via a
+   * contained mutate→write→restore (source annotations are left unchanged).
+   */
+  private writePendingAnnotations(): void {
+    const writeBucket = <T extends AnnLinked>(
+      bucket: AnnBucket<T>,
+      fn: (
+        file: any,
+        anns: T[],
+        videos: Video[],
+        tracks: Track[],
+        instances: never[],
+        ctx: [number, number][],
+      ) => void,
+    ): void => {
+      if (bucket.anns.length === 0) return;
+      const saved = bucket.anns.map(
+        (a) => [a.instance, a._instanceIdx] as const,
+      );
+      try {
+        for (let i = 0; i < bucket.anns.length; i++) {
+          bucket.anns[i].instance = null;
+          bucket.anns[i]._instanceIdx =
+            bucket.inst[i] >= 0 ? bucket.inst[i] : null;
+        }
+        fn(this.file, bucket.anns, this.videos, this.tracks, [], bucket.ctx);
+      } finally {
+        for (let i = 0; i < bucket.anns.length; i++) {
+          bucket.anns[i].instance = saved[i][0];
+          bucket.anns[i]._instanceIdx = saved[i][1];
+        }
+      }
+    };
+    writeBucket(this.pendingRois, writeRois);
+    writeBucket(this.pendingMasks, writeMasks);
+    writeBucket(this.pendingBboxes, writeBboxes);
+    writeBucket(this.pendingCentroids, writeCentroids);
+    if (this.pendingLabelImages.anns.length > 0) {
+      writeLabelImages(
+        this.file,
+        this.pendingLabelImages.anns,
+        this.videos,
+        this.tracks,
+        [],
+        this.pendingLabelImages.ctx,
+      );
+    }
+  }
+
+  /** Write pending `negative_frames` and close the HDF5 file (shared finalize). */
+  private finalizeFile(): void {
+    this.writePendingAnnotations();
     if (this.negativeFrames.size > 0) {
       const rows: number[][] = [];
       for (const key of this.negativeFrames) {
@@ -1036,12 +1245,73 @@ export class SlpStreamWriter {
         "<i8",
       );
     }
-
     this.file.close();
+  }
+
+  /** Finalize the file (writes `negative_frames` if any) and return its bytes. */
+  close(): Uint8Array {
+    if (this.closed) throw new Error("SlpStreamWriter is already closed");
+    this.closed = true;
+    this.finalizeFile();
     const fs = getH5FileSystem(this.module);
     const bytes = fs.readFile!(this.memPath);
     fs.unlink!(this.memPath);
     return bytes;
+  }
+
+  /**
+   * Finalize and stream the file to `sink` in chunks, then unlink it — the
+   * output-side companion to {@link appendStore}, so the finished file never has
+   * to be resident as one big `Uint8Array` on the JS side. Reads the in-memory
+   * HDF5 file with chunked FS reads when available (falling back to a single
+   * read). `sink.close()` is awaited if present.
+   *
+   * @param opts.chunkBytes Chunk size (default 8 MiB).
+   */
+  async writeToSink(
+    sink: SlpWriteSink,
+    opts?: { chunkBytes?: number },
+  ): Promise<void> {
+    if (this.closed) throw new Error("SlpStreamWriter is already closed");
+    this.closed = true;
+    this.finalizeFile();
+
+    const fs = getH5FileSystem(this.module);
+    const cfs = fs as unknown as ChunkedFs;
+    const chunkBytes = Math.max(
+      1,
+      Math.trunc(opts?.chunkBytes ?? 8 * 1024 * 1024),
+    );
+    try {
+      if (cfs.open && cfs.read && cfs.close && cfs.stat) {
+        const size = Number(cfs.stat(this.memPath).size);
+        const stream = cfs.open(this.memPath, "r");
+        try {
+          const buf = new Uint8Array(chunkBytes);
+          let pos = 0;
+          while (pos < size) {
+            const want = Math.min(chunkBytes, size - pos);
+            const n = cfs.read(stream, buf, 0, want, pos);
+            if (n <= 0) break;
+            await sink.write(buf.slice(0, n)); // copy — buf is reused
+            pos += n;
+          }
+        } finally {
+          cfs.close(stream);
+        }
+      } else {
+        // No chunked FS reads: read once, then hand out slices.
+        const bytes = fs.readFile!(this.memPath);
+        for (let pos = 0; pos < bytes.length; pos += chunkBytes) {
+          await sink.write(
+            bytes.slice(pos, Math.min(pos + chunkBytes, bytes.length)),
+          );
+        }
+      }
+      if (sink.close) await sink.close();
+    } finally {
+      fs.unlink!(this.memPath);
+    }
   }
 
   /**
@@ -1166,24 +1436,32 @@ function skeletonSignature(skeletons: Skeleton[]): string {
  *
  * @returns the SLP file bytes (round-trips via `readSlpStreaming` / `readSlp`).
  */
-export async function saveSlpMergedFromStores(
+export interface MergeStoresOptions {
+  sessions?: RecordingSession[];
+  identities?: Identity[];
+  suggestions?: SuggestionFrame[];
+  provenance?: Record<string, unknown>;
+  windowFrames?: number;
+}
+
+/**
+ * Validate the stores share a skeleton, open a writer over the concatenated
+ * videos/tracks, and append every store (windowed) with cumulative offsets.
+ * Returns the OPEN writer — the caller finalizes via `close()` (bytes) or
+ * `writeToSink()` (streamed output). On error the partial file is disposed.
+ */
+async function buildMergedWriter(
   stores: LazyDataStore[],
-  options?: {
-    sessions?: RecordingSession[];
-    identities?: Identity[];
-    suggestions?: SuggestionFrame[];
-    provenance?: Record<string, unknown>;
-    windowFrames?: number;
-  },
-): Promise<Uint8Array> {
+  options?: MergeStoresOptions,
+): Promise<SlpStreamWriter> {
   if (stores.length === 0) {
-    throw new Error("saveSlpMergedFromStores requires at least one store");
+    throw new Error("merging SLP stores requires at least one store");
   }
   const sig = skeletonSignature(stores[0].skeletons);
   for (let i = 1; i < stores.length; i++) {
     if (skeletonSignature(stores[i].skeletons) !== sig) {
       throw new Error(
-        `saveSlpMergedFromStores: store ${i} has a different skeleton than store 0; ` +
+        `merging SLP stores: store ${i} has a different skeleton than store 0; ` +
           "all stores must share the same skeletons to merge into one file.",
       );
     }
@@ -1202,20 +1480,59 @@ export async function saveSlpMergedFromStores(
     provenance: options?.provenance,
   });
 
-  let videoOffset = 0;
-  let trackOffset = 0;
-  for (const store of stores) {
-    writer.appendStore(store, {
-      videoIndexOffset: videoOffset,
-      trackOffset,
-      skeletonOffset: 0, // shared skeletons (validated)
-      windowFrames: options?.windowFrames,
-    });
-    videoOffset += store.videos.length;
-    trackOffset += store.tracks.length;
+  try {
+    let videoOffset = 0;
+    let trackOffset = 0;
+    for (const store of stores) {
+      writer.appendStore(store, {
+        videoIndexOffset: videoOffset,
+        trackOffset,
+        skeletonOffset: 0, // shared skeletons (validated)
+        windowFrames: options?.windowFrames,
+      });
+      videoOffset += store.videos.length;
+      trackOffset += store.tracks.length;
+    }
+  } catch (e) {
+    writer.dispose();
+    throw e;
   }
 
+  return writer;
+}
+
+/**
+ * Merge N per-camera {@link LazyDataStore}s into one combined multi-video
+ * `.slp`, streaming each store's frames in bounded windows (peak memory ≪ the
+ * whole graph). The combined `videos` and `tracks` are the concatenation of the
+ * stores' (video index and track index remapped accordingly); all stores must
+ * share a structurally-identical skeleton list (the multi-camera case), which
+ * becomes the combined skeleton set. Session graph / identities / suggestions /
+ * provenance for the combined file are supplied via `options`.
+ *
+ * @returns the SLP file bytes (round-trips via `readSlpStreaming` / `readSlp`).
+ */
+export async function saveSlpMergedFromStores(
+  stores: LazyDataStore[],
+  options?: MergeStoresOptions,
+): Promise<Uint8Array> {
+  const writer = await buildMergedWriter(stores, options);
   return writer.close();
+}
+
+/**
+ * Like {@link saveSlpMergedFromStores}, but streams the combined file to `sink`
+ * in chunks instead of returning bytes — so neither the input `Labels` graph nor
+ * the whole output is ever fully resident. Use with a browser
+ * `FileSystemWritableFileStream` (OPFS / save picker) or Node `fs.WriteStream`.
+ */
+export async function saveSlpMergedToSink(
+  stores: LazyDataStore[],
+  sink: SlpWriteSink,
+  options?: MergeStoresOptions & { chunkBytes?: number },
+): Promise<void> {
+  const writer = await buildMergedWriter(stores, options);
+  await writer.writeToSink(sink, { chunkBytes: options?.chunkBytes });
 }
 
 export async function saveSlpToBytes(

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -683,6 +683,11 @@ export class SlpStreamWriter {
   private predPointRows = 0;
   private negativeFrames = new Set<string>();
   private closed = false;
+  // Combined `${videoIndex}:${frameIdx}` keys already written, for dedup across
+  // appendStore/appendFrames. First write wins: a later append that repeats a
+  // key skips that frame entirely. Append overlays (appendFrames) BEFORE bulk
+  // stores so the overlay's frame is the one kept. See #208 follow-up.
+  private writtenFrames = new Set<string>();
 
   // Per-frame annotations (masks/rois/bboxes/centroids/label-images) accumulated
   // across appends and written once at finalize — they're far fewer than pose
@@ -723,6 +728,13 @@ export class SlpStreamWriter {
    * copied verbatim from the store's columns — no `Instance`/`LabeledFrame`
    * object is constructed. The store's frame/instance/point tables are assumed
    * ordered by frame (the SLP on-disk invariant).
+   *
+   * A `(video, frameIdx)` already written (by an earlier append) is SKIPPED — so
+   * append overlays via {@link appendFrames} first for them to win. Frame /
+   * instance / point ids are assigned from running OUTPUT counters (not the
+   * store's positions), so skips leave no gaps; cross-references
+   * (`from_predicted`, annotation instance links) are remapped through the
+   * skipped ranges. `store` must not itself contain duplicate `(video, frameIdx)`.
    */
   appendStore(store: LazyDataStore, opts?: AppendStoreOptions): void {
     if (this.closed) throw new Error("SlpStreamWriter is closed");
@@ -741,9 +753,9 @@ export class SlpStreamWriter {
     const videoIdMap = buildVideoIdMap(fd, store.videos);
     const remapVideo = (raw: number) => vOff + (videoIdMap.get(raw) ?? raw);
 
-    // Per-store bases: within the store, tables are 0-based, so a store row `r`
-    // maps to global `base + r`. Appends advance the running counters in lock-step
-    // with these bases, so instance/point ranges stay consistent across windows.
+    // Per-store OUTPUT bases: the first output row/instance/point this store
+    // contributes. Ids are `base + <running output counter>`, so skipped frames
+    // leave no gaps.
     const frameBase = this.frameRows;
     const instBase = this.instRows;
     const pointBase = this.pointRows;
@@ -759,11 +771,38 @@ export class SlpStreamWriter {
       qc = store.predPointsData.complete,
       qs = store.predPointsData.score;
 
-    // Running counts of user / predicted points emitted for THIS store, across
-    // all its windows. Points are re-packed into frame-iteration order, so an
-    // instance's new point range is its position in that packed stream — NOT the
-    // store's original `point_id_start` (which need not be monotonic in frame
-    // order for a reader-valid store, and would then misattribute points). #208.
+    // Pre-pass: the instance ranges of frames that will be SKIPPED (their
+    // `(video, frameIdx)` was already written). Sorted by construction (frames
+    // are in order). `outIdxOf` maps a store instance index to its output
+    // position — identity when nothing is skipped, so the no-overlap path is
+    // unchanged — or `null` when that instance falls in a skipped frame.
+    const skippedRanges: Array<[number, number]> = [];
+    const skippedKeys = new Set<string>();
+    for (let r = 0; r < nFrames; r++) {
+      const key = `${remapVideo(numAt(fd.video, r))}:${numAt(fd.frame_idx, r)}`;
+      if (this.writtenFrames.has(key)) {
+        skippedRanges.push([
+          numAt(fd.instance_id_start, r),
+          numAt(fd.instance_id_end, r),
+        ]);
+        skippedKeys.add(key);
+      }
+    }
+    const outIdxOf = (idx: number): number | null => {
+      if (skippedRanges.length === 0) return idx;
+      let shift = 0;
+      for (const [s, e] of skippedRanges) {
+        if (idx < s) break; // ranges sorted; the rest are past idx
+        if (idx < e) return null; // idx is inside a skipped frame → dangling
+        shift += e - s;
+      }
+      return idx - shift;
+    };
+
+    // Running OUTPUT counters for this store (across all its windows): emitted
+    // frames, instances, and re-packed user / predicted points.
+    let outFrames = 0;
+    let outInsts = 0;
     let userWritten = 0;
     let predWritten = 0;
 
@@ -772,7 +811,8 @@ export class SlpStreamWriter {
         const wEnd = Math.min(wStart + windowFrames, nFrames);
         const wFrames = wEnd - wStart;
 
-        // Pass 1: size the window's instance / user-point / pred-point buffers.
+        // Pass 1: size the window's buffers at max (skips only shrink usage; the
+        // actually-filled slice is written below).
         let nInst = 0;
         let nUserPts = 0;
         let nPredPts = 0;
@@ -797,19 +837,24 @@ export class SlpStreamWriter {
         let upi = 0;
         let ppi = 0;
 
-        // Pass 2: emit rows, rebasing every cross-reference onto the store bases.
+        // Pass 2: emit rows for non-skipped frames, assigning ids from the
+        // running output counters.
         for (let r = wStart; r < wEnd; r++) {
-          const newFrameId = frameBase + r;
           const combinedVideo = remapVideo(numAt(fd.video, r));
           const frameIdx = numAt(fd.frame_idx, r);
+          const key = `${combinedVideo}:${frameIdx}`;
           const iStart = numAt(fd.instance_id_start, r);
           const iEnd = numAt(fd.instance_id_end, r);
 
+          if (this.writtenFrames.has(key)) continue; // dedup: first write wins
+
+          const newFrameId = frameBase + outFrames;
+          outFrames++;
           framesFlat[fi++] = newFrameId;
           framesFlat[fi++] = combinedVideo;
           framesFlat[fi++] = frameIdx;
-          framesFlat[fi++] = instBase + iStart;
-          framesFlat[fi++] = instBase + iEnd;
+          framesFlat[fi++] = instBase + outInsts; // instance range start
+          framesFlat[fi++] = instBase + outInsts + (iEnd - iStart); // end
 
           if (store.negativeFrames.has(`${numAt(fd.video, r)}:${frameIdx}`)) {
             this.negativeFrames.add(`${combinedVideo}:${frameIdx}`);
@@ -821,13 +866,14 @@ export class SlpStreamWriter {
             const ptEnd = numAt(idn.point_id_end, j);
             const trk = numAt(idn.track, j, -1);
             const fp = numAt(idn.from_predicted, j, -1);
+            const fpOut = fp >= 0 ? outIdxOf(fp) : null;
 
-            instFlat[ii++] = instBase + j; // instance_id
+            instFlat[ii++] = instBase + outInsts; // instance_id
             instFlat[ii++] = type; // instance_type
             instFlat[ii++] = newFrameId; // frame_id
             instFlat[ii++] = numAt(idn.skeleton, j) + kOff; // skeleton
             instFlat[ii++] = trk >= 0 ? trk + tOff : -1; // track
-            instFlat[ii++] = fp >= 0 ? instBase + fp : -1; // from_predicted
+            instFlat[ii++] = fpOut != null ? instBase + fpOut : -1; // from_predicted
             instFlat[ii++] = numAt(idn.score, j); // score
             if (type === 1) {
               // point_id range = position in the re-packed pred-point stream.
@@ -853,49 +899,62 @@ export class SlpStreamWriter {
               userWritten += ptEnd - ptStart;
             }
             instFlat[ii++] = numAt(idn.tracking_score, j); // tracking_score
+            outInsts++;
           }
+          this.writtenFrames.add(key);
         }
 
+        // Write only the actually-filled slice of each (max-sized) buffer.
+        const emFrames = fi / 5;
+        const emInsts = ii / 10;
+        const emUserPts = upi / 4;
+        const emPredPts = ppi / 5;
         appendMatrixRows(
           this.file,
           "frames",
-          framesFlat,
-          wFrames,
+          framesFlat.subarray(0, fi),
+          emFrames,
           5,
           this.frameRows,
         );
-        this.frameRows += wFrames;
+        this.frameRows += emFrames;
         appendMatrixRows(
           this.file,
           "instances",
-          instFlat,
-          nInst,
+          instFlat.subarray(0, ii),
+          emInsts,
           10,
           this.instRows,
         );
-        this.instRows += nInst;
+        this.instRows += emInsts;
         appendMatrixRows(
           this.file,
           "points",
-          userPtsFlat,
-          nUserPts,
+          userPtsFlat.subarray(0, upi),
+          emUserPts,
           4,
           this.pointRows,
         );
-        this.pointRows += nUserPts;
+        this.pointRows += emUserPts;
         appendMatrixRows(
           this.file,
           "pred_points",
-          predPtsFlat,
-          nPredPts,
+          predPtsFlat.subarray(0, ppi),
+          emPredPts,
           5,
           this.predPointRows,
         );
-        this.predPointRows += nPredPts;
+        this.predPointRows += emPredPts;
       }
       // Per-frame + undistributed annotations (masks/rois/…), video + instance
-      // remapped, written once at finalize.
-      this.collectStoreAnnotations(store, vOff, instBase);
+      // remapped, skipping any that belong to a skipped (overlaid) frame.
+      this.collectStoreAnnotations(
+        store,
+        vOff,
+        instBase,
+        outIdxOf,
+        skippedKeys,
+      );
     } catch (e) {
       // A mid-write failure leaves a partial file — release it rather than leak.
       this.dispose();
@@ -929,9 +988,12 @@ export class SlpStreamWriter {
       const links: Array<[number, PredictedInstance]> = [];
 
       for (const frame of frames) {
+        const videoIndex = Math.max(0, this.videos.indexOf(frame.video));
+        const key = `${videoIndex}:${frame.frameIdx}`;
+        if (this.writtenFrames.has(key)) continue; // dedup: first write wins
+        this.writtenFrames.add(key);
         const localFrameId = framesRows.length;
         const instanceStart = instRows.length;
-        const videoIndex = Math.max(0, this.videos.indexOf(frame.video));
         for (const inst of frame.instances) {
           const localInstId = instRows.length;
           localId.set(inst as Instance, localInstId);
@@ -1077,16 +1139,23 @@ export class SlpStreamWriter {
 
   /**
    * Collect a store's per-frame + undistributed annotations, remapping the
-   * video index (`+vOff`) and the instance link (`+instBase`) onto the combined
-   * file. The store's map keys are `"videoIndex:frameIdx"` (array-index video).
+   * video index (`+vOff`) and the instance link (through `outIdxOf`, `+instBase`)
+   * onto the combined file. Annotations on a SKIPPED (overlaid) frame — whose
+   * combined `"vid:frameIdx"` key is in `skippedKeys` — are dropped. The store's
+   * map keys are `"videoIndex:frameIdx"` (array-index video).
    */
   private collectStoreAnnotations(
     store: LazyDataStore,
     vOff: number,
     instBase: number,
+    outIdxOf: (idx: number) => number | null,
+    skippedKeys: Set<string>,
   ): void {
-    const resolve = (idx: number | null | undefined): number =>
-      idx != null && idx >= 0 ? instBase + idx : -1;
+    const resolve = (idx: number | null | undefined): number => {
+      if (idx == null || idx < 0) return -1;
+      const o = outIdxOf(idx);
+      return o != null ? instBase + o : -1;
+    };
     const fromMap = <T extends AnnLinked>(
       map: Map<string, T[]>,
       bucket: AnnBucket<T>,
@@ -1095,6 +1164,7 @@ export class SlpStreamWriter {
         const sep = key.indexOf(":");
         const vid = vOff + Number(key.slice(0, sep));
         const fidx = Number(key.slice(sep + 1));
+        if (skippedKeys.has(`${vid}:${fidx}`)) continue; // overlaid frame wins
         for (const ann of list) {
           bucket.anns.push(ann);
           bucket.ctx.push([vid, fidx]);
@@ -1110,6 +1180,7 @@ export class SlpStreamWriter {
       const sep = key.indexOf(":");
       const vid = vOff + Number(key.slice(0, sep));
       const fidx = Number(key.slice(sep + 1));
+      if (skippedKeys.has(`${vid}:${fidx}`)) continue;
       for (const li of list) {
         this.pendingLabelImages.anns.push(li);
         this.pendingLabelImages.ctx.push([vid, fidx]);

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -153,10 +153,13 @@ export {
   openSlpWriter,
   SlpStreamWriter,
   saveSlpMergedFromStores,
+  saveSlpMergedToSink,
 } from "../codecs/slp/write.js";
 export type {
   SlpWriteHeader,
   AppendStoreOptions,
+  SlpWriteSink,
+  MergeStoresOptions,
 } from "../codecs/slp/write.js";
 
 /**

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -147,6 +147,17 @@ export async function saveSlp(
 }
 
 export { saveSlpToBytes } from "../codecs/slp/write.js";
+// Streaming / incremental SLP writer + multi-store merge (issue #207): build a
+// large multi-camera `.slp` without holding the whole `Labels` graph in memory.
+export {
+  openSlpWriter,
+  SlpStreamWriter,
+  saveSlpMergedFromStores,
+} from "../codecs/slp/write.js";
+export type {
+  SlpWriteHeader,
+  AppendStoreOptions,
+} from "../codecs/slp/write.js";
 
 /**
  * Load a SLEAP Analysis HDF5 file (.h5).

--- a/src/model/labels.ts
+++ b/src/model/labels.ts
@@ -288,6 +288,33 @@ export class Labels {
   }
 
   /**
+   * Drop the cached (materialized) frame at `i` from a lazy `Labels`, so a
+   * windowed read→transform→write sweep over a huge file stays memory-bounded
+   * without reaching into internals. No-op on an eager `Labels`. See #207.
+   */
+  releaseFrame(i: number): void {
+    this._lazyFrameList?.release(i);
+  }
+
+  /** Drop cached lazy frames in the half-open range `[start, end)`. No-op if eager. */
+  releaseFrameWindow(start: number, end: number): void {
+    this._lazyFrameList?.releaseWindow(start, end);
+  }
+
+  /**
+   * Bound how many materialized frames a lazy `Labels` keeps cached (0 =
+   * unbounded). When exceeded, oldest-first eviction keeps peak memory flat
+   * across a sequential sweep. No-op / returns 0 on an eager `Labels`.
+   */
+  get frameCacheLimit(): number {
+    return this._lazyFrameList?.cacheLimit ?? 0;
+  }
+
+  set frameCacheLimit(n: number) {
+    if (this._lazyFrameList) this._lazyFrameList.cacheLimit = Math.max(0, n);
+  }
+
+  /**
    * Collect tracks from annotations on a frame into this.tracks.
    *
    * `seen` lets a caller iterating many frames share one membership set instead

--- a/src/model/lazy.ts
+++ b/src/model/lazy.ts
@@ -454,6 +454,14 @@ export class LazyFrameList {
   private store: LazyDataStore;
   private cache: Map<number, LabeledFrame>;
   _supplementary: LabeledFrame[] = [];
+  /**
+   * Max materialized frames to keep cached (0 = unbounded, the default). When
+   * exceeded, the oldest-inserted entries are evicted (FIFO ≈ LRU for a
+   * sequential sweep) so a read→transform→write pass over a huge lazy file stays
+   * memory-bounded without the caller touching internals. Combine with (or use
+   * instead of) explicit {@link release}/{@link releaseWindow}. See #207.
+   */
+  cacheLimit = 0;
 
   constructor(store: LazyDataStore) {
     this.store = store;
@@ -482,8 +490,29 @@ export class LazyFrameList {
     const frame = this.store.materializeFrame(index);
     if (frame) {
       this.cache.set(index, frame);
+      if (this.cacheLimit > 0 && this.cache.size > this.cacheLimit) {
+        for (const k of this.cache.keys()) {
+          if (this.cache.size <= this.cacheLimit) break;
+          if (k !== index) this.cache.delete(k);
+        }
+      }
     }
     return frame ?? undefined;
+  }
+
+  /** Drop the cached (materialized) frame at `index`, if any. */
+  release(index: number): void {
+    this.cache.delete(index);
+  }
+
+  /** Drop cached frames in the half-open range `[start, end)`. */
+  releaseWindow(start: number, end: number): void {
+    for (let i = start; i < end; i++) this.cache.delete(i);
+  }
+
+  /** Drop all cached frames (keeps the underlying store). */
+  clearCache(): void {
+    this.cache.clear();
   }
 
   /** Materialize all frames and return as a regular array. */

--- a/tests/codecs/streaming-writer.test.ts
+++ b/tests/codecs/streaming-writer.test.ts
@@ -14,6 +14,7 @@ import { readSlp, readSlpLazy } from "../../src/codecs/slp/read.js";
 import {
   openSlpWriter,
   saveSlpMergedFromStores,
+  saveSlpMergedToSink,
 } from "../../src/codecs/slp/write.js";
 import { LazyDataStore } from "../../src/model/lazy.js";
 import { Video } from "../../src/model/video.js";
@@ -24,6 +25,10 @@ import {
   PredictedInstance,
   Track,
 } from "../../src/model/instance.js";
+import { Labels } from "../../src/model/labels.js";
+import { UserSegmentationMask } from "../../src/model/mask.js";
+import { UserROI } from "../../src/model/roi.js";
+import { saveSlpToBytes } from "../../src/codecs/slp/write.js";
 
 const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 const slp = (name: string) => path.join(fixtureRoot, "slp", name);
@@ -48,6 +53,38 @@ const store = async (p: string) => {
   if (!s) throw new Error("no lazy store");
   return s;
 };
+
+/** A chunk-collecting {@link SlpWriteSink} for tests. */
+function collectingSink() {
+  const chunks: Uint8Array[] = [];
+  let closed = false;
+  return {
+    sink: {
+      write(c: Uint8Array) {
+        chunks.push(c.slice());
+      },
+      close() {
+        closed = true;
+      },
+    },
+    get closed() {
+      return closed;
+    },
+    get chunkCount() {
+      return chunks.length;
+    },
+    bytes(): Uint8Array {
+      const total = chunks.reduce((s, c) => s + c.length, 0);
+      const out = new Uint8Array(total);
+      let o = 0;
+      for (const c of chunks) {
+        out.set(c, o);
+        o += c.length;
+      }
+      return out;
+    },
+  };
+}
 
 describe("openSlpWriter — single-store streaming write", () => {
   it("round-trips frame-for-frame with the eager reader", async () => {
@@ -308,5 +345,124 @@ describe("SlpStreamWriter.appendFrames — materialized-frame overlay", () => {
     expect(overlay.map((f) => f.instances[0].points[0].xy[0]).sort()).toEqual([
       100, 200,
     ]);
+  });
+});
+
+describe("writeToSink / saveSlpMergedToSink — streamed output", () => {
+  it("writeToSink streams a valid file in multiple chunks", async () => {
+    const s = await store(FIX);
+    const eager = await readSlp(FIX, { openVideos: false });
+
+    const writer = await openSlpWriter({
+      skeletons: s.skeletons,
+      videos: s.videos,
+      tracks: s.tracks,
+    });
+    writer.appendStore(s);
+    const collected = collectingSink();
+    await writer.writeToSink(collected.sink, { chunkBytes: 64 * 1024 });
+
+    expect(collected.closed).toBe(true);
+    expect(collected.chunkCount).toBeGreaterThan(1); // actually chunked
+    // The streamed bytes are a valid SLP that round-trips frame-for-frame.
+    const rt = await readSlp(new Uint8Array(collected.bytes()).buffer, {
+      openVideos: false,
+    });
+    expect(rt.labeledFrames.length).toBe(eager.labeledFrames.length);
+    expect(rt.labeledFrames.map(frameSig)).toEqual(
+      eager.labeledFrames.map(frameSig),
+    );
+  });
+
+  it("saveSlpMergedToSink streams a merged multi-video file", async () => {
+    const collected = collectingSink();
+    await saveSlpMergedToSink(
+      [await store(FIX), await store(FIX)],
+      collected.sink,
+      { chunkBytes: 128 * 1024 },
+    );
+    expect(collected.closed).toBe(true);
+    const merged = await readSlp(new Uint8Array(collected.bytes()).buffer, {
+      openVideos: false,
+    });
+    expect(merged.videos.length).toBe(2);
+    const eager = await readSlp(FIX, { openVideos: false });
+    expect(merged.labeledFrames.length).toBe(2 * eager.labeledFrames.length);
+  });
+});
+
+describe("annotation overlays (masks / rois)", () => {
+  it("carries a store's per-frame masks + rois through appendStore", async () => {
+    // Build a Labels with a frame-bound mask + roi, save eager, read lazy so the
+    // store carries the annotation maps.
+    const video = new Video({ filename: "ann.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [0, 0] }, skeleton });
+    const mask = UserSegmentationMask.fromArray(new Uint8Array(16), 4, 4, {
+      name: "m1",
+      category: "cell",
+    });
+    const roi = UserROI.fromBbox(0, 0, 50, 50, { category: "box" });
+    const labels = new Labels({
+      labeledFrames: [
+        new LabeledFrame({
+          video,
+          frameIdx: 3,
+          instances: [inst],
+          masks: [mask],
+          rois: [roi],
+        }),
+      ],
+    });
+    const lazy = await readSlpLazy(
+      new Uint8Array(await saveSlpToBytes(labels)).buffer,
+      { openVideos: false },
+    );
+    const s = lazy._lazyDataStore!;
+
+    const writer = await openSlpWriter({
+      skeletons: s.skeletons,
+      videos: s.videos,
+      tracks: s.tracks,
+    });
+    writer.appendStore(s);
+    const rt = await readSlp(new Uint8Array(writer.close()).buffer, {
+      openVideos: false,
+    });
+
+    const f = rt.labeledFrames.find((x) => x.frameIdx === 3)!;
+    expect(f.masks).toHaveLength(1);
+    expect(f.masks[0].name).toBe("m1");
+    expect(f.masks[0].category).toBe("cell");
+    expect(f.rois).toHaveLength(1);
+  });
+
+  it("carries masks from appendFrames (materialized overlay)", async () => {
+    const video = new Video({ filename: "ann.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const inst = new Instance({ points: { A: [0, 0] }, skeleton });
+    const mask = UserSegmentationMask.fromArray(new Uint8Array(16), 4, 4, {
+      name: "mm",
+      category: "cell",
+    });
+    const frame = new LabeledFrame({
+      video,
+      frameIdx: 7,
+      instances: [inst],
+      masks: [mask],
+    });
+    const writer = await openSlpWriter({
+      skeletons: [skeleton],
+      videos: [video],
+      tracks: [],
+    });
+    writer.appendFrames([frame]);
+    const rt = await readSlp(new Uint8Array(writer.close()).buffer, {
+      openVideos: false,
+    });
+
+    const f = rt.labeledFrames.find((x) => x.frameIdx === 7)!;
+    expect(f.masks).toHaveLength(1);
+    expect(f.masks[0].name).toBe("mm");
   });
 });

--- a/tests/codecs/streaming-writer.test.ts
+++ b/tests/codecs/streaming-writer.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Streaming / incremental SLP writer + multi-store merge (issue #207).
+ *
+ * The write-side companion to `readSlpStreaming({ lazy })`: `openSlpWriter` +
+ * `appendStore` + `close` build an SLP by appending pose frames to resizable
+ * HDF5 datasets, and `saveSlpMergedFromStores` concatenates N per-camera
+ * `LazyDataStore`s into one combined multi-video `.slp`. These tests assert the
+ * output round-trips frame-for-frame through the eager reader.
+ */
+import { describe, it, expect } from "../bun-test";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { readSlp, readSlpLazy } from "../../src/codecs/slp/read.js";
+import {
+  openSlpWriter,
+  saveSlpMergedFromStores,
+} from "../../src/codecs/slp/write.js";
+import type { LabeledFrame } from "../../src/model/labeled-frame.js";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+const slp = (name: string) => path.join(fixtureRoot, "slp", name);
+const FIX = slp("centered_pair_predictions.slp");
+const OTHER = slp("predictions_1.2.7_provenance_and_tracking.slp");
+
+/** Order-preserving structural signature of a frame's pose content. */
+function frameSig(f: LabeledFrame): string {
+  const insts = f.instances.map((inst) => {
+    const isPred = inst.constructor.name.includes("Predicted");
+    const trackName = inst.track?.name ?? "";
+    const score = (inst as { score?: number }).score ?? "";
+    const pts = inst.points.map((p) => `${p.xy[0]},${p.xy[1]}`).join(";");
+    return `${isPred ? "P" : "U"}|${trackName}|${score}|${pts}`;
+  });
+  return `f${f.frameIdx}[${insts.join("/")}]`;
+}
+
+const store = async (p: string) => {
+  const lazy = await readSlpLazy(p, { openVideos: false });
+  const s = lazy._lazyDataStore;
+  if (!s) throw new Error("no lazy store");
+  return s;
+};
+
+describe("openSlpWriter — single-store streaming write", () => {
+  it("round-trips frame-for-frame with the eager reader", async () => {
+    const eager = await readSlp(FIX, { openVideos: false });
+    const s = await store(FIX);
+
+    const writer = await openSlpWriter({
+      skeletons: s.skeletons,
+      videos: s.videos,
+      tracks: s.tracks,
+    });
+    writer.appendStore(s);
+    const bytes = writer.close();
+
+    const rt = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
+    expect(rt.videos.length).toBe(eager.videos.length);
+    expect(rt.labeledFrames.length).toBe(eager.labeledFrames.length);
+    expect(rt.labeledFrames.map(frameSig)).toEqual(
+      eager.labeledFrames.map(frameSig),
+    );
+  });
+
+  it("rejects use after close", async () => {
+    const s = await store(FIX);
+    const writer = await openSlpWriter({
+      skeletons: s.skeletons,
+      videos: s.videos,
+      tracks: s.tracks,
+    });
+    writer.close();
+    expect(() => writer.appendStore(s)).toThrow(/closed/);
+    expect(() => writer.close()).toThrow(/already closed/);
+  });
+});
+
+describe("saveSlpMergedFromStores — multi-store merge", () => {
+  it("concatenates two stores into one multi-video file, frame-for-frame", async () => {
+    const eager = await readSlp(FIX, { openVideos: false });
+    const nFramesEach = eager.labeledFrames.length;
+
+    // Two lazy loads of the same fixture stand in for two cameras that share a
+    // skeleton but have distinct videos.
+    const s0 = await store(FIX);
+    const s1 = await store(FIX);
+    const bytes = await saveSlpMergedFromStores([s0, s1]);
+
+    const merged = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
+
+    // Two videos, double the frames, correctly split by source video.
+    expect(merged.videos.length).toBe(2);
+    expect(merged.labeledFrames.length).toBe(2 * nFramesEach);
+
+    const vi = (f: LabeledFrame) => merged.videos.indexOf(f.video);
+    const v0 = merged.labeledFrames.filter((f) => vi(f) === 0);
+    const v1 = merged.labeledFrames.filter((f) => vi(f) === 1);
+    expect(v0.length).toBe(nFramesEach);
+    expect(v1.length).toBe(nFramesEach);
+
+    // Each video's frames match the original fixture frame-for-frame.
+    const ref = eager.labeledFrames.map(frameSig);
+    expect(v0.map(frameSig)).toEqual(ref);
+    expect(v1.map(frameSig)).toEqual(ref);
+  });
+
+  it("remaps tracks per store (combined tracks = concatenation)", async () => {
+    const eager = await readSlp(FIX, { openVideos: false });
+    const srcTrackNames = new Set(
+      eager.labeledFrames.flatMap((f) =>
+        f.instances.map((i) => i.track?.name).filter(Boolean),
+      ),
+    );
+    // Only meaningful if the fixture actually has tracks.
+    if (srcTrackNames.size === 0) return;
+
+    const bytes = await saveSlpMergedFromStores([
+      await store(FIX),
+      await store(FIX),
+    ]);
+    const merged = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
+
+    // Combined tracks = both stores' tracks concatenated (distinct objects).
+    expect(merged.tracks.length).toBe(2 * eager.tracks.length);
+    // Every instance still resolves to a track with one of the original names.
+    for (const f of merged.labeledFrames) {
+      for (const inst of f.instances) {
+        if (inst.track) expect(srcTrackNames.has(inst.track.name)).toBe(true);
+      }
+    }
+  });
+
+  it("throws when stores have different skeletons", async () => {
+    const a = await store(FIX);
+    const b = await store(OTHER);
+    await expect(saveSlpMergedFromStores([a, b])).rejects.toThrow(
+      /different skeleton/,
+    );
+  });
+
+  it("throws for an empty store list", async () => {
+    await expect(saveSlpMergedFromStores([])).rejects.toThrow(
+      /at least one store/,
+    );
+  });
+});

--- a/tests/codecs/streaming-writer.test.ts
+++ b/tests/codecs/streaming-writer.test.ts
@@ -391,6 +391,95 @@ describe("writeToSink / saveSlpMergedToSink — streamed output", () => {
   });
 });
 
+describe("(video, frameIdx) dedup across appendStore / appendFrames", () => {
+  /** Count of distinct (videoIndex, frameIdx) keys in a read-back Labels. */
+  function uniqueFrameKeys(labels: {
+    labeledFrames: LabeledFrame[];
+    videos: unknown[];
+  }): number {
+    return new Set(
+      labels.labeledFrames.map(
+        (f) => `${labels.videos.indexOf(f.video)}:${f.frameIdx}`,
+      ),
+    ).size;
+  }
+
+  it("overlay-first wins: appendFrames then appendStore yields one frame per key", async () => {
+    // A store of predicted frames 0,1,2 on one video.
+    const video = new Video({ filename: "dedup.mp4" });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const labels = new Labels({
+      labeledFrames: [0, 1, 2].map(
+        (fx) =>
+          new LabeledFrame({
+            video,
+            frameIdx: fx,
+            instances: [
+              PredictedInstance.fromArray([[fx * 10, fx * 10]], skeleton, 0.5),
+            ],
+          }),
+      ),
+    });
+    const lazy = await readSlpLazy(
+      new Uint8Array(await saveSlpToBytes(labels)).buffer,
+      { openVideos: false },
+    );
+    const store = lazy._lazyDataStore!;
+
+    // Overlay a USER instance on frame 1 (same reconstructed video/skeleton).
+    const overlay = new LabeledFrame({
+      video: store.videos[0],
+      frameIdx: 1,
+      instances: [
+        new Instance({
+          points: { A: [999, 999] },
+          skeleton: store.skeletons[0],
+        }),
+      ],
+    });
+
+    const writer = await openSlpWriter({
+      skeletons: store.skeletons,
+      videos: store.videos,
+      tracks: store.tracks,
+    });
+    writer.appendFrames([overlay]); // overlay first...
+    writer.appendStore(store); // ...bulk second (frame 1 is skipped)
+    const rt = await readSlp(new Uint8Array(writer.close()).buffer, {
+      openVideos: false,
+    });
+
+    // Exactly one frame per key, no duplicates.
+    expect(rt.labeledFrames.length).toBe(3);
+    expect(uniqueFrameKeys(rt)).toBe(3);
+
+    const byIdx = new Map(rt.labeledFrames.map((f) => [f.frameIdx, f]));
+    expect([...byIdx.keys()].sort((a, b) => a - b)).toEqual([0, 1, 2]);
+
+    // Frame 1 is the OVERLAY (user instance at (999,999)), not the store's pred.
+    const f1 = byIdx.get(1)!;
+    expect(f1.instances).toHaveLength(1);
+    expect(f1.instances[0].constructor.name).not.toContain("Predicted");
+    expect(f1.instances[0].points[0].xy).toEqual([999, 999]);
+
+    // Frames 0 and 2 come from the store (predicted), intact.
+    expect(byIdx.get(0)!.instances[0].constructor.name).toContain("Predicted");
+    expect(byIdx.get(0)!.instances[0].points[0].xy).toEqual([0, 0]);
+    expect(byIdx.get(2)!.instances[0].points[0].xy).toEqual([20, 20]);
+  });
+
+  it("keeps merge round-trips duplicate-free (frame count == unique keys)", async () => {
+    const bytes = await saveSlpMergedFromStores([
+      await store(FIX),
+      await store(FIX),
+    ]);
+    const merged = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
+    expect(uniqueFrameKeys(merged)).toBe(merged.labeledFrames.length);
+  });
+});
+
 describe("annotation overlays (masks / rois)", () => {
   it("carries a store's per-frame masks + rois through appendStore", async () => {
     // Build a Labels with a frame-bound mask + roi, save eager, read lazy so the

--- a/tests/codecs/streaming-writer.test.ts
+++ b/tests/codecs/streaming-writer.test.ts
@@ -15,7 +15,15 @@ import {
   openSlpWriter,
   saveSlpMergedFromStores,
 } from "../../src/codecs/slp/write.js";
-import type { LabeledFrame } from "../../src/model/labeled-frame.js";
+import { LazyDataStore } from "../../src/model/lazy.js";
+import { Video } from "../../src/model/video.js";
+import { Skeleton } from "../../src/model/skeleton.js";
+import { LabeledFrame } from "../../src/model/labeled-frame.js";
+import {
+  Instance,
+  PredictedInstance,
+  Track,
+} from "../../src/model/instance.js";
 
 const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 const slp = (name: string) => path.join(fixtureRoot, "slp", name);
@@ -148,5 +156,157 @@ describe("saveSlpMergedFromStores — multi-store merge", () => {
     await expect(saveSlpMergedFromStores([])).rejects.toThrow(
       /at least one store/,
     );
+  });
+});
+
+describe("appendStore — non-monotonic point ranges (#208 review)", () => {
+  it("attributes points correctly when store point ranges aren't frame-ordered", async () => {
+    // A reader-valid store whose point table is NOT monotonic in frame order:
+    // frame 0's instance owns store points [3,6); frame 1's owns [0,3). The
+    // writer re-packs points in frame order, so it must stamp the PACKED index,
+    // not the store's original offset — otherwise the two frames' point sets swap.
+    const skeleton = new Skeleton({ nodes: ["A", "B", "C"] });
+    const video = new Video({
+      filename: ".",
+      backendMetadata: { dataset: "video0/video" },
+    });
+    const store = new LazyDataStore({
+      framesData: {
+        frame_id: [0, 1],
+        video: [0, 0],
+        frame_idx: [0, 1],
+        instance_id_start: [0, 1],
+        instance_id_end: [1, 2],
+      },
+      instancesData: {
+        instance_type: [0, 0],
+        skeleton: [0, 0],
+        track: [-1, -1],
+        from_predicted: [-1, -1],
+        score: [0, 0],
+        point_id_start: [3, 0], // frame 0 -> points 3..6, frame 1 -> points 0..3
+        point_id_end: [6, 3],
+        tracking_score: [0, 0],
+      },
+      pointsData: {
+        x: [10, 11, 12, 30, 31, 32],
+        y: [10, 11, 12, 30, 31, 32],
+        visible: [1, 1, 1, 1, 1, 1],
+        complete: [1, 1, 1, 1, 1, 1],
+        score: [0, 0, 0, 0, 0, 0],
+      },
+      predPointsData: { x: [], y: [], visible: [], complete: [], score: [] },
+      skeletons: [skeleton],
+      tracks: [],
+      videos: [video],
+      formatId: 1.2,
+    });
+
+    const writer = await openSlpWriter({
+      skeletons: [skeleton],
+      videos: [video],
+      tracks: [],
+    });
+    writer.appendStore(store);
+    const bytes = writer.close();
+    const rt = await readSlp(new Uint8Array(bytes).buffer, {
+      openVideos: false,
+    });
+
+    const f0 = rt.labeledFrames.find((f) => f.frameIdx === 0)!;
+    const f1 = rt.labeledFrames.find((f) => f.frameIdx === 1)!;
+    // frame 0 owns the (30,31,32) block; frame 1 owns the (10,11,12) block.
+    expect(f0.instances[0].points.map((p) => p.xy[0])).toEqual([30, 31, 32]);
+    expect(f1.instances[0].points.map((p) => p.xy[0])).toEqual([10, 11, 12]);
+  });
+});
+
+describe("SlpStreamWriter.appendFrames — materialized-frame overlay", () => {
+  const skeleton = new Skeleton(["A", "B"]);
+  const video = new Video({ filename: "overlay.mp4" });
+  const track = new Track("t0");
+  const mkUser = (frameIdx: number, x: number) =>
+    new LabeledFrame({
+      video,
+      frameIdx,
+      instances: [
+        new Instance({
+          points: [
+            { xy: [x, x + 1], visible: true, complete: true },
+            { xy: [x + 2, x + 3], visible: true, complete: true },
+          ],
+          skeleton,
+          track,
+        }),
+      ],
+    });
+
+  it("writes a batch of user + predicted frames that round-trip", async () => {
+    const pred = new LabeledFrame({
+      video,
+      frameIdx: 1,
+      instances: [
+        new PredictedInstance({
+          points: [
+            { xy: [5, 6], visible: true, complete: true, score: 0.9 },
+            { xy: [7, 8], visible: true, complete: true, score: 0.8 },
+          ],
+          skeleton,
+          score: 0.7,
+        }),
+      ],
+    });
+
+    const writer = await openSlpWriter({
+      skeletons: [skeleton],
+      videos: [video],
+      tracks: [track],
+    });
+    writer.appendFrames([mkUser(0, 1), pred]);
+    const rt = await readSlp(new Uint8Array(writer.close()).buffer, {
+      openVideos: false,
+    });
+
+    expect(rt.labeledFrames.length).toBe(2);
+    const f0 = rt.labeledFrames.find((f) => f.frameIdx === 0)!;
+    const f1 = rt.labeledFrames.find((f) => f.frameIdx === 1)!;
+    expect(f0.instances[0].points.map((p) => p.xy)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(f0.instances[0].track?.name).toBe("t0");
+    expect(f1.instances[0].constructor.name).toContain("Predicted");
+    expect(f1.instances[0].points.map((p) => p.xy)).toEqual([
+      [5, 6],
+      [7, 8],
+    ]);
+  });
+
+  it("interleaves appendStore (bulk) with appendFrames (overlay edits)", async () => {
+    const eager = await readSlp(FIX, { openVideos: false });
+    const s = await store(FIX);
+
+    const writer = await openSlpWriter({
+      skeletons: s.skeletons,
+      videos: [...s.videos, video], // store's video(s) + the overlay video
+      tracks: [...s.tracks, track],
+    });
+    writer.appendStore(s); // bulk lazy frames onto video 0
+    writer.appendFrames([mkUser(0, 100), mkUser(1, 200)]); // 2 extra frames on the overlay video
+    const rt = await readSlp(new Uint8Array(writer.close()).buffer, {
+      openVideos: false,
+    });
+
+    expect(rt.videos.length).toBe(s.videos.length + 1);
+    expect(rt.labeledFrames.length).toBe(eager.labeledFrames.length + 2);
+    // The two overlay frames landed on the last video with the right points.
+    const overlayIdx = rt.videos.length - 1;
+    const overlay = rt.labeledFrames.filter(
+      (f) => rt.videos.indexOf(f.video) === overlayIdx,
+    );
+    expect(overlay.length).toBe(2);
+    expect(overlay.map((f) => f.instances[0].points[0].xy[0]).sort()).toEqual([
+      100, 200,
+    ]);
   });
 });

--- a/tests/model/lazy-frame-release.test.ts
+++ b/tests/model/lazy-frame-release.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Public frame-release API for lazy `Labels` (#207): `releaseFrame` /
+ * `releaseFrameWindow` / `frameCacheLimit` let a windowed read→transform→write
+ * sweep over a huge lazy file stay memory-bounded WITHOUT reaching into the
+ * private `_lazyFrameList.cache` (the fragile workaround this replaces).
+ */
+import { describe, it, expect } from "../bun-test";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { readSlp, readSlpLazy } from "../../src/codecs/slp/read.js";
+import type { Labels } from "../../src/model/labels.js";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+const FIX = path.join(fixtureRoot, "slp", "centered_pair_predictions.slp");
+
+const matCount = (labels: Labels): number =>
+  labels._lazyFrameList?.materializedCount ?? 0;
+
+describe("lazy frame release", () => {
+  it("releaseFrame / releaseFrameWindow drop cached frames", async () => {
+    const labels = await readSlpLazy(FIX, { openVideos: false });
+    expect(labels.isLazy).toBe(true);
+    expect(matCount(labels)).toBe(0);
+
+    labels.frameAt(0);
+    labels.frameAt(1);
+    labels.frameAt(2);
+    expect(matCount(labels)).toBe(3);
+
+    labels.releaseFrame(1);
+    expect(matCount(labels)).toBe(2);
+
+    labels.releaseFrameWindow(0, 3);
+    expect(matCount(labels)).toBe(0);
+  });
+
+  it("frameCacheLimit bounds the cache across a sequential sweep", async () => {
+    const labels = await readSlpLazy(FIX, { openVideos: false });
+    labels.frameCacheLimit = 4;
+    expect(labels.frameCacheLimit).toBe(4);
+
+    for (let i = 0; i < 20; i++) labels.frameAt(i);
+
+    // Never exceeds the cap, and the most-recent frames are retained.
+    expect(matCount(labels)).toBeLessThanOrEqual(4);
+    expect(matCount(labels)).toBeGreaterThan(0);
+    expect(labels.frameAt(19)).toBeDefined();
+  });
+
+  it("is a no-op on an eager Labels", async () => {
+    const eager = await readSlp(FIX, { openVideos: false });
+    expect(eager.isLazy).toBe(false);
+    expect(() => eager.releaseFrame(0)).not.toThrow();
+    expect(() => eager.releaseFrameWindow(0, 5)).not.toThrow();
+    expect(eager.frameCacheLimit).toBe(0);
+    eager.frameCacheLimit = 5;
+    expect(eager.frameCacheLimit).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #207 — the **write-side companion to `readSlpStreaming({ lazy })`**: build/export a large multi-camera `.slp` without holding the whole `Labels` graph in memory. Reviewed adversarially; all deferred pieces now included.

h5wasm supports the primitives (`create_dataset({ maxshape })` → `resize` → `write_slice`, and chunked FS reads), verified before building.

## API (re-exported from `io/main.ts`)

```ts
const w = await openSlpWriter({ skeletons, videos, tracks, sessions, provenance });
w.appendFrames([correctedFrame, addedFrame]);              // edit overlay — append these FIRST
w.appendStore(store, { videoIndexOffset, trackOffset });   // bulk lazy frames, windowed
const bytes = w.close();                                   // ...or:
await w.writeToSink(fileStream, { chunkBytes });           // stream output in chunks (OPFS / fs.WriteStream)

// merge N per-camera lazy stores into one file
const bytes = await saveSlpMergedFromStores([storeA, storeB], { sessions });
await saveSlpMergedToSink([storeA, storeB], fileStream);   // ...streamed

// read-side companion: keep a windowed read→write sweep memory-bounded
labels.frameCacheLimit = 256;             // FIFO-evict beyond the cap
labels.releaseFrame(i);                   // or releaseFrameWindow(start, end)
```

## Capabilities

- **Incremental append** — `appendStore` streams a `LazyDataStore` window-by-window into resizable HDF5 datasets, rebasing every id, constructing zero `LabeledFrame`/`Instance`.
- **Multi-store merge** — concatenate N per-camera stores (shared-skeleton) into one multi-video file, video/track/id remapped.
- **Edit overlay** — `appendFrames` appends materialized (corrected/added) frames; interleaves with `appendStore`.
- **`(video, frameIdx)` dedup** — first-write-wins across `appendStore`/`appendFrames`: a later append repeating a key skips that frame, so appending overlays first makes them win. `appendStore` assigns frame/instance/point ids from running **output** counters (not store positions) so skips leave no gaps, and remaps cross-references (`from_predicted`, annotation instance links) through the skipped ranges — identity, hence unchanged, when nothing is skipped. Stays streaming/bounded (no full-frame buffering).
- **Annotation overlays** — masks / rois / bboxes / centroids / label-images carried from stores (`appendStore`) and materialized frames (`appendFrames`), video + instance-link remapped, written at finalize; annotations on an overlaid (skipped) frame are dropped.
- **Streamed output** — `writeToSink` / `saveSlpMergedToSink` chunk the finished file to a browser `FileSystemWritableFileStream` or Node `fs.WriteStream`.
- **Read-side frame release** — `releaseFrame` / `releaseFrameWindow` / `frameCacheLimit` replace LUCID's fragile `_lazyFrameList.cache` workaround.

## Adversarial review

5 dimensions × 3 refutation skeptics. **1 confirmed finding, fixed:** `appendStore` stamped instance `point_id` ranges from the store's *original* offsets while re-packing points in frame order → misattribution for a reader-valid store with non-monotonic point ranges. Now stamps the packed position; regression test added. Hardening: skeleton signature includes edges/symmetries; MEMFS file released on error (`dispose()`).

## Documented edges / follow-ups

- Sessions written with an empty labeled-frame list (frame-group refs resolved by lf-index are dropped) — matches the existing lazy fast-path.
- Label-image **per-object** instance links are context-remapped but not offset across stores (correct single-store; niche in multi-store merge).

## Tests

`tests/codecs/streaming-writer.test.ts` (15) + `tests/model/lazy-frame-release.test.ts` (3): single-store round-trip; two-store merge (frame-for-frame); track remap; non-monotonic point-range regression; `appendFrames` user+predicted; `appendStore`+`appendFrames` interleave; **overlay-first dedup (one frame per key, overlay wins, other store frames intact) + merge duplicate-free guard**; mask/roi round-trip (both paths); `writeToSink`/`saveSlpMergedToSink` chunked streaming; frame release + cap; guards. `tsc` + `biome check` clean; writer suites green in isolation; CI green (ubuntu + windows).

_Note: the full local `bun test --parallel` run intermittently flakes on an unrelated file (a different one each run, or none) — the known Windows h5wasm+Bun teardown issue (#199 / #159), surfaced more often by an added h5wasm-heavy test file; not from this change._

Refs #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQDXxA9TYiC3aCtKWD7Eqn