### PR TITLE
fix(slp): compound + chunked pose tables — Python interop + in-place-editable (#218)

### DIFF
--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -301,16 +301,31 @@ function makeLazySourceLabels(labels: Labels): Labels {
 }
 
 /**
- * Write `frames`/`instances`/`points`/`pred_points` HDF5 datasets directly
- * from the lazy store's parsed column data, bypassing materialization.
- *
- * The columns are stored as `Record<string, any[]>` (parsed from the original
- * HDF5 reader). We rebuild row-major typed arrays and call the existing
- * {@link createMatrixDataset} helper so we get identical output to the eager
- * writer for these four datasets.
+ * Rebuild row-major `number[][]` from a lazy store's parsed column data
+ * (`Record<string, any[]>`, from the HDF5 reader), so the pose datasets can be
+ * written with the same helpers the eager writer uses ({@link createMatrixDataset}
+ * / {@link createCompoundDataset}) for byte-identical output.
  *
  * TODO: a column-aware fast path could avoid the row rebuild entirely.
  */
+function lazyColumnsToRows(
+  columns: Record<string, any[]>,
+  fieldNames: string[],
+): number[][] {
+  const rowCount = (columns[fieldNames[0]] ?? []).length;
+  const colCount = fieldNames.length;
+  const rows: number[][] = [];
+  for (let i = 0; i < rowCount; i++) {
+    const row = new Array<number>(colCount);
+    for (let j = 0; j < colCount; j++) {
+      const v = (columns[fieldNames[j]] ?? [])[i];
+      row[j] = v === undefined || v === null ? 0 : Number(v);
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
 function writeLazyMatrixDataset(
   file: any,
   name: string,
@@ -318,21 +333,34 @@ function writeLazyMatrixDataset(
   fieldNames: string[],
   dtype: string,
 ): void {
-  const rowCount = (columns[fieldNames[0]] ?? []).length;
-  const colCount = fieldNames.length;
-  const rows: number[][] = [];
-  for (let i = 0; i < rowCount; i++) {
-    const row = new Array<number>(colCount);
-    for (let j = 0; j < colCount; j++) {
-      const col = columns[fieldNames[j]] ?? [];
-      const v = col[i];
-      row[j] = v === undefined || v === null ? 0 : Number(v);
-    }
-    rows.push(row);
-  }
   // resizable=true: the lazy fast-path writer's label tables must also be
-  // in-place-editable on re-save (matches the eager writer).
-  createMatrixDataset(file, name, rows, fieldNames, dtype, true);
+  // in-place-editable on re-save (matches the eager writer). Only `frames` (a
+  // flat int matrix) uses this now; the pose tables go through
+  // writeLazyCompoundDataset.
+  createMatrixDataset(
+    file,
+    name,
+    lazyColumnsToRows(columns, fieldNames),
+    fieldNames,
+    dtype,
+    true,
+  );
+}
+
+/** Lazy-store analog of {@link createCompoundDataset}: columns → compound. */
+function writeLazyCompoundDataset(
+  file: any,
+  name: string,
+  columns: Record<string, any[]>,
+  fields: CompoundField[],
+): void {
+  const fieldNames = fields.map(([fieldName]) => fieldName);
+  createCompoundDataset(
+    file,
+    name,
+    lazyColumnsToRows(columns, fieldNames),
+    fields,
+  );
 }
 
 function writeLazyFramesAndInstances(file: any, store: LazyDataStore): void {
@@ -343,37 +371,23 @@ function writeLazyFramesAndInstances(file: any, store: LazyDataStore): void {
     ["frame_id", "video", "frame_idx", "instance_id_start", "instance_id_end"],
     "<i8",
   );
-  writeLazyMatrixDataset(
+  writeLazyCompoundDataset(
     file,
     "instances",
     store.instancesData,
-    [
-      "instance_id",
-      "instance_type",
-      "frame_id",
-      "skeleton",
-      "track",
-      "from_predicted",
-      "score",
-      "point_id_start",
-      "point_id_end",
-      "tracking_score",
-    ],
-    "<f8",
+    INSTANCE_COMPOUND_FIELDS,
   );
-  writeLazyMatrixDataset(
+  writeLazyCompoundDataset(
     file,
     "points",
     store.pointsData,
-    ["x", "y", "visible", "complete"],
-    "<f8",
+    POINT_COMPOUND_FIELDS,
   );
-  writeLazyMatrixDataset(
+  writeLazyCompoundDataset(
     file,
     "pred_points",
     store.predPointsData,
-    ["x", "y", "visible", "complete", "score"],
-    "<f8",
+    PRED_POINT_COMPOUND_FIELDS,
   );
 }
 
@@ -386,13 +400,11 @@ function writeLazyNegativeFrames(file: any, store: LazyDataStore): void {
   }
   // Deterministic ordering for byte-stable output.
   rows.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
-  createMatrixDataset(
+  createCompoundDataset(
     file,
     "negative_frames",
     rows,
-    NEGATIVE_FRAMES_FIELDS,
-    "<i8",
-    true,
+    NEGATIVE_FRAME_COMPOUND_FIELDS,
   );
 }
 
@@ -3057,39 +3069,32 @@ export function buildLabelTableRows(labels: Labels): LabelTableRows {
 function writeLabeledFrames(file: any, labels: Labels): void {
   const { frames, instances, points, predPoints } = buildLabelTableRows(labels);
 
-  // Mutable label tables are written CHUNKED + unlimited (resizable=true) so a
-  // later edit can be re-saved in place (write_slice / resize) without touching
-  // the embedded video groups. See createMatrixDataset / writeLabelTablesInPlace.
+  // `frames` stays a flat int matrix (Python reads it positionally), written
+  // CHUNKED + unlimited (resizable=true) so it can be resized in place on an edit
+  // re-save. The pose tables are HDF5 COMPOUND with integer id columns — so files
+  // open in Python sleap-io / the PyQt GUI (#218) — AND chunked + unlimited, so
+  // the fast in-place edit-save can patch them via write_slice / resize without
+  // rewriting the embedded video groups. See createCompoundDataset /
+  // writeLabelTablesInPlace.
   createMatrixDataset(file, "frames", frames, FRAMES_FIELDS, "<i8", true);
-  createMatrixDataset(
-    file,
-    "instances",
-    instances,
-    INSTANCES_FIELDS,
-    "<f8",
-    true,
-  );
-  createMatrixDataset(file, "points", points, POINTS_FIELDS, "<f8", true);
-  createMatrixDataset(
+  createCompoundDataset(file, "instances", instances, INSTANCE_COMPOUND_FIELDS);
+  createCompoundDataset(file, "points", points, POINT_COMPOUND_FIELDS);
+  createCompoundDataset(
     file,
     "pred_points",
     predPoints,
-    PRED_POINTS_FIELDS,
-    "<f8",
-    true,
+    PRED_POINT_COMPOUND_FIELDS,
   );
 }
 
 function writeNegativeFrames(file: any, labels: Labels): void {
   const rows = buildNegativeFrameRows(labels);
   if (!rows.length) return;
-  createMatrixDataset(
+  createCompoundDataset(
     file,
     "negative_frames",
     rows,
-    NEGATIVE_FRAMES_FIELDS,
-    "<i8",
-    true,
+    NEGATIVE_FRAME_COMPOUND_FIELDS,
   );
 }
 
@@ -4105,6 +4110,101 @@ function createMatrixDataset(
   }
   const dataset = file.get(name);
   setStringAttr(dataset, "field_names", JSON.stringify(fieldNames));
+}
+
+/** One member of a compound (structured) dataset: `[name, HDF5 dtype]`. */
+type CompoundField = [name: string, dtype: string];
+
+// Per-member (name, dtype) layout for the pose tables written as HDF5 COMPOUND
+// datasets — matching Python sleap-io's on-disk dtypes (see `io/slp.py`
+// `instance_dtype`/`point_dtype`/`predicted_point_dtype` + the negative-frames
+// dtype). Writing these as a flat float matrix made Python read the id/count
+// columns (skeleton, track, …) back as `numpy.float32`, so `skeletons[id]`
+// raised `TypeError: list indices must be integers` (#218) — the values were
+// fine, only the on-disk dtype was wrong.
+//
+// NB: h5wasm dtype strings are SINGLE-CHAR — the trailing digits are ignored
+// (`<f8` is really float32!), and `u`/numpy widths aren't accepted. The chars:
+// `q`/`Q` = (u)int64, `i`/`I` = (u)int32, `b`/`B` = (u)int8, `f` = float32,
+// `d` = float64. Python stores `visible`/`complete` as bool (`?`); HDF5-bool
+// isn't writable through h5wasm, so we store them as uint8 (Python casts them
+// back to bool on read).
+const INSTANCE_COMPOUND_FIELDS: CompoundField[] = [
+  ["instance_id", "<q"], // i8
+  ["instance_type", "<B"], // u1
+  ["frame_id", "<Q"], // u8
+  ["skeleton", "<I"], // u4
+  ["track", "<i"], // i4 (carries -1)
+  ["from_predicted", "<q"], // i8 (carries -1)
+  ["score", "<f"], // f4
+  ["point_id_start", "<Q"], // u8
+  ["point_id_end", "<Q"], // u8
+  ["tracking_score", "<f"], // f4
+];
+const POINT_COMPOUND_FIELDS: CompoundField[] = [
+  ["x", "<d"], // f8
+  ["y", "<d"], // f8
+  ["visible", "<B"], // bool -> u1
+  ["complete", "<B"], // bool -> u1
+];
+const PRED_POINT_COMPOUND_FIELDS: CompoundField[] = [
+  ["x", "<d"], // f8
+  ["y", "<d"], // f8
+  ["visible", "<B"], // bool -> u1
+  ["complete", "<B"], // bool -> u1
+  ["score", "<d"], // f8
+];
+const NEGATIVE_FRAME_COMPOUND_FIELDS: CompoundField[] = [
+  ["video_id", "<I"], // u4
+  ["frame_idx", "<Q"], // u8
+];
+
+/**
+ * Write `rows` as an HDF5 COMPOUND (structured) dataset — one struct per row,
+ * each member with its own dtype — the layout Python sleap-io expects for the
+ * pose tables. `fields` gives `[memberName, hdf5Dtype]` in column order;
+ * `rows[i][j]` supplies member j of row i. h5wasm takes the columns as a
+ * per-member `Map` and packs them into an array-of-structures; passing plain
+ * number columns lets it widen 64-bit int members to BigInt itself.
+ *
+ * A `field_names` attribute is stamped too — Python ignores it (it reads the
+ * compound member names), and it keeps this dataset shape identical to the old
+ * matrix output for any JS reader that keys off the attribute.
+ */
+function createCompoundDataset(
+  file: any,
+  name: string,
+  rows: number[][],
+  fields: CompoundField[],
+): void {
+  const rowCount = rows.length;
+  const columns = new Map<string, number[]>();
+  for (let j = 0; j < fields.length; j++) {
+    const col = new Array<number>(rowCount);
+    for (let i = 0; i < rowCount; i++) col[i] = rows[i][j];
+    columns.set(fields[j][0], col);
+  }
+  // Emit the compound pose tables CHUNKED + unlimited (1-D `maxshape: [null]`) so
+  // a later edit can be re-saved IN PLACE (`write_slice` for value edits,
+  // `resize` + `write_slice` for structural edits) without rewriting the
+  // multi-GB embedded video groups — the reconciliation of #218 (compound, for
+  // Python interop) with the in-place edit-save (which requires resizable tables;
+  // see writeLabelTablesInPlace / checkInPlaceWritable). chunk >= 1 is required by
+  // HDF5 even for 0 rows.
+  const chunkRows = Math.max(1, Math.min(WRITE_CHUNK_ROWS, rowCount || 1));
+  file.create_dataset({
+    name,
+    data: columns,
+    shape: [rowCount],
+    maxshape: [null],
+    chunks: [chunkRows],
+    dtype: fields,
+  });
+  setStringAttr(
+    file.get(name),
+    "field_names",
+    JSON.stringify(fields.map(([fieldName]) => fieldName)),
+  );
 }
 
 function writeRois(

--- a/tests/python-compat-gen.test.ts
+++ b/tests/python-compat-gen.test.ts
@@ -252,10 +252,11 @@ describe("Python compatibility (#76)", () => {
     try {
       writeFileSync(slpPath, bytes);
 
-      // Test metadata reading (#76) and skeleton decoding (format fix).
-      // Full sio.load_slp() not yet supported because JS writes flat <f8
-      // matrices (no compound dtype), so Python gets float indices for the
-      // instances dataset. h5wasm doesn't support compound dtype creation.
+      // Test metadata reading (#76) and skeleton decoding (format fix). Full
+      // sio.load_slp() now works too (JS writes the pose tables as compound
+      // datasets with integer id columns — #218; end-to-end coverage lives in
+      // skeleton-edgeless-nodes.test.ts); this test stays scoped to the
+      // metadata/skeleton readers it was written for.
       //
       // Write the script to a file and invoke via execFileSync (no shell), so
       // the SLP path interpolation and multiline script body don't have to
@@ -373,11 +374,9 @@ describe("ImageVideo serialization (#221)", () => {
       writeFileSync(slpPath, await saveSlpToBytes(imageSeqLabels()));
       // Exercise the video-reading path (`read_videos` → `make_video`), which is
       // exactly where #221 crashed: pre-fix the frame list landed in the scalar
-      // `filename`, so `make_video` did `Path([...])` → TypeError. We deliberately
-      // don't call full `sio.load_slp` here — JS writes flat <f8 instance matrices
-      // (no HDF5 compound dtype), so `read_instances` gets float skeleton indices;
-      // that's a separate, pre-existing limitation (see the #76 test above),
-      // unrelated to ImageVideo serialization. open_backend=False since the image
+      // `filename`, so `make_video` did `Path([...])` → TypeError. Scoped to
+      // `read_videos` on purpose — this test is about ImageVideo serialization,
+      // not the full instance read path. open_backend=False since the image
       // files don't exist on disk (we only assert the filename metadata).
       const pyScript = `
 from pathlib import Path

--- a/tests/slp-identity-catalog.test.ts
+++ b/tests/slp-identity-catalog.test.ts
@@ -158,12 +158,35 @@ describe("Identity catalog (SLP 2.5)", () => {
       const copyDs = (name: string) => {
         const d = src.get(name) as any;
         if (!d?.value) return;
-        dst.create_dataset({
-          name,
-          data: d.value,
-          shape: d.shape,
-          dtype: d.dtype,
-        });
+        // The pose tables (`instances`/`points`/`pred_points`) are now HDF5
+        // COMPOUND datasets (#218). h5wasm's create_dataset takes compound data
+        // as a per-member column Map, not the array-of-rows that `.value`
+        // returns — pass columns for compound, raw value otherwise.
+        const members = d.metadata?.compound_type?.members as
+          | { name: string }[]
+          | undefined;
+        if (members?.length) {
+          const rows = d.value as ArrayLike<ArrayLike<unknown>>;
+          const columns = new Map<string, unknown[]>();
+          members.forEach((m, j) => {
+            const col = new Array<unknown>(rows.length);
+            for (let i = 0; i < rows.length; i++) col[i] = rows[i][j];
+            columns.set(m.name, col);
+          });
+          dst.create_dataset({
+            name,
+            data: columns,
+            shape: d.shape,
+            dtype: d.dtype,
+          });
+        } else {
+          dst.create_dataset({
+            name,
+            data: d.value,
+            shape: d.shape,
+            dtype: d.dtype,
+          });
+        }
         const fn = d.attrs?.field_names;
         if (fn) {
           const s =

--- a/tests/slp-inplace-update.test.ts
+++ b/tests/slp-inplace-update.test.ts
@@ -3,7 +3,9 @@
 // writeLabelTablesInPlace patches ONLY the small label tables (value-only via
 // write_slice, structural via resize+write_slice) and NEVER the embedded
 // `video{i}/video` group or the file's overall size (for value-only edits), on
-// BOTH flat (app-written) and compound (Python-written / #218) table layouts.
+// BOTH app-written (compound, uint8 bool) and Python-written (compound, enum
+// bool / #218) table layouts — the pose tables are compound + chunked so they
+// open in Python AND stay in-place editable.
 import { describe, it, expect } from "./bun-test";
 import {
   saveSlpToBytes,
@@ -116,22 +118,38 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   return true;
 }
 
-/** Read a FLAT 2-D dataset's row-major `.value` into `number[][]`. */
-function readFlatMatrix(f: any, name: string, cols: number): number[][] {
-  const flat = Array.from(f.get(name).value as ArrayLike<number>, Number);
+/**
+ * Read a label table into row-major `number[][]`, handling BOTH on-disk layouts:
+ * a flat 2-D matrix (e.g. `frames`) and an HDF5 COMPOUND 1-D dataset (the pose
+ * tables `instances`/`points`/`pred_points` after #218). For a compound dataset
+ * `.value` is already an array of member-ordered rows (64-bit members come back
+ * as BigInt → coerced to Number); `cols` is used only for the flat layout.
+ */
+function readTableRows(f: any, name: string, cols: number): number[][] {
+  const ds = f.get(name);
+  const members = ds.metadata?.compound_type?.members as
+    | { name: string }[]
+    | undefined;
+  if (members?.length) {
+    const rows = (ds.value as ArrayLike<ArrayLike<unknown>>) ?? [];
+    return Array.from(rows, (row) =>
+      Array.from(row as ArrayLike<unknown>, Number),
+    );
+  }
+  const flat = Array.from((ds.value as ArrayLike<number>) ?? [], Number);
   const out: number[][] = [];
   for (let i = 0; i < flat.length; i += cols) out.push(flat.slice(i, i + cols));
   return out;
 }
 
-describe("writeLabelTablesInPlace — flat (app-written) tables", () => {
+describe("writeLabelTablesInPlace — app-written (compound, uint8 bool) tables", () => {
   it("value-only edit: coords change, other rows + video bytes + file size unchanged", async () => {
     await ready;
     const fp = path.join(SCRATCH, `inplace_flat_value_${Date.now()}.pkg.slp`);
     if (existsSync(fp)) rmSync(fp);
     const blob = makeVideoBlob();
 
-    // App-written .pkg.slp (flat chunked pose tables), plus an embedded video.
+    // App-written .pkg.slp (compound chunked pose tables, #218), plus an embedded video.
     const v1 = makeLabels(3, 0);
     writeFileSync(fp, await saveSlpToBytes(v1));
     injectEmbeddedVideo(fp, blob);
@@ -154,7 +172,7 @@ describe("writeLabelTablesInPlace — flat (app-written) tables", () => {
 
     const f2 = new H5File(fp, "r");
     try {
-      const pts = readFlatMatrix(f2, "points", 4);
+      const pts = readTableRows(f2, "points", 4);
       // point 0 overwritten
       expect(pts[0][0]).toBeCloseTo(999.5, 6);
       expect(pts[0][1]).toBeCloseTo(888.25, 6);
@@ -204,12 +222,12 @@ describe("writeLabelTablesInPlace — flat (app-written) tables", () => {
     try {
       expect(f2.get("instances").shape[0]).toBe(3); // resized up
       expect(f2.get("points").shape[0]).toBe(6);
-      const pts = readFlatMatrix(f2, "points", 4);
+      const pts = readTableRows(f2, "points", 4);
       // new instance 2, node A → [21,22]
       expect(pts[4][0]).toBeCloseTo(21, 6);
       expect(pts[4][1]).toBeCloseTo(22, 6);
       // frames' instance range end must now be 3
-      const frames = readFlatMatrix(f2, "frames", 5);
+      const frames = readTableRows(f2, "frames", 5);
       expect(frames[0][4]).toBe(3);
     } finally {
       f2.close();

--- a/tests/slp-point-span-invariant.test.ts
+++ b/tests/slp-point-span-invariant.test.ts
@@ -72,6 +72,24 @@ async function readTables(bytes: Uint8Array): Promise<{
     const readMatrix = (name: string): { flat: number[]; ncols: number } => {
       const ds = file.get(name) as any;
       if (!ds) return { flat: [], ncols: 0 };
+      // The pose tables (`instances`/`points`/`pred_points`) are HDF5 COMPOUND
+      // datasets (integer id columns for Python interop, #218): 1-D shape, and
+      // `.value` is an array of rows, each row an array of member values in
+      // member order — the same column order as the old flat matrix, so the
+      // downstream offsets are unchanged. Flatten to the flat-matrix layout.
+      const members = ds.metadata?.compound_type?.members as
+        | { name: string }[]
+        | undefined;
+      if (members?.length) {
+        const rows = (ds.value as ArrayLike<ArrayLike<unknown>>) ?? [];
+        const flat: number[] = [];
+        for (let i = 0; i < rows.length; i++) {
+          const row = rows[i];
+          for (let j = 0; j < members.length; j++) flat.push(Number(row[j]));
+        }
+        return { flat, ncols: members.length };
+      }
+      // Legacy flat float-matrix layout (pre-#218 files).
       const shape = ds.shape as number[];
       return {
         flat: Array.from((ds.value as ArrayLike<number>) ?? []).map(Number),

--- a/tests/slp-read-compat.test.ts
+++ b/tests/slp-read-compat.test.ts
@@ -251,12 +251,33 @@ describe("Python format compatibility", () => {
       for (const name of ["frames", "instances", "points", "pred_points"]) {
         const src = srcFile.get(name) as any;
         if (src?.value != null) {
-          newFile.create_dataset({
-            name,
-            data: src.value,
-            shape: src.shape,
-            dtype: src.dtype,
-          });
+          if (Array.isArray(src.dtype)) {
+            // Compound (structured) dataset — the pose tables now match Python's
+            // on-disk layout. `.value` yields array-of-rows, but `create_dataset`
+            // takes compound data as a per-member column Map, so transpose first.
+            const members = src.dtype as [string, string][];
+            const rows = src.value as any[][];
+            const columns = new Map<string, any[]>();
+            members.forEach(([member], j) => {
+              columns.set(
+                member,
+                rows.map((row) => row[j]),
+              );
+            });
+            newFile.create_dataset({
+              name,
+              data: columns,
+              shape: src.shape,
+              dtype: src.dtype,
+            });
+          } else {
+            newFile.create_dataset({
+              name,
+              data: src.value,
+              shape: src.shape,
+              dtype: src.dtype,
+            });
+          }
           const fn = src.attrs?.field_names;
           if (fn) {
             const fnStr =


### PR DESCRIPTION
Reconciles the compound pose-table writer (Python interop, closes #218) with the in-place edit-save stack (#229), **restacked** onto `feat/update-labels-in-place` so the io PRs merge linearly (main ← #223 ← #229 ← #228) with no `write.ts` conflict.

## What
`instances`/`points`/`pred_points`/`negative_frames` are written as HDF5 **compound** (integer id columns — so files open in Python sleap-io / PyQt) **and chunked + unlimited** (so the fast in-place `write_slice`/`resize` edit-save patches them without rewriting embedded video). `frames` stays a flat int matrix, chunked/resizable. Test helpers read both compound and flat layouts.

## Merge order
Top of the io stack — merge **#223 → #229 → #228**. After each squash-merge, rebase the next branch onto the updated `main`.

## Verification
Full suite **2111 pass / 1 skip / 0 fail** (JS→Python edgeless interop now passes on the compound writer); lint/biome/build/check:pack green. tauri-pilot device check: a fresh app save produces compound pose tables that load in Python sleap-io 0.7.1 with no `numpy.float32` error.

Supersedes the earlier standalone compound-contiguous commit.