### PR TITLE
fix(video): resolve external/ImageVideo paths against the labels dir; withhold unreadable backends (#213)

### DIFF
--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -29,6 +29,13 @@ import {
   UnsupportedVideoFormatError,
   isImageSource,
 } from "../../video/factory.js";
+import {
+  resolveVideoSource,
+  posixDirname,
+  posixBasename,
+} from "../../video/path-resolve.js";
+import { getFsResolver } from "../../model/matching.js";
+import { isUrl } from "../../io/remote.js";
 import { CropVideoBackend } from "../../video/crop-backend.js";
 import { resolveSourceFrameCount } from "./frame-count.js";
 import type { CropRect } from "../../transform/points.js";
@@ -866,41 +873,83 @@ async function readVideos(
       channelOrderFromAttrs ??
       (formatId < 1.4 ? "BGR" : "RGB");
 
+    // Resolve external (non-embedded) source paths against the labels-file
+    // directory so a project moved between machines — or whose media now lives
+    // in a subfolder next to the `.slp` — still opens. Uses the injected
+    // FsResolver for existence checks (Node, Tauri, and browser-injected all
+    // share one policy); with no resolver, or for URLs / embedded videos, the
+    // stored source is used verbatim. See issue #213 and video/path-resolve.ts.
+    let openFilename: string | string[] = filename;
+    let sourceMissing = false;
+    if (openVideos && !embedded) {
+      const fsResolver = getFsResolver();
+      const sourceIsUrl = typeof filename === "string" && isUrl(filename);
+      if (fsResolver && !sourceIsUrl && !isUrl(labelsPath)) {
+        const resolved = await resolveVideoSource(
+          filename,
+          posixDirname(labelsPath),
+          fsResolver,
+        );
+        openFilename = resolved.filename;
+        sourceMissing = resolved.firstMissing;
+      }
+    }
+
     let backend = null;
     let backendError: VideoBackendError | null = null;
     if (openVideos) {
-      try {
-        backend = await createVideoBackend(filename, {
-          dataset: datasetPath ?? undefined,
-          embedded,
-          frameNumbers,
-          frameSizes: readFrameSizes(file, datasetPath),
-          format,
-          channelOrder,
-          shape,
-          fps: backendMeta.fps,
-          // Persist the remote `.slp` auth headers onto remote/embedded video
-          // backends so reopens / existence probes stay authenticated. The
-          // factory only uses them for URL-backed backends; embedded/local
-          // backends ignore them.
-          headers: urlHeaders,
-        });
-      } catch (err) {
-        // Resilient load: a single video whose backend can't be built — an
-        // image-sequence with missing files, an unsupported `.avi`/`.mpeg`, or
-        // a decode failure — must NOT abort the whole project load. Leave the
-        // backend null and record the reason so the consumer can show an
-        // actionable message / resolver instead of the load throwing.
-        backend = null;
+      if (sourceMissing && isImageSource(filename)) {
+        // The resolver confirms the first image is unreachable. Do NOT hand back
+        // a backend that looks healthy: an ImageVideo given a stored `shape`
+        // skips the up-front frame-0 decode, so it would open "successfully"
+        // while unable to read a single frame (issue #213). Record the reason so
+        // consumers can surface a locate/repair affordance instead of silently
+        // rendering blank frames.
+        const firstStored = Array.isArray(filename)
+          ? (filename[0] ?? "")
+          : filename;
         backendError = {
-          kind:
-            err instanceof UnsupportedVideoFormatError
-              ? "unsupported-format"
-              : isImageSource(filename)
-                ? "image-sequence"
-                : "decode",
-          message: err instanceof Error ? err.message : String(err),
+          kind: "image-sequence",
+          message:
+            `Image sequence not found: could not locate ` +
+            `"${posixBasename(firstStored)}" relative to the labels directory ` +
+            `"${posixDirname(labelsPath)}". The stored path "${firstStored}" ` +
+            `was likely saved on another machine; move or locate the image folder.`,
         };
+      } else {
+        try {
+          backend = await createVideoBackend(openFilename, {
+            dataset: datasetPath ?? undefined,
+            embedded,
+            frameNumbers,
+            frameSizes: readFrameSizes(file, datasetPath),
+            format,
+            channelOrder,
+            shape,
+            fps: backendMeta.fps,
+            // Persist the remote `.slp` auth headers onto remote/embedded video
+            // backends so reopens / existence probes stay authenticated. The
+            // factory only uses them for URL-backed backends; embedded/local
+            // backends ignore them.
+            headers: urlHeaders,
+          });
+        } catch (err) {
+          // Resilient load: a single video whose backend can't be built — an
+          // image-sequence with missing files, an unsupported `.avi`/`.mpeg`, or
+          // a decode failure — must NOT abort the whole project load. Leave the
+          // backend null and record the reason so the consumer can show an
+          // actionable message / resolver instead of the load throwing.
+          backend = null;
+          backendError = {
+            kind:
+              err instanceof UnsupportedVideoFormatError
+                ? "unsupported-format"
+                : isImageSource(filename)
+                  ? "image-sequence"
+                  : "decode",
+            message: err instanceof Error ? err.message : String(err),
+          };
+        }
       }
     }
 

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -30,6 +30,22 @@ export {
   type ImageBytesReader,
 } from "./video/image-source.js";
 export {
+  resolveVideoSource,
+  videoPathCandidates,
+  anchorCandidate,
+  derivePrefixSwap,
+  applyPrefixSwap,
+  resolveFirstExisting,
+  parsePath,
+  formatPath,
+  posixDirname,
+  posixBasename,
+  posixJoin,
+  type PosixPath,
+  type PrefixSwap,
+  type ResolvedVideoSource,
+} from "./video/path-resolve.js";
+export {
   SeqVideoBackend,
   SeqHeader,
   SeqIndex,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,22 @@ export {
   type ImageBytesReader,
 } from "./video/image-source.js";
 export {
+  resolveVideoSource,
+  videoPathCandidates,
+  anchorCandidate,
+  derivePrefixSwap,
+  applyPrefixSwap,
+  resolveFirstExisting,
+  parsePath,
+  formatPath,
+  posixDirname,
+  posixBasename,
+  posixJoin,
+  type PosixPath,
+  type PrefixSwap,
+  type ResolvedVideoSource,
+} from "./video/path-resolve.js";
+export {
   SeqVideoBackend,
   SeqHeader,
   SeqIndex,

--- a/src/video/backend.ts
+++ b/src/video/backend.ts
@@ -68,6 +68,16 @@ export interface VideoBackend {
   ): Promise<VideoFrame | null>;
   getFrameTimes?(): Promise<number[] | null>;
   /**
+   * Optional cheap liveness probe: resolve to `true` if the backend can read its
+   * first frame's SOURCE bytes (no decode), else `false` (never throws). Used to
+   * detect a backend built from stored metadata (an `ImageVideo` given a `shape`
+   * skips the up-front decode) whose media is not actually reachable, so a
+   * consumer can offer a locate/repair affordance instead of rendering blanks.
+   * Backends that always read on `getFrame` (or verify at construction) may omit
+   * this. See issue #213.
+   */
+  probeFirstFrame?(): Promise<boolean>;
+  /**
    * Optional crop pushdown hook (Item 1 of JS issue #153, mirroring Python
    * `read_crop`, `video_reading.py:1647`).
    *

--- a/src/video/image-video.ts
+++ b/src/video/image-video.ts
@@ -253,6 +253,28 @@ export class ImageVideoBackend implements VideoBackend {
     this.lastPrefetch = this.prefetch(window);
   }
 
+  /**
+   * Cheap liveness probe: attempt to read frame 0's ENCODED bytes (no decode),
+   * serving from / seeding the bytes cache. Resolves `true` when the read
+   * succeeds, `false` when it throws (missing file, unreadable path, injected
+   * reader that rejects). Never throws.
+   *
+   * When {@link create} is given a `shape` it skips the up-front frame-0 decode,
+   * so the returned backend can look healthy while pointing at media that isn't
+   * there (issue #213). This lets the SLP loader — or any consumer that opens a
+   * backend from stored metadata — confirm the first frame is reachable and drop
+   * the backend if not.
+   */
+  async probeFirstFrame(): Promise<boolean> {
+    if (this.filename.length === 0) return false;
+    try {
+      await this.startRead(0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   close(): void {
     this.bytesCache.clear();
     this.decodedCache.clear();

--- a/src/video/path-resolve.ts
+++ b/src/video/path-resolve.ts
@@ -1,0 +1,361 @@
+// src/video/path-resolve.ts
+//
+// External video path resolution against the labels-file directory (issue #213).
+//
+// A `.slp` stores video sources by the ABSOLUTE path they had on the machine
+// that wrote them. When the project is opened elsewhere — a different OS, or the
+// media moved into a subfolder next to the `.slp` — those paths no longer point
+// at anything, and the video silently fails to open. This module resolves a
+// stored source (a single file OR an `ImageVideo` image list) to where the media
+// actually lives, using the injected {@link FsResolver} (`setFsResolver`) for
+// existence checks so the browser (injected), Node, and Tauri all share ONE
+// resolution policy. With no resolver available it is never invoked; the caller
+// degrades to the stored path verbatim.
+//
+// Candidate strategy (mirrors Python sleap-io's resolve-relative-to-`.slp` plus
+// its `find_changed_subpath` / prefix-change logic, and unifies both):
+//   1. the stored path verbatim (absolute / same-machine),
+//   2. the stored path relative to the labels directory,
+//   3. a common-suffix "anchor" between the labels dir and the stored path,
+//   4. progressively shorter trailing tails grafted onto the labels dir
+//      (`sub/sub/basename` → … → `basename`), most-specific-first.
+//
+// For an image sequence, only the FIRST frame is probed against the candidates;
+// the winning candidate yields a single prefix-swap that is applied to every
+// path in the list (an O(N) string op — never N filesystem checks), so a
+// 15,000-image sequence resolves with a handful of `exists()` calls.
+
+import type { FsResolver } from "../model/matching.js";
+
+/** Deepest trailing-tail depth grafted onto the labels dir (bounds `exists()` calls). */
+const DEFAULT_MAX_TAIL_DEPTH = 16;
+
+/**
+ * A path decomposed for cross-platform reasoning: backslashes normalized to `/`,
+ * a Windows `drive` letter (`"C:"`, no slash) split out, and the remaining
+ * segments in `parts` (with `.` and empty segments dropped, `..` preserved).
+ */
+export interface PosixPath {
+  /** Whether the path is rooted (leading `/`, a UNC `//`, or a `drive` + `/`). */
+  absolute: boolean;
+  /** Windows drive prefix like `"C:"` (no trailing slash), or `null`. */
+  drive: string | null;
+  /**
+   * A UNC / network-share root (leading `\\` or `//`, e.g. `\\server\share`).
+   * Tracked separately so it round-trips as `//…` and is not collapsed to a
+   * single-slash POSIX root — which on Windows would silently re-root the path
+   * to the current drive and lose the share (issue #213).
+   */
+  unc: boolean;
+  /** Path segments after the root/drive. */
+  parts: string[];
+}
+
+/** Split a slash-joined remainder into segments, dropping `""` and `.`. */
+function splitParts(s: string): string[] {
+  return s.split("/").filter((c) => c.length > 0 && c !== ".");
+}
+
+/**
+ * Parse a path string into a {@link PosixPath}. Handles UNC (`\\server\share`),
+ * POSIX absolute (`/a/b`), Windows drive-absolute (`C:/a/b` or `C:\a\b`),
+ * Windows drive-relative (`C:a`), and relative (`a/b`) forms. Never throws.
+ */
+export function parsePath(p: string): PosixPath {
+  const norm = p.replace(/\\/g, "/");
+  // UNC / network share (`\\server\share\…` -> `//server/share/…`): keep the
+  // double-slash root so it is not collapsed to a single-slash POSIX root.
+  if (norm.startsWith("//")) {
+    return { absolute: true, drive: null, unc: true, parts: splitParts(norm) };
+  }
+  const driveMatch = /^([A-Za-z]:)(.*)$/.exec(norm);
+  if (driveMatch) {
+    const rest = driveMatch[2];
+    return {
+      absolute: rest.startsWith("/"),
+      drive: driveMatch[1],
+      unc: false,
+      parts: splitParts(rest),
+    };
+  }
+  if (norm.startsWith("/")) {
+    return { absolute: true, drive: null, unc: false, parts: splitParts(norm) };
+  }
+  return { absolute: false, drive: null, unc: false, parts: splitParts(norm) };
+}
+
+/** Render a {@link PosixPath} back to a forward-slash string. Inverse of {@link parsePath}. */
+export function formatPath(pp: PosixPath): string {
+  const body = pp.parts.join("/");
+  if (pp.unc) return `//${body}`;
+  if (pp.drive) {
+    return pp.absolute ? `${pp.drive}/${body}` : `${pp.drive}${body}`;
+  }
+  return pp.absolute ? `/${body}` : body;
+}
+
+/** Final path segment (cross-platform), or `""` for a rootless empty path. */
+export function posixBasename(p: string): string {
+  const { parts } = parsePath(p);
+  return parts.length > 0 ? parts[parts.length - 1] : "";
+}
+
+/** Directory portion of a path (cross-platform), preserving root/drive. */
+export function posixDirname(p: string): string {
+  const pp = parsePath(p);
+  return formatPath({ ...pp, parts: pp.parts.slice(0, -1) });
+}
+
+/** Join `tail` (treated as a relative segment) onto directory `dir`. */
+export function posixJoin(dir: string, tail: string): string {
+  const d = parsePath(dir);
+  const t = parsePath(tail);
+  return formatPath({ ...d, parts: [...d.parts, ...t.parts] });
+}
+
+/**
+ * Index in `hay` just AFTER the last contiguous occurrence of `needle`, or `-1`
+ * if `needle` is empty or does not occur. Used to locate the deepest shared
+ * "anchor" run between the labels dir and a stored path.
+ */
+function lastIndexAfterContiguous(hay: string[], needle: string[]): number {
+  if (needle.length === 0) return -1;
+  for (let start = hay.length - needle.length; start >= 0; start--) {
+    let ok = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (hay[start + j] !== needle[j]) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) return start + needle.length;
+  }
+  return -1;
+}
+
+/**
+ * Reconstruct a candidate by grafting the stored path's tail onto the labels dir
+ * at their longest shared "anchor": the longest suffix of the labels-dir
+ * segments that also occurs contiguously within the stored path's directory
+ * segments. The stored directory portion AFTER that anchor (plus the basename)
+ * is appended to the FULL labels dir.
+ *
+ * Example — labels dir `L:/code/proj/2026-mars`, stored
+ * `/home/u/code/proj/2026-mars/raw/img_0.jpg`: the anchor is
+ * `code/proj/2026-mars`, so the candidate is
+ * `L:/code/proj/2026-mars/raw/img_0.jpg`.
+ *
+ * Returns `null` when there is no shared anchor.
+ */
+export function anchorCandidate(
+  storedPath: string,
+  labelsDir: string,
+): string | null {
+  const sp = parsePath(storedPath);
+  if (sp.parts.length === 0) return null;
+  const basename = sp.parts[sp.parts.length - 1];
+  const storedDir = sp.parts.slice(0, -1);
+  const ld = parsePath(labelsDir);
+  const ldParts = ld.parts;
+
+  const maxL = Math.min(ldParts.length, storedDir.length);
+  for (let L = maxL; L >= 1; L--) {
+    const suffix = ldParts.slice(ldParts.length - L);
+    const end = lastIndexAfterContiguous(storedDir, suffix);
+    if (end >= 0) {
+      const remainder = storedDir.slice(end);
+      return formatPath({ ...ld, parts: [...ldParts, ...remainder, basename] });
+    }
+  }
+  return null;
+}
+
+/**
+ * Ordered, de-duplicated candidate paths for a single stored source path,
+ * resolved against `labelsDir`. The first entry is always the verbatim
+ * (normalized) stored path. Later entries require a non-empty `labelsDir`.
+ * The trailing-tail grafts are emitted MOST-SPECIFIC-FIRST (deepest tail before
+ * basename) so the first existing match is the least ambiguous.
+ */
+export function videoPathCandidates(
+  storedPath: string,
+  labelsDir: string,
+  maxDepth: number = DEFAULT_MAX_TAIL_DEPTH,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (c: string): void => {
+    if (c.length > 0 && !seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  };
+
+  const sp = parsePath(storedPath);
+  // 1. Verbatim (normalized) — absolute / same-machine.
+  add(formatPath(sp));
+
+  if (labelsDir != null && labelsDir !== "") {
+    // 2. Relative-to-labels-dir (only when the stored path is itself relative).
+    if (!sp.absolute && sp.drive == null) {
+      add(posixJoin(labelsDir, storedPath));
+    }
+    // 3. Common-suffix anchor — high-precision single guess.
+    const anchor = anchorCandidate(storedPath, labelsDir);
+    if (anchor != null) add(anchor);
+    // 4. Trailing tails grafted onto the labels dir, deepest-first.
+    const parts = sp.parts;
+    const maxK = Math.min(maxDepth, parts.length);
+    for (let k = maxK; k >= 1; k--) {
+      add(posixJoin(labelsDir, parts.slice(parts.length - k).join("/")));
+    }
+  }
+
+  return out;
+}
+
+/**
+ * A leading-prefix substitution derived from how the first frame resolved:
+ * replace the `old` leading segment (root + parts) of a path with the `new` one,
+ * preserving the shared `suffixLen` trailing segments. Applied to every path in
+ * an image sequence so the whole list is remapped from one resolution probe.
+ */
+export interface PrefixSwap {
+  old: PosixPath;
+  new: PosixPath;
+  suffixLen: number;
+}
+
+/**
+ * Derive the {@link PrefixSwap} that turns `firstStored` into `firstResolved` by
+ * keeping their longest common trailing segments and swapping everything before.
+ */
+export function derivePrefixSwap(
+  firstStored: string,
+  firstResolved: string,
+): PrefixSwap {
+  const s = parsePath(firstStored);
+  const r = parsePath(firstResolved);
+  let suffixLen = 0;
+  while (
+    suffixLen < s.parts.length &&
+    suffixLen < r.parts.length &&
+    s.parts[s.parts.length - 1 - suffixLen] ===
+      r.parts[r.parts.length - 1 - suffixLen]
+  ) {
+    suffixLen++;
+  }
+  return {
+    old: {
+      absolute: s.absolute,
+      drive: s.drive,
+      unc: s.unc,
+      parts: s.parts.slice(0, s.parts.length - suffixLen),
+    },
+    new: {
+      absolute: r.absolute,
+      drive: r.drive,
+      unc: r.unc,
+      parts: r.parts.slice(0, r.parts.length - suffixLen),
+    },
+    suffixLen,
+  };
+}
+
+/**
+ * Apply a {@link PrefixSwap} to `path`: if `path` starts with the swap's `old`
+ * leading prefix (same root/drive and leading segments), replace that prefix
+ * with `new`; otherwise return `path` normalized and unchanged (paths in the
+ * list that don't share the first frame's prefix are left as-is).
+ */
+export function applyPrefixSwap(path: string, swap: PrefixSwap): string {
+  const p = parsePath(path);
+  const { old: o, new: n } = swap;
+  if (p.absolute !== o.absolute || p.drive !== o.drive || p.unc !== o.unc) {
+    return formatPath(p);
+  }
+  if (p.parts.length < o.parts.length) return formatPath(p);
+  for (let i = 0; i < o.parts.length; i++) {
+    if (p.parts[i] !== o.parts[i]) return formatPath(p);
+  }
+  return formatPath({
+    absolute: n.absolute,
+    drive: n.drive,
+    unc: n.unc,
+    parts: [...n.parts, ...p.parts.slice(o.parts.length)],
+  });
+}
+
+/**
+ * First candidate that {@link FsResolver.exists} confirms, or `null` if none do.
+ * A resolver that throws on a candidate is treated as "does not exist" for that
+ * candidate (the scan continues) — matching the conservative degrade elsewhere.
+ */
+export async function resolveFirstExisting(
+  candidates: string[],
+  fs: FsResolver,
+): Promise<string | null> {
+  for (const candidate of candidates) {
+    try {
+      if (await fs.exists(candidate)) return candidate;
+    } catch {
+      // Treat a resolver error as "not found here" and try the next candidate.
+    }
+  }
+  return null;
+}
+
+/** Result of resolving a video source against the labels directory. */
+export interface ResolvedVideoSource {
+  /**
+   * The source remapped to on-disk paths where resolution succeeded, or the
+   * original source unchanged when it resolved verbatim / could not be located.
+   * Same shape as the input (string vs string[]).
+   */
+  filename: string | string[];
+  /**
+   * `true` IFF the resolver was consulted and the first frame/file could NOT be
+   * located at ANY candidate — the signal for callers to withhold an unreadable
+   * backend and record a "missing" reason.
+   */
+  firstMissing: boolean;
+}
+
+/**
+ * Resolve a stored video source (single file or `ImageVideo` list) against the
+ * labels-file directory using `fs` for existence checks.
+ *
+ * Only the first frame of a list is probed; the winning candidate yields one
+ * prefix-swap applied to the whole list. Returns the original source unchanged
+ * on a verbatim hit (no churn) or when nothing could be located (`firstMissing`
+ * then flags the miss). Callers MUST only invoke this when an `FsResolver` is
+ * available; with none, degrade to the stored source directly.
+ */
+export async function resolveVideoSource(
+  source: string | string[],
+  labelsDir: string,
+  fs: FsResolver,
+): Promise<ResolvedVideoSource> {
+  if (Array.isArray(source)) {
+    if (source.length === 0) return { filename: source, firstMissing: false };
+    const first = source[0];
+    const candidates = videoPathCandidates(first, labelsDir);
+    const resolved = await resolveFirstExisting(candidates, fs);
+    if (resolved == null) return { filename: source, firstMissing: true };
+    // Verbatim hit: leave the list byte-for-byte unchanged.
+    if (resolved === candidates[0])
+      return { filename: source, firstMissing: false };
+    const swap = derivePrefixSwap(first, resolved);
+    return {
+      filename: source.map((p) => applyPrefixSwap(p, swap)),
+      firstMissing: false,
+    };
+  }
+
+  const candidates = videoPathCandidates(source, labelsDir);
+  const resolved = await resolveFirstExisting(candidates, fs);
+  if (resolved == null) return { filename: source, firstMissing: true };
+  if (resolved === candidates[0])
+    return { filename: source, firstMissing: false };
+  return { filename: resolved, firstMissing: false };
+}

--- a/tests/codecs/imagevideo-resolve.test.ts
+++ b/tests/codecs/imagevideo-resolve.test.ts
@@ -1,0 +1,224 @@
+/**
+ * End-to-end path resolution for external ImageVideo sequences loaded from a
+ * `.slp` whose stored image paths were written on ANOTHER machine (issue #213).
+ *
+ * A `.slp` is written to a temp dir referencing a 3-image sequence by FOREIGN
+ * absolute paths, with a stored `shape` (so `ImageVideoBackend.create` skips the
+ * up-front frame-0 decode). The images actually live in a `raw_images_top/`
+ * subfolder next to the `.slp`. On load with the Node FsResolver:
+ *  - the loader grafts the subfolder tail onto the labels dir, opens the backend
+ *    against the resolved paths, and decodes a real frame; and
+ *  - when the images are NOT present, the loader withholds the (would-be
+ *    "healthy") backend and records `backendError.kind === "image-sequence"`
+ *    instead of silently rendering blanks.
+ *
+ * Also covers `ImageVideoBackend.probeFirstFrame` and the graceful degrade when
+ * no FsResolver is available.
+ */
+import { describe, it, expect, afterEach } from "../bun-test";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { readSlp } from "../../src/codecs/slp/read.js";
+import { saveSlpToBytes } from "../../src/codecs/slp/write.js";
+import { Video } from "../../src/model/video.js";
+import { Labels } from "../../src/model/labels.js";
+import { ImageVideoBackend } from "../../src/video/image-video.js";
+import {
+  getFsResolver,
+  setFsResolver,
+  setDefaultFsResolver,
+} from "../../src/model/matching.js";
+
+const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
+const srcJpg = (i: number) =>
+  path.join(fixtureRoot, "videos", "imgs", `img.0${i}.jpg`);
+
+/** Foreign (Linux) absolute paths as they would be stored on the writing box. */
+const FOREIGN = [0, 1, 2].map(
+  (i) =>
+    `/home/talmo/scratch/2026-07-10-mars/raw_images_top/MARS_top_0000${i}.jpg`,
+);
+
+/** Build the .slp bytes for an image sequence stored by FOREIGN abs paths + shape. */
+async function makeImageSeqSlpBytes(): Promise<Uint8Array> {
+  const video = new Video({
+    filename: FOREIGN,
+    backendMetadata: {
+      filename: FOREIGN[0],
+      filenames: FOREIGN,
+      // A stored shape is what makes ImageVideoBackend.create skip the decode.
+      shape: [3, 384, 384, 3],
+    },
+    openBackend: false,
+  });
+  const labels = new Labels({ videos: [video] });
+  return new Uint8Array(await saveSlpToBytes(labels));
+}
+
+/** Write the .slp bytes and (optionally) the images-under-subfolder to a temp dir. */
+function writeProject(bytes: Uint8Array, withImages: boolean): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sleap-213-"));
+  fs.writeFileSync(path.join(dir, "mars_top.slp"), bytes);
+  if (withImages) {
+    const sub = path.join(dir, "raw_images_top");
+    fs.mkdirSync(sub, { recursive: true });
+    for (let i = 0; i < 3; i++) {
+      fs.copyFileSync(srcJpg(i), path.join(sub, `MARS_top_0000${i}.jpg`));
+    }
+  }
+  return dir;
+}
+
+afterEach(() => setFsResolver(null));
+
+describe("ImageVideo external path resolution on load (issue #213)", () => {
+  it("grafts the subfolder tail and opens a readable backend", async () => {
+    const dir = writeProject(await makeImageSeqSlpBytes(), true);
+    try {
+      const labels = await readSlp(path.join(dir, "mars_top.slp"), {
+        openVideos: true,
+      });
+      const video = labels.videos[0];
+      expect(video.backendError).toBeNull();
+      expect(video.backend).toBeInstanceOf(ImageVideoBackend);
+
+      // The backend reads from the RESOLVED subfolder paths...
+      const resolved = (video.backend as ImageVideoBackend).filename;
+      const expectedFirst = path
+        .join(dir, "raw_images_top", "MARS_top_00000.jpg")
+        .replace(/\\/g, "/");
+      expect(resolved[0]).toBe(expectedFirst);
+      expect(resolved).toHaveLength(3);
+
+      // ...while Video.filename keeps the ORIGINAL stored (foreign) paths so a
+      // re-save stays portable and identity/matching is unchanged.
+      expect(video.filename).toEqual(FOREIGN);
+
+      // A real frame decodes end to end.
+      const frame = (await video.getFrame(1)) as ImageData;
+      expect(frame).not.toBeNull();
+      expect(frame.width).toBeGreaterThan(0);
+      expect(frame.height).toBeGreaterThan(0);
+
+      // The stored backend metadata (what the writer serializes) also keeps the
+      // ORIGINAL foreign paths, so a re-save stays portable.
+      expect(video.backendMetadata.filenames).toEqual(FOREIGN);
+      expect(video.backendMetadata.filename).toBe(FOREIGN[0]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("re-saving after a resolved load writes the ORIGINAL foreign paths, not resolved temp paths", async () => {
+    const dir = writeProject(await makeImageSeqSlpBytes(), true);
+    try {
+      const labels = await readSlp(path.join(dir, "mars_top.slp"), {
+        openVideos: true,
+      });
+      // The backend resolved to the local subfolder, but a re-save must not leak
+      // machine-local paths into the portable videos_json.
+      const bytes = new Uint8Array(await saveSlpToBytes(labels));
+      const reloaded = await readSlp(bytes.buffer, { openVideos: false });
+      const rv = reloaded.videos[0];
+      expect(rv.filename).toEqual(FOREIGN);
+      expect(rv.backendMetadata.filenames).toEqual(FOREIGN);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("a MISSING single-file video is never routed through the image-sequence withhold gate", async () => {
+    // Single-file (.mp4) source stored by a foreign absolute path, with a shape,
+    // and no file on disk: the resolver reports it missing, but single files must
+    // take the createVideoBackend path (lazy backend / decode error), NOT the
+    // image-sequence withhold gate.
+    const clip = "/home/talmo/scratch/2026-07-10-mars/clip.mp4";
+    const video = new Video({
+      filename: clip,
+      backendMetadata: { filename: clip, shape: [3, 384, 384, 3] },
+      openBackend: false,
+    });
+    const bytes = new Uint8Array(
+      await saveSlpToBytes(new Labels({ videos: [video] })),
+    );
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sleap-213-mp4-"));
+    fs.writeFileSync(path.join(dir, "mars_top.slp"), bytes);
+    try {
+      const labels = await readSlp(path.join(dir, "mars_top.slp"), {
+        openVideos: true,
+      });
+      const rv = labels.videos[0];
+      // Whatever happened (lazy backend, or a decode/unsupported error), it must
+      // NOT be classified as an image-sequence miss.
+      expect(rv.backendError?.kind).not.toBe("image-sequence");
+      // Identity is preserved regardless.
+      expect(rv.filename).toBe(clip);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("withholds an unreadable backend and flags image-sequence when images are missing", async () => {
+    const dir = writeProject(await makeImageSeqSlpBytes(), false);
+    try {
+      const labels = await readSlp(path.join(dir, "mars_top.slp"), {
+        openVideos: true,
+      });
+      const video = labels.videos[0];
+      // Would-be "healthy" (shape present → decode skipped), but the resolver
+      // confirms frame 0 is unreachable, so no backend is handed back.
+      expect(video.backend).toBeNull();
+      expect(video.backendError?.kind).toBe("image-sequence");
+      expect(video.backendError?.message).toContain("MARS_top_00000.jpg");
+      // Filename is preserved for a locate/repair affordance.
+      expect(video.filename).toEqual(FOREIGN);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("degrades gracefully (verbatim, no missing flag) when no FsResolver is available", async () => {
+    // Simulate a browser build with neither an override nor a default resolver.
+    const savedDefault = getFsResolver();
+    setFsResolver(null);
+    setDefaultFsResolver(null);
+    const dir = writeProject(await makeImageSeqSlpBytes(), false);
+    try {
+      const labels = await readSlp(path.join(dir, "mars_top.slp"), {
+        openVideos: true,
+      });
+      const video = labels.videos[0];
+      // With no resolver we cannot verify existence: build the backend from the
+      // stored (foreign) paths + shape, exactly as before this change. It is NOT
+      // flagged missing (the consumer's injected reader owns resolution).
+      expect(video.backend).toBeInstanceOf(ImageVideoBackend);
+      expect(video.backendError).toBeNull();
+      expect((video.backend as ImageVideoBackend).filename).toEqual(FOREIGN);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      setDefaultFsResolver(savedDefault);
+    }
+  });
+});
+
+describe("ImageVideoBackend.probeFirstFrame", () => {
+  it("resolves true for a readable first frame and false for a broken reader", async () => {
+    const good = await ImageVideoBackend.create({
+      filename: [srcJpg(0)],
+      reader: async (p) => new Uint8Array(fs.readFileSync(p)),
+      shape: [1, 384, 384, 3], // skip the decode so create() does no read
+    });
+    expect(await good.probeFirstFrame()).toBe(true);
+
+    const bad = await ImageVideoBackend.create({
+      filename: ["/does/not/exist.jpg"],
+      reader: async () => {
+        throw new Error("nope");
+      },
+      shape: [1, 384, 384, 3],
+    });
+    expect(await bad.probeFirstFrame()).toBe(false);
+  });
+});

--- a/tests/video/path-resolve.test.ts
+++ b/tests/video/path-resolve.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for external video path resolution (issue #213).
+ *
+ * Covers the pure path algebra (parse/format/join/dirname/basename), candidate
+ * generation (verbatim, relative-to-labels-dir, common-suffix anchor, and
+ * deepest-first trailing-tail grafts), the prefix-swap that remaps a whole image
+ * sequence from one probe, and the async `resolveVideoSource` against a stubbed
+ * `FsResolver` — including the cross-machine "images moved to a subfolder" repro
+ * from the issue and the "confirmed missing" signal.
+ */
+import { describe, it, expect } from "../bun-test";
+import type { FsResolver } from "../../src/model/matching.js";
+import {
+  parsePath,
+  formatPath,
+  posixDirname,
+  posixBasename,
+  posixJoin,
+  anchorCandidate,
+  videoPathCandidates,
+  derivePrefixSwap,
+  applyPrefixSwap,
+  resolveFirstExisting,
+  resolveVideoSource,
+} from "../../src/video/path-resolve.js";
+
+/** An FsResolver whose `exists` returns true only for the given set of paths. */
+function stubFs(existing: string[]): FsResolver {
+  const set = new Set(existing);
+  return {
+    async exists(p: string) {
+      return set.has(p);
+    },
+    async sameFile() {
+      return false;
+    },
+    async realpath(p: string) {
+      return p;
+    },
+  };
+}
+
+describe("parsePath / formatPath", () => {
+  it("round-trips POSIX absolute, relative, and Windows drive paths", () => {
+    expect(parsePath("/home/u/a.jpg")).toEqual({
+      absolute: true,
+      drive: null,
+      unc: false,
+      parts: ["home", "u", "a.jpg"],
+    });
+    expect(parsePath("raw/a.jpg")).toEqual({
+      absolute: false,
+      drive: null,
+      unc: false,
+      parts: ["raw", "a.jpg"],
+    });
+    expect(parsePath("L:\\code\\a.jpg")).toEqual({
+      absolute: true,
+      drive: "L:",
+      unc: false,
+      parts: ["code", "a.jpg"],
+    });
+    expect(parsePath("C:relative\\a.jpg")).toEqual({
+      absolute: false,
+      drive: "C:",
+      unc: false,
+      parts: ["relative", "a.jpg"],
+    });
+    for (const p of [
+      "/home/u/a.jpg",
+      "raw/a.jpg",
+      "L:/code/a.jpg",
+      "C:relative/a.jpg",
+    ]) {
+      expect(formatPath(parsePath(p))).toBe(p.replace(/\\/g, "/"));
+    }
+  });
+
+  it("normalizes backslashes and drops '.'/empty segments", () => {
+    expect(formatPath(parsePath("a\\.\\b\\\\c.jpg"))).toBe("a/b/c.jpg");
+  });
+
+  it("preserves a UNC / network-share root (does not collapse `//`)", () => {
+    // `\\server\share\a.jpg` and `//server/share/a.jpg` both round-trip as UNC —
+    // collapsing to `/server/...` would re-root to the current drive on Windows.
+    expect(parsePath("\\\\server\\share\\imgs\\a.jpg")).toEqual({
+      absolute: true,
+      drive: null,
+      unc: true,
+      parts: ["server", "share", "imgs", "a.jpg"],
+    });
+    expect(formatPath(parsePath("\\\\server\\share\\imgs\\a.jpg"))).toBe(
+      "//server/share/imgs/a.jpg",
+    );
+    expect(formatPath(parsePath("//server/share/imgs/a.jpg"))).toBe(
+      "//server/share/imgs/a.jpg",
+    );
+    expect(posixDirname("//server/share/proj/labels.slp")).toBe(
+      "//server/share/proj",
+    );
+    // The verbatim (same-machine) candidate keeps the UNC root intact.
+    expect(
+      videoPathCandidates(
+        "\\\\server\\share\\imgs\\a.jpg",
+        "//server/share",
+      )[0],
+    ).toBe("//server/share/imgs/a.jpg");
+  });
+
+  it("derives dirname / basename cross-platform", () => {
+    expect(posixDirname("L:\\code\\proj\\a.jpg")).toBe("L:/code/proj");
+    expect(posixBasename("L:\\code\\proj\\a.jpg")).toBe("a.jpg");
+    expect(posixDirname("/root")).toBe("/");
+    expect(posixBasename("only.jpg")).toBe("only.jpg");
+  });
+
+  it("joins a relative tail onto a directory, ignoring the tail's root", () => {
+    expect(posixJoin("L:/code/proj", "raw/a.jpg")).toBe(
+      "L:/code/proj/raw/a.jpg",
+    );
+    expect(posixJoin("/base", "/abs/tail.jpg")).toBe("/base/abs/tail.jpg");
+  });
+});
+
+describe("videoPathCandidates", () => {
+  it("puts the verbatim (normalized) stored path first", () => {
+    const c = videoPathCandidates("L:\\a\\b.jpg", "L:/proj");
+    expect(c[0]).toBe("L:/a/b.jpg");
+  });
+
+  it("adds relative-to-labels-dir only for a relative stored path", () => {
+    const rel = videoPathCandidates("raw/b.jpg", "L:/proj");
+    expect(rel).toContain("L:/proj/raw/b.jpg");
+    // Absolute stored path: no naive relative join of the absolute string.
+    const abs = videoPathCandidates("/x/raw/b.jpg", "L:/proj");
+    expect(abs).not.toContain("L:/proj//x/raw/b.jpg");
+  });
+
+  it("emits trailing-tail grafts deepest-first, ending at the basename", () => {
+    const c = videoPathCandidates("/a/b/c/d.jpg", "L:/proj");
+    const grafts = c.filter((x) => x.startsWith("L:/proj/"));
+    expect(grafts).toEqual([
+      "L:/proj/a/b/c/d.jpg",
+      "L:/proj/b/c/d.jpg",
+      "L:/proj/c/d.jpg",
+      "L:/proj/d.jpg",
+    ]);
+  });
+
+  it("caps the trailing-tail depth", () => {
+    const deep = `/${Array.from({ length: 30 }, (_, i) => `d${i}`).join("/")}/f.jpg`;
+    const c = videoPathCandidates(deep, "L:/proj", 3);
+    const grafts = c.filter((x) => x.startsWith("L:/proj/"));
+    expect(grafts.length).toBeLessThanOrEqual(3);
+    // Basename graft is always the shallowest included.
+    expect(grafts[grafts.length - 1]).toBe("L:/proj/f.jpg");
+  });
+
+  it("de-duplicates candidates", () => {
+    const c = videoPathCandidates("b.jpg", "L:/proj");
+    expect(new Set(c).size).toBe(c.length);
+  });
+});
+
+describe("anchorCandidate", () => {
+  it("reconstructs via the deepest shared directory anchor (issue repro)", () => {
+    const stored =
+      "/home/talmo/code/sleap-nn/scratch/2026-07-10-mars/raw_images_top/MARS_top_00000.jpg";
+    const labelsDir = "L:/code/sleap-nn/scratch/2026-07-10-mars";
+    expect(anchorCandidate(stored, labelsDir)).toBe(
+      "L:/code/sleap-nn/scratch/2026-07-10-mars/raw_images_top/MARS_top_00000.jpg",
+    );
+  });
+
+  it("returns null when there is no shared anchor", () => {
+    expect(anchorCandidate("/x/y/z.jpg", "L:/totally/different")).toBeNull();
+  });
+});
+
+describe("derivePrefixSwap / applyPrefixSwap", () => {
+  it("swaps a foreign absolute prefix for a local drive prefix across a list", () => {
+    const swap = derivePrefixSwap(
+      "/home/u/proj/raw/f0.jpg",
+      "L:/data/proj/raw/f0.jpg",
+    );
+    expect(applyPrefixSwap("/home/u/proj/raw/f0.jpg", swap)).toBe(
+      "L:/data/proj/raw/f0.jpg",
+    );
+    expect(applyPrefixSwap("/home/u/proj/raw/f9.jpg", swap)).toBe(
+      "L:/data/proj/raw/f9.jpg",
+    );
+  });
+
+  it("leaves a path that does not share the old prefix unchanged", () => {
+    const swap = derivePrefixSwap("/a/raw/f0.jpg", "L:/proj/raw/f0.jpg");
+    expect(applyPrefixSwap("/other/raw/f0.jpg", swap)).toBe(
+      "/other/raw/f0.jpg",
+    );
+  });
+
+  it("leaves a path with a different root/drive unchanged (root-equality guard)", () => {
+    // old prefix is POSIX-absolute (`/home/u`); a differently-rooted member
+    // (Windows drive, or relative) must NOT be rewritten.
+    const swap = derivePrefixSwap("/home/u/raw/f0.jpg", "L:/proj/raw/f0.jpg");
+    expect(applyPrefixSwap("C:/other/raw/f9.jpg", swap)).toBe(
+      "C:/other/raw/f9.jpg",
+    );
+    expect(applyPrefixSwap("relative/raw/f9.jpg", swap)).toBe(
+      "relative/raw/f9.jpg",
+    );
+  });
+
+  it("is the identity when stored already equals resolved", () => {
+    const swap = derivePrefixSwap("L:/proj/raw/f0.jpg", "L:/proj/raw/f0.jpg");
+    expect(applyPrefixSwap("L:/proj/raw/f3.jpg", swap)).toBe(
+      "L:/proj/raw/f3.jpg",
+    );
+  });
+});
+
+describe("resolveFirstExisting", () => {
+  it("returns the first candidate the resolver confirms", async () => {
+    const fs = stubFs(["b", "c"]);
+    expect(await resolveFirstExisting(["a", "b", "c"], fs)).toBe("b");
+  });
+
+  it("treats a throwing resolver call as 'not here' and continues", async () => {
+    const fs: FsResolver = {
+      async exists(p) {
+        if (p === "a") throw new Error("boom");
+        return p === "b";
+      },
+      async sameFile() {
+        return false;
+      },
+      async realpath(p) {
+        return p;
+      },
+    };
+    expect(await resolveFirstExisting(["a", "b"], fs)).toBe("b");
+  });
+
+  it("returns null when nothing exists", async () => {
+    expect(await resolveFirstExisting(["a", "b"], stubFs([]))).toBeNull();
+  });
+});
+
+describe("resolveVideoSource", () => {
+  const labelsDir = "L:/code/sleap-nn/scratch/2026-07-10-mars";
+
+  it("single file: returns the source unchanged on a verbatim hit", async () => {
+    const fs = stubFs(["L:/vids/a.mp4"]);
+    const r = await resolveVideoSource("L:/vids/a.mp4", labelsDir, fs);
+    expect(r.filename).toBe("L:/vids/a.mp4");
+    expect(r.firstMissing).toBe(false);
+  });
+
+  it("single file: grafts the subfolder tail onto the labels dir", async () => {
+    const fs = stubFs([`${labelsDir}/videos/clip.mp4`]);
+    const r = await resolveVideoSource(
+      "/foreign/box/videos/clip.mp4",
+      labelsDir,
+      fs,
+    );
+    expect(r.filename).toBe(`${labelsDir}/videos/clip.mp4`);
+    expect(r.firstMissing).toBe(false);
+  });
+
+  it("single file: flags firstMissing when no candidate exists", async () => {
+    const r = await resolveVideoSource(
+      "/foreign/clip.mp4",
+      labelsDir,
+      stubFs([]),
+    );
+    expect(r.firstMissing).toBe(true);
+    expect(r.filename).toBe("/foreign/clip.mp4");
+  });
+
+  it("image sequence: remaps the whole list from one first-frame probe", async () => {
+    const stored = [
+      "/home/talmo/code/sleap-nn/scratch/2026-07-10-mars/raw_images_top/MARS_top_00000.jpg",
+      "/home/talmo/code/sleap-nn/scratch/2026-07-10-mars/raw_images_top/MARS_top_00001.jpg",
+      "/home/talmo/code/sleap-nn/scratch/2026-07-10-mars/raw_images_top/MARS_top_00002.jpg",
+    ];
+    // Only the FIRST frame is present in the resolver's set — the rest must be
+    // remapped by the derived prefix swap, not probed individually.
+    const fs = stubFs([`${labelsDir}/raw_images_top/MARS_top_00000.jpg`]);
+    const r = await resolveVideoSource(stored, labelsDir, fs);
+    expect(r.firstMissing).toBe(false);
+    expect(r.filename).toEqual([
+      `${labelsDir}/raw_images_top/MARS_top_00000.jpg`,
+      `${labelsDir}/raw_images_top/MARS_top_00001.jpg`,
+      `${labelsDir}/raw_images_top/MARS_top_00002.jpg`,
+    ]);
+  });
+
+  it("image sequence: returns the list unchanged on a verbatim hit", async () => {
+    const stored = [`${labelsDir}/imgs/a.jpg`, `${labelsDir}/imgs/b.jpg`];
+    const fs = stubFs([`${labelsDir}/imgs/a.jpg`]);
+    const r = await resolveVideoSource(stored, labelsDir, fs);
+    expect(r.filename).toBe(stored); // same reference — no churn
+    expect(r.firstMissing).toBe(false);
+  });
+
+  it("image sequence: flags firstMissing when the first frame is unreachable", async () => {
+    const stored = ["/foreign/raw/a.jpg", "/foreign/raw/b.jpg"];
+    const r = await resolveVideoSource(stored, labelsDir, stubFs([]));
+    expect(r.firstMissing).toBe(true);
+    expect(r.filename).toBe(stored);
+  });
+
+  it("empty image list is a no-op", async () => {
+    const r = await resolveVideoSource([], labelsDir, stubFs([]));
+    expect(r.filename).toEqual([]);
+    expect(r.firstMissing).toBe(false);
+  });
+
+  it("image sequence: only members sharing the first frame's prefix are remapped", async () => {
+    // A mixed-prefix list: frame 0 resolves via a tail graft; a differently
+    // rooted member does not share the swapped prefix and is left verbatim.
+    const stored = ["/foreign/sub/f0.jpg", "D:/unrelated/other.jpg"];
+    const fs = stubFs([`${labelsDir}/sub/f0.jpg`]);
+    const r = await resolveVideoSource(stored, labelsDir, fs);
+    expect(r.firstMissing).toBe(false);
+    expect(r.filename).toEqual([
+      `${labelsDir}/sub/f0.jpg`,
+      "D:/unrelated/other.jpg",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #213.

A `.slp` that references external videos — especially **`ImageVideo` image sequences** — by **absolute paths saved on another machine** could not be opened when the media now lives in a **subfolder under the `.slp`'s directory**, and the loader gave consumers no signal that a video was unreadable. Two problems, both fixed here:

1. **Path resolution dropped intermediate subfolders.** Only verbatim + basename-in-labels-dir were tried, so a file in `…/2026-07-10-mars/raw_images_top/` next to a `.slp` in `…/2026-07-10-mars/` was never found.
2. **The loader returned a "healthy" backend it couldn't read a frame from.** An `ImageVideoBackend` built from a stored `shape` skips the frame-0 decode, so it opened `backend != null` / `backendError == null` even when not a single frame was readable — consumers silently rendered blanks with no repair affordance.

## Key changes

### `src/video/path-resolve.ts` (new)
Browser-safe path resolution using the injected `FsResolver` (`setFsResolver`/`getFsResolver`) for existence checks, so **Node, Tauri, and browser-injected** resolvers share one policy and it **degrades to verbatim** when none is available.

Candidate strategy (single files *and* image sequences), mirroring Python sleap-io's resolve-relative-to-`.slp` plus its `find_changed_subpath` prefix-change logic, and unifying both:

1. the stored path **verbatim** (absolute / same-machine),
2. **relative-to-labels-dir**,
3. a **common-suffix "anchor"** between the labels dir and the stored path,
4. progressively shorter **trailing-tail grafts** onto the labels dir (`sub/sub/basename → … → basename`), deepest-first.

For an image sequence only the **first frame** is probed; the winning candidate yields a single **prefix-swap** applied to the whole list — an `O(N)` string op, so a 15,000-image sequence resolves with a handful of `exists()` calls, not `N` filesystem checks. Paths are **UNC-aware** (`\\server\share` round-trips instead of collapsing to a current-drive-rooted path).

### `src/codecs/slp/read.ts`
`readVideos` (eager + lazy Node readers) resolves external, non-embedded, non-URL sources against `posixDirname(labelsPath)` when a resolver is available. When the resolver **confirms** an image source's first frame is unreachable, the loader **withholds** the backend and records `backendError.kind = "image-sequence"`. Resolution feeds **only the backend read path** — `Video.filename` and `backendMetadata` keep the **original stored paths**, so a re-save stays portable and matching/identity is unchanged.

### `ImageVideoBackend.probeFirstFrame()` (+ optional `VideoBackend.probeFirstFrame?()`)
A cheap async liveness probe (reads frame-0 bytes, no decode; never throws) for consumers — e.g. the browser streaming path — that open backends themselves.

New utilities are exported from both `index.ts` and `index.browser.ts`.

## Example

```
.slp opened from:  L:\...\2026-07-10-mars\mars_top.slp
frames stored as:  /home/talmo/.../2026-07-10-mars/raw_images_top/MARS_top_00000.jpg   (×15000)
images actually at: L:\...\2026-07-10-mars\raw_images_top\MARS_top_00000.jpg
```

Before: verbatim (Linux path on Windows) and basename-in-labels-dir both miss → blank frames, no signal.
After: the `raw_images_top/…` tail grafts onto the labels dir, the whole list is remapped from one probe, and frames decode. If the images are genuinely absent, `backend` is `null` with `backendError.kind === "image-sequence"`.

## Testing

- **`tests/video/path-resolve.test.ts`** — pure path algebra, candidate generation/ordering/cap, anchor, prefix-swap (incl. drive/UNC root-equality guard and mixed-prefix lists), and `resolveVideoSource` against a stubbed `FsResolver` (subfolder graft, verbatim no-churn, confirmed-missing).
- **`tests/codecs/imagevideo-resolve.test.ts`** — end-to-end through `readSlp`: subfolder graft opens a readable backend; a missing sequence is withheld with `image-sequence`; **re-save preserves the original foreign paths**; a missing **single-file** video is never mislabeled `image-sequence`; no-resolver graceful degrade; `probeFirstFrame`.
- Full suites green (codecs 148, model 542, video 160 — the 5 MediaBunny WebM failures are pre-existing on `main`, a documented cross-file mock-leak flake). `tsc` clean; no new lint findings.

## Design decisions

- **Existence via `FsResolver`, not a read** — cheapest truthful check and the one mechanism shared across Node/Tauri/browser; resolution and the image-bytes reader operate on the same resolved path.
- **Don't mutate identity** — feeding only the backend keeps `Video.filename`/`backendMetadata.filenames` at the stored paths so `serializeVideo` re-writes portable paths (covered by a round-trip test).
- **Withhold gate is image-only** — single-file videos keep their prior lazy-backend behavior; only `ImageVideo` (whose stored `shape` hides the missing media) is gated.
- Goes beyond Python's current `make_video` (verbatim + basename, with a `TODO` to expand); the canonical logic now lives here so all consumers (incl. sleap-app, tracking talmolab/sleap-app#203) share it.

## Review

Ran a 4-lens adversarial review over the diff; it confirmed the UNC-collapse edge case (fixed here, with tests) and refuted the rest. The highest-value coverage suggestions were adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
