### PR TITLE
fix(slp): serialize ImageVideo frames under `filenames`, not scalar `filename` (#221)

### DIFF
--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -1951,7 +1951,17 @@ function serializeVideo(video: Video): Record<string, unknown> {
     string,
     unknown
   >;
-  if (backend.filename == null) backend.filename = video.filename;
+  // ImageVideo (image sequence): the canonical SLP format stores the full
+  // ordered list under `filenames` (plural) and only the FIRST image under the
+  // scalar `filename` (Python `video_to_dict`, and sleap-io.js's own reader in
+  // parsers.ts `resolveVideoFilename`). Emitting the whole list under `filename`
+  // makes Python's `make_video` do `Path(list)` and crash (#221).
+  if (Array.isArray(video.filename)) {
+    backend.filenames = video.filename;
+    backend.filename = video.filename[0] ?? "";
+  } else if (backend.filename == null) {
+    backend.filename = video.filename;
+  }
 
   // Crop unwrap (SLP 2.3): a cropped Video serializes as its UNCROPPED inner so
   // videos_json describes the full frame and old readers never hit an unknown

--- a/tests/python-compat-gen.test.ts
+++ b/tests/python-compat-gen.test.ts
@@ -307,3 +307,104 @@ print("OK: Python reads metadata and skeletons from JS-written SLP")
     }
   });
 });
+
+describe("ImageVideo serialization (#221)", () => {
+  const IMG_LIST = [
+    "frames/img_000.png",
+    "frames/img_001.png",
+    "frames/img_002.png",
+  ];
+
+  function imageSeqLabels(): Labels {
+    const skeleton = new Skeleton({ name: "fly", nodes: ["head", "thorax"] });
+    const video = new Video({ filename: IMG_LIST });
+    const inst = new Instance({
+      skeleton,
+      points: [
+        { xy: [10, 20], visible: true, complete: true },
+        { xy: [30, 40], visible: true, complete: true },
+      ],
+    });
+    const frame = new LabeledFrame({ video, frameIdx: 0, instances: [inst] });
+    return new Labels({
+      skeletons: [skeleton],
+      videos: [video],
+      labeledFrames: [frame],
+    });
+  }
+
+  it("serializes the frame list under `filenames` (plural) + a scalar `filename`", async () => {
+    const bytes = await saveSlpToBytes(imageSeqLabels());
+    const module = await ready;
+    const memPath = `/tmp/imgseq_${Date.now()}.slp`;
+    module.FS.writeFile(memPath, bytes);
+    const file = new H5File(memPath, "r");
+    try {
+      const raw = (file.get("videos_json") as { value: unknown }).value;
+      const entry = Array.isArray(raw) ? raw[0] : raw;
+      const s =
+        typeof entry === "string"
+          ? entry
+          : new TextDecoder().decode(entry as Uint8Array);
+      const meta = JSON.parse(s.replace(/[\s\0]+$/, "")) as {
+        backend: { filename: unknown; filenames: unknown };
+      };
+      // Canonical Python shape: scalar first frame + full list under `filenames`.
+      expect(meta.backend.filename).toBe(IMG_LIST[0]);
+      expect(meta.backend.filenames).toEqual(IMG_LIST);
+    } finally {
+      file.close();
+      module.FS.unlink(memPath);
+    }
+  });
+
+  it("round-trips: sleap-io.js reads its own image sequence as the full list", async () => {
+    const { readSlp } = await import("../src/codecs/slp/read.js");
+    const loaded = await readSlp(await saveSlpToBytes(imageSeqLabels()), {
+      openVideos: false,
+    });
+    expect(loaded.videos[0].filename).toEqual(IMG_LIST);
+  });
+
+  it("Python sleap-io reads the JS-written image sequence (would crash pre-#221)", async () => {
+    const slpPath = tmpSlp();
+    const pyPath = slpPath.replace(/\.slp$/, ".py");
+    try {
+      writeFileSync(slpPath, await saveSlpToBytes(imageSeqLabels()));
+      // Exercise the video-reading path (`read_videos` → `make_video`), which is
+      // exactly where #221 crashed: pre-fix the frame list landed in the scalar
+      // `filename`, so `make_video` did `Path([...])` → TypeError. We deliberately
+      // don't call full `sio.load_slp` here — JS writes flat <f8 instance matrices
+      // (no HDF5 compound dtype), so `read_instances` gets float skeleton indices;
+      // that's a separate, pre-existing limitation (see the #76 test above),
+      // unrelated to ImageVideo serialization. open_backend=False since the image
+      // files don't exist on disk (we only assert the filename metadata).
+      const pyScript = `
+from pathlib import Path
+from sleap_io.io.slp import read_videos
+videos = read_videos(${JSON.stringify(slpPath)}, open_backend=False)
+fn = videos[0].filename
+assert isinstance(fn, list), f"expected a list, got {type(fn).__name__}"
+assert len(fn) == 3, f"expected 3 frames, got {len(fn)}"
+assert [Path(p).name for p in fn] == ["img_000.png", "img_001.png", "img_002.png"], (
+    f"wrong frames/order: {fn}"
+)
+print("OK: Python reads JS-written image sequence")
+`;
+      writeFileSync(pyPath, pyScript);
+      const result = execFileSync(
+        "uv",
+        ["run", "--with", "sleap-io", "python", pyPath],
+        { encoding: "utf-8", timeout: 120000 },
+      );
+      expect(result).toContain("OK: Python reads JS-written image sequence");
+    } finally {
+      try {
+        unlinkSync(slpPath);
+      } catch {}
+      try {
+        unlinkSync(pyPath);
+      } catch {}
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #221.

The SLP writer dumped an ImageVideo's full ordered frame list into the singular `backend.filename` and never wrote `backend.filenames`. The canonical SLP format — Python `video_to_dict`, and sleap-io.js's own reader (`parsers.ts` `resolveVideoFilename`) — stores the full list under **`filenames`** (plural) and only the **first** image under the scalar **`filename`**.

Emitting the whole list under `filename` makes Python `make_video` do `Path([...])`:

```
TypeError: argument should be a str or an os.PathLike object where __fspath__
returns a str, not 'list'
```

…which crashes training / `load_slp` on any image-sequence (`ImageVideo`) project written by sleap-io.js.

## Fix

In `serializeVideo` (`src/codecs/slp/write.ts`), when `video.filename` is an array, write the full list to `filenames` and the first element to the scalar `filename`. Scalar-video behavior is unchanged.

```ts
if (Array.isArray(video.filename)) {
  backend.filenames = video.filename;
  backend.filename = video.filename[0] ?? "";
} else if (backend.filename == null) {
  backend.filename = video.filename;
}
```

This is the only divergence between reader and writer: the reader already prefers `backend.filenames` and falls back to the scalar, so the round-trip is now symmetric and matches Python.

## Tests

New `describe("ImageVideo serialization (#221)")` in `tests/python-compat-gen.test.ts`:

1. **videos_json shape** — scalar first frame + full ordered list under `filenames`.
2. **JS round-trip** — sleap-io.js reads its own image sequence back as the full list.
3. **Python cross-compat** — Python `read_videos` (the `make_video` path that crashed pre-fix) reads the JS-written image sequence as a 3-frame list. (Uses `read_videos` rather than full `load_slp`, which hits the separate, pre-existing flat-`<f8`-matrix / compound-dtype limitation documented in the #76 test.)

`bun test tests/python-compat-gen.test.ts` → 7 pass. Full suite unaffected (the single `skeleton-edgeless-nodes` failure is the pre-existing compound-dtype limitation, present on `main` too). `tsc --noEmit` clean.

With the help of Claude.