### PR TITLE
feat(slp): lazyVideoMetadata — fast open for many-video pkg.slp via deferred per-video reads

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": false,
   "type": "module",
   "exports": {

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -88,6 +88,19 @@ export interface StreamingSlpOptions {
    */
   lazy?: boolean;
   /**
+   * Defer per-video metadata reads. When `true`, embedded videos are built from
+   * `videos_json` ALONE — skipping the per-video HDF5 reads (dataset lookup,
+   * `getAttrs`, `frame_numbers`, `frame_sizes`, `source_video`) that dominate
+   * open time on many-video `pkg.slp` files read over high-latency storage
+   * (hundreds of videos × several serial reads each). Shape/channel_order come
+   * from JSON (with the `format_id` default fallback), so the videos panel still
+   * shows dimensions; backends are NOT built — the caller opens them on demand
+   * (e.g. on first view). Default `false`. Independent of `openVideos`; when
+   * set, embedded backends are always deferred. Frames render blank until the
+   * caller builds a backend on demand.
+   */
+  lazyVideoMetadata?: boolean;
+  /**
    * Optional progress callback fired as loading advances through its stages.
    * `current` counts completed stages out of `total`; `message` labels the
    * stage about to run. Matches the (current, total, message?) convention used
@@ -146,6 +159,7 @@ export async function readSlpStreaming(
   });
 
   const openVideos = options?.openVideos ?? false;
+  const lazyVideoMetadata = options?.lazyVideoMetadata ?? false;
 
   // Determine the source path for video resolution
   const sourcePath =
@@ -164,11 +178,13 @@ export async function readSlpStreaming(
       options?.onProgress,
       options?.rawSessions ?? false,
       options?.lazy ?? false,
+      lazyVideoMetadata,
     );
   } finally {
-    // Only close the file if we're NOT opening video backends.
-    // When openVideos is true, the file must remain open for video frame access.
-    if (!openVideos) {
+    // Keep the file open when video backends need it: eager (openVideos) OR
+    // deferred (lazyVideoMetadata), whose per-video backends read frame data on
+    // demand from this same StreamingH5File. Only close for pure metadata reads.
+    if (!openVideos && !lazyVideoMetadata) {
       await file.close();
     }
   }
@@ -190,6 +206,7 @@ export async function readFromStreamingFile(
   onProgress?: (current: number, total: number, message?: string) => void,
   rawSessions: boolean = false,
   lazy: boolean = false,
+  lazyVideoMetadata: boolean = false,
 ): Promise<Labels> {
   // Stage-level progress. The orchestration in this function runs on the MAIN
   // thread — only the low-level HDF5 byte reads are delegated to the worker via
@@ -262,6 +279,7 @@ export async function readFromStreamingFile(
     formatId,
     videoCrops,
     openVideos ? (i, n) => report(2, `Opening videos (${i}/${n})`) : undefined,
+    lazyVideoMetadata,
   );
 
   report(3);
@@ -482,6 +500,7 @@ async function readVideosStreaming(
   formatId: number = 1.0,
   videoCrops?: Map<number, VideoCropEntry>,
   onVideoProgress?: (current: number, total: number) => void,
+  lazyVideoMetadata: boolean = false,
 ): Promise<Video[]> {
   try {
     const keys = file.keys();
@@ -496,6 +515,64 @@ async function readVideosStreaming(
     for (let videoIndex = 0; videoIndex < metadataList.length; videoIndex++) {
       onVideoProgress?.(videoIndex + 1, metadataList.length);
       const meta = metadataList[videoIndex];
+
+      // Fast path: build the embedded Video from videos_json ALONE, skipping
+      // every per-video HDF5 read (dataset lookup, getAttrs, frame_numbers,
+      // frame_sizes, source_video). Those serial reads dominate open time on
+      // many-video pkg.slp over high-latency storage. No backend is built here —
+      // the caller opens one on demand (frames render blank until then). Shape
+      // and channel_order come from JSON (with the format_id default fallback),
+      // so the videos panel still reports dimensions.
+      if (lazyVideoMetadata && meta.embedded) {
+        const datasetPath = meta.dataset ?? `video${videoIndex}/video`;
+        // Seed the source frame count from videos_json (the embedded/labeled
+        // count); the deferred backend corrects it to the true source count from
+        // frame_numbers/`frames` attr on first view.
+        const frameCount = resolveSourceFrameCount({
+          jsonFrameCount: meta.frameCount,
+        });
+        const shape: [number, number, number, number] | undefined =
+          meta.height && meta.width && meta.channels
+            ? [frameCount ?? 0, meta.height, meta.width, meta.channels]
+            : undefined;
+        const channelOrder =
+          meta.channelOrder ?? (formatId < 1.4 ? "BGR" : "RGB");
+        // Deferred backend: no per-video HDF5 reads now; getFrame() lazily reads
+        // frame_numbers/frame_sizes/attrs on first view (ensureLoaded). Holds the
+        // still-open StreamingH5File, so readSlpStreaming must NOT close it.
+        const backend = new StreamingHdf5VideoBackend({
+          filename: Array.isArray(meta.filename)
+            ? (meta.filename[0] ?? "")
+            : meta.filename,
+          h5file: file,
+          datasetPath,
+          format: meta.format ?? "png",
+          channelOrder,
+          shape,
+          fps: meta.fps,
+          deferred: true,
+        });
+        const sourceVideo = meta.sourceVideo
+          ? buildSourceVideoFromDict(meta.sourceVideo, labelsPath)
+          : null;
+        videos.push(
+          new Video({
+            filename: meta.filename,
+            backend,
+            backendMetadata: {
+              dataset: datasetPath,
+              format: meta.format,
+              shape,
+              fps: meta.fps,
+              channel_order: channelOrder,
+            },
+            sourceVideo,
+            openBackend: false,
+            embedded: meta.embedded,
+          }),
+        );
+        continue;
+      }
 
       // Auto-detect dataset path when embedded but not specified in metadata
       let datasetPath: string | undefined = meta.dataset;

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -40,6 +40,15 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
   private frameSizes: number[] | undefined;
   private legacy: LegacyFrameCache;
   private metaCache: { shape: number[]; dtype: string } | null;
+  /**
+   * Deferred (lazyVideoMetadata) backend: constructed WITHOUT per-video HDF5
+   * reads. The first getFrame() reads frame_numbers/frame_sizes/attrs on demand
+   * (ensureLoaded) so a many-video pkg.slp opens fast and pays the per-video
+   * cost only for videos actually viewed.
+   */
+  private deferred: boolean;
+  private loaded: boolean;
+  private loadPromise: Promise<void> | null;
 
   constructor(options: {
     filename: string;
@@ -51,6 +60,8 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     channelOrder?: string;
     shape?: [number, number, number, number];
     fps?: number;
+    /** Build without per-video reads; ensureLoaded() fetches them on first use. */
+    deferred?: boolean;
   }) {
     this.filename = options.filename;
     this.h5file = options.h5file;
@@ -69,9 +80,85 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     this.fps = options.fps;
     this.legacy = { whole: null, offsets: null };
     this.metaCache = null;
+    this.deferred = options.deferred ?? false;
+    // Non-deferred backends already have everything; deferred ones load lazily.
+    this.loaded = !this.deferred;
+    this.loadPromise = null;
+  }
+
+  /** Whether a deferred backend has fetched its per-video metadata yet. */
+  get isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  /**
+   * Read the per-video HDF5 metadata skipped at load (lazyVideoMetadata):
+   * frame_numbers (source→storage map + true source frame count), frame_sizes
+   * (1D concatenated layout), and format/channel_order/dimensions from the
+   * dataset attrs. Idempotent — the first getFrame() triggers it. Afterwards
+   * `shape[0]` reflects the real source frame count, so the seekbar spans the
+   * whole video (not just the embedded/labeled frames). No-op when not deferred.
+   */
+  async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    if (this.loadPromise) return this.loadPromise;
+    this.loadPromise = (async () => {
+      const groupPath = this.datasetPath.endsWith("/video")
+        ? this.datasetPath.slice(0, -6)
+        : this.datasetPath;
+      try {
+        const keys = await this.h5file.getKeys(groupPath);
+        if (keys.includes("frame_numbers")) {
+          const fn = await this.h5file.getDatasetValue(
+            `${groupPath}/frame_numbers`,
+          );
+          const nums = toNumberArray(fn.value);
+          this.frameNumbers = nums;
+          this.frameNumberToIndex = new Map(nums.map((num, idx) => [num, idx]));
+        }
+        if (keys.includes("frame_sizes")) {
+          const fs = await this.h5file.getDatasetValue(
+            `${groupPath}/frame_sizes`,
+          );
+          this.frameSizes = toNumberArray(fs.value);
+        }
+      } catch {
+        /* leave frame maps empty; getFrame falls back to a direct index */
+      }
+      try {
+        const attrs = await this.h5file.getAttrs(this.datasetPath);
+        const fmt = attrToStr(attrs.format);
+        if (fmt) this.format = fmt;
+        const co = attrToStr(attrs.channel_order);
+        if (co) this.channelOrder = co;
+        // True source frame count = max(`frames` attr, max(frame_numbers)+1).
+        // The `frames` attr can badly under-report (bogus small values seen in
+        // the wild: 18/109/424 while frame_numbers span 47k–175k), so never let
+        // it shrink the axis below the highest stored source index. Mirrors the
+        // eager reader's resolveSourceFrameCount.
+        let count = attrToNum(attrs.frames) ?? 0;
+        if (this.frameNumberToIndex.size > 0) {
+          let maxNum = 0;
+          for (const k of this.frameNumberToIndex.keys())
+            if (k > maxNum) maxNum = k;
+          count = Math.max(count, maxNum + 1);
+        }
+        const h = attrToNum(attrs.height) ?? this.shape?.[1] ?? 0;
+        const w = attrToNum(attrs.width) ?? this.shape?.[2] ?? 0;
+        const c = attrToNum(attrs.channels) ?? this.shape?.[3] ?? 0;
+        if (count > 0 && h > 0 && w > 0) {
+          this.shape = [count, h, w, c];
+        }
+      } catch {
+        /* keep the JSON-seeded shape */
+      }
+      this.loaded = true;
+    })();
+    return this.loadPromise;
   }
 
   async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+    if (!this.loaded) await this.ensureLoaded();
     // Use O(1) Map lookup; if no frame numbers provided, use frameIndex directly
     const index =
       this.frameNumberToIndex.size > 0
@@ -187,6 +274,37 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     this.metaCache = null;
     // Note: We don't close the h5file here as it may be shared across multiple backends
   }
+}
+
+/** Coerce an HDF5 dataset value (array or typed-array) into number[]. */
+function toNumberArray(values: unknown): number[] {
+  if (Array.isArray(values)) return values.map((v) => Number(v));
+  if (ArrayBuffer.isView(values))
+    return Array.from(values as unknown as ArrayLike<number>).map(Number);
+  return [];
+}
+
+/** Unwrap an h5wasm attribute ({value} or plain) to a non-empty string. */
+function attrToStr(attr: unknown): string | undefined {
+  if (attr == null) return undefined;
+  const v =
+    typeof attr === "object" && attr !== null && "value" in attr
+      ? (attr as { value: unknown }).value
+      : attr;
+  if (v == null) return undefined;
+  const s = String(Array.isArray(v) ? v[0] : v);
+  return s.length > 0 ? s : undefined;
+}
+
+/** Unwrap an h5wasm attribute to a positive finite number, else undefined. */
+function attrToNum(attr: unknown): number | undefined {
+  if (attr == null) return undefined;
+  const v =
+    typeof attr === "object" && attr !== null && "value" in attr
+      ? (attr as { value: unknown }).value
+      : attr;
+  const n = Number(Array.isArray(v) ? v[0] : v);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
 async function decodeImageBytes(

--- a/tests/streaming-lazy-video-metadata.test.ts
+++ b/tests/streaming-lazy-video-metadata.test.ts
@@ -1,0 +1,226 @@
+/**
+ * lazyVideoMetadata option for the streaming SLP reader
+ * (`readSlpStreaming({ lazyVideoMetadata: true })`).
+ *
+ * When set, embedded videos are built from `videos_json` ALONE and every
+ * per-video HDF5 read (dataset lookup, `getAttrs`, `frame_numbers`,
+ * `frame_sizes`, `source_video`) is deferred to a self-initializing backend
+ * that reads them on the first `getFrame`/`ensureLoaded`. That is what lets a
+ * many-video `pkg.slp` open fast over high-latency storage: the ~N serial
+ * per-video reads that dominate open time are skipped for videos never viewed.
+ *
+ * `readSlpStreaming` is Worker-gated, so we drive the exported orchestrator
+ * `readFromStreamingFile` with a fake `StreamingH5File` (backed by h5wasm/node)
+ * that COUNTS reads per path — so we can assert the per-video reads do NOT
+ * happen until the backend's `ensureLoaded()` runs.
+ */
+import { describe, it, expect } from "./bun-test";
+import { readSlpLazy } from "../src/codecs/slp/read.js";
+import { readFromStreamingFile } from "../src/codecs/slp/read-streaming.js";
+import type { StreamingH5File } from "../src/codecs/slp/h5-streaming.js";
+import { ready, File as H5File } from "h5wasm/node";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
+const slpPath = (name: string) => path.join(fixtureRoot, "slp", name);
+
+// minimal_instance embeds 1 frame at source index 0 (H=384,W=384,C=1) with NO
+// `frames` attr — so the true source count is max(frame_numbers)+1 = 1.
+const FIXTURE = "minimal_instance.pkg.slp";
+const EXPECTED_SHAPE = [1, 384, 384, 1];
+
+/** Unwrap h5wasm/node attr entries (`{ value }`) to the worker's bare form. */
+function unwrapAttrs(attrs: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(attrs ?? {})) {
+    out[k] =
+      v && typeof v === "object" && "value" in (v as Record<string, unknown>)
+        ? (v as { value: unknown }).value
+        : v;
+  }
+  return out;
+}
+
+type Counts = {
+  attrs: Map<string, number>;
+  keys: Map<string, number>;
+  values: Map<string, number>;
+};
+
+/** A fake StreamingH5File that records per-path read counts. */
+async function makeCountingFake(opts?: {
+  framesAttrOverride?: number;
+  frameNumbersOverride?: number[];
+}): Promise<{
+  fake: StreamingH5File;
+  counts: Counts;
+  close: () => void;
+}> {
+  const module = await ready;
+  try {
+    module.FS.mkdir("/tmp");
+  } catch {
+    /* already exists */
+  }
+  const p = `/tmp/lvm_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
+  module.FS.writeFile(p, readFileSync(slpPath(FIXTURE)));
+  const h5 = new H5File(p, "r");
+
+  const store = (await readSlpLazy(slpPath(FIXTURE), { openVideos: false }))
+    ._lazyDataStore;
+  if (!store) throw new Error("readSlpLazy did not produce a lazy store");
+  const columns: Record<string, Record<string, unknown[]>> = {
+    frames: store.framesData,
+    instances: store.instancesData,
+    points: store.pointsData,
+    pred_points: store.predPointsData,
+  };
+
+  const get = (dp: string) => h5.get(dp) as unknown as Record<string, unknown>;
+  const counts: Counts = {
+    attrs: new Map(),
+    keys: new Map(),
+    values: new Map(),
+  };
+  const bump = (m: Map<string, number>, k: string) =>
+    m.set(k, (m.get(k) ?? 0) + 1);
+
+  const fake = {
+    keys: () => h5.keys() as string[],
+    getKeys: async (dp: string) => {
+      bump(counts.keys, dp);
+      const g = get(dp);
+      if (g && typeof (g as { keys?: unknown }).keys === "function") {
+        return (g as unknown as { keys: () => string[] }).keys();
+      }
+      return h5.keys() as string[];
+    },
+    getAttrs: async (dp: string) => {
+      bump(counts.attrs, dp);
+      const a = unwrapAttrs((get(dp)?.attrs as Record<string, unknown>) ?? {});
+      if (opts?.framesAttrOverride !== undefined && dp.endsWith("/video")) {
+        a.frames = opts.framesAttrOverride;
+      }
+      return a;
+    },
+    getDatasetMeta: async (dp: string) => {
+      const d = get(dp);
+      return {
+        shape: (d?.shape as number[]) ?? [],
+        dtype: (d?.dtype as string) ?? "",
+      };
+    },
+    getDatasetValue: async (dp: string) => {
+      bump(counts.values, dp);
+      if (dp in columns) return { value: columns[dp], shape: [], dtype: "" };
+      if (opts?.frameNumbersOverride && dp.endsWith("/frame_numbers")) {
+        return { value: opts.frameNumbersOverride, shape: [], dtype: "" };
+      }
+      const d = get(dp);
+      return {
+        value: d?.value,
+        shape: (d?.shape as number[]) ?? [],
+        dtype: (d?.dtype as string) ?? "",
+      };
+    },
+  } as unknown as StreamingH5File;
+
+  return {
+    fake,
+    counts,
+    close: () => {
+      h5.close();
+      try {
+        module.FS.unlink(p);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+// (file, url, filenameHint, openVideos, onProgress, rawSessions, lazy, lazyVideoMetadata)
+function read(
+  fake: StreamingH5File,
+  { openVideos = false, lazyVideoMetadata = false } = {},
+) {
+  return readFromStreamingFile(
+    fake,
+    "test.slp",
+    "test.slp",
+    openVideos,
+    undefined,
+    false,
+    false,
+    lazyVideoMetadata,
+  );
+}
+
+// Minimal shape of the deferred backend surface we assert against.
+type DeferredBackend = {
+  isLoaded: boolean;
+  ensureLoaded: () => Promise<void>;
+  shape?: number[];
+};
+
+describe("readSlpStreaming lazyVideoMetadata option", () => {
+  it("defers ALL per-video reads until the backend is opened", async () => {
+    const { fake, counts, close } = await makeCountingFake();
+    try {
+      const labels = await read(fake, { lazyVideoMetadata: true });
+      expect(labels.videos.length).toBe(1);
+
+      const backend = labels.videos[0].backend as unknown as DeferredBackend;
+      expect(backend).toBeTruthy();
+      expect(backend.isLoaded).toBe(false);
+
+      // The master list (videos_json) is read, but NOT any per-video metadata.
+      expect(counts.values.has("videos_json")).toBe(true);
+      expect(counts.attrs.get("video0/video")).toBeUndefined();
+      expect(counts.values.has("video0/frame_numbers")).toBe(false);
+
+      // Opening the backend performs the deferred per-video reads and resolves
+      // the true shape (H/W/C from attrs; count from max(frame_numbers)+1).
+      await backend.ensureLoaded();
+      expect(backend.isLoaded).toBe(true);
+      expect(counts.attrs.get("video0/video")).toBeGreaterThanOrEqual(1);
+      expect(counts.values.has("video0/frame_numbers")).toBe(true);
+      expect(backend.shape).toEqual(EXPECTED_SHAPE);
+    } finally {
+      close();
+    }
+  });
+
+  it("never shrinks the frame axis below max(frame_numbers)+1 (bogus `frames` attr)", async () => {
+    // Real pkg.slp files carry a `frames` attr that badly under-reports (e.g.
+    // 18 while frame_numbers span ~47k). Simulate a sparse video whose labels
+    // sit at source index 100, with a too-small `frames`=2: the resolved count
+    // must be the frame-number span (101), never the bogus attr.
+    const { fake, close } = await makeCountingFake({
+      framesAttrOverride: 2,
+      frameNumbersOverride: [0, 100],
+    });
+    try {
+      const labels = await read(fake, { lazyVideoMetadata: true });
+      const backend = labels.videos[0].backend as unknown as DeferredBackend;
+      await backend.ensureLoaded();
+      expect(backend.shape?.[0]).toBe(101); // max(2, 100+1)
+    } finally {
+      close();
+    }
+  });
+
+  it("eager path (openVideos) still reads per-video metadata at load", async () => {
+    const { fake, counts, close } = await makeCountingFake();
+    try {
+      const labels = await read(fake, { openVideos: true });
+      expect(labels.videos.length).toBe(1);
+      // Eager opens backends up front — the per-video reads happen during load.
+      expect(counts.values.has("video0/frame_numbers")).toBe(true);
+    } finally {
+      close();
+    }
+  });
+});


### PR DESCRIPTION
## What is `lazyVideoMetadata`?

A new opt-in option on `readSlpStreaming` / `readFromStreamingFile`. When set, embedded (`pkg.slp`) videos are built from the **`videos_json` master record alone**, and *every* per-video HDF5 read — dataset lookup, `getAttrs`, `frame_numbers`, `frame_sizes`, `source_video` — is **deferred**. The `Video` gets a new **`deferred` `StreamingHdf5VideoBackend`** that reads that metadata on demand (first `getFrame`, via `ensureLoaded()`), rather than at load.

```ts
const labels = await readSlpStreaming(source, { lazyVideoMetadata: true });
// open is metadata-only; each video's per-video reads happen when it's first viewed
```

## Why it's needed — `openVideos` and `lazy` don't cover this

The streaming reader opens a many-video `pkg.slp` slowly because `readVideosStreaming` walks **every** embedded video serially, doing ~13 tiny HDF5 reads each. On a real **874-video / 3.4 GB** training package over NFS that's **~11,778 serial reads ≈ 30 s** — and it happens even though the user views one video at a time. The existing options each address a *different* axis:

| Option | What it defers | Effect on this bottleneck |
|---|---|---|
| `openVideos: false` | building the video **decoders** | ~**15%** — `frame_numbers`/`frame_sizes` are skipped, but `findDataset` + `getAttrs` + `source_video` still run per video |
| `lazy: true` (#203) | `LabeledFrame`/`Instance` **materialization** (memory) | **none** — doesn't touch video reading |
| **`lazyVideoMetadata: true`** (this PR) | **all per-video HDF5 reads** → on-demand | attacks the **~85%** that dominates open |

So this is the only lever that removes the per-video read *count* that governs open time. Measured downstream (SLEAP app, same file): **~30 s → ~3.4 s open, 11,778 → 266 reads.** You pay each video's ~13 reads only when you actually open it.

## What changed

- **`read-streaming.ts`** — thread `lazyVideoMetadata` through `StreamingSlpOptions` → `readSlpStreaming` → `readFromStreamingFile` → `readVideosStreaming`; a fast branch builds each embedded `Video` from `videos_json` (dataset by convention `video{i}/video`, shape/`channel_order` from JSON with the `format_id` default fallback) and attaches a deferred backend. The `StreamingH5File` is kept **open** after a `lazyVideoMetadata` parse (the deferred backends read from it later).
- **`streaming-hdf5-video.ts`** — a `deferred` construction mode + `ensureLoaded()` that reads `frame_numbers`/`frame_sizes`/attrs on first `getFrame` and resolves the true source frame count as **`max(frames_attr, max(frame_numbers)+1)`**. The `frames` attr can badly under-report (real files: `18`/`109`/`424` while `frame_numbers` span 47k–175k), so it never shrinks the axis below the highest stored source index — mirrors the eager reader's `resolveSourceFrameCount`.

## Tests

`tests/streaming-lazy-video-metadata.test.ts` drives `readFromStreamingFile` with a read-counting fake `StreamingH5File` and asserts:
1. **Deferral** — `lazyVideoMetadata` performs **no** per-video reads at load (only `videos_json`); `ensureLoaded()` then performs them and resolves shape `[1, 384, 384, 1]`.
2. **Bogus `frames` guard** — with `frames=2` but `frame_numbers` spanning to 100, the resolved count is **101**, never the bogus attr.
3. **Eager unchanged** — `openVideos` still reads per-video metadata at load.

Full suite green (1962 pass; the one failing `edge-less skeletons` Python-interop test also fails on `main` — unrelated, local Python `sleap-io` version issue). Opt-in; default behavior unchanged. Bumps to **0.5.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)