### PR TITLE
feat(video): RangeSource mode for MP4/MediaBunny backends — stream large videos

### DIFF
--- a/src/video/backend.ts
+++ b/src/video/backend.ts
@@ -19,6 +19,38 @@ export interface GetFrameOptions {
   signal?: AbortSignal;
 }
 
+/**
+ * A lazy, seekable byte source for a video file — the video counterpart of the
+ * HDF5 streaming reader's range source. Lets a backend read only the byte ranges
+ * it needs (the container index + the samples for the frames being viewed)
+ * instead of materializing the whole file in memory.
+ *
+ * The canonical use is desktop (Tauri), where the WebView has no lazy disk-backed
+ * `File` for a raw path: `readRange` is backed by a native `read_range` command
+ * so a multi-GB video never has to be read whole into RAM. Structurally mirrors
+ * the HDF5 `RangeSource` used by `readSlpStreaming`.
+ */
+export interface RangeSource {
+  /** Total file size in bytes. */
+  size: number;
+  /** Read `[offset, offset + length)`; may return fewer bytes at EOF. */
+  readRange: (offset: number, length: number) => Promise<Uint8Array>;
+}
+
+/**
+ * True for a {@link RangeSource} — distinguishes it from a `string` URL / `File`
+ * / `Blob`. A `Blob` also has a numeric `size`, so the `readRange` function is
+ * the discriminator.
+ */
+export function isRangeSource(source: unknown): source is RangeSource {
+  return (
+    typeof source === "object" &&
+    source !== null &&
+    typeof (source as RangeSource).size === "number" &&
+    typeof (source as RangeSource).readRange === "function"
+  );
+}
+
 export interface VideoBackend {
   filename: string | string[];
   shape?: [number, number, number, number];

--- a/src/video/mediabunny-video.ts
+++ b/src/video/mediabunny-video.ts
@@ -8,11 +8,12 @@
  * built on initialization by iterating all packets.
  */
 
-import { VideoBackend, VideoFrame } from "./backend.js";
+import type { VideoBackend, VideoFrame, RangeSource } from "./backend.js";
 import {
   Input,
   UrlSource,
   BlobSource,
+  StreamSource,
   VideoSampleSink,
   EncodedPacketSink,
   ALL_FORMATS,
@@ -68,6 +69,33 @@ export class MediaBunnyVideoBackend implements VideoBackend {
     const backend = new MediaBunnyVideoBackend(filename, options);
     backend.input = new Input({
       source: new BlobSource(blob),
+      formats: ALL_FORMATS,
+    });
+    await backend.initialize();
+    return backend;
+  }
+
+  /**
+   * Build from a lazy {@link RangeSource} — reads only the container index +
+   * decoded frames' byte ranges via `readRange`, never the whole file. The
+   * desktop counterpart of {@link fromBlob}, avoiding a multi-GB in-memory copy.
+   * MediaBunny's {@link StreamSource} drives the reads; `read(start, end)` uses
+   * an EXCLUSIVE end, so length is `end - start`.
+   */
+  static async fromRangeSource(
+    rangeSource: RangeSource,
+    filename: string,
+    options?: MediaBunnyOptions,
+  ): Promise<MediaBunnyVideoBackend> {
+    const backend = new MediaBunnyVideoBackend(filename, options);
+    backend.input = new Input({
+      source: new StreamSource({
+        getSize: () => rangeSource.size,
+        read: (start, end) => rangeSource.readRange(start, end - start),
+        // Local disk over IPC: page-aligned bidirectional prefetch fits better
+        // than the aggressive network profile.
+        prefetchProfile: "fileSystem",
+      }),
       formats: ALL_FORMATS,
     });
     await backend.initialize();

--- a/src/video/mp4box-video.ts
+++ b/src/video/mp4box-video.ts
@@ -1,4 +1,10 @@
-import { VideoBackend, VideoFrame, GetFrameOptions } from "./backend.js";
+import {
+  type VideoBackend,
+  type VideoFrame,
+  type GetFrameOptions,
+  type RangeSource,
+  isRangeSource,
+} from "./backend.js";
 import {
   RemoteIOError,
   fetchRetrying,
@@ -85,17 +91,25 @@ export class Mp4BoxVideoBackend implements VideoBackend {
   private fileSize: number;
   private supportsRangeRequests: boolean;
   private fileBlob: Blob | null;
+  /**
+   * Lazy byte source (desktop): read only the ranges we need via a native
+   * `read_range` instead of materializing the whole file. Mutually exclusive
+   * with `fileBlob` / URL fetching.
+   */
+  private rangeSource: RangeSource | null;
   private decodeQueue: Promise<void>;
   private latestRequestedFrame: number | null;
   /** Extra HTTP headers (e.g. Authorization) applied to every byte fetch. */
   private headers: Record<string, string>;
 
   constructor(
-    source: string | File | Blob,
+    source: string | File | Blob | RangeSource,
     options?: {
       cacheSize?: number;
       lookahead?: number;
       headers?: Record<string, string>;
+      /** Display name when the source carries none (e.g. a {@link RangeSource}). */
+      filename?: string;
     },
   ) {
     if (!hasWebCodecs()) {
@@ -104,8 +118,12 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     if (!isBrowser()) {
       throw new Error("Mp4BoxVideoBackend requires a browser environment.");
     }
-    this.filename =
-      source instanceof Blob ? ((source as File).name ?? "") : source;
+    const asRange = isRangeSource(source);
+    this.filename = asRange
+      ? (options?.filename ?? "")
+      : source instanceof Blob
+        ? ((source as File).name ?? "")
+        : source;
     this.dataset = null;
     this.headers = options?.headers ?? {};
     this.samples = [];
@@ -118,10 +136,15 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     this.fileSize = 0;
     this.supportsRangeRequests = false;
     this.fileBlob = null;
+    this.rangeSource = null;
     this.decodeQueue = Promise.resolve();
     this.latestRequestedFrame = null;
 
-    if (source instanceof Blob) {
+    if (asRange) {
+      // Lazy on-disk source: we already know the size; readChunk pulls ranges.
+      this.rangeSource = source;
+      this.fileSize = source.size;
+    } else if (source instanceof Blob) {
       this.fileBlob = source;
       this.fileSize = source.size;
       this.supportsRangeRequests = false;
@@ -183,10 +206,13 @@ export class Mp4BoxVideoBackend implements VideoBackend {
     });
     this.cache.clear();
     this.fileBlob = null;
+    this.rangeSource = null;
   }
 
   private async init(): Promise<void> {
-    if (!this.fileBlob) {
+    // A RangeSource already knows the size and serves bytes via readChunk; only
+    // a URL source needs the ranged probe in openSource().
+    if (!this.fileBlob && !this.rangeSource) {
       await this.openSource();
     }
 
@@ -287,6 +313,16 @@ export class Mp4BoxVideoBackend implements VideoBackend {
 
   private async readChunk(offset: number, size: number): Promise<ArrayBuffer> {
     const end = Math.min(offset + size, this.fileSize);
+    if (this.rangeSource) {
+      // Lazy on-disk read: only the requested bytes cross into memory. Copy to a
+      // standalone ArrayBuffer so mp4box owns a right-sized buffer (the returned
+      // Uint8Array may be a view onto a larger backing buffer).
+      const bytes = await this.rangeSource.readRange(offset, end - offset);
+      return bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+      ) as ArrayBuffer;
+    }
     if (this.supportsRangeRequests) {
       // Ranged read: force Accept-Encoding: identity (gzip would corrupt the
       // byte range) and retry transient failures with backoff.

--- a/tests/video/range-source.test.ts
+++ b/tests/video/range-source.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "../bun-test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { isRangeSource, type RangeSource } from "../../src/video/backend.js";
+
+const WEBM_PATH = resolve(
+  __dirname,
+  "../data/videos/centered_pair_low_quality.webm",
+);
+
+/**
+ * A {@link RangeSource} backed by an in-memory buffer, recording each read so a
+ * test can assert the reader pulled ranges (never the whole file in one shot) —
+ * the same lazy access pattern a native `read_range` gives on desktop.
+ */
+function bufferRangeSource(buf: Uint8Array): {
+  source: RangeSource;
+  calls: Array<{ offset: number; length: number }>;
+} {
+  const calls: Array<{ offset: number; length: number }> = [];
+  return {
+    calls,
+    source: {
+      size: buf.byteLength,
+      readRange: async (offset: number, length: number) => {
+        calls.push({ offset, length });
+        return buf.subarray(offset, offset + length);
+      },
+    },
+  };
+}
+
+describe("isRangeSource", () => {
+  it("accepts a { size, readRange } object", () => {
+    expect(
+      isRangeSource({ size: 10, readRange: async () => new Uint8Array() }),
+    ).toBe(true);
+  });
+
+  it("rejects a Blob (has size but no readRange)", () => {
+    expect(isRangeSource(new Blob([new Uint8Array([1, 2, 3])]))).toBe(false);
+  });
+
+  it("rejects strings, null, and partial shapes", () => {
+    expect(isRangeSource("path/to/video.mp4")).toBe(false);
+    expect(isRangeSource(null)).toBe(false);
+    expect(isRangeSource({ size: 10 })).toBe(false);
+    expect(isRangeSource({ readRange: async () => new Uint8Array() })).toBe(
+      false,
+    );
+  });
+});
+
+describe("MediaBunnyVideoBackend.fromRangeSource (real WebM via range reads)", () => {
+  beforeEach(() => {
+    (globalThis as any).createImageBitmap = async () => ({
+      width: 388,
+      height: 384,
+      close: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).createImageBitmap;
+  });
+
+  it("parses the same metadata as fromBlob, reading only ranges", async () => {
+    const { MediaBunnyVideoBackend } = await import(
+      "../../src/video/mediabunny-video.js"
+    );
+
+    const data = new Uint8Array(readFileSync(WEBM_PATH));
+    const { source, calls } = bufferRangeSource(data);
+    const backend = await MediaBunnyVideoBackend.fromRangeSource(
+      source,
+      "test.webm",
+    );
+
+    // Same metadata the fromBlob integration test asserts — proof the
+    // StreamSource fed bytes correctly (incl. the end-EXCLUSIVE read convention:
+    // a wrong length here would corrupt the demux and change the frame count).
+    expect(backend.shape).toEqual([30, 384, 388, 3]);
+    expect(backend.fps!).toBeCloseTo(15, 0);
+    expect(backend.numFrames).toBe(30);
+    expect(backend.filename).toBe("test.webm");
+
+    // All bytes came through readRange (never a whole-file materialization by
+    // the backend itself), and no read ran past EOF. (A small fixture may be
+    // read in one range; big-file laziness — only the needed ranges — is
+    // inherently E2E-verified, not provable with a tiny file.)
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((c) => c.offset + c.length <= data.byteLength)).toBe(
+      true,
+    );
+
+    backend.close();
+  });
+
+  it("returns the frame-time index from a range source", async () => {
+    const { MediaBunnyVideoBackend } = await import(
+      "../../src/video/mediabunny-video.js"
+    );
+    const data = new Uint8Array(readFileSync(WEBM_PATH));
+    const { source } = bufferRangeSource(data);
+    const backend = await MediaBunnyVideoBackend.fromRangeSource(
+      source,
+      "test.webm",
+    );
+
+    const times = await backend.getFrameTimes();
+    expect(times!.length).toBe(30);
+    for (let i = 1; i < times!.length; i++) {
+      expect(times![i]).toBeGreaterThan(times![i - 1]);
+    }
+
+    backend.close();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a lazy byte-range source to the video backends so a large external video is read **only where it's needed** (the container index + the byte ranges of the frames being viewed) instead of being materialized whole in memory. This is the video counterpart of the HDF5 `readSlpStreaming` range reader.

### Why
On desktop (Tauri), the WebView has no lazy disk-backed `File` for a raw path, so the app reads the **entire** file via `readFile` before decoding. For a multi-GB video that freezes the UI on the allocation and OOM-crashes lower-RAM machines. The backends were already chunk-based (they read via `readChunk` / MediaBunny sources); they just needed a source that reads on demand.

## Changes
- **`backend.ts`** — `RangeSource { size, readRange(offset, length) }` + `isRangeSource` guard (structurally mirrors the HDF5 range source; a `Blob` also has a numeric `size`, so `readRange` is the discriminator).
- **`Mp4BoxVideoBackend`** — accept a `RangeSource` as a third source mode alongside URL+Range and `Blob.slice()`. It's already chunk-based, so this only adds a branch in `readChunk` and skips the URL probe; `init()`/`decodeRange()`/cache are untouched. `moov`-at-end files still work via mp4box's `next`-offset skip.
- **`MediaBunnyVideoBackend.fromRangeSource`** — drives mediabunny's `StreamSource` (`getSize`/`read`) off `readRange`. `read(start, end)` is end-**exclusive** (`length = end - start`), with `prefetchProfile: 'fileSystem'`.

## Tests
`tests/video/range-source.test.ts`:
- `isRangeSource` discrimination (accepts `{size, readRange}`; rejects `Blob`/string/null/partial shapes).
- A real WebM parsed **end-to-end through `fromRangeSource`** — same `shape`/`fps`/`frameCount` as `fromBlob`, proving the `StreamSource` wiring and the end-exclusive read convention (a wrong length would corrupt the demux).

Big-file laziness (only-needed ranges, flat memory) is **device-verified** in the downstream app: opening a real **3.7 GB** external mp4 over an SMB mount kept the WebView RSS at its ~183 MB idle baseline (vs a ~3.7 GB spike + freeze before) and loaded near-instantly.

Full suite green (the one failing `edge-less skeletons` Python cross-compat test fails identically on `main` — a local env/venv issue, not this change).

Downstream: [talmolab/sleap-app streaming-video wiring](https://github.com/talmolab/sleap-app) consumes this via `assignVideoBackendFromPath` + the native `read_range`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)