### PR TITLE
chore(ci): set coverage artifact retention to 1 day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,4 @@ jobs:
         with:
           name: coverage-${{ matrix.os }}
           path: coverage
+          retention-days: 1


### PR DESCRIPTION
The coverage artifacts (coverage-<os>) are uploaded on every CI run with the default 90-day retention, leaving 300+ stale copies in the Actions storage quota.

These are transient CI byproducts, so this pins them to etention-days: 1.