### PR TITLE
chore(release): bump version to 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bumps `package.json` 0.5.2 → 0.5.3.

Since v0.5.2, `main` gained the **streaming/incremental SLP writer** (#208, closes #207) — append writer + multi-store merge + edit overlay + `(video, frameIdx)` dedup + annotation overlays + streamed FS-sink + read-side frame release.

Version bump only — **no GitHub release / npm publish yet** (holding for the next release cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQDXxA9TYiC3aCtKWD7Eqn