### PR TITLE
chore(release): bump version to 0.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump `package.json` version **0.5.4 → 0.5.5** ahead of the v0.5.5 release.

Since v0.5.4, `main` has picked up three new SLP format subsystems and two loader/serialization fixes:

- **feat** #226 — SLP 2.7 class/category subsystem (`/categories` + links + embeddings)
- **feat** #225 — per-2D-detection identity stack (`/identity` + links + embeddings, SLP 2.5)
- **feat** #224 — columnar `/session_data` 3D storage (SLP 2.8) + fail-loud
- **fix** #222 — serialize `ImageVideo` frames under `filenames`, not scalar `filename`
- **fix** #219 — preserve embedded images on re-save via raw-blob copy
- **chore** #217 — CI: coverage artifact retention → 1 day

Version-only change (`package.json` `version` field). Publishing to npm is driven separately by publishing the GitHub Release (`.github/workflows/release.yml`, OIDC trusted publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uVvy9CF2wmFECEtkAzC89