### PR TITLE
feat(slp): in-place label edit-save (updateLabelsInPlace) — ~100x faster edits on large embedded pkg.slp

### DIFF
--- a/src/codecs/slp/h5-streaming.ts
+++ b/src/codecs/slp/h5-streaming.ts
@@ -14,7 +14,11 @@ import {
   type H5WorkerResponse,
 } from "./h5-worker.js";
 import { RemoteIOError, isUrl, resolveUrl } from "../../io/remote.js";
-import type { SerializableEmbedEntry } from "./write.js";
+import type {
+  SerializableEmbedEntry,
+  LabelTableUpdate,
+  LabelTable,
+} from "./write.js";
 
 /**
  * Options for opening a streaming HDF5 file.
@@ -553,13 +557,23 @@ export class StreamingH5File {
   }
 
   /**
-   * Get dataset metadata (shape, dtype) without reading values.
+   * Get dataset metadata (shape, dtype, and the raw h5wasm `metadata`) without
+   * reading values. `metadata` carries the layout details the in-place
+   * writability gate needs — `compound_type.members` (per-member dtype class,
+   * used to detect Python's non-writable enum/bool columns) and `chunks` (⇒
+   * resizable). Pass this straight to `onDiskTableFromMeta`.
    */
-  async getDatasetMeta(
-    path: string,
-  ): Promise<{ shape: number[]; dtype: string }> {
+  async getDatasetMeta(path: string): Promise<{
+    shape: number[];
+    dtype: string;
+    metadata?: Record<string, unknown>;
+  }> {
     const result = await this.send("getDatasetMeta", { path });
-    const meta = result.meta as { shape: number[]; dtype: string };
+    const meta = result.meta as {
+      shape: number[];
+      dtype: string;
+      metadata?: Record<string, unknown>;
+    };
     return meta;
   }
 
@@ -729,11 +743,12 @@ export class StreamingH5Writer {
   private send(
     type: H5WorkerMessage["type"],
     payload?: Record<string, unknown>,
+    transfer?: Transferable[],
   ): Promise<H5WorkerResponse> {
     return new Promise((resolve, reject) => {
       const id = ++this.messageId;
       this.pendingMessages.set(id, { resolve, reject });
-      this.worker.postMessage({ type, payload, id });
+      this.worker.postMessage({ type, payload, id }, transfer ?? []);
     });
   }
 
@@ -818,6 +833,104 @@ export class StreamingH5Writer {
     entries: SerializableEmbedEntry[],
   ): Promise<H5WorkerResponse> {
     return this.send("appendEmbeddedVideos", { entries });
+  }
+
+  /**
+   * SINGLE-file write B-seam for the in-place label save: open ONLY the DEST
+   * file (`destPath`, backed by `destSink`) in h5wasm append mode `"a"` (no
+   * truncate), no source file. The counterpart to {@link openAppend} that
+   * {@link updateLabelsInPlace} uses to patch the small label tables of an
+   * existing `.pkg.slp` without re-copying its embedded video.
+   *
+   * The caller must have already opened `destPath` on the native side in a
+   * NON-truncating mode so its pre-existing bytes are intact; `destSize` seeds
+   * the Worker's writable device with the file's real current size. Requires
+   * cross-origin isolation (SharedArrayBuffer / COOP+COEP).
+   */
+  async openWrite(
+    destSink: RangeSink,
+    destPath: string,
+    destSize: number,
+    h5wasmUrl?: string,
+  ): Promise<void> {
+    if (typeof SharedArrayBuffer === "undefined") {
+      throw new Error(
+        "RangeSink streaming requires SharedArrayBuffer (enable cross-origin isolation: COOP 'same-origin' + COEP 'require-corp')",
+      );
+    }
+    await this.init(h5wasmUrl);
+    this.destSink = destSink;
+    this.sourceReader = undefined; // single-file: all bridge ops are 'dest'
+
+    const CONTROL_BYTES = 32;
+    const MAX_CHUNK = 4 * 1024 * 1024;
+    const sab = new SharedArrayBuffer(CONTROL_BYTES + MAX_CHUNK);
+    this.control = new Int32Array(sab, 0, 8);
+    this.data = new Uint8Array(sab, CONTROL_BYTES);
+
+    await this.send("openWrite", {
+      sab,
+      controlBytes: CONTROL_BYTES,
+      destFilename: destPath,
+      destSize,
+    });
+  }
+
+  /**
+   * Patch the open DEST file's label tables in place from `update` (see
+   * {@link openWrite}). Each table's `number[][]` rows are pre-flattened to a
+   * row-major `Float64Array` here and TRANSFERRED to the Worker (rather than
+   * structured-cloning a nested array), which packs them into the on-disk layout
+   * (flat matrix or compound record) and replaces the `/metadata` json attr when
+   * `update.metadataJson` is set. Never touches any `video{i}/video` group.
+   */
+  async updateLabelsInPlace(
+    update: LabelTableUpdate,
+  ): Promise<H5WorkerResponse> {
+    const tables: Array<{
+      name: string;
+      fields: string[];
+      flat: Float64Array;
+      rowCount: number;
+      colCount: number;
+      dtype: string;
+    }> = [];
+    const transfer: Transferable[] = [];
+    const push = (
+      name: string,
+      dtype: string,
+      table: LabelTable | undefined,
+    ): void => {
+      if (!table) return;
+      const rowCount = table.rows.length;
+      const colCount = table.fields.length;
+      const flat = new Float64Array(rowCount * colCount);
+      for (let i = 0; i < rowCount; i++) {
+        const row = table.rows[i];
+        const off = i * colCount;
+        for (let j = 0; j < colCount; j++) flat[off + j] = row[j];
+      }
+      tables.push({
+        name,
+        fields: table.fields,
+        flat,
+        rowCount,
+        colCount,
+        dtype,
+      });
+      transfer.push(flat.buffer);
+    };
+    push("frames", "<i8", update.frames);
+    push("instances", "<f8", update.instances);
+    push("points", "<f8", update.points);
+    push("pred_points", "<f8", update.predPoints);
+    push("negative_frames", "<i8", update.negativeFrames);
+
+    return this.send(
+      "updateLabelsInPlace",
+      { tables, metadataJson: update.metadataJson ?? null },
+      transfer,
+    );
   }
 
   /**

--- a/src/codecs/slp/h5-worker.ts
+++ b/src/codecs/slp/h5-worker.ts
@@ -173,6 +173,21 @@ self.onmessage = async function(e) {
         respond(id, appendResult);
         break;
 
+      case 'openWrite':
+        const openWriteResult = openWrite(
+          payload.sab,
+          payload.controlBytes,
+          payload.destFilename,
+          payload.destSize
+        );
+        respond(id, openWriteResult);
+        break;
+
+      case 'updateLabelsInPlace':
+        const updateResult = updateLabelsInPlace(payload);
+        respond(id, updateResult);
+        break;
+
       case 'getKeys':
         const keys = getKeys(payload.path);
         respond(id, { success: true, keys });
@@ -613,6 +628,32 @@ function openAppend(sab, controlBytes, sourceFilename, sourceSize, destFilename,
   };
 }
 
+// SINGLE-file write B-seam (in-place label save — openWrite/updateLabelsInPlace):
+// open ONLY a read+write DEST file in h5wasm append mode ('a', non-truncating)
+// backed by createWriteRangeFile (tag 'dest'), no source file. Reuses the same
+// dual-bridge dest globals (currentDestFile/destMountPath) so closeFile ->
+// closeAppendFiles tears it down. \`destSize\` seeds writeFileSize with the file's
+// real on-disk size so h5wasm can read the existing bytes (same rationale as
+// openAppend). The Rust side must already hold the file open in a non-truncating
+// mode. Used to patch the small label tables in place (never the video groups).
+function openWrite(sab, controlBytes, destFilename, destSize) {
+  if (!h5wasmModule) throw new Error('h5wasm not initialized');
+  closeFile();
+
+  rangeControl = new Int32Array(sab, 0, 8);
+  rangeData = new Uint8Array(sab, controlBytes || 32);
+  rangeMaxChunk = rangeData.length;
+
+  var dstFname = (((destFilename || 'dest.h5').split('/').pop() || '').split('\\\\').pop()) || 'dest.h5';
+  destMountPath = '/write-dst-' + Date.now();
+  destMountFilename = dstFname;
+  FS.mkdir(destMountPath);
+  createWriteRangeFile(destMountPath, dstFname, destSize);
+  currentDestFile = new h5wasm.File(destMountPath + '/' + dstFname, 'a');
+
+  return { success: true, destKeys: currentDestFile.keys() };
+}
+
 // Per-window byte budget for appendEmbeddedVideos' streamed raw blob copy, and
 // the HDF5 chunk length (elements) for the 1-D embedded video byte dataset.
 // MUST match EMBED_WRITE_WINDOW_BYTES / EMBED_VIDEO_CHUNK_BYTES in write.ts
@@ -869,6 +910,112 @@ function appendEmbeddedVideos(entries) {
 
   currentDestFile.flush();
   return { success: true, perVideo: perVideo };
+}
+
+// HDF5 datatype class ids used by the in-place writer port (H5Tget_class).
+var H5T_ENUM_CLASS = 8;
+var H5T_FLOAT_CLASS = 1;
+
+// Worker port of memberColumnTypedArray (write.ts — KEEP IN LOCKSTEP): pack one
+// logical column (numbers) into the TypedArray matching an on-disk compound
+// member's dtype (int/float, width, signedness). int64 -> Big(U)Int64Array.
+function memberColumnTypedArrayWorker(member, values) {
+  var size = member.size == null ? 8 : member.size;
+  if (member.type === H5T_ENUM_CLASS) {
+    throw new Error('cannot write enum/bool compound member ' + member.name + ' in place');
+  }
+  if (member.type === H5T_FLOAT_CLASS) {
+    return size === 4 ? Float32Array.from(values) : Float64Array.from(values);
+  }
+  var signed = member.signed !== false;
+  if (size === 8) {
+    var big = values.map(function (v) { return BigInt(Math.trunc(v)); });
+    return signed ? BigInt64Array.from(big) : BigUint64Array.from(big);
+  }
+  if (size === 1) return (signed ? Int8Array : Uint8Array).from(values);
+  if (size === 2) return (signed ? Int16Array : Uint16Array).from(values);
+  return (signed ? Int32Array : Uint32Array).from(values);
+}
+
+// Worker port of writeOneTableInPlace (write.ts — KEEP IN LOCKSTEP): overwrite
+// one already-open dataset from a row-major Float64Array (\`flat\`), resizing first
+// when the row count changed, handling BOTH flat 2-D and 1-D compound layouts.
+// Creates the dataset (chunked flat) if absent AND non-empty. NEVER touches a
+// video group.
+function writeOneTableInPlaceWorker(file, diskName, fields, flat, rowCount, colCount, dtype) {
+  var ds = file.get(diskName);
+  if (!ds) {
+    if (rowCount === 0) return;
+    var chunkRows = Math.max(1, Math.min(8192, rowCount));
+    file.create_dataset({
+      name: diskName,
+      data: flat,
+      shape: [rowCount, colCount],
+      maxshape: [null, colCount],
+      chunks: [chunkRows, colCount],
+      dtype: dtype
+    });
+    setStringAttrWorker(file.get(diskName), 'field_names', JSON.stringify(fields));
+    return;
+  }
+  var md = ds.metadata;
+  var members = md && md.compound_type && md.compound_type.members;
+  var isCompound = !!(members && members.length > 0);
+  var curRows = (ds.shape && ds.shape[0]) || 0;
+  if (curRows !== rowCount) {
+    ds.resize(isCompound ? [rowCount] : [rowCount, colCount]);
+    // h5wasm silently no-ops resize on a non-resizable dataset — read the shape
+    // back and THROW so a short write / ghost rows can't corrupt the file (KEEP
+    // IN LOCKSTEP with writeOneTableInPlace in write.ts).
+    var newRows = (ds.shape && ds.shape[0]);
+    if (newRows === undefined || newRows === null) newRows = -1;
+    if (newRows !== rowCount) {
+      throw new Error('in-place resize of ' + diskName + ' did not take effect (had ' + curRows + ' rows, wanted ' + rowCount + ', got ' + newRows + '); the dataset is not resizable - re-save the whole file instead');
+    }
+  }
+  if (rowCount === 0) return;
+  if (isCompound) {
+    var fieldIndex = {};
+    for (var fi = 0; fi < fields.length; fi++) fieldIndex[fields[fi]] = fi;
+    var columns = new Map();
+    for (var mi = 0; mi < members.length; mi++) {
+      var m = members[mi];
+      var ci = fieldIndex[m.name];
+      if (ci === undefined) {
+        throw new Error('in-place update for ' + diskName + ' is missing compound member ' + m.name);
+      }
+      var colVals = new Array(rowCount);
+      for (var r = 0; r < rowCount; r++) colVals[r] = flat[r * colCount + ci];
+      columns.set(m.name, memberColumnTypedArrayWorker(m, colVals));
+    }
+    ds.write_slice([[0, rowCount]], columns);
+  } else {
+    ds.write_slice([[0, rowCount], [0, colCount]], flat);
+  }
+}
+
+// Worker port of writeLabelTablesInPlace (write.ts — KEEP IN LOCKSTEP): patch the
+// label tables of the open DEST file (openWrite) from the transferred update, then
+// (if metadataJson is set) replace the /metadata json attr. Payload tables carry
+// pre-flattened Float64Array columns (row-major) to avoid structured-cloning a
+// number[][]. Flushes at the end. Never opens a video group.
+function updateLabelsInPlace(payload) {
+  if (!currentDestFile) throw new Error('updateLabelsInPlace: no dest file open (call openWrite first)');
+  var tables = payload.tables || [];
+  for (var t = 0; t < tables.length; t++) {
+    var tb = tables[t];
+    var flat = tb.flat instanceof Float64Array ? tb.flat : new Float64Array(tb.flat);
+    writeOneTableInPlaceWorker(currentDestFile, tb.name, tb.fields, flat, tb.rowCount, tb.colCount, tb.dtype);
+  }
+  if (payload.metadataJson !== undefined && payload.metadataJson !== null) {
+    var mg = currentDestFile.get('metadata');
+    if (mg) {
+      try { mg.delete_attribute('json'); } catch (e) {}
+      setStringAttrWorker(mg, 'json', payload.metadataJson);
+    }
+  }
+  currentDestFile.flush();
+  return { success: true };
 }
 
 function getKeys(path) {
@@ -1207,6 +1354,8 @@ export type H5WorkerMessageType =
   | "openRange"
   | "openAppend"
   | "appendEmbeddedVideos"
+  | "openWrite"
+  | "updateLabelsInPlace"
   | "getKeys"
   | "getAttr"
   | "getAttrs"

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -330,7 +330,9 @@ function writeLazyMatrixDataset(
     }
     rows.push(row);
   }
-  createMatrixDataset(file, name, rows, fieldNames, dtype);
+  // resizable=true: the lazy fast-path writer's label tables must also be
+  // in-place-editable on re-save (matches the eager writer).
+  createMatrixDataset(file, name, rows, fieldNames, dtype, true);
 }
 
 function writeLazyFramesAndInstances(file: any, store: LazyDataStore): void {
@@ -388,8 +390,9 @@ function writeLazyNegativeFrames(file: any, store: LazyDataStore): void {
     file,
     "negative_frames",
     rows,
-    ["video_id", "frame_idx"],
+    NEGATIVE_FRAMES_FIELDS,
     "<i8",
+    true,
   );
 }
 
@@ -594,6 +597,7 @@ const INSTANCES_FIELDS = [
 ];
 const POINTS_FIELDS = ["x", "y", "visible", "complete"];
 const PRED_POINTS_FIELDS = ["x", "y", "visible", "complete", "score"];
+const NEGATIVE_FRAMES_FIELDS = ["video_id", "frame_idx"];
 
 /** Read a numeric column cell with a default (mirrors the lazy reader). */
 function numAt(col: any[] | undefined, i: number, def = 0): number {
@@ -1810,7 +1814,15 @@ export async function writeSlp(
   }
 }
 
-function writeMetadata(file: any, labels: Labels): void {
+/**
+ * Build the exact JSON string written into the `/metadata` `json` attribute by
+ * {@link writeMetadata}. Exposed so the in-place saver can re-emit that attribute
+ * (via {@link writeLabelTablesInPlace}) without re-serializing the whole file.
+ * The caller decides WHEN metadata actually changed and passes this into
+ * {@link buildLabelTableUpdate}'s `metadataJson` option; a value-only pose edit
+ * leaves it unset so the attribute is untouched.
+ */
+export function buildMetadataJson(labels: Labels): string {
   const { skeletons, nodes } = serializeSkeletons(labels.skeletons);
   const metadata = {
     version: "2.0.0",
@@ -1822,6 +1834,11 @@ function writeMetadata(file: any, labels: Labels): void {
     negative_anchors: {},
     provenance: labels.provenance ?? {},
   };
+  return JSON.stringify(metadata);
+}
+
+function writeMetadata(file: any, labels: Labels): void {
+  const metadataJson = buildMetadataJson(labels);
 
   const hasRoiInstance = labels.rois.some((roi) => roi.instance !== null);
   const hasIdentities = (labels.identities?.length ?? 0) > 0;
@@ -1916,7 +1933,7 @@ function writeMetadata(file: any, labels: Labels): void {
   file.create_group("metadata");
   const metadataGroup = file.get("metadata");
   metadataGroup.create_attribute("format_id", formatId);
-  setStringAttr(metadataGroup, "json", JSON.stringify(metadata));
+  setStringAttr(metadataGroup, "json", metadataJson);
 }
 
 function serializeSkeletons(skeletons: Skeleton[]): {
@@ -2153,11 +2170,56 @@ function writeVideoCrops(file: any, videos: Video[]): void {
   file.create_dataset({ name: "video_crops", data: [payload] });
 }
 
-function writeTracks(file: any, tracks: Array<{ name: string }>): void {
-  const payload = tracks.map((track) =>
-    JSON.stringify([SPAWNED_ON, track.name]),
+/**
+ * Serialize `tracks` to the exact per-track JSON strings written into the
+ * `tracks_json` dataset. Shared by {@link writeTracks} and the in-place
+ * writability gate ({@link buildExpectedSidecars}) so the gate's comparison to
+ * the on-disk `tracks_json` is byte-exact.
+ */
+export function buildTracksJson(tracks: Array<{ name: string }>): string[] {
+  return tracks.map((track) => JSON.stringify([SPAWNED_ON, track.name]));
+}
+
+/**
+ * Serialize `suggestions` to the exact per-suggestion JSON strings written into
+ * the `suggestions_json` dataset. Shared by {@link writeSuggestions} and the
+ * in-place writability gate so the comparison is byte-exact.
+ */
+export function buildSuggestionsJson(
+  suggestions: SuggestionFrame[],
+  videos: Video[],
+): string[] {
+  return suggestions.map((suggestion) =>
+    JSON.stringify({
+      video: String(videos.indexOf(suggestion.video)),
+      frame_idx: suggestion.frameIdx,
+      group: suggestion.group ?? "default",
+    }),
   );
-  file.create_dataset({ name: "tracks_json", data: payload });
+}
+
+/**
+ * A cheap per-video signature — filename(s), shape, and embedded-flag — that
+ * uniquely identifies a video WITHOUT reproducing the full `videos_json`
+ * serialization (which depends on backend metadata and is easy to diff
+ * spuriously). Used by the in-place writability gate to refuse an edit that
+ * added/removed/repointed a video (which would leave `videos_json` — and the
+ * embedded `video{i}` groups — stale relative to the rewritten frames table).
+ * The caller builds the on-disk side from the videos it parsed on open, and the
+ * expected side (via {@link buildExpectedSidecars}) from the current labels.
+ */
+export function buildVideoSignatures(videos: Video[]): string[] {
+  return videos.map((v) =>
+    JSON.stringify({
+      filename: v.filename,
+      shape: v.shape ?? null,
+      embedded: v.hasEmbeddedImages,
+    }),
+  );
+}
+
+function writeTracks(file: any, tracks: Array<{ name: string }>): void {
+  file.create_dataset({ name: "tracks_json", data: buildTracksJson(tracks) });
 }
 
 function writeSuggestions(
@@ -2165,14 +2227,10 @@ function writeSuggestions(
   suggestions: SuggestionFrame[],
   videos: Video[],
 ): void {
-  const payload = suggestions.map((suggestion) =>
-    JSON.stringify({
-      video: String(videos.indexOf(suggestion.video)),
-      frame_idx: suggestion.frameIdx,
-      group: suggestion.group ?? "default",
-    }),
-  );
-  file.create_dataset({ name: "suggestions_json", data: payload });
+  file.create_dataset({
+    name: "suggestions_json",
+    data: buildSuggestionsJson(suggestions, videos),
+  });
 }
 
 function writeIdentities(file: any, identities: Identity[]): void {
@@ -2881,7 +2939,36 @@ function emitInstancePoints(
   }
 }
 
-function writeLabeledFrames(file: any, labels: Labels): void {
+/** The five mutable label tables as `number[][]` matrices (shared row builder). */
+export interface LabelTableRows {
+  frames: number[][];
+  instances: number[][];
+  points: number[][];
+  predPoints: number[][];
+  negativeFrames: number[][];
+}
+
+/** Build the `negative_frames` rows (`[video_id, frame_idx]`), in frame order. */
+function buildNegativeFrameRows(labels: Labels): number[][] {
+  const rows: number[][] = [];
+  for (const frame of labels.labeledFrames) {
+    if (!frame.isNegative) continue;
+    const videoIndex = Math.max(0, labels.videos.indexOf(frame.video));
+    rows.push([videoIndex, frame.frameIdx]);
+  }
+  return rows;
+}
+
+/**
+ * Build the `frames`/`instances`/`points`/`pred_points`/`negative_frames` row
+ * matrices from `labels`, exactly as the eager writer would serialize them.
+ *
+ * Shared by {@link writeLabeledFrames} (the full save path) and
+ * {@link buildLabelTableUpdate} (the in-place save path) so both emit
+ * byte-identical columns using the same field-name constants. Contains no HDF5
+ * I/O — pure `Labels` → `number[][]`.
+ */
+export function buildLabelTableRows(labels: Labels): LabelTableRows {
   const frames: number[][] = [];
   const instances: number[][] = [];
   const points: number[][] = [];
@@ -2958,62 +3045,537 @@ function writeLabeledFrames(file: any, labels: Labels): void {
     }
   }
 
-  createMatrixDataset(
-    file,
-    "frames",
+  return {
     frames,
-    ["frame_id", "video", "frame_idx", "instance_id_start", "instance_id_end"],
-    "<i8",
-  );
+    instances,
+    points,
+    predPoints,
+    negativeFrames: buildNegativeFrameRows(labels),
+  };
+}
+
+function writeLabeledFrames(file: any, labels: Labels): void {
+  const { frames, instances, points, predPoints } = buildLabelTableRows(labels);
+
+  // Mutable label tables are written CHUNKED + unlimited (resizable=true) so a
+  // later edit can be re-saved in place (write_slice / resize) without touching
+  // the embedded video groups. See createMatrixDataset / writeLabelTablesInPlace.
+  createMatrixDataset(file, "frames", frames, FRAMES_FIELDS, "<i8", true);
   createMatrixDataset(
     file,
     "instances",
     instances,
-    [
-      "instance_id",
-      "instance_type",
-      "frame_id",
-      "skeleton",
-      "track",
-      "from_predicted",
-      "score",
-      "point_id_start",
-      "point_id_end",
-      "tracking_score",
-    ],
+    INSTANCES_FIELDS,
     "<f8",
+    true,
   );
-  createMatrixDataset(
-    file,
-    "points",
-    points,
-    ["x", "y", "visible", "complete"],
-    "<f8",
-  );
+  createMatrixDataset(file, "points", points, POINTS_FIELDS, "<f8", true);
   createMatrixDataset(
     file,
     "pred_points",
     predPoints,
-    ["x", "y", "visible", "complete", "score"],
+    PRED_POINTS_FIELDS,
     "<f8",
+    true,
   );
 }
 
 function writeNegativeFrames(file: any, labels: Labels): void {
-  const negativeFrames = labels.labeledFrames.filter((f) => f.isNegative);
-  if (!negativeFrames.length) return;
-  const rows: number[][] = [];
-  for (const frame of negativeFrames) {
-    const videoIndex = Math.max(0, labels.videos.indexOf(frame.video));
-    rows.push([videoIndex, frame.frameIdx]);
-  }
+  const rows = buildNegativeFrameRows(labels);
+  if (!rows.length) return;
   createMatrixDataset(
     file,
     "negative_frames",
     rows,
-    ["video_id", "frame_idx"],
+    NEGATIVE_FRAMES_FIELDS,
     "<i8",
+    true,
   );
+}
+
+// ===========================================================================
+// Fast in-place label save (edit re-save)
+//
+// Re-save an existing `.pkg.slp` by patching ONLY the small label tables
+// (frames/instances/points/pred_points/negative_frames) + the /metadata `json`
+// attribute, NEVER reading or writing the multi-GB embedded `video{i}/video`
+// groups. On a network share this makes an edit-save ~100x faster (no re-copy of
+// the embedded images). Feasibility + primitives were validated against h5wasm:
+// `write_slice` (same-shape overwrite) works on flat AND compound datasets with
+// ZERO file growth; `resize` (H5Dset_extent) grows/shrinks chunked+unlimited
+// datasets in place. Python-written files store points `visible`/`complete` as an
+// HDF5 enum/bool (typeClass 8) that h5wasm cannot write — such files must fall
+// back to a full re-save (see checkInPlaceWritable).
+// ===========================================================================
+
+/** HDF5 datatype class id for an enum member (bool/enum) — not writable by h5wasm. */
+const H5T_ENUM_CLASS = 8;
+/** HDF5 datatype class id for a float member. */
+const H5T_FLOAT_CLASS = 1;
+
+/** One label table as logical rows + its column (field) names. */
+export interface LabelTable {
+  fields: string[];
+  rows: number[][];
+}
+
+/**
+ * The small, mutable structure of a `.pkg.slp`, ready to patch in place. Each
+ * table is `{ fields, rows }` (logical `number[][]`, layout-agnostic — the writer
+ * packs it into whatever on-disk layout the target dataset uses). `metadataJson`
+ * is set only when metadata actually changed (caller decides) so a value-only
+ * pose edit leaves the `/metadata` attribute untouched.
+ */
+export interface LabelTableUpdate {
+  frames: LabelTable;
+  instances: LabelTable;
+  points: LabelTable;
+  predPoints: LabelTable;
+  negativeFrames?: LabelTable;
+  metadataJson?: string;
+}
+
+/**
+ * Build a {@link LabelTableUpdate} from `labels` — the in-place counterpart to
+ * the eager writer. Reuses {@link buildLabelTableRows} so the columns are
+ * byte-identical to a full save. `negativeFrames` is always included (possibly
+ * with 0 rows) so an in-place save can also empty an existing `negative_frames`
+ * table when the user removed all negative frames. Pass `opts.metadataJson`
+ * (e.g. from {@link buildMetadataJson}) only when metadata changed.
+ */
+export function buildLabelTableUpdate(
+  labels: Labels,
+  opts?: { metadataJson?: string },
+): LabelTableUpdate {
+  const r = buildLabelTableRows(labels);
+  const update: LabelTableUpdate = {
+    frames: { fields: FRAMES_FIELDS, rows: r.frames },
+    instances: { fields: INSTANCES_FIELDS, rows: r.instances },
+    points: { fields: POINTS_FIELDS, rows: r.points },
+    predPoints: { fields: PRED_POINTS_FIELDS, rows: r.predPoints },
+    negativeFrames: { fields: NEGATIVE_FRAMES_FIELDS, rows: r.negativeFrames },
+  };
+  if (opts?.metadataJson !== undefined) update.metadataJson = opts.metadataJson;
+  return update;
+}
+
+/** One on-disk compound member's identity (for the writability gate). */
+export interface OnDiskMember {
+  name: string;
+  /** HDF5 datatype class id (`H5Tget_class`): 0=int, 1=float, 8=enum. */
+  typeClass: number;
+  /** Member size in bytes. */
+  size?: number;
+  /** Whether the integer member is signed (h5wasm reports float as unsigned). */
+  signed?: boolean;
+}
+
+/** On-disk shape/layout of one label table, as seen by the writability gate. */
+export interface OnDiskTable {
+  /** Current row count (axis-0 extent). */
+  rows: number;
+  /** Column count (matrix width, or compound member count). */
+  cols: number;
+  /** Storage layout: a 2-D numeric matrix, or a 1-D compound record dataset. */
+  layout: "flat" | "compound";
+  /** Whether the dataset is chunked (⇒ resizable on axis 0). */
+  chunked?: boolean;
+  /** Compound members (only for `layout: "compound"`). */
+  members?: OnDiskMember[];
+}
+
+/** The on-disk state of the label tables the gate inspects. */
+export interface OnDiskTables {
+  frames?: OnDiskTable;
+  instances?: OnDiskTable;
+  points?: OnDiskTable;
+  predPoints?: OnDiskTable;
+  negativeFrames?: OnDiskTable;
+}
+
+/** Result of {@link checkInPlaceWritable}. */
+export type InPlaceWritable = { ok: true } | { ok: false; reason: string };
+
+/** Minimal `getDatasetMeta` shape consumed by {@link onDiskTableFromMeta}. */
+export interface DatasetMetaLike {
+  shape?: number[];
+  metadata?: {
+    chunks?: unknown;
+    compound_type?: {
+      members?: Array<{
+        name: string;
+        type: number;
+        size?: number;
+        signed?: boolean;
+      }>;
+    };
+  };
+}
+
+/**
+ * Convert a `getDatasetMeta` result (from the streaming reader) into an
+ * {@link OnDiskTable} for the writability gate. Returns `undefined` when the
+ * dataset is absent. Detects compound vs flat from the presence of
+ * `compound_type.members`, and resizability from the presence of `chunks`.
+ */
+export function onDiskTableFromMeta(
+  meta: DatasetMetaLike | null | undefined,
+): OnDiskTable | undefined {
+  if (!meta || !Array.isArray(meta.shape)) return undefined;
+  const md = meta.metadata;
+  const members = md?.compound_type?.members;
+  const chunked = !!md?.chunks;
+  if (members && members.length > 0) {
+    return {
+      rows: meta.shape[0] ?? 0,
+      cols: members.length,
+      layout: "compound",
+      chunked,
+      members: members.map((m) => ({
+        name: m.name,
+        typeClass: m.type,
+        size: m.size,
+        signed: m.signed,
+      })),
+    };
+  }
+  return {
+    rows: meta.shape[0] ?? 0,
+    cols: meta.shape[1] ?? 1,
+    layout: "flat",
+    chunked,
+  };
+}
+
+/**
+ * The JSON sidecar datasets/attribute that the in-place writer does NOT rewrite
+ * but which the label tables reference by index — so an edit that changed any of
+ * them would leave the (rewritten) tables pointing into stale sidecar data. The
+ * gate compares these to prove the save is confined to the label tables (+ the
+ * `/metadata` json attr). `tracks_json` / `suggestions_json` are the on-disk
+ * per-element JSON string arrays; `metadataJson` is the `/metadata` `json`
+ * attribute string. `null` means the dataset/attr is absent.
+ *
+ * The video SET is covered SEMANTICALLY via `videos` (per-video signatures, see
+ * {@link buildVideoSignatures}) rather than a byte-exact `videos_json` compare.
+ *
+ * NOT covered here (the in-place path is only safe for edits that leave these
+ * unchanged; the caller must guarantee it, and the app's post-write verify is the
+ * final backstop): `identities_json`, `sessions_json`, and the annotation
+ * datasets (rois/masks/bboxes/centroids/label_images) — their serializers are
+ * complex and reproducing them risks spurious refusals. Extending the gate to
+ * those is a follow-up.
+ */
+export interface OnDiskSidecars {
+  tracksJson: string[] | null;
+  suggestionsJson: string[] | null;
+  metadataJson: string | null;
+  /** Per-video signatures (see {@link buildVideoSignatures}). */
+  videos: string[] | null;
+}
+
+/**
+ * Serialize the sidecars a `labels` would write, for exact comparison against
+ * {@link OnDiskSidecars} in {@link checkInPlaceWritable}. Reuses the same
+ * serializers the full writer uses ({@link buildTracksJson},
+ * {@link buildSuggestionsJson}, {@link buildMetadataJson}) so the comparison is
+ * byte-exact.
+ */
+export function buildExpectedSidecars(labels: Labels): OnDiskSidecars {
+  return {
+    tracksJson: buildTracksJson(labels.tracks),
+    suggestionsJson: buildSuggestionsJson(labels.suggestions, labels.videos),
+    metadataJson: buildMetadataJson(labels),
+    videos: buildVideoSignatures(labels.videos),
+  };
+}
+
+/** Element-wise string-array equality (null treated as empty). */
+function sameStringArray(a: string[] | null, b: string[] | null): boolean {
+  const aa = a ?? [];
+  const bb = b ?? [];
+  if (aa.length !== bb.length) return false;
+  for (let i = 0; i < aa.length; i++) if (aa[i] !== bb[i]) return false;
+  return true;
+}
+
+/**
+ * Decide whether `update` can be written into `onDisk` IN PLACE, or whether the
+ * caller must fall back to a full re-save. NOT writable when:
+ *  - any table's compound members include an HDF5 enum/bool (typeClass 8) —
+ *    Python-written points store `visible`/`complete` this way and h5wasm cannot
+ *    write them; OR
+ *  - a table's row count changes (structural edit) but the on-disk dataset is
+ *    contiguous (not chunked ⇒ not resizable) — an old file written before the
+ *    chunked-table change (value-only edits are fine on contiguous); OR
+ *  - the track set/order or the suggestions changed — the in-place writer does
+ *    NOT rewrite `tracks_json` / `suggestions_json`, so the (rewritten) instances
+ *    table's `track` indices would point into a STALE `tracks_json` → silent
+ *    track/suggestion corruption on reload (the HIGH bug this guards); OR
+ *  - the VIDEO SET changed (a video was added/removed/repointed) — the in-place
+ *    writer does NOT rewrite `videos_json` or the embedded `video{i}` groups, so
+ *    the (rewritten) frames table's `video` indices would point into a stale
+ *    video list. Compared semantically via per-video signatures
+ *    ({@link buildVideoSignatures}), not a byte-exact `videos_json` diff; OR
+ *  - the `/metadata` json changed (e.g. a skeleton or provenance edit) but
+ *    `update.metadataJson` was not set to carry that change into the attr.
+ *
+ * A pose/point/visibility/score/track-membership-preserving edit still passes.
+ *
+ * CALLER CONTRACT:
+ *  - `onDisk` MUST describe every label table that actually exists on disk
+ *    (frames/instances/points/pred_points/negative_frames) — an omitted table
+ *    skips its resizability check here; the post-resize assertion inside
+ *    {@link writeLabelTablesInPlace} is the loud backstop if one is missed.
+ *  - This gate proves confinement for the label tables + tracks + suggestions +
+ *    videos + metadata ONLY. It does NOT check `identities_json`, `sessions_json`,
+ *    or the annotation datasets (rois/masks/bboxes/centroids/label_images). The
+ *    in-place path therefore ASSUMES those are unchanged; the caller (app) MUST
+ *    NOT route an edit that touches them to in-place (route it to a full re-save),
+ *    and its post-write verify is the final backstop.
+ * Pure function (no I/O): the caller reads `sidecars.onDisk` from the file (the
+ * videos it parsed on open) and builds `sidecars.expected` via
+ * {@link buildExpectedSidecars}.
+ */
+export function checkInPlaceWritable(
+  update: LabelTableUpdate,
+  onDisk: OnDiskTables,
+  sidecars: { onDisk: OnDiskSidecars; expected: OnDiskSidecars },
+): InPlaceWritable {
+  const checks: Array<
+    [string, LabelTable | undefined, OnDiskTable | undefined]
+  > = [
+    ["frames", update.frames, onDisk.frames],
+    ["instances", update.instances, onDisk.instances],
+    ["points", update.points, onDisk.points],
+    ["pred_points", update.predPoints, onDisk.predPoints],
+    ["negative_frames", update.negativeFrames, onDisk.negativeFrames],
+  ];
+  for (const [name, table, od] of checks) {
+    if (!od) continue; // absent on disk → writer creates it (resizable)
+    if (od.layout === "compound" && od.members) {
+      const enumMember = od.members.find((m) => m.typeClass === H5T_ENUM_CLASS);
+      if (enumMember) {
+        return {
+          ok: false,
+          reason: `table "${name}" member "${enumMember.name}" is an HDF5 enum/bool (typeClass ${H5T_ENUM_CLASS}); h5wasm cannot write it — re-save the whole file instead`,
+        };
+      }
+    }
+    if (table && table.rows.length !== od.rows && !od.chunked) {
+      return {
+        ok: false,
+        reason: `table "${name}" row count changed (${od.rows} → ${table.rows.length}) but the on-disk dataset is contiguous (not resizable) — re-save the whole file instead`,
+      };
+    }
+  }
+
+  // Confinement: the label tables index into tracks_json / suggestions_json /
+  // metadata, which the in-place writer does NOT rewrite (except the /metadata
+  // attr, and only when update.metadataJson is set). If any changed, an in-place
+  // save would desync — refuse so the caller full-rewrites.
+  if (
+    !sameStringArray(sidecars.onDisk.tracksJson, sidecars.expected.tracksJson)
+  ) {
+    return {
+      ok: false,
+      reason:
+        "the track set/order changed; an in-place save cannot update tracks_json (the instances table would point into a stale track list) — re-save the whole file instead",
+    };
+  }
+  if (
+    !sameStringArray(
+      sidecars.onDisk.suggestionsJson,
+      sidecars.expected.suggestionsJson,
+    )
+  ) {
+    return {
+      ok: false,
+      reason:
+        "the suggestions changed; an in-place save cannot update suggestions_json — re-save the whole file instead",
+    };
+  }
+  if (!sameStringArray(sidecars.onDisk.videos, sidecars.expected.videos)) {
+    return {
+      ok: false,
+      reason:
+        "the video set changed (a video was added, removed, or repointed); an in-place save cannot update videos_json or the embedded video groups (the frames table would point into a stale video list) — re-save the whole file instead",
+    };
+  }
+  if (
+    sidecars.onDisk.metadataJson !== sidecars.expected.metadataJson &&
+    update.metadataJson === undefined
+  ) {
+    return {
+      ok: false,
+      reason:
+        "the /metadata json changed (e.g. a skeleton or provenance edit) but update.metadataJson was not set to carry it — set update.metadataJson, or re-save the whole file instead",
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Pack one logical column (`values`, extracted from the update rows) into the
+ * TypedArray that matches an on-disk compound `member`'s dtype, honoring
+ * h5wasm's single-char member dtype (int/float, width, signedness). Int64
+ * members become Big(U)Int64Array (values are exact ≤ 2^53). Throws on an enum
+ * member (the gate should have refused the file first).
+ */
+function memberColumnTypedArray(
+  member: { name: string; type: number; size?: number; signed?: boolean },
+  values: number[],
+): ArrayBufferView {
+  const size = member.size ?? 8;
+  if (member.type === H5T_ENUM_CLASS) {
+    throw new Error(
+      `cannot write enum/bool compound member "${member.name}" in place`,
+    );
+  }
+  if (member.type === H5T_FLOAT_CLASS) {
+    return size === 4 ? Float32Array.from(values) : Float64Array.from(values);
+  }
+  // Integer member. h5wasm reports floats as signed:false, so default ints to
+  // signed unless explicitly unsigned (matches readCompoundColumnsManual).
+  const signed = member.signed !== false;
+  if (size === 8) {
+    const big = values.map((v) => BigInt(Math.trunc(v)));
+    return signed ? BigInt64Array.from(big) : BigUint64Array.from(big);
+  }
+  if (size === 1) return (signed ? Int8Array : Uint8Array).from(values);
+  if (size === 2) return (signed ? Int16Array : Uint16Array).from(values);
+  return (signed ? Int32Array : Uint32Array).from(values);
+}
+
+/**
+ * Overwrite one already-open dataset (`diskName`) with `table`'s rows, resizing
+ * first when the row count changed. Handles BOTH on-disk layouts:
+ *  - flat 2-D matrix: `write_slice([[0,n],[0,cols]], Float64Array)` (h5wasm
+ *    converts f64 → the dataset's `<i8`/`<f8` dtype, mirroring how it was
+ *    written); and
+ *  - 1-D compound: a per-member column `Map` keyed by the on-disk member name,
+ *    each column packed to the member's dtype.
+ * Creates the dataset (chunked/resizable, flat) if it is absent AND non-empty.
+ * NEVER touches any `video{i}` group.
+ */
+function writeOneTableInPlace(
+  file: any,
+  diskName: string,
+  table: LabelTable,
+  dtype: string,
+): void {
+  const rowCount = table.rows.length;
+  const colCount = table.fields.length;
+  const ds = file.get(diskName);
+  if (!ds) {
+    // Absent on disk: create it fresh (resizable, matching the eager writer).
+    // Skip an empty table so we don't add a dataset a file never had.
+    if (rowCount === 0) return;
+    createMatrixDataset(file, diskName, table.rows, table.fields, dtype, true);
+    return;
+  }
+
+  const md = ds.metadata;
+  const members = md?.compound_type?.members as
+    | Array<{ name: string; type: number; size?: number; signed?: boolean }>
+    | undefined;
+  const isCompound = !!(members && members.length > 0);
+  const curRows = ds.shape?.[0] ?? 0;
+
+  if (curRows !== rowCount) {
+    ds.resize(isCompound ? [rowCount] : [rowCount, colCount]);
+    // h5wasm SILENTLY no-ops resize() on a non-resizable (contiguous) dataset
+    // rather than throwing — which would leave stale ghost rows / a short write.
+    // Read the shape back and abort loudly so the caller full-rewrites instead
+    // of corrupting the file. (The gate should have refused this, but this is the
+    // backstop if the caller passed an incomplete OnDiskTables.)
+    const newRows = ds.shape?.[0] ?? -1;
+    if (newRows !== rowCount) {
+      throw new Error(
+        `in-place resize of "${diskName}" did not take effect (had ${curRows} rows, wanted ${rowCount}, got ${newRows}); the dataset is not resizable — re-save the whole file instead`,
+      );
+    }
+  }
+  if (rowCount === 0) return; // resized to empty; nothing to write
+
+  if (isCompound) {
+    const fieldIndex = new Map(table.fields.map((f, i) => [f, i]));
+    const columns = new Map<string, ArrayBufferView>();
+    for (const m of members!) {
+      const ci = fieldIndex.get(m.name);
+      if (ci === undefined) {
+        throw new Error(
+          `in-place update for "${diskName}" is missing compound member "${m.name}"`,
+        );
+      }
+      const colVals = table.rows.map((row) => row[ci]);
+      columns.set(m.name, memberColumnTypedArray(m, colVals));
+    }
+    ds.write_slice([[0, rowCount]], columns);
+  } else {
+    const flat = new Float64Array(rowCount * colCount);
+    for (let i = 0; i < rowCount; i++) {
+      const row = table.rows[i];
+      const off = i * colCount;
+      for (let j = 0; j < colCount; j++) flat[off + j] = row[j];
+    }
+    ds.write_slice(
+      [
+        [0, rowCount],
+        [0, colCount],
+      ],
+      flat,
+    );
+  }
+}
+
+/**
+ * Patch the label tables of an ALREADY-OPEN, writable h5wasm `File` (opened r+ /
+ * mode `"a"`) in place from `update`, then (if `update.metadataJson` is set)
+ * replace the `/metadata` `json` attribute. Works on any open h5wasm File —
+ * Node FS, MEMFS, or the bridged write device (the streaming worker).
+ *
+ * DATA SAFETY: only the frames/instances/points/pred_points/negative_frames
+ * datasets and the `/metadata` attribute are ever referenced — the embedded
+ * `video{i}/video` groups are never opened, read, or written. The caller is
+ * responsible for having gated with {@link checkInPlaceWritable} (and, ideally,
+ * a post-write verify) before calling this: the gate proves the edit is confined
+ * to these tables (tracks/suggestions/metadata unchanged or carried). As a
+ * backstop for an incomplete gate, each per-table resize is asserted to have
+ * actually taken effect (h5wasm silently no-ops resize on a non-resizable
+ * dataset) — a resize that can't happen THROWS here rather than writing ghost
+ * rows, so the caller falls back to a full re-save.
+ *
+ * Does NOT flush or close the file — the caller owns the file lifecycle.
+ */
+export function writeLabelTablesInPlace(
+  file: any,
+  update: LabelTableUpdate,
+): void {
+  writeOneTableInPlace(file, "frames", update.frames, "<i8");
+  writeOneTableInPlace(file, "instances", update.instances, "<f8");
+  writeOneTableInPlace(file, "points", update.points, "<f8");
+  writeOneTableInPlace(file, "pred_points", update.predPoints, "<f8");
+  if (update.negativeFrames) {
+    writeOneTableInPlace(file, "negative_frames", update.negativeFrames, "<i8");
+  }
+
+  if (update.metadataJson !== undefined) {
+    const metadataGroup = file.get("metadata");
+    if (metadataGroup) {
+      // The json attr is a fixed-length S-string; a new value of a different
+      // length can't overwrite in place, so delete + recreate. (Attribute
+      // storage may relocate within the object header — harmless to dataset
+      // bytes, but noted as a risk for very large metadata.)
+      try {
+        metadataGroup.delete_attribute("json");
+      } catch {
+        // no existing attr — fine
+      }
+      setStringAttr(metadataGroup, "json", update.metadataJson);
+    }
+  }
 }
 
 /**
@@ -3490,12 +4052,25 @@ function writeEncodedEmbeddedVideo(
   return { writtenFns, sizes };
 }
 
+/**
+ * Write a 2-D matrix dataset with a `field_names` attribute.
+ *
+ * When `resizable` is true the dataset is created CHUNKED with an unlimited
+ * axis-0 `maxshape` (mirroring {@link createAppendableMatrixDataset}) so it can
+ * later be grown/shrunk in place via `resize` + `write_slice` — the on-disk
+ * pre-requisite for the fast in-place label save ({@link writeLabelTablesInPlace}).
+ * The logical content is byte-for-byte identical to the contiguous layout; only
+ * the storage layout changes. Used for the mutable label tables
+ * (frames/instances/points/pred_points/negative_frames); the annotation tables
+ * stay contiguous (`resizable` defaults to false).
+ */
 function createMatrixDataset(
   file: any,
   name: string,
   rows: number[][],
   fieldNames: string[],
   dtype: string,
+  resizable = false,
 ): void {
   const rowCount = rows.length;
   const colCount = fieldNames.length;
@@ -3513,7 +4088,21 @@ function createMatrixDataset(
       data[offset + j] = row[j];
     }
   }
-  file.create_dataset({ name, data, shape: [rowCount, colCount], dtype });
+  if (resizable) {
+    // Chunk rows cap the per-chunk allocation for large tables while staying
+    // small for tiny files (chunk >= 1 is required by HDF5, even for 0 rows).
+    const chunkRows = Math.max(1, Math.min(WRITE_CHUNK_ROWS, rowCount || 1));
+    file.create_dataset({
+      name,
+      data,
+      shape: [rowCount, colCount],
+      maxshape: [null, colCount],
+      chunks: [chunkRows, colCount],
+      dtype,
+    });
+  } else {
+    file.create_dataset({ name, data, shape: [rowCount, colCount], dtype });
+  }
   const dataset = file.get(name);
   setStringAttr(dataset, "field_names", JSON.stringify(fieldNames));
 }

--- a/src/io/main.ts
+++ b/src/io/main.ts
@@ -176,6 +176,32 @@ export type {
   SerializableEmbedEntry,
   SerializableEmbedPlan,
 } from "../codecs/slp/write.js";
+// Fast in-place label save (edit re-save): patch ONLY the small label tables +
+// the /metadata json attr of an existing .pkg.slp, never touching the multi-GB
+// embedded `video{i}/video` groups — ~100x faster edit-saves on network shares.
+export {
+  buildLabelTableRows,
+  buildLabelTableUpdate,
+  buildMetadataJson,
+  buildTracksJson,
+  buildSuggestionsJson,
+  buildVideoSignatures,
+  buildExpectedSidecars,
+  checkInPlaceWritable,
+  onDiskTableFromMeta,
+  writeLabelTablesInPlace,
+} from "../codecs/slp/write.js";
+export type {
+  LabelTable,
+  LabelTableRows,
+  LabelTableUpdate,
+  OnDiskMember,
+  OnDiskTable,
+  OnDiskTables,
+  OnDiskSidecars,
+  InPlaceWritable,
+  DatasetMetaLike,
+} from "../codecs/slp/write.js";
 
 /**
  * Load a SLEAP Analysis HDF5 file (.h5).

--- a/tests/slp-inplace-update.test.ts
+++ b/tests/slp-inplace-update.test.ts
@@ -1,0 +1,781 @@
+// In-place label save (edit re-save) tests — mirror the validated reference
+// scripts (compound_inplace_test.mjs / real_fixture_test.mjs). Verify that
+// writeLabelTablesInPlace patches ONLY the small label tables (value-only via
+// write_slice, structural via resize+write_slice) and NEVER the embedded
+// `video{i}/video` group or the file's overall size (for value-only edits), on
+// BOTH flat (app-written) and compound (Python-written / #218) table layouts.
+import { describe, it, expect } from "./bun-test";
+import {
+  saveSlpToBytes,
+  buildLabelTableUpdate,
+  buildMetadataJson,
+  buildTracksJson,
+  buildSuggestionsJson,
+  buildVideoSignatures,
+  buildExpectedSidecars,
+  checkInPlaceWritable,
+  onDiskTableFromMeta,
+  writeLabelTablesInPlace,
+  type LabelTableUpdate,
+  type OnDiskTables,
+  type OnDiskSidecars,
+} from "../src/io/main.js";
+import { Labels } from "../src/model/labels.js";
+import { LabeledFrame } from "../src/model/labeled-frame.js";
+import { Instance, Track } from "../src/model/instance.js";
+import { Skeleton } from "../src/model/skeleton.js";
+import { Video } from "../src/model/video.js";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import {
+  mkdtempSync,
+  statSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { ready, File as H5File } from "h5wasm/node";
+
+// A fresh OS temp dir per run — these tests write real .pkg.slp files to disk
+// (h5wasm reopens them from the real filesystem, not MEMFS). Must NOT be a
+// hardcoded path: CI runners don't have the author's scratchpad dir.
+const SCRATCH = mkdtempSync(path.join(tmpdir(), "sleap-inplace-"));
+const fixtureRoot = fileURLToPath(new URL("./data", import.meta.url));
+
+/** Build a small user-only Labels: 1 skeleton (A,B), 1 video, `nInst` instances
+ *  in a single frame, each with 2 points offset by `base`. */
+function makeLabels(nInst: number, base = 0): Labels {
+  const skeleton = new Skeleton({ name: "s", nodes: ["A", "B"] });
+  const video = new Video({ filename: "vid.mp4" });
+  const instances: Instance[] = [];
+  for (let i = 0; i < nInst; i++) {
+    instances.push(
+      new Instance({
+        skeleton,
+        points: [
+          {
+            xy: [base + i * 10 + 1, base + i * 10 + 2],
+            visible: true,
+            complete: true,
+          },
+          {
+            xy: [base + i * 10 + 3, base + i * 10 + 4],
+            visible: true,
+            complete: true,
+          },
+        ],
+      }),
+    );
+  }
+  const frame = new LabeledFrame({ video, frameIdx: 0, instances });
+  return new Labels({
+    skeletons: [skeleton],
+    videos: [video],
+    labeledFrames: [frame],
+  });
+}
+
+/** Deterministic "embedded video" blob we must never touch. */
+function makeVideoBlob(n = 4096): Uint8Array {
+  const b = new Uint8Array(n);
+  for (let i = 0; i < n; i++) b[i] = (i * 37 + 11) & 0xff;
+  return b;
+}
+
+/** Inject a chunked `video0/video` <B dataset (an "embedded video") into an
+ *  existing on-disk SLP so we can assert it survives an in-place edit. */
+function injectEmbeddedVideo(fp: string, blob: Uint8Array): void {
+  const f = new H5File(fp, "a");
+  f.create_group("video0");
+  f.create_dataset({
+    name: "video0/video",
+    data: blob,
+    shape: [blob.length],
+    maxshape: [null],
+    chunks: [1024],
+    dtype: "<B",
+  });
+  f.flush();
+  f.close();
+}
+
+function readVideoBlob(fp: string): Uint8Array {
+  const f = new H5File(fp, "r");
+  try {
+    const v = f.get("video0/video").value as ArrayLike<number>;
+    return v instanceof Uint8Array ? v : Uint8Array.from(v as number[]);
+  } finally {
+    f.close();
+  }
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** Read a FLAT 2-D dataset's row-major `.value` into `number[][]`. */
+function readFlatMatrix(f: any, name: string, cols: number): number[][] {
+  const flat = Array.from(f.get(name).value as ArrayLike<number>, Number);
+  const out: number[][] = [];
+  for (let i = 0; i < flat.length; i += cols) out.push(flat.slice(i, i + cols));
+  return out;
+}
+
+describe("writeLabelTablesInPlace — flat (app-written) tables", () => {
+  it("value-only edit: coords change, other rows + video bytes + file size unchanged", async () => {
+    await ready;
+    const fp = path.join(SCRATCH, `inplace_flat_value_${Date.now()}.pkg.slp`);
+    if (existsSync(fp)) rmSync(fp);
+    const blob = makeVideoBlob();
+
+    // App-written .pkg.slp (flat chunked pose tables), plus an embedded video.
+    const v1 = makeLabels(3, 0);
+    writeFileSync(fp, await saveSlpToBytes(v1));
+    injectEmbeddedVideo(fp, blob);
+    const sizeBefore = statSync(fp).size;
+
+    // Edit: change instance 0's first point x/y (same row counts → value-only).
+    const v2 = makeLabels(3, 0);
+    (v2.labeledFrames[0].instances[0] as Instance).points[0].xy = [
+      999.5, 888.25,
+    ];
+    const update = buildLabelTableUpdate(v2);
+
+    const f = new H5File(fp, "a");
+    writeLabelTablesInPlace(f, update);
+    f.flush();
+    f.close();
+
+    const sizeAfter = statSync(fp).size;
+    expect(sizeAfter - sizeBefore).toBe(0); // ZERO growth for a value-only edit
+
+    const f2 = new H5File(fp, "r");
+    try {
+      const pts = readFlatMatrix(f2, "points", 4);
+      // point 0 overwritten
+      expect(pts[0][0]).toBeCloseTo(999.5, 6);
+      expect(pts[0][1]).toBeCloseTo(888.25, 6);
+      // point 1 (instance 0, node B) unchanged: base 0, i=0 → [3,4]
+      expect(pts[1][0]).toBeCloseTo(3, 6);
+      expect(pts[1][1]).toBeCloseTo(4, 6);
+      // point of instance 2 unchanged: i=2 → node A [21,22]
+      expect(pts[4][0]).toBeCloseTo(21, 6);
+    } finally {
+      f2.close();
+    }
+
+    // Embedded video bytes untouched.
+    expect(bytesEqual(readVideoBlob(fp), blob)).toBe(true);
+    rmSync(fp);
+  });
+
+  it("structural edit: add an instance (resize+write_slice), images intact", async () => {
+    await ready;
+    const fp = path.join(SCRATCH, `inplace_flat_struct_${Date.now()}.pkg.slp`);
+    if (existsSync(fp)) rmSync(fp);
+    const blob = makeVideoBlob();
+
+    writeFileSync(fp, await saveSlpToBytes(makeLabels(2, 0)));
+    injectEmbeddedVideo(fp, blob);
+
+    // Read on-disk shape before the structural edit.
+    let instRowsBefore = 0;
+    let ptRowsBefore = 0;
+    {
+      const f = new H5File(fp, "r");
+      instRowsBefore = f.get("instances").shape[0];
+      ptRowsBefore = f.get("points").shape[0];
+      f.close();
+    }
+    expect(instRowsBefore).toBe(2);
+    expect(ptRowsBefore).toBe(4);
+
+    // Edit: 3 instances now (add one) → more instance/point rows.
+    const update = buildLabelTableUpdate(makeLabels(3, 0));
+    const f = new H5File(fp, "a");
+    writeLabelTablesInPlace(f, update);
+    f.flush();
+    f.close();
+
+    const f2 = new H5File(fp, "r");
+    try {
+      expect(f2.get("instances").shape[0]).toBe(3); // resized up
+      expect(f2.get("points").shape[0]).toBe(6);
+      const pts = readFlatMatrix(f2, "points", 4);
+      // new instance 2, node A → [21,22]
+      expect(pts[4][0]).toBeCloseTo(21, 6);
+      expect(pts[4][1]).toBeCloseTo(22, 6);
+      // frames' instance range end must now be 3
+      const frames = readFlatMatrix(f2, "frames", 5);
+      expect(frames[0][4]).toBe(3);
+    } finally {
+      f2.close();
+    }
+    expect(bytesEqual(readVideoBlob(fp), blob)).toBe(true);
+    rmSync(fp);
+  });
+
+  it("shrinking edit: remove an instance (resize down), images intact", async () => {
+    await ready;
+    const fp = path.join(SCRATCH, `inplace_flat_shrink_${Date.now()}.pkg.slp`);
+    if (existsSync(fp)) rmSync(fp);
+    const blob = makeVideoBlob();
+    writeFileSync(fp, await saveSlpToBytes(makeLabels(3, 0)));
+    injectEmbeddedVideo(fp, blob);
+
+    const update = buildLabelTableUpdate(makeLabels(1, 0));
+    const f = new H5File(fp, "a");
+    writeLabelTablesInPlace(f, update);
+    f.flush();
+    f.close();
+
+    const f2 = new H5File(fp, "r");
+    try {
+      expect(f2.get("instances").shape[0]).toBe(1);
+      expect(f2.get("points").shape[0]).toBe(2);
+    } finally {
+      f2.close();
+    }
+    expect(bytesEqual(readVideoBlob(fp), blob)).toBe(true);
+    rmSync(fp);
+  });
+
+  it("replaces the /metadata json attr only when metadataJson is set", async () => {
+    await ready;
+    const fp = path.join(SCRATCH, `inplace_meta_${Date.now()}.pkg.slp`);
+    if (existsSync(fp)) rmSync(fp);
+    writeFileSync(fp, await saveSlpToBytes(makeLabels(1, 0)));
+
+    // Build a labels with a DIFFERENT skeleton name → different metadata json.
+    const edited = makeLabels(1, 0);
+    edited.skeletons[0].name = "renamed";
+    const newJson = buildMetadataJson(edited);
+    const update = buildLabelTableUpdate(edited, { metadataJson: newJson });
+
+    const f = new H5File(fp, "a");
+    writeLabelTablesInPlace(f, update);
+    f.flush();
+    f.close();
+
+    const f2 = new H5File(fp, "r");
+    try {
+      const json = (f2.get("metadata") as any).attrs["json"].value as string;
+      expect(json).toBe(newJson);
+      expect(json).toContain("renamed");
+    } finally {
+      f2.close();
+    }
+    rmSync(fp);
+  });
+});
+
+describe("writeLabelTablesInPlace — compound (Python-format / #218) tables", () => {
+  // Build a compound-format SLP by hand (app-style: visible/complete = uint8, NOT
+  // enum) with an embedded video, then value-only patch it. Mirrors the members
+  // that #218's compound writer / Python emit.
+  const framesDtype: [string, string][] = [
+    ["frame_id", "<q"],
+    ["video", "<i"],
+    ["frame_idx", "<q"],
+    ["instance_id_start", "<q"],
+    ["instance_id_end", "<q"],
+  ];
+  const instancesDtype: [string, string][] = [
+    ["instance_id", "<q"],
+    ["instance_type", "<B"],
+    ["frame_id", "<q"],
+    ["skeleton", "<I"],
+    ["track", "<i"],
+    ["from_predicted", "<q"],
+    ["score", "<f"],
+    ["point_id_start", "<Q"],
+    ["point_id_end", "<Q"],
+    ["tracking_score", "<f"],
+  ];
+  const pointsDtype: [string, string][] = [
+    ["x", "<d"],
+    ["y", "<d"],
+    ["visible", "<B"],
+    ["complete", "<B"],
+  ];
+  const predPointsDtype: [string, string][] = [
+    ["x", "<d"],
+    ["y", "<d"],
+    ["visible", "<B"],
+    ["complete", "<B"],
+    ["score", "<f"],
+  ];
+
+  function makeCompoundFile(fp: string, blob: Uint8Array): void {
+    const f = new H5File(fp, "w");
+    // frames: 1 frame, 2 instances, 4 points.
+    f.create_dataset({
+      name: "frames",
+      data: new Map<string, ArrayBufferView>([
+        ["frame_id", BigInt64Array.from([0n])],
+        ["video", Int32Array.from([0])],
+        ["frame_idx", BigInt64Array.from([0n])],
+        ["instance_id_start", BigInt64Array.from([0n])],
+        ["instance_id_end", BigInt64Array.from([2n])],
+      ]),
+      shape: [1],
+      dtype: framesDtype,
+      maxshape: [null],
+      chunks: [8192],
+    });
+    f.create_dataset({
+      name: "instances",
+      data: new Map<string, ArrayBufferView>([
+        ["instance_id", BigInt64Array.from([0n, 1n])],
+        ["instance_type", Uint8Array.from([0, 0])],
+        ["frame_id", BigInt64Array.from([0n, 0n])],
+        ["skeleton", Uint32Array.from([0, 0])],
+        ["track", Int32Array.from([-1, -1])],
+        ["from_predicted", BigInt64Array.from([-1n, -1n])],
+        ["score", Float32Array.from([0, 0])],
+        ["point_id_start", BigUint64Array.from([0n, 2n])],
+        ["point_id_end", BigUint64Array.from([2n, 4n])],
+        ["tracking_score", Float32Array.from([0, 0])],
+      ]),
+      shape: [2],
+      dtype: instancesDtype,
+      maxshape: [null],
+      chunks: [8192],
+    });
+    f.create_dataset({
+      name: "points",
+      data: new Map<string, ArrayBufferView>([
+        ["x", Float64Array.from([1, 3, 11, 13])],
+        ["y", Float64Array.from([2, 4, 12, 14])],
+        ["visible", Uint8Array.from([1, 1, 1, 1])],
+        ["complete", Uint8Array.from([1, 1, 1, 1])],
+      ]),
+      shape: [4],
+      dtype: pointsDtype,
+      maxshape: [null],
+      chunks: [8192],
+    });
+    f.create_dataset({
+      name: "pred_points",
+      data: new Map<string, ArrayBufferView>([
+        ["x", Float64Array.from([])],
+        ["y", Float64Array.from([])],
+        ["visible", Uint8Array.from([])],
+        ["complete", Uint8Array.from([])],
+        ["score", Float32Array.from([])],
+      ]),
+      shape: [0],
+      dtype: predPointsDtype,
+      maxshape: [null],
+      chunks: [8192],
+    });
+    f.create_group("video0");
+    f.create_dataset({
+      name: "video0/video",
+      data: blob,
+      shape: [blob.length],
+      maxshape: [null],
+      chunks: [1024],
+      dtype: "<B",
+    });
+    f.flush();
+    f.close();
+  }
+
+  it("value-only edit on compound points: coords change, video bytes + size unchanged", async () => {
+    await ready;
+    const fp = path.join(SCRATCH, `inplace_compound_${Date.now()}.pkg.slp`);
+    if (existsSync(fp)) rmSync(fp);
+    const blob = makeVideoBlob();
+    makeCompoundFile(fp, blob);
+    const sizeBefore = statSync(fp).size;
+
+    // Hand-built value-only update (same row counts as the compound file).
+    const update: LabelTableUpdate = {
+      frames: {
+        fields: [
+          "frame_id",
+          "video",
+          "frame_idx",
+          "instance_id_start",
+          "instance_id_end",
+        ],
+        rows: [[0, 0, 0, 0, 2]],
+      },
+      instances: {
+        fields: [
+          "instance_id",
+          "instance_type",
+          "frame_id",
+          "skeleton",
+          "track",
+          "from_predicted",
+          "score",
+          "point_id_start",
+          "point_id_end",
+          "tracking_score",
+        ],
+        rows: [
+          [0, 0, 0, 0, -1, -1, 0, 0, 2, 0],
+          [1, 0, 0, 0, -1, -1, 0, 2, 4, 0],
+        ],
+      },
+      points: {
+        fields: ["x", "y", "visible", "complete"],
+        rows: [
+          [777.5, 666.25, 0, 1], // <- changed x/y AND visible flag (uint8)
+          [3, 4, 1, 1],
+          [11, 12, 1, 1],
+          [13, 14, 1, 1],
+        ],
+      },
+      predPoints: {
+        fields: ["x", "y", "visible", "complete", "score"],
+        rows: [],
+      },
+    };
+
+    const f = new H5File(fp, "a");
+    writeLabelTablesInPlace(f, update);
+    f.flush();
+    f.close();
+
+    expect(statSync(fp).size - sizeBefore).toBe(0);
+
+    const f2 = new H5File(fp, "r");
+    try {
+      const pts = f2.get("points").value as number[][];
+      expect(pts[0][0]).toBeCloseTo(777.5, 6);
+      expect(pts[0][1]).toBeCloseTo(666.25, 6);
+      expect(pts[0][2]).toBe(0); // visible uint8 overwritten to 0
+      expect(pts[1][0]).toBeCloseTo(3, 6); // untouched
+      // instances int64 members preserved through the round-trip
+      const ins = f2.get("instances").value as any[][];
+      expect(Number(ins[1][7])).toBe(2); // point_id_start
+      expect(Number(ins[1][8])).toBe(4); // point_id_end
+    } finally {
+      f2.close();
+    }
+    expect(bytesEqual(readVideoBlob(fp), blob)).toBe(true);
+    rmSync(fp);
+  });
+});
+
+describe("checkInPlaceWritable + onDiskTableFromMeta", () => {
+  /** Chunked flat OnDiskTables sized to `update` (⇒ value-only, so the enum /
+   *  resizability checks pass and the sidecar checks drive the verdict). */
+  function chunkedOnDiskFor(update: LabelTableUpdate): OnDiskTables {
+    const t = (rows: number, cols: number): any => ({
+      rows,
+      cols,
+      layout: "flat" as const,
+      chunked: true,
+    });
+    return {
+      frames: t(update.frames.rows.length, 5),
+      instances: t(update.instances.rows.length, 10),
+      points: t(update.points.rows.length, 4),
+      predPoints: t(update.predPoints.rows.length, 5),
+      negativeFrames: update.negativeFrames
+        ? t(update.negativeFrames.rows.length, 2)
+        : undefined,
+    };
+  }
+  /** Sidecars where on-disk == expected (nothing changed → confinement holds). */
+  function matchingSidecars(labels: Labels): {
+    onDisk: OnDiskSidecars;
+    expected: OnDiskSidecars;
+  } {
+    return {
+      onDisk: buildExpectedSidecars(labels),
+      expected: buildExpectedSidecars(labels),
+    };
+  }
+
+  it("refuses a Python-written file (enum points) with an /enum/ reason", async () => {
+    await ready;
+    const src = path.join(fixtureRoot, "slp", "minimal_instance.slp");
+    // Build OnDiskTables from the Python fixture's real dataset metadata.
+    const f = new H5File(src, "r");
+    const onDisk: OnDiskTables = {};
+    try {
+      for (const [key, name] of [
+        ["frames", "frames"],
+        ["instances", "instances"],
+        ["points", "points"],
+        ["predPoints", "pred_points"],
+      ] as const) {
+        const ds = f.keys().includes(name) ? f.get(name) : null;
+        if (ds) {
+          (onDisk as any)[key] = onDiskTableFromMeta({
+            shape: (ds as any).shape,
+            metadata: (ds as any).metadata,
+          });
+        }
+      }
+    } finally {
+      f.close();
+    }
+
+    // points must have been detected as compound with an enum member.
+    expect(onDisk.points?.layout).toBe("compound");
+    expect(onDisk.points?.members?.some((m) => m.typeClass === 8)).toBe(true);
+
+    const labels = makeLabels(1, 0);
+    const update = buildLabelTableUpdate(labels);
+    // Matching sidecars so ONLY the enum check can drive the refusal.
+    const res = checkInPlaceWritable(update, onDisk, matchingSidecars(labels));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/enum/i);
+  });
+
+  it("allows a pure pose edit on flat chunked (app) tables — sidecars unchanged", () => {
+    const labels = makeLabels(3, 0);
+    const update = buildLabelTableUpdate(labels); // 3 inst, 6 pts, 1 frame
+    const res = checkInPlaceWritable(
+      update,
+      chunkedOnDiskFor(update),
+      matchingSidecars(labels),
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it("refuses a structural edit when the on-disk table is contiguous", () => {
+    const labels = makeLabels(3, 0);
+    const onDisk: OnDiskTables = {
+      frames: { rows: 1, cols: 5, layout: "flat", chunked: false },
+      instances: { rows: 2, cols: 10, layout: "flat", chunked: false },
+      points: { rows: 4, cols: 4, layout: "flat", chunked: false },
+      predPoints: { rows: 0, cols: 5, layout: "flat", chunked: false },
+    };
+    const update = buildLabelTableUpdate(labels); // 3 inst → structural
+    const res = checkInPlaceWritable(update, onDisk, matchingSidecars(labels));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/contiguous|resizable/i);
+  });
+
+  it("allows a value-only edit even on a contiguous table", () => {
+    const labels = makeLabels(3, 0);
+    const onDisk: OnDiskTables = {
+      frames: { rows: 1, cols: 5, layout: "flat", chunked: false },
+      instances: { rows: 3, cols: 10, layout: "flat", chunked: false },
+      points: { rows: 6, cols: 4, layout: "flat", chunked: false },
+      predPoints: { rows: 0, cols: 5, layout: "flat", chunked: false },
+    };
+    const update = buildLabelTableUpdate(labels); // same counts → value-only
+    expect(
+      checkInPlaceWritable(update, onDisk, matchingSidecars(labels)).ok,
+    ).toBe(true);
+  });
+
+  // ---- FIX 1: track/suggestion/metadata desync must be refused ----
+
+  it("refuses when a track was ADDED (tracks_json would desync)", () => {
+    const labels = makeLabels(2, 0);
+    const update = buildLabelTableUpdate(labels);
+    const meta = buildMetadataJson(labels);
+    const vids = buildVideoSignatures(labels.videos);
+    const onDisk: OnDiskSidecars = {
+      tracksJson: buildTracksJson([{ name: "t1" }]),
+      suggestionsJson: [],
+      metadataJson: meta,
+      videos: vids,
+    };
+    const expected: OnDiskSidecars = {
+      tracksJson: buildTracksJson([{ name: "t1" }, { name: "t2" }]),
+      suggestionsJson: [],
+      metadataJson: meta,
+      videos: vids,
+    };
+    const res = checkInPlaceWritable(update, chunkedOnDiskFor(update), {
+      onDisk,
+      expected,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/track/i);
+  });
+
+  it("refuses when tracks were REORDERED", () => {
+    const labels = makeLabels(2, 0);
+    const update = buildLabelTableUpdate(labels);
+    const meta = buildMetadataJson(labels);
+    const vids = buildVideoSignatures(labels.videos);
+    const res = checkInPlaceWritable(update, chunkedOnDiskFor(update), {
+      onDisk: {
+        tracksJson: buildTracksJson([{ name: "t1" }, { name: "t2" }]),
+        suggestionsJson: [],
+        metadataJson: meta,
+        videos: vids,
+      },
+      expected: {
+        tracksJson: buildTracksJson([{ name: "t2" }, { name: "t1" }]),
+        suggestionsJson: [],
+        metadataJson: meta,
+        videos: vids,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/track/i);
+  });
+
+  it("refuses when the suggestions changed", () => {
+    const labels = makeLabels(1, 0);
+    const update = buildLabelTableUpdate(labels);
+    const meta = buildMetadataJson(labels);
+    const vids = buildVideoSignatures(labels.videos);
+    const res = checkInPlaceWritable(update, chunkedOnDiskFor(update), {
+      onDisk: {
+        tracksJson: [],
+        suggestionsJson: [],
+        metadataJson: meta,
+        videos: vids,
+      },
+      expected: {
+        tracksJson: [],
+        suggestionsJson: ['{"video":"0","frame_idx":5,"group":"default"}'],
+        metadataJson: meta,
+        videos: vids,
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/suggestion/i);
+  });
+
+  it("refuses when /metadata changed but update.metadataJson is not set", () => {
+    const labels = makeLabels(1, 0);
+    const renamed = makeLabels(1, 0);
+    renamed.skeletons[0].name = "renamed";
+    const update = buildLabelTableUpdate(renamed); // no metadataJson carried
+    const res = checkInPlaceWritable(update, chunkedOnDiskFor(update), {
+      onDisk: {
+        tracksJson: [],
+        suggestionsJson: [],
+        metadataJson: buildMetadataJson(labels),
+        videos: buildVideoSignatures(labels.videos),
+      },
+      expected: buildExpectedSidecars(renamed),
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/metadata/i);
+  });
+
+  it("allows a /metadata change when update.metadataJson carries it", () => {
+    const labels = makeLabels(1, 0);
+    const renamed = makeLabels(1, 0);
+    renamed.skeletons[0].name = "renamed";
+    const update = buildLabelTableUpdate(renamed, {
+      metadataJson: buildMetadataJson(renamed),
+    });
+    const res = checkInPlaceWritable(update, chunkedOnDiskFor(update), {
+      onDisk: {
+        tracksJson: [],
+        suggestionsJson: [],
+        metadataJson: buildMetadataJson(labels),
+        videos: buildVideoSignatures(labels.videos),
+      },
+      expected: buildExpectedSidecars(renamed),
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  // ---- video-set confinement ----
+
+  it("refuses when a video was ADDED (videos_json would desync)", () => {
+    const labels = makeLabels(1, 0);
+    const update = buildLabelTableUpdate(labels);
+    const base = buildExpectedSidecars(labels);
+    const res = checkInPlaceWritable(update, chunkedOnDiskFor(update), {
+      onDisk: base, // 1 video
+      expected: {
+        ...base,
+        videos: buildVideoSignatures([
+          new Video({ filename: "vid.mp4" }),
+          new Video({ filename: "vid2.mp4" }),
+        ]),
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/video/i);
+  });
+
+  it("refuses when a video was REPOINTED (filename changed)", () => {
+    const labels = makeLabels(1, 0);
+    const update = buildLabelTableUpdate(labels);
+    const base = buildExpectedSidecars(labels);
+    const res = checkInPlaceWritable(update, chunkedOnDiskFor(update), {
+      onDisk: {
+        ...base,
+        videos: buildVideoSignatures([new Video({ filename: "a.mp4" })]),
+      },
+      expected: {
+        ...base,
+        videos: buildVideoSignatures([new Video({ filename: "b.mp4" })]),
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toMatch(/video/i);
+  });
+
+  it("allows a pure pose edit when the video set is identical", () => {
+    const labels = makeLabels(2, 0);
+    const update = buildLabelTableUpdate(labels);
+    const res = checkInPlaceWritable(
+      update,
+      chunkedOnDiskFor(update),
+      matchingSidecars(labels),
+    );
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe("writeLabelTablesInPlace — resize backstop (FIX 2)", () => {
+  it("throws (does not corrupt) when a structural edit hits a contiguous table", async () => {
+    await ready;
+    const fp = path.join(SCRATCH, `inplace_contig_${Date.now()}.pkg.slp`);
+    if (existsSync(fp)) rmSync(fp);
+
+    // Build a file whose pose tables are CONTIGUOUS (non-resizable) — as if
+    // written by an old app build before the chunked-table change.
+    {
+      const f = new H5File(fp, "w");
+      const mk = (name: string, rows: number, cols: number, dtype: string) => {
+        const d = new Float64Array(rows * cols);
+        f.create_dataset({ name, data: d, shape: [rows, cols], dtype });
+      };
+      mk("frames", 1, 5, "<i8");
+      mk("instances", 2, 10, "<f8");
+      mk("points", 4, 4, "<f8");
+      mk("pred_points", 0, 5, "<f8");
+      f.create_group("video0");
+      const blob = makeVideoBlob(512);
+      f.create_dataset({
+        name: "video0/video",
+        data: blob,
+        shape: [blob.length],
+        dtype: "<B",
+      });
+      f.flush();
+      f.close();
+    }
+
+    // Structural edit (2 → 3 instances) — resize of the contiguous `instances`
+    // table silently no-ops, so the shape-readback assertion must THROW.
+    const update = buildLabelTableUpdate(makeLabels(3, 0));
+    const f = new H5File(fp, "a");
+    let threw: string | null = null;
+    try {
+      writeLabelTablesInPlace(f, update);
+    } catch (e) {
+      threw = String(e);
+    } finally {
+      f.flush();
+      f.close();
+    }
+    expect(threw).not.toBeNull();
+    expect(threw ?? "").toMatch(/resize|resizable/i);
+    rmSync(fp);
+  });
+});


### PR DESCRIPTION
## What
Adds `updateLabelsInPlace` — a fast edit-save that patches only the small HDF5 label tables of an existing `.pkg.slp` in place, never touching the embedded `video{i}` image groups. See the commit for the full breakdown (gate, worker r+ path, chunked writers, 18 tests).

**Device-verified** (in the SLEAP web app on real files): a keypoint-edit save of a **3.77 GB / 140-video** embedded `.pkg.slp` on an SMB share dropped from **~195 s → ~2 s**, file **byte-identical** (zero growth, images untouched); 5.1 GB local ~3.3 s; 11.5 MB ~1 s. Adversarially reviewed (5 lenses) — the one HIGH found (track/suggestion desync) + two guards are fixed and gated.

## ⚠️ Stacked on #223
This is stacked on `feat/streaming-writer` (**#223**) — it reuses that PR's SharedArrayBuffer→disk write bridge. **Merge #223 first**, then this.

## Reconciliation with #228 (compound / Python interop)
This branch's writers emit **chunked** label tables (so files become in-place-editable) in the current **flat** layout. The in-place gate + writer are **format-agnostic** (they already handle compound datasets). When **#228** (compound int `skeleton_id`, Python interop) merges, ensure its compound writer also emits chunked+unlimited (a one-line change) so that large/in-place-saved files stay Python-openable. Recommend bundling **#223 + this + #228** into one io release, then bumping the app's `@talmolab/sleap-io.js` dep.
