### PR TITLE
fix(slp): preserve embedded images on re-save via raw-blob copy

### DIFF
--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -518,6 +518,15 @@ function writeSlpToFileLazy(file: any, labels: Labels): void {
  * - `"suggestions"` - Embed only suggestion frames
  * - `"user+suggestions"` - Embed user instance frames and suggestion frames
  * - `"source"` - Restore original video paths (no embedding)
+ *
+ * ALREADY-EMBEDDED videos (a `.pkg.slp` loaded with open backends) are ALWAYS
+ * preserved: their full stored set of encoded image blobs is copied VERBATIM
+ * (no decode/re-encode — see {@link writeRawEmbeddedVideo}), regardless of the
+ * `embed` mode, UNLESS `embed:"source"` is passed to externalize them. So even
+ * a bare `saveSlpToBytes(labels)` (no options) cannot silently drop embedded
+ * images — the fix for the #213 re-save data loss. As a backstop, the raw-copy
+ * path THROWS (rather than writing a stripped file) if it planned to copy N
+ * frames but could read fewer than N blobs.
  */
 // ===========================================================================
 // Streaming / incremental SLP writer (issue #207)
@@ -2685,7 +2694,8 @@ function writeEmbeddedVideosJson(
  * decode/re-encode); encode entries write the pre-collected bytes.
  *
  * Peak memory: the raw path STREAMS stored blobs into a resizable 1-D `<B`
- * dataset in bounded byte windows (peak ~= one window + the h5wasm MEMFS copy),
+ * dataset in bounded byte windows (peak ~= 2x one window during a flush — the
+ * window's blobs plus their concatenated buffer — plus the h5wasm MEMFS copy),
  * rather than holding every blob plus a full concatenated buffer at once. The
  * encode path keeps accumulate-then-write — its bytes are already fully in JS
  * memory (`frameData`), so there is nothing to stream. Either way the on-disk
@@ -2758,7 +2768,8 @@ async function writeEmbeddedVideoData(
 /**
  * Raw path: stream a video's stored encoded blobs into a resizable 1-D `<B`
  * dataset at `{group}/video`, flushing to the dataset tail in bounded byte
- * windows so peak JS memory is ~one window rather than every blob plus a full
+ * windows so peak JS memory is ~2x one window during a flush (the window's blobs
+ * plus their concatenated buffer) rather than every blob plus a full
  * concatenated buffer. The on-disk bytes are the in-order concatenation of the
  * blobs — byte-identical to an accumulate-then-write. A blob that reads back
  * null/empty is skipped (the caller's backstop then refuses to write a file

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -1719,20 +1719,25 @@ export async function saveSlpToBytes(
   // source-mode `writeLabels` copy — but source mode never embeds (plan is null).
   const plan = doEmbed ? await planEmbedding(labels, embedMode) : null;
 
+  const fs = getH5FileSystem(module);
   const file = new module.File(memPath, "w");
   try {
-    writeSlpToFile(file, writeLabels, plan);
-    if (plan && plan.size > 0) {
-      await writeEmbeddedVideoData(file, labels, plan);
+    try {
+      writeSlpToFile(file, writeLabels, plan);
+      if (plan && plan.size > 0) {
+        await writeEmbeddedVideoData(file, labels, plan);
+      }
+    } finally {
+      file.close();
     }
+    return fs.readFile!(memPath);
   } finally {
-    file.close();
+    try {
+      fs.unlink!(memPath);
+    } catch {
+      // best-effort cleanup
+    }
   }
-
-  const fs = getH5FileSystem(module);
-  const bytes = fs.readFile!(memPath);
-  fs.unlink!(memPath);
-  return bytes;
 }
 
 export async function writeSlp(
@@ -2564,7 +2569,7 @@ async function collectEncodedFrames(
 ): Promise<Map<number, Uint8Array>> {
   const frameData = new Map<number, Uint8Array>();
   const video = labels.videos[videoIndex];
-  if (!video || !video.backend) return frameData;
+  if (!video?.backend) return frameData;
 
   const mode = embedMode === true ? "all" : String(embedMode).toLowerCase();
   const frameIndices = new Set<number>();
@@ -2707,16 +2712,18 @@ async function writeEmbeddedVideoData(
       writtenFns.push(fn);
     }
 
-    // Backstop (raw path only): planned N but wrote 0 -> refuse to write a
-    // stripped file. (encode path keeps today's lenient behavior -> deferred.)
-    if (
-      entry.kind === "raw" &&
-      entry.frameNumbers.length > 0 &&
-      blobs.length === 0
-    ) {
+    // Backstop (raw path only): a raw copy's frameNumbers IS the exact stored
+    // set (embeddedFrameIndices), so every frame must read a blob — a partial
+    // read is anomalous data loss. Refuse to write a stripped file rather than
+    // silently drop images (the #213 data-loss this fix prevents). Note
+    // frameNumbers.length is always > 0 for a raw entry (planEmbedding skips
+    // 0-frame videos). The encode path keeps today's lenient behavior ->
+    // deferred follow-up.
+    if (entry.kind === "raw" && blobs.length < entry.frameNumbers.length) {
       throw new Error(
-        `embedding video${entry.videoIndex}: intended ${entry.frameNumbers.length} ` +
-          `frame(s) but read 0 - refusing to write a file with dropped images.`,
+        `embedding video${entry.videoIndex}: read ${blobs.length} of ` +
+          `${entry.frameNumbers.length} planned frame(s) - refusing to write a ` +
+          `file with dropped images.`,
       );
     }
 

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -80,29 +80,41 @@ export type SlpWriteOptions = {
   restoreOriginalVideos?: boolean;
 };
 
-/** Frame data collected for embedding a single video. */
-interface EmbeddedVideoFrames {
-  /** Video index in labels.videos */
+/**
+ * A planned embedded video output: copy raw blobs, or (legacy) encode.
+ *
+ * `kind: "raw"` copies an already-embedded video's stored encoded blobs verbatim
+ * via `getFrameBuffer` (no decode / re-encode) — the fast, lossless path that
+ * mirrors Python's re-save of a `.pkg.slp`. `kind: "encode"` is the legacy
+ * new-embed of a continuous video (read + `getFrame` + `frameToBytes`), kept for
+ * Node compatibility.
+ */
+type EmbedPlanEntry = {
+  kind: "raw" | "encode";
   videoIndex: number;
-  /** Frame indices (original video frame numbers) */
-  frameNumbers: number[];
-  /** Encoded frame bytes (PNG/JPEG) indexed by frame number */
-  frameData: Map<number, Uint8Array>;
-  /** Image format (png, jpeg) */
+  video: Video;
+  frameNumbers: number[]; // source frame numbers to write, in order
   format: string;
-  /** Channel order (RGB, BGR) */
   channelOrder: string;
+  /** For "encode": pre-collected bytes keyed by frame number. */
+  frameData?: Map<number, Uint8Array>;
+};
+type EmbedPlan = Map<number, EmbedPlanEntry>;
+
+/** True for a video whose stored encoded blobs we can copy verbatim. */
+function isRawCopyable(video: Video): boolean {
+  return !!(video.hasEmbeddedImages && video.backend?.getFrameBuffer);
 }
 
 function writeSlpToFile(
   file: any,
   labels: Labels,
-  embeddedVideoData?: Map<number, EmbeddedVideoFrames> | null,
+  plan?: EmbedPlan | null,
 ): void {
   writeMetadata(file, labels);
 
-  if (embeddedVideoData && embeddedVideoData.size > 0) {
-    writeEmbeddedVideos(file, labels, embeddedVideoData);
+  if (plan && plan.size > 0) {
+    writeEmbeddedVideosJson(file, labels, plan);
   } else {
     writeVideos(file, labels.videos);
   }
@@ -1612,17 +1624,22 @@ export async function saveSlpToBytes(
 ): Promise<Uint8Array> {
   const embedMode = options?.embed ?? false;
 
-  // Lazy fast path: skip materialization for embed modes that don't need
-  // to read pixel data from videos. Mirrors Python's write_labels dispatch.
-  if (labels.isLazy) {
-    const needsMaterialization =
-      embedMode === true ||
-      embedMode === "all" ||
-      embedMode === "user" ||
-      embedMode === "suggestions" ||
-      embedMode === "user+suggestions";
+  // Auto-preserve already-embedded videos unless the caller externalizes them.
+  // An already-embedded video is ALWAYS raw-copied (preserved) unless the caller
+  // explicitly passes embed:"source" (which restores the external source video),
+  // so even a bare saveSlpToBytes(labels) keeps its stored images (fixes #213).
+  const hasEmbeddedToPreserve =
+    embedMode !== "source" && labels.videos.some(isRawCopyable);
+  const doEmbed =
+    (embedMode !== false && embedMode !== "source") || hasEmbeddedToPreserve;
 
-    if (!needsMaterialization) {
+  // Lazy fast path: skip materialization only when we don't need frame data.
+  // Any real embed OR a preserve of already-embedded images needs frame bytes,
+  // so materialize and continue with the eager path. Mirrors Python's dispatch.
+  if (labels.isLazy) {
+    if (doEmbed) {
+      labels.materialize();
+    } else {
       let lazyWriteLabels: Labels = labels;
       let proceedWithFastPath = true;
 
@@ -1656,9 +1673,6 @@ export async function saveSlpToBytes(
         fs.unlink!(memPath);
         return bytes;
       }
-    } else {
-      // Embed modes that need pixel data: materialize and continue with eager path.
-      labels.materialize();
     }
   }
 
@@ -1700,15 +1714,17 @@ export async function saveSlpToBytes(
   ensureH5StagingDir(module);
   const memPath = `/tmp/sleap_output_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`;
 
-  // If embedding, we need to determine frames per video and prepare embedded data
-  let embeddedVideoData: Map<number, EmbeddedVideoFrames> | null = null;
-  if (embedMode && embedMode !== "source") {
-    embeddedVideoData = await collectFramesForEmbedding(labels, embedMode);
-  }
+  // Plan which videos to embed (raw-copy preserved ones + any new-embed target).
+  // The plan reads raw blobs from `labels.videos` (the ORIGINAL videos), not the
+  // source-mode `writeLabels` copy — but source mode never embeds (plan is null).
+  const plan = doEmbed ? await planEmbedding(labels, embedMode) : null;
 
   const file = new module.File(memPath, "w");
   try {
-    writeSlpToFile(file, writeLabels, embeddedVideoData);
+    writeSlpToFile(file, writeLabels, plan);
+    if (plan && plan.size > 0) {
+      await writeEmbeddedVideoData(file, labels, plan);
+    }
   } finally {
     file.close();
   }
@@ -2489,85 +2505,99 @@ function writeNegativeFrames(file: any, labels: Labels): void {
 }
 
 /**
- * Collect frame data for embedding from video backends.
+ * Plan which videos to embed and how. An already-embedded video is ALWAYS
+ * raw-copied (its FULL stored set preserved via `getFrameBuffer`, no decode)
+ * regardless of `embedMode`; only a NEW embed of a continuous video takes the
+ * legacy getFrame+encode path — and only when a real embed mode was requested.
+ * (`embedMode === "source"` never reaches here — the caller externalizes.)
  */
-async function collectFramesForEmbedding(
+async function planEmbedding(
   labels: Labels,
   embedMode: boolean | string,
-): Promise<Map<number, EmbeddedVideoFrames>> {
-  const result = new Map<number, EmbeddedVideoFrames>();
+): Promise<EmbedPlan> {
+  const plan: EmbedPlan = new Map();
+  const isRealMode = embedMode !== false && embedMode !== "source";
+  for (let vi = 0; vi < labels.videos.length; vi++) {
+    const video = labels.videos[vi];
+    if (isRawCopyable(video)) {
+      // Preserve the FULL stored set regardless of embedMode (semantics A).
+      await video.backend!.ensureLoaded?.();
+      const frameNumbers = video.embeddedFrameIndices ?? [];
+      if (frameNumbers.length === 0) continue;
+      plan.set(vi, {
+        kind: "raw",
+        videoIndex: vi,
+        video,
+        frameNumbers,
+        format: video.backend!.embeddedFormat ?? "png",
+        channelOrder: video.backend!.embeddedChannelOrder ?? "RGB",
+      });
+    } else if (isRealMode && video.backend) {
+      // New-embed of a continuous video: legacy getFrame+encode path (kept for
+      // Node compat; browser-broken — a separate deferred follow-up).
+      const frameData = await collectEncodedFrames(labels, vi, embedMode);
+      if (frameData.size === 0) continue;
+      const frameNumbers = [...frameData.keys()].sort((a, b) => a - b);
+      plan.set(vi, {
+        kind: "encode",
+        videoIndex: vi,
+        video,
+        frameNumbers,
+        format: (video.backendMetadata?.format as string) ?? "png",
+        channelOrder: (video.backendMetadata?.channel_order as string) ?? "RGB",
+        frameData,
+      });
+    }
+  }
+  return plan;
+}
 
-  // Determine which frame indices to embed per video
-  const framesByVideo = new Map<number, Set<number>>();
+/**
+ * Collect encoded frame bytes for a NEW embed of one continuous video, reading
+ * each selected frame via `getFrame` + {@link frameToBytes} (the legacy path).
+ * Selection mirrors the per-video body of the old `collectFramesForEmbedding`.
+ */
+async function collectEncodedFrames(
+  labels: Labels,
+  videoIndex: number,
+  embedMode: boolean | string,
+): Promise<Map<number, Uint8Array>> {
+  const frameData = new Map<number, Uint8Array>();
+  const video = labels.videos[videoIndex];
+  if (!video || !video.backend) return frameData;
+
   const mode = embedMode === true ? "all" : String(embedMode).toLowerCase();
+  const frameIndices = new Set<number>();
 
   for (const frame of labels.labeledFrames) {
-    const videoIndex = labels.videos.indexOf(frame.video);
-    if (videoIndex < 0) continue;
-
+    if (labels.videos.indexOf(frame.video) !== videoIndex) continue;
     let include = false;
     if (mode === "all") {
       include = true;
     } else if (mode === "user") {
       include = frame.hasUserInstances;
-    } else if (mode === "suggestions") {
-      // Include if this frame is a suggestion
-      include = false; // handled below
     } else if (mode === "user+suggestions") {
       include = frame.hasUserInstances;
-    }
-
-    if (include) {
-      if (!framesByVideo.has(videoIndex))
-        framesByVideo.set(videoIndex, new Set());
-      framesByVideo.get(videoIndex)!.add(frame.frameIdx);
-    }
+    } // "suggestions": added below
+    if (include) frameIndices.add(frame.frameIdx);
   }
 
-  // Add suggestion frames
   if (mode === "suggestions" || mode === "user+suggestions") {
     for (const suggestion of labels.suggestions) {
-      const videoIndex = labels.videos.indexOf(suggestion.video);
-      if (videoIndex < 0) continue;
-      if (!framesByVideo.has(videoIndex))
-        framesByVideo.set(videoIndex, new Set());
-      framesByVideo.get(videoIndex)!.add(suggestion.frameIdx);
+      if (labels.videos.indexOf(suggestion.video) !== videoIndex) continue;
+      frameIndices.add(suggestion.frameIdx);
     }
   }
 
-  // Read frames from backends
-  for (const [videoIndex, frameIndices] of framesByVideo) {
-    const video = labels.videos[videoIndex];
-    if (!video || !video.backend) continue;
-
-    const sortedFrames = Array.from(frameIndices).sort((a, b) => a - b);
-    const frameData = new Map<number, Uint8Array>();
-
-    for (const frameIdx of sortedFrames) {
-      const frame = await video.getFrame(frameIdx);
-      if (frame) {
-        const bytes = frameToBytes(frame);
-        if (bytes) {
-          frameData.set(frameIdx, bytes);
-        }
-      }
-    }
-
-    if (frameData.size > 0) {
-      const backendFormat = (video.backendMetadata?.format as string) ?? "png";
-      const backendChannelOrder =
-        (video.backendMetadata?.channel_order as string) ?? "RGB";
-      result.set(videoIndex, {
-        videoIndex,
-        frameNumbers: sortedFrames.filter((f) => frameData.has(f)),
-        frameData,
-        format: backendFormat,
-        channelOrder: backendChannelOrder,
-      });
+  const sortedFrames = Array.from(frameIndices).sort((a, b) => a - b);
+  for (const frameIdx of sortedFrames) {
+    const frame = await video.getFrame(frameIdx);
+    if (frame) {
+      const bytes = frameToBytes(frame);
+      if (bytes) frameData.set(frameIdx, bytes);
     }
   }
-
-  return result;
+  return frameData;
 }
 
 /**
@@ -2584,22 +2614,27 @@ function frameToBytes(frame: unknown): Uint8Array | null {
 }
 
 /**
- * Write video metadata and embedded frame data for videos that are being embedded.
+ * Write ONLY the `videos_json` dataset for a plan-driven embed: each planned
+ * video gets an embedded-pointer entry (`filename:"."`, backend pointing at
+ * `video{vi}/video` with the planned format/channel_order + crop-aware inner
+ * shape/fps + source_video lineage); every other video is serialized normally.
+ * The per-group image datasets are written separately by
+ * {@link writeEmbeddedVideoData}.
  */
-function writeEmbeddedVideos(
+function writeEmbeddedVideosJson(
   file: any,
   labels: Labels,
-  embeddedVideoData: Map<number, EmbeddedVideoFrames>,
+  plan: EmbedPlan,
 ): void {
   const payload = labels.videos.map((video, videoIndex) => {
-    const embedData = embeddedVideoData.get(videoIndex);
-    if (embedData) {
+    const entry = plan.get(videoIndex);
+    if (entry) {
       // This video is being embedded - update metadata
       const backend: Record<string, unknown> = {
         filename: ".",
         dataset: `video${videoIndex}/video`,
-        format: embedData.format,
-        channel_order: embedData.channelOrder,
+        format: entry.format,
+        channel_order: entry.channelOrder,
       };
       // For a cropped video, videos_json must describe the UNCROPPED inner frame
       // (the crop rides /video_crops and is re-applied once on read); read the
@@ -2614,7 +2649,7 @@ function writeEmbeddedVideos(
       if (innerShape) backend.shape = innerShape;
       if (inner?.fps != null) backend.fps = inner.fps;
 
-      const entry: Record<string, unknown> = {
+      const outEntry: Record<string, unknown> = {
         filename: ".",
         backend,
       };
@@ -2622,71 +2657,99 @@ function writeEmbeddedVideos(
       // + deeper chain), mirroring newer Python which nests it in videos_json as
       // well as the authoritative HDF5 group written below. See #160.
       const srcDict = sourceVideoDict(video);
-      if (srcDict) entry.source_video = srcDict;
-      return JSON.stringify(entry);
-    } else {
-      return JSON.stringify(serializeVideo(video));
+      if (srcDict) outEntry.source_video = srcDict;
+      return JSON.stringify(outEntry);
     }
+    return JSON.stringify(serializeVideo(video));
   });
   file.create_dataset({ name: "videos_json", data: payload });
+}
 
-  // Write embedded video datasets
-  for (const [videoIndex, embedData] of embeddedVideoData) {
-    const groupName = `video${videoIndex}`;
-    file.create_group(groupName);
+/**
+ * Write the per-video embedded image datasets (`video{vi}/video`,
+ * `frame_numbers`, `frame_sizes`, `source_video`) for each planned video. Raw
+ * entries copy the stored encoded blobs verbatim via `getFrameBuffer` (no
+ * decode/re-encode); encode entries write the pre-collected bytes.
+ *
+ * Correctness-first accumulate-then-write: blobs for a video are gathered into
+ * one combined buffer before the single dataset write. (A later task makes this
+ * low-peak/streaming into a resizable 1-D dataset.)
+ *
+ * Backstop (raw path only): if a video planned N frames but 0 blobs could be
+ * read, throw rather than silently write a file with the images stripped —
+ * exactly the #213 data-loss this fix prevents.
+ */
+async function writeEmbeddedVideoData(
+  file: any,
+  labels: Labels,
+  plan: EmbedPlan,
+): Promise<void> {
+  for (const entry of plan.values()) {
+    const group = `video${entry.videoIndex}`;
+    file.create_group(group);
 
     // Write the source video lineage into the authoritative
     // `{group}/source_video` HDF5 group — the location Python reads for an
     // embedded `.pkg.slp` (it ignores videos_json's source_video for embedded
     // videos). Mirrors Python `write_videos`' lineage pass. See #160.
-    const srcDict = sourceVideoDict(labels.videos[videoIndex]);
-    if (srcDict) writeSourceVideoJson(file, groupName, srcDict);
+    const srcDict = sourceVideoDict(labels.videos[entry.videoIndex]);
+    if (srcDict) writeSourceVideoJson(file, group, srcDict);
 
-    // Write frame data as vlen array
-    const frameBytes: Uint8Array[] = [];
-    for (const frameNum of embedData.frameNumbers) {
-      const data = embedData.frameData.get(frameNum);
-      if (data) frameBytes.push(data);
+    const blobs: Uint8Array[] = [];
+    const writtenFns: number[] = [];
+    for (const fn of entry.frameNumbers) {
+      const blob =
+        entry.kind === "raw"
+          ? await entry.video.getFrameBuffer(fn)
+          : (entry.frameData!.get(fn) ?? null);
+      if (!blob || blob.length === 0) continue;
+      blobs.push(blob);
+      writtenFns.push(fn);
     }
 
-    // Concatenate all frame bytes into a single buffer
-    const totalSize = frameBytes.reduce((sum, b) => sum + b.length, 0);
-    const combined = new Uint8Array(totalSize);
-    let offset = 0;
-    for (const bytes of frameBytes) {
-      combined.set(bytes, offset);
-      offset += bytes.length;
+    // Backstop (raw path only): planned N but wrote 0 -> refuse to write a
+    // stripped file. (encode path keeps today's lenient behavior -> deferred.)
+    if (
+      entry.kind === "raw" &&
+      entry.frameNumbers.length > 0 &&
+      blobs.length === 0
+    ) {
+      throw new Error(
+        `embedding video${entry.videoIndex}: intended ${entry.frameNumbers.length} ` +
+          `frame(s) but read 0 - refusing to write a file with dropped images.`,
+      );
     }
 
-    // Write video data as a 1D uint8 dataset
+    // Concatenate all frame bytes into a single 1-D uint8 dataset.
+    const total = blobs.reduce((n, b) => n + b.length, 0);
+    const combined = new Uint8Array(total);
+    let off = 0;
+    for (const b of blobs) {
+      combined.set(b, off);
+      off += b.length;
+    }
     file.create_dataset({
-      name: `${groupName}/video`,
+      name: `${group}/video`,
       data: combined,
       shape: [combined.length],
       dtype: "<B",
     });
-
-    // Set format and channel_order attributes on the dataset
-    const videoDs = file.get(`${groupName}/video`);
-    if (videoDs) {
-      setStringAttr(videoDs, "format", embedData.format);
-      setStringAttr(videoDs, "channel_order", embedData.channelOrder);
+    const ds = file.get(`${group}/video`);
+    if (ds) {
+      setStringAttr(ds, "format", entry.format);
+      setStringAttr(ds, "channel_order", entry.channelOrder);
     }
-
-    // Write frame_numbers dataset
     file.create_dataset({
-      name: `${groupName}/frame_numbers`,
-      data: embedData.frameNumbers,
-      shape: [embedData.frameNumbers.length],
+      name: `${group}/frame_numbers`,
+      data: writtenFns,
+      shape: [writtenFns.length],
       dtype: "<i4",
     });
-
-    // Write frame_sizes dataset for reliable frame boundary detection
-    const frameSizes = frameBytes.map((b) => b.length);
+    const sizes = blobs.map((b) => b.length);
     file.create_dataset({
-      name: `${groupName}/frame_sizes`,
-      data: frameSizes,
-      shape: [frameSizes.length],
+      name: `${group}/frame_sizes`,
+      data: sizes,
+      shape: [sizes.length],
       dtype: "<i4",
     });
   }

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -541,6 +541,14 @@ function writeSlpToFileLazy(file: any, labels: Labels): void {
 const DEFAULT_WRITE_WINDOW_FRAMES = 5000;
 /** HDF5 chunk row count for the appendable pose datasets. */
 const WRITE_CHUNK_ROWS = 8192;
+/**
+ * Per-window byte budget for the streamed raw embedded-blob copy: blobs
+ * accumulate up to this many bytes before one `resize` + `write_slice` flush,
+ * bounding peak JS memory to ~one window instead of the whole concatenation.
+ */
+const EMBED_WRITE_WINDOW_BYTES = 32 * 1024 * 1024;
+/** HDF5 chunk length (elements) for the 1-D embedded video byte dataset. */
+const EMBED_VIDEO_CHUNK_BYTES = 1 << 20;
 
 const FRAMES_FIELDS = [
   "frame_id",
@@ -2676,12 +2684,16 @@ function writeEmbeddedVideosJson(
  * entries copy the stored encoded blobs verbatim via `getFrameBuffer` (no
  * decode/re-encode); encode entries write the pre-collected bytes.
  *
- * Correctness-first accumulate-then-write: blobs for a video are gathered into
- * one combined buffer before the single dataset write. (A later task makes this
- * low-peak/streaming into a resizable 1-D dataset.)
+ * Peak memory: the raw path STREAMS stored blobs into a resizable 1-D `<B`
+ * dataset in bounded byte windows (peak ~= one window + the h5wasm MEMFS copy),
+ * rather than holding every blob plus a full concatenated buffer at once. The
+ * encode path keeps accumulate-then-write — its bytes are already fully in JS
+ * memory (`frameData`), so there is nothing to stream. Either way the on-disk
+ * `{group}/video` layout is byte-identical to a single concatenated write; the
+ * reader slices it back into frames via `frame_sizes`.
  *
- * Backstop (raw path only): if a video planned N frames but 0 blobs could be
- * read, throw rather than silently write a file with the images stripped —
+ * Backstop (raw path only): if a video planned N frames but fewer blobs could
+ * be read, throw rather than silently write a file with the images stripped —
  * exactly the #213 data-loss this fix prevents.
  */
 async function writeEmbeddedVideoData(
@@ -2700,17 +2712,13 @@ async function writeEmbeddedVideoData(
     const srcDict = sourceVideoDict(labels.videos[entry.videoIndex]);
     if (srcDict) writeSourceVideoJson(file, group, srcDict);
 
-    const blobs: Uint8Array[] = [];
-    const writtenFns: number[] = [];
-    for (const fn of entry.frameNumbers) {
-      const blob =
-        entry.kind === "raw"
-          ? await entry.video.getFrameBuffer(fn)
-          : (entry.frameData!.get(fn) ?? null);
-      if (!blob || blob.length === 0) continue;
-      blobs.push(blob);
-      writtenFns.push(fn);
-    }
+    // Write `{group}/video` and collect the frame numbers/sizes actually
+    // written. Raw entries stream stored blobs (low peak); encode entries write
+    // their pre-collected in-memory bytes in one shot.
+    const { writtenFns, sizes } =
+      entry.kind === "raw"
+        ? await writeRawEmbeddedVideo(file, group, entry)
+        : writeEncodedEmbeddedVideo(file, group, entry);
 
     // Backstop (raw path only): a raw copy's frameNumbers IS the exact stored
     // set (embeddedFrameIndices), so every frame must read a blob — a partial
@@ -2719,28 +2727,14 @@ async function writeEmbeddedVideoData(
     // frameNumbers.length is always > 0 for a raw entry (planEmbedding skips
     // 0-frame videos). The encode path keeps today's lenient behavior ->
     // deferred follow-up.
-    if (entry.kind === "raw" && blobs.length < entry.frameNumbers.length) {
+    if (entry.kind === "raw" && writtenFns.length < entry.frameNumbers.length) {
       throw new Error(
-        `embedding video${entry.videoIndex}: read ${blobs.length} of ` +
+        `embedding video${entry.videoIndex}: read ${writtenFns.length} of ` +
           `${entry.frameNumbers.length} planned frame(s) - refusing to write a ` +
           `file with dropped images.`,
       );
     }
 
-    // Concatenate all frame bytes into a single 1-D uint8 dataset.
-    const total = blobs.reduce((n, b) => n + b.length, 0);
-    const combined = new Uint8Array(total);
-    let off = 0;
-    for (const b of blobs) {
-      combined.set(b, off);
-      off += b.length;
-    }
-    file.create_dataset({
-      name: `${group}/video`,
-      data: combined,
-      shape: [combined.length],
-      dtype: "<B",
-    });
     const ds = file.get(`${group}/video`);
     if (ds) {
       setStringAttr(ds, "format", entry.format);
@@ -2752,7 +2746,6 @@ async function writeEmbeddedVideoData(
       shape: [writtenFns.length],
       dtype: "<i4",
     });
-    const sizes = blobs.map((b) => b.length);
     file.create_dataset({
       name: `${group}/frame_sizes`,
       data: sizes,
@@ -2760,6 +2753,97 @@ async function writeEmbeddedVideoData(
       dtype: "<i4",
     });
   }
+}
+
+/**
+ * Raw path: stream a video's stored encoded blobs into a resizable 1-D `<B`
+ * dataset at `{group}/video`, flushing to the dataset tail in bounded byte
+ * windows so peak JS memory is ~one window rather than every blob plus a full
+ * concatenated buffer. The on-disk bytes are the in-order concatenation of the
+ * blobs — byte-identical to an accumulate-then-write. A blob that reads back
+ * null/empty is skipped (the caller's backstop then refuses to write a file
+ * with dropped images). Returns the frame numbers/sizes actually written.
+ */
+async function writeRawEmbeddedVideo(
+  file: any,
+  group: string,
+  entry: EmbedPlanEntry,
+): Promise<{ writtenFns: number[]; sizes: number[] }> {
+  file.create_dataset({
+    name: `${group}/video`,
+    data: new Uint8Array(0),
+    shape: [0],
+    maxshape: [null],
+    chunks: [EMBED_VIDEO_CHUNK_BYTES],
+    dtype: "<B",
+  });
+  const vds = file.get(`${group}/video`);
+  const sizes: number[] = [];
+  const writtenFns: number[] = [];
+  let total = 0;
+  let win: Uint8Array[] = [];
+  let winBytes = 0;
+  const flush = () => {
+    if (winBytes === 0) return;
+    const buf = new Uint8Array(winBytes);
+    let o = 0;
+    for (const b of win) {
+      buf.set(b, o);
+      o += b.length;
+    }
+    vds.resize([total + winBytes]);
+    vds.write_slice([[total, total + winBytes]], buf);
+    total += winBytes;
+    win = [];
+    winBytes = 0;
+  };
+  for (const fn of entry.frameNumbers) {
+    const blob = await entry.video.getFrameBuffer(fn);
+    if (!blob || blob.length === 0) continue;
+    win.push(blob);
+    winBytes += blob.length;
+    sizes.push(blob.length);
+    writtenFns.push(fn);
+    if (winBytes >= EMBED_WRITE_WINDOW_BYTES) flush();
+  }
+  flush();
+  return { writtenFns, sizes };
+}
+
+/**
+ * Encode path: write a video's pre-collected frame bytes (`entry.frameData`,
+ * already fully in memory) as a single concatenated 1-D `<B` dataset at
+ * `{group}/video`. Accumulate-then-write is appropriate here — there is nothing
+ * to stream. Returns the frame numbers/sizes written.
+ */
+function writeEncodedEmbeddedVideo(
+  file: any,
+  group: string,
+  entry: EmbedPlanEntry,
+): { writtenFns: number[]; sizes: number[] } {
+  const blobs: Uint8Array[] = [];
+  const writtenFns: number[] = [];
+  for (const fn of entry.frameNumbers) {
+    const blob = entry.frameData!.get(fn) ?? null;
+    if (!blob || blob.length === 0) continue;
+    blobs.push(blob);
+    writtenFns.push(fn);
+  }
+  const total = blobs.reduce((n, b) => n + b.length, 0);
+  const combined = new Uint8Array(total);
+  let off = 0;
+  for (const b of blobs) {
+    combined.set(b, off);
+    off += b.length;
+  }
+  file.create_dataset({
+    name: `${group}/video`,
+    data: combined,
+    shape: [combined.length],
+    dtype: "<B",
+  });
+  const sizes = blobs.map((b) => b.length);
+  return { writtenFns, sizes };
 }
 
 function createMatrixDataset(

--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -250,6 +250,16 @@ export class Video {
     return this.backend.getFrame(frameIndex, opts);
   }
 
+  /**
+   * Raw stored encoded blob for `frameNumber` on an embedded video, WITHOUT
+   * decoding — mirrors Python `HDF5Video.get_frame_raw_bytes`. Returns null for
+   * a continuous video, a closed backend, or an unstored frame.
+   */
+  async getFrameBuffer(frameNumber: number): Promise<Uint8Array | null> {
+    if (!this.backend?.getFrameBuffer) return null;
+    return this.backend.getFrameBuffer(frameNumber);
+  }
+
   async getFrameTimes(): Promise<number[] | null> {
     if (!this.backend?.getFrameTimes) return null;
     return this.backend.getFrameTimes();

--- a/src/video/backend.ts
+++ b/src/video/backend.ts
@@ -100,5 +100,23 @@ export interface VideoBackend {
     crop: CropRect,
     fill: Fill,
   ): Promise<RawFrame | null>;
+  /**
+   * Embedded-image (pkg.slp) backends: return the RAW stored encoded bytes
+   * (PNG/JPEG blob, or raw-pixel row) for source frame number `frameNumber`,
+   * WITHOUT decoding — the JS analog of Python `HDF5Video.get_frame_raw_bytes`.
+   * Returns null if this backend has no stored image for that frame or cannot
+   * provide raw bytes. Continuous-video backends omit this method.
+   */
+  getFrameBuffer?(frameNumber: number): Promise<Uint8Array | null>;
+  /** Encoded format of stored blobs ("png"|"jpg"|"jpeg"|raw). Embedded only. */
+  readonly embeddedFormat?: string;
+  /** Channel order of stored blobs ("RGB"|"BGR"). Embedded only. */
+  readonly embeddedChannelOrder?: string;
+  /**
+   * Deferred (lazyVideoMetadata) backends: fetch per-video metadata skipped at
+   * load. Idempotent; callers await it before reading frameNumbers. No-op /
+   * omitted when everything is already loaded.
+   */
+  ensureLoaded?(): Promise<void>;
   close(): void;
 }

--- a/src/video/crop-backend.ts
+++ b/src/video/crop-backend.ts
@@ -228,6 +228,32 @@ export class CropVideoBackend implements VideoBackend {
     return this.inner.frameNumbers;
   }
 
+  /** Inner backend's embedded blob format (delegated; a crop is spatial). */
+  get embeddedFormat(): string | undefined {
+    return this.inner.embeddedFormat;
+  }
+
+  /** Inner backend's embedded blob channel order (delegated). */
+  get embeddedChannelOrder(): string | undefined {
+    return this.inner.embeddedChannelOrder;
+  }
+
+  /**
+   * Raw stored blob for `frameNumber`, delegated to the inner backend. The
+   * stored blobs are the uncropped inner frames (the crop rides `/video_crops`),
+   * so re-embedding copies the inner blobs verbatim.
+   */
+  getFrameBuffer(frameNumber: number): Promise<Uint8Array | null> {
+    return this.inner.getFrameBuffer
+      ? this.inner.getFrameBuffer(frameNumber)
+      : Promise.resolve(null);
+  }
+
+  /** Deferred-metadata load, delegated to the inner backend (no-op if absent). */
+  ensureLoaded(): Promise<void> {
+    return this.inner.ensureLoaded?.() ?? Promise.resolve();
+  }
+
   /**
    * Cropped frame shape `[F, h, w, c]`.
    *

--- a/src/video/hdf5-video.ts
+++ b/src/video/hdf5-video.ts
@@ -95,6 +95,29 @@ export class Hdf5VideoBackend implements VideoBackend {
     return image ?? rawBytes;
   }
 
+  get embeddedFormat(): string {
+    return this.format;
+  }
+  get embeddedChannelOrder(): string {
+    return this.channelOrder;
+  }
+
+  /** Raw stored blob for source `frameNumber`, without decoding. */
+  async getFrameBuffer(frameNumber: number): Promise<Uint8Array | null> {
+    const dataset = this.file.get(this.datasetPath);
+    if (!dataset) return null;
+    const index =
+      this.frameNumberToIndex.size > 0
+        ? this.frameNumberToIndex.get(frameNumber)
+        : frameNumber;
+    if (index === undefined) return null;
+    const bytes = await readEmbeddedFrameBytes(
+      this.buildReader(dataset),
+      index,
+    );
+    return bytes && bytes.length > 0 ? bytes : null;
+  }
+
   /**
    * Crop pushdown hook (Item 1 of JS issue #153). Always returns `null`: this
    * embedded backend stores opaque encoded blobs (PNG/JPEG) or per-frame-indexed

--- a/src/video/streaming-hdf5-video.ts
+++ b/src/video/streaming-hdf5-video.ts
@@ -187,6 +187,28 @@ export class StreamingHdf5VideoBackend implements VideoBackend {
     return image ?? rawBytes;
   }
 
+  get embeddedFormat(): string {
+    return this.format;
+  }
+  get embeddedChannelOrder(): string {
+    return this.channelOrder;
+  }
+
+  async getFrameBuffer(frameNumber: number): Promise<Uint8Array | null> {
+    if (!this.loaded) await this.ensureLoaded();
+    const index =
+      this.frameNumberToIndex.size > 0
+        ? this.frameNumberToIndex.get(frameNumber)
+        : frameNumber;
+    if (index === undefined) return null;
+    try {
+      const bytes = await readEmbeddedFrameBytes(this.buildReader(), index);
+      return bytes && bytes.length > 0 ? bytes : null;
+    } catch {
+      return null;
+    }
+  }
+
   async probeShape(sourceFrameCount?: number): Promise<void> {
     if (this.shape && this.shape[0] > 0) return;
     try {

--- a/tests/reembed-preserve.test.ts
+++ b/tests/reembed-preserve.test.ts
@@ -243,6 +243,35 @@ describe("re-embed preserves embedded images (raw copy)", () => {
     cleanup();
   });
 
+  it("streams into a resizable 1-D uint8 dataset (h5wasm capability)", async () => {
+    const { getH5Module, getH5FileSystem, ensureH5StagingDir } = await import(
+      "../src/codecs/slp/h5.js"
+    );
+    const m = await getH5Module();
+    ensureH5StagingDir(m);
+    const p = `/tmp/cap_${Date.now()}.h5`;
+    const f = new (m as any).File(p, "w");
+    f.create_dataset({
+      name: "v",
+      data: new Uint8Array(0),
+      shape: [0],
+      maxshape: [null],
+      chunks: [8],
+      dtype: "<B",
+    });
+    const ds = f.get("v");
+    ds.resize([3]);
+    ds.write_slice([[0, 3]], new Uint8Array([1, 2, 3]));
+    ds.resize([5]);
+    ds.write_slice([[3, 5]], new Uint8Array([4, 5]));
+    f.close();
+    const f2 = new (m as any).File(p, "r");
+    const val = Array.from(f2.get("v").value as Uint8Array);
+    f2.close();
+    getH5FileSystem(m).unlink!(p);
+    expect(val).toEqual([1, 2, 3, 4, 5]);
+  });
+
   it("throws (never silently writes 0) when a planned blob can't be read", async () => {
     const frameNumbers = [0, 1];
     const backend = {

--- a/tests/reembed-preserve.test.ts
+++ b/tests/reembed-preserve.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "./bun-test";
+import { loadSlp } from "../src/io/main.js";
+import {
+  PNG_MAGIC,
+  JPEG_MAGIC,
+  matchesMagicAt,
+} from "../src/video/embedded-frame.js";
+import { Hdf5VideoBackend } from "../src/video/hdf5-video.js";
+import { openH5File } from "../src/codecs/slp/h5.js";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
+const pkg = (name: string) => path.join(fixtureRoot, "slp", name);
+
+function isEncodedBlob(b: Uint8Array): boolean {
+  return matchesMagicAt(b, 0, PNG_MAGIC) || matchesMagicAt(b, 0, JPEG_MAGIC);
+}
+
+describe("getFrameBuffer (raw encoded blob accessor)", () => {
+  it("returns the raw encoded bytes, not a decoded image", async () => {
+    const labels = await loadSlp(pkg("minimal_instance.pkg.slp"), {
+      openVideos: true,
+    });
+    const video = labels.videos[0];
+    expect(video.hasEmbeddedImages).toBe(true);
+    const fns = video.embeddedFrameIndices!;
+    expect(fns.length).toBeGreaterThan(0);
+    for (const fn of fns) {
+      const blob = await video.getFrameBuffer(fn);
+      expect(blob).not.toBeNull();
+      expect(blob).toBeInstanceOf(Uint8Array);
+      expect(isEncodedBlob(blob!)).toBe(true); // PNG/JPEG magic, i.e. NOT ImageData
+    }
+    video.close();
+  });
+
+  it("reports the source image format and channel order", async () => {
+    const labels = await loadSlp(pkg("minimal_instance.pkg.slp"), {
+      openVideos: true,
+    });
+    const b = labels.videos[0].backend!;
+    expect(typeof b.embeddedFormat).toBe("string");
+    expect(["png", "jpg", "jpeg"]).toContain(b.embeddedFormat!.toLowerCase());
+    expect(["RGB", "BGR"]).toContain(b.embeddedChannelOrder);
+    labels.videos[0].close();
+  });
+
+  it("reads vlen-layout blobs", async () => {
+    // vlen_multiframe.pkg.slp is a bare synthetic vlen-of-int8 fixture (N>1)
+    // written by gen_vlen_multiframe_fixture.py with NO `metadata` JSON group,
+    // so it cannot be loaded via loadSlp (h5wasm can't WRITE vlen-of-int8, so
+    // the layout can only come from an h5py-authored file). Construct the
+    // backend directly against the raw file — the same pattern the existing
+    // vlen test in tests/video/embedded-frame.test.ts uses — and exercise
+    // getFrameBuffer on the vlen path.
+    const bytes = fs.readFileSync(pkg("vlen_multiframe.pkg.slp"));
+    const { file, close } = await openH5File(new Uint8Array(bytes));
+    const frameNumbers = Array.from(
+      file.get("video0/frame_numbers").value as ArrayLike<number>,
+    ).map((v) => Number(v));
+    const backend = new Hdf5VideoBackend({
+      filename: ".",
+      file,
+      datasetPath: "video0/video",
+      frameNumbers,
+      format: "png",
+      channelOrder: "RGB",
+    });
+    for (const fn of frameNumbers) {
+      const blob = await backend.getFrameBuffer(fn);
+      expect(blob).not.toBeNull();
+      expect(isEncodedBlob(blob!)).toBe(true);
+    }
+    backend.close();
+    close();
+  });
+
+  it("delegates through a crop backend to the inner embedded frames", async () => {
+    const labels = await loadSlp(pkg("cropped_format_2_3.pkg.slp"), {
+      openVideos: true,
+    });
+    const video = labels.videos[0];
+    expect(video.hasEmbeddedImages).toBe(true);
+    const fns = video.embeddedFrameIndices!;
+    const blob = await video.getFrameBuffer(fns[0]);
+    expect(blob).not.toBeNull();
+    expect(isEncodedBlob(blob!)).toBe(true);
+    video.close();
+  });
+});

--- a/tests/reembed-preserve.test.ts
+++ b/tests/reembed-preserve.test.ts
@@ -163,22 +163,25 @@ describe("re-embed preserves embedded images (raw copy)", () => {
     out.videos[0].close();
   });
 
-  it("vlen and cropped fixtures round-trip byte-for-byte", async () => {
-    for (const name of ["cropped_format_2_3.pkg.slp"]) {
-      const src = await loadSlp(pkg(name), { openVideos: true });
-      const fns = src.videos[0].embeddedFrameIndices!;
-      const srcBlobs = await blobsOf(src.videos[0], fns);
-      const bytes = await saveSlpToBytes(src);
-      const { labels: out, cleanup } = await reloadFromDisk(bytes);
-      expect(out.videos[0].embeddedFrameIndices).toEqual(fns);
-      const outBlobs = await blobsOf(out.videos[0], fns);
-      for (let i = 0; i < fns.length; i++) {
-        expect(bytesEqual(outBlobs[i]!, srcBlobs[i]!)).toBe(true);
-      }
-      src.videos[0].close();
-      out.videos[0].close();
-      cleanup();
+  it("cropped fixture round-trips byte-for-byte", async () => {
+    // vlen's raw-READ path is covered by the earlier Task-1 test ("reads
+    // vlen-layout blobs"); it can't round-trip through loadSlp (bare synthetic
+    // fixture with no metadata JSON group), so only cropped is exercised here.
+    const src = await loadSlp(pkg("cropped_format_2_3.pkg.slp"), {
+      openVideos: true,
+    });
+    const fns = src.videos[0].embeddedFrameIndices!;
+    const srcBlobs = await blobsOf(src.videos[0], fns);
+    const bytes = await saveSlpToBytes(src);
+    const { labels: out, cleanup } = await reloadFromDisk(bytes);
+    expect(out.videos[0].embeddedFrameIndices).toEqual(fns);
+    const outBlobs = await blobsOf(out.videos[0], fns);
+    for (let i = 0; i < fns.length; i++) {
+      expect(bytesEqual(outBlobs[i]!, srcBlobs[i]!)).toBe(true);
     }
+    src.videos[0].close();
+    out.videos[0].close();
+    cleanup();
   });
 
   it('embed:"source" externalizes (drops embedded images)', async () => {
@@ -229,9 +232,15 @@ describe("re-embed preserves embedded images (raw copy)", () => {
       skeletons: [skeleton],
     });
     const bytes = await saveSlpToBytes(labels); // preserve default
-    const out = await loadSlp(bytes, { openVideos: true });
+    // Reload from DISK (not loadSlp(bytes)) so the embedded blob BYTES can be
+    // read back, then byte-compare frame 0 to the fake PNG the sim served.
+    const { labels: out, cleanup } = await reloadFromDisk(bytes);
     expect(out.videos[0].embeddedFrameIndices).toEqual(frameNumbers);
+    const outBlob = await out.videos[0].getFrameBuffer(0);
+    expect(outBlob).not.toBeNull();
+    expect(bytesEqual(outBlob!, PNG)).toBe(true);
     out.videos[0].close();
+    cleanup();
   });
 
   it("throws (never silently writes 0) when a planned blob can't be read", async () => {

--- a/tests/reembed-preserve.test.ts
+++ b/tests/reembed-preserve.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from "./bun-test";
 import { loadSlp } from "../src/io/main.js";
+import { readSlp } from "../src/codecs/slp/read.js";
+import { saveSlpToBytes } from "../src/codecs/slp/write.js";
+import {
+  Labels,
+  LabeledFrame,
+  Video,
+  Skeleton,
+  Instance,
+} from "../src/index.js";
+import type { VideoBackend } from "../src/index.js";
 import {
   PNG_MAGIC,
   JPEG_MAGIC,
@@ -8,6 +18,7 @@ import {
 import { Hdf5VideoBackend } from "../src/video/hdf5-video.js";
 import { openH5File } from "../src/codecs/slp/h5.js";
 import fs from "node:fs";
+import * as os from "node:os";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -16,6 +27,32 @@ const pkg = (name: string) => path.join(fixtureRoot, "slp", name);
 
 function isEncodedBlob(b: Uint8Array): boolean {
   return matchesMagicAt(b, 0, PNG_MAGIC) || matchesMagicAt(b, 0, JPEG_MAGIC);
+}
+
+async function blobsOf(video: any, fns: number[]): Promise<Uint8Array[]> {
+  return Promise.all(fns.map((fn) => video.getFrameBuffer(fn)));
+}
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/**
+ * Reload saved SLP bytes via a temp DISK file. Reading embedded frame BYTES
+ * back requires this: the in-memory `loadSlp(bytes)` node path stages to a temp
+ * file whose handle is unlinked after load (openBytesNode in h5-node.ts), so a
+ * retained embedded backend can't read frames from it. `embed.test.ts` uses the
+ * same temp-file pattern for the same reason.
+ */
+async function reloadFromDisk(bytes: Uint8Array) {
+  const p = path.join(
+    os.tmpdir(),
+    `reembed_${process.pid}_${Math.random().toString(16).slice(2)}.slp`,
+  );
+  fs.writeFileSync(p, bytes);
+  const labels = await readSlp(p, { openVideos: true });
+  return { labels, cleanup: () => fs.unlinkSync(p) };
 }
 
 describe("getFrameBuffer (raw encoded blob accessor)", () => {
@@ -88,5 +125,140 @@ describe("getFrameBuffer (raw encoded blob accessor)", () => {
     expect(blob).not.toBeNull();
     expect(isEncodedBlob(blob!)).toBe(true);
     video.close();
+  });
+});
+
+describe("re-embed preserves embedded images (raw copy)", () => {
+  it("bare saveSlpToBytes(labels) preserves the full set byte-for-byte", async () => {
+    const src = await loadSlp(pkg("minimal_instance.pkg.slp"), {
+      openVideos: true,
+    });
+    const fns = src.videos[0].embeddedFrameIndices!;
+    const srcBlobs = await blobsOf(src.videos[0], fns);
+
+    // No embed option — the old silent-loss default. Must now PRESERVE.
+    const bytes = await saveSlpToBytes(src);
+
+    const { labels: out, cleanup } = await reloadFromDisk(bytes);
+    expect(out.videos[0].hasEmbeddedImages).toBe(true);
+    expect(out.videos[0].embeddedFrameIndices).toEqual(fns);
+    const outBlobs = await blobsOf(out.videos[0], fns);
+    for (let i = 0; i < fns.length; i++) {
+      expect(bytesEqual(outBlobs[i]!, srcBlobs[i]!)).toBe(true);
+    }
+    src.videos[0].close();
+    out.videos[0].close();
+    cleanup();
+  });
+
+  it('embed:"user+suggestions" still preserves the FULL stored set', async () => {
+    const src = await loadSlp(pkg("minimal_instance.pkg.slp"), {
+      openVideos: true,
+    });
+    const fns = src.videos[0].embeddedFrameIndices!;
+    const bytes = await saveSlpToBytes(src, { embed: "user+suggestions" });
+    const out = await loadSlp(bytes, { openVideos: true });
+    expect(out.videos[0].embeddedFrameIndices).toEqual(fns);
+    src.videos[0].close();
+    out.videos[0].close();
+  });
+
+  it("vlen and cropped fixtures round-trip byte-for-byte", async () => {
+    for (const name of ["cropped_format_2_3.pkg.slp"]) {
+      const src = await loadSlp(pkg(name), { openVideos: true });
+      const fns = src.videos[0].embeddedFrameIndices!;
+      const srcBlobs = await blobsOf(src.videos[0], fns);
+      const bytes = await saveSlpToBytes(src);
+      const { labels: out, cleanup } = await reloadFromDisk(bytes);
+      expect(out.videos[0].embeddedFrameIndices).toEqual(fns);
+      const outBlobs = await blobsOf(out.videos[0], fns);
+      for (let i = 0; i < fns.length; i++) {
+        expect(bytesEqual(outBlobs[i]!, srcBlobs[i]!)).toBe(true);
+      }
+      src.videos[0].close();
+      out.videos[0].close();
+      cleanup();
+    }
+  });
+
+  it('embed:"source" externalizes (drops embedded images)', async () => {
+    const src = await loadSlp(pkg("minimal_instance.pkg.slp"), {
+      openVideos: true,
+    });
+    const bytes = await saveSlpToBytes(src, { embed: "source" });
+    const out = await loadSlp(bytes, { openVideos: false });
+    expect(out.videos[0].hasEmbeddedImages).toBe(false);
+    src.videos[0].close();
+  });
+
+  it("does NOT rely on getFrame (browser simulation): copies even when getFrame returns ImageData", async () => {
+    const PNG = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3,
+    ]);
+    const frameNumbers = [0, 1, 2];
+    const backend = {
+      frameNumbers,
+      shape: [3, 2, 2, 1] as [number, number, number, number],
+      dataset: "video0/video",
+      embeddedFormat: "png",
+      embeddedChannelOrder: "RGB",
+      async getFrame() {
+        return { width: 2, height: 2, data: new Uint8ClampedArray(16) } as any;
+      },
+      async getFrameBuffer(fn: number) {
+        return frameNumbers.includes(fn) ? PNG.slice() : null;
+      },
+      close() {},
+    };
+    const video = new Video({
+      filename: "sim.pkg.slp",
+      backend: backend as unknown as VideoBackend,
+      embedded: true,
+    });
+    const skeleton = new Skeleton({ nodes: ["A"] });
+    const labels = new Labels({
+      labeledFrames: frameNumbers.map(
+        (fn) =>
+          new LabeledFrame({
+            video,
+            frameIdx: fn,
+            instances: [new Instance({ points: { A: [1, 1] }, skeleton })],
+          }),
+      ),
+      videos: [video],
+      skeletons: [skeleton],
+    });
+    const bytes = await saveSlpToBytes(labels); // preserve default
+    const out = await loadSlp(bytes, { openVideos: true });
+    expect(out.videos[0].embeddedFrameIndices).toEqual(frameNumbers);
+    out.videos[0].close();
+  });
+
+  it("throws (never silently writes 0) when a planned blob can't be read", async () => {
+    const frameNumbers = [0, 1];
+    const backend = {
+      frameNumbers,
+      shape: [2, 2, 2, 1] as [number, number, number, number],
+      dataset: "video0/video",
+      embeddedFormat: "png",
+      embeddedChannelOrder: "RGB",
+      async getFrame() {
+        return null;
+      },
+      async getFrameBuffer() {
+        return null; // simulate a closed/unreadable backend
+      },
+      close() {},
+    };
+    const video = new Video({
+      filename: "broken.pkg.slp",
+      backend: backend as unknown as VideoBackend,
+      embedded: true,
+    });
+    const labels = new Labels({
+      labeledFrames: [new LabeledFrame({ video, frameIdx: 0 })],
+      videos: [video],
+    });
+    await expect(saveSlpToBytes(labels)).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Re-saving an already-embedded `.pkg.slp` silently dropped **all** embedded images (labels saved fine, every embedded frame gone). This ports Python sleap-io's proven *fast path* to JS: for an already-embedded video, copy the stored encoded blobs **verbatim** — no `getFrame`, no decode, no re-encode.

Closes #218 (and fixes the downstream sleap-app data loss, talmolab/sleap-app#213).

### Root cause
`collectFramesForEmbedding` re-read each frame via `video.getFrame()`, which for a real embedded backend **decodes** the stored blob to an `ImageData` in the browser; `frameToBytes` then returns `null` for anything that isn't a byte array → every frame skipped → `writeEmbeddedVideos` wrote no `videoN/video` dataset → 0 embedded frames. (In bun/node, `getFrame` happens to return raw bytes because decode returns null off-browser — which is why existing tests never caught it; it only bit in the WebView.)

Python avoids this with `HDF5Video.get_frame_raw_bytes` + a `can_use_fast_path` check (`slp.py`). The JS port simply never implemented that path.

## What changed

- **`getFrameBuffer(frameNumber)` on the embedded backends** (`VideoBackend`, `Hdf5VideoBackend`, `StreamingHdf5VideoBackend`, delegated through `CropVideoBackend` to its inner) — returns the raw stored encoded blob (reusing the existing `readEmbeddedFrameBytes`), **without decoding**. Plus `embeddedFormat` / `embeddedChannelOrder` / `ensureLoaded` on the interface. Mirrors Python `get_frame_raw_bytes`.
- **`saveSlpToBytes` preserves embedded images by copying raw blobs.** An already-embedded video is **always** preserved (full stored set, byte-for-byte) **unless** the caller passes `embed:"source"` to externalize it. So `embed:` true/false/undefined/`"user"`/`"user+suggestions"`/omitted all preserve — even a bare `saveSlpToBytes(labels)` can no longer silently drop embedded images.
- **Low-peak streaming write** — raw blobs are streamed into a resizable 1-D `<B` dataset in bounded 32 MB windows (`resize`+`write_slice`), so peak memory is window-bounded instead of "all blobs + a full concatenated buffer". Output is byte-identical to a single concatenated write (verified). The new-embed/encode path keeps accumulate-then-write.
- **Backstop** — the raw-copy path **throws** rather than writing a stripped file if it planned N frames but could read fewer than N blobs.
- **Crop-over-embedded** (`cropped_format_2_3.pkg.slp`) is copied losslessly from the inner blobs (a small improvement over Python, which re-encodes crops).
- MEMFS temp file is now always unlinked, even when a write throws (relevant to the new backstop abort path).

## Test plan

New `tests/reembed-preserve.test.ts` (11 tests), on real fixtures:
- `getFrameBuffer` returns raw PNG/JPEG bytes (magic-byte checked), not a decoded image — concat, vlen, and crop layouts.
- Re-save round-trips **byte-for-byte** (bare `saveSlpToBytes(labels)` and `embed:"user+suggestions"` both preserve the full stored set; cropped fixture byte-identical).
- **Browser-simulation:** a backend whose `getFrame` returns `ImageData` but whose `getFrameBuffer` returns bytes — proves the writer does not rely on `getFrame`; the reloaded blob byte-equals the source.
- `embed:"source"` externalizes.
- Backstop throws when a planned blob can't be read.
- h5wasm capability test for the resizable 1-D `<B` `write_slice` the streaming path relies on.

Gate: `bun run lint` (tsc) clean · `bun run check` (biome) clean · `bun run build` (tsup) ok · `bun run test` 2033 pass / 1 skip. (The one remaining full-suite failure — `edge-less skeletons … JS -> Python` — is a pre-existing, unrelated Python-side `numpy.float32` skeleton_id issue in the installed `sleap_io`; it fails identically without this change.)

> Note on the test harness: reading embedded frame **bytes** back from an in-memory `loadSlp(bytes)` doesn't work in node because `openBytesNode` unlinks its temp file after load, so a retained embedded backend can't read frames. The byte-identity tests therefore reload from a temp **disk** file (matching the existing `embed.test.ts` pattern); the writer output itself is proven byte-identical.

## Deferred follow-ups (not in this PR)
1. The `"user"`-predicate gap (`hasUserInstances` misses centroid-only frames) — moot here because we copy the full stored set, but relevant for *new* embedding.
2. The new-embed-from-continuous-video encode path is still browser-broken (`frameToBytes` drops `ImageData`) — separate from #213.
3. A true >4 GB embedded re-save needs a native (Rust) HDF5 append-to-disk writer — h5wasm stages the whole output in wasm MEMFS, so no in-wasm writer lifts the ~4 GB wall (this is why PyQt/Python, using `h5py(path,"a")`, has no such limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
