### PR TITLE
fix(slp): write streaming `instances` pose table as float64, not float32 (#231)

### DIFF
--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -1494,8 +1494,28 @@ export async function openSlpWriter(
       headerLabels.identities,
     );
 
+    // dtype chars matter: h5wasm keys off the type CHAR and IGNORES the trailing
+    // digit, so "<f8" resolves to float32 (char 'f'=4 bytes) and "<i8" to int32
+    // (char 'i'=4). See the notes above INSTANCE_COMPOUND_FIELDS and
+    // SESSION_FRAME_GROUP_FIELDS.
+    //
+    // `frames`: this is actually int32 ("<q" is h5wasm's int64 code). Harmless
+    // below 2^31 frame/instance rows; the Python reader casts positionally.
     createAppendableMatrixDataset(file, "frames", FRAMES_FIELDS, "<i8");
-    createAppendableMatrixDataset(file, "instances", INSTANCES_FIELDS, "<f8");
+    // `instances`: MUST be true float64 ("<d"), NOT "<f8" (== float32 in h5wasm).
+    // This table holds integer bookkeeping columns (instance_id, frame_id,
+    // skeleton, track, point_id_start/point_id_end, …); float32 cannot represent
+    // odd integers above 2^24 (16,777,216), so on files with >~16.7M point rows the
+    // point_id_start/end spans round to even → instances read back with the wrong
+    // node count → points misattributed to the wrong skeleton nodes, silently
+    // (#231). "<d" (char 'd'=8 bytes) is exact to 2^53. The eager/lazy writers dodge
+    // this via HDF5 compound columns (#218); this streaming path stays a float
+    // matrix, so it must use true float64 here.
+    createAppendableMatrixDataset(file, "instances", INSTANCES_FIELDS, "<d");
+    // `points`/`pred_points` hold only coordinates, visibility flags, and scores —
+    // no large integer ids — so float32 ("<f8") is an intentional, acceptable
+    // choice here (contrast `instances` above, which MUST be "<d"). Remember "<f8"
+    // == float32 in h5wasm (only the type char is read).
     createAppendableMatrixDataset(file, "points", POINTS_FIELDS, "<f8");
     createAppendableMatrixDataset(
       file,
@@ -3558,8 +3578,15 @@ export function writeLabelTablesInPlace(
   file: any,
   update: LabelTableUpdate,
 ): void {
+  // The `dtype` here is only consulted when a table is ABSENT on disk and gets
+  // created fresh as a flat matrix (writeOneTableInPlace → createMatrixDataset);
+  // for an existing dataset the on-disk layout/dtype wins and this arg is ignored.
+  // Even so, `instances` uses "<d" (true float64), NEVER "<f8" (== float32 in
+  // h5wasm — only the type char is read): its id / point_id columns must survive
+  // integers past 2^24 (#231). frames stays int32 ("<i8"); points/pred_points are
+  // coordinate-only, so float32 ("<f8") is acceptable.
   writeOneTableInPlace(file, "frames", update.frames, "<i8");
-  writeOneTableInPlace(file, "instances", update.instances, "<f8");
+  writeOneTableInPlace(file, "instances", update.instances, "<d");
   writeOneTableInPlace(file, "points", update.points, "<f8");
   writeOneTableInPlace(file, "pred_points", update.predPoints, "<f8");
   if (update.negativeFrames) {

--- a/tests/codecs/streaming-writer.test.ts
+++ b/tests/codecs/streaming-writer.test.ts
@@ -29,6 +29,7 @@ import { Labels } from "../../src/model/labels.js";
 import { UserSegmentationMask } from "../../src/model/mask.js";
 import { UserROI } from "../../src/model/roi.js";
 import { saveSlpToBytes } from "../../src/codecs/slp/write.js";
+import { ready, File as H5File } from "h5wasm/node";
 
 const fixtureRoot = fileURLToPath(new URL("../data", import.meta.url));
 const slp = (name: string) => path.join(fixtureRoot, "slp", name);
@@ -553,5 +554,81 @@ describe("annotation overlays (masks / rois)", () => {
     const f = rt.labeledFrames.find((x) => x.frameIdx === 7)!;
     expect(f.masks).toHaveLength(1);
     expect(f.masks[0].name).toBe("mm");
+  });
+});
+
+describe("instances pose table dtype (#231 — float32 corrupts large ids)", () => {
+  it("writes `instances` as true float64 (size 8), so ids past 2^24 survive", async () => {
+    // h5wasm keys its dtype parser off the type CHAR and IGNORES the trailing
+    // digit, so the old "<f8" resolved to float32 (4 bytes). float32 cannot
+    // represent odd integers above 2^24 (16,777,216), so the integer bookkeeping
+    // columns in the `instances` table (instance_id, frame_id, point_id_start/end,
+    // …) round to even → instance point-spans read back with the wrong node count
+    // → points misattributed to the wrong skeleton nodes, silently (#231). The
+    // streaming append writer must create `instances` as "<d" (true float64).
+    const module = await ready;
+    const s = await store(FIX);
+    const writer = await openSlpWriter({
+      skeletons: s.skeletons,
+      videos: s.videos,
+      tracks: s.tracks,
+    });
+    writer.appendStore(s);
+    const bytes = new Uint8Array(writer.close());
+
+    const memPath = `/tmp/streaming_instances_dtype_${Date.now()}.slp`;
+    module.FS.writeFile(memPath, bytes);
+
+    // (a) On-disk dtype of `instances` must be an 8-byte float (float64), NOT a
+    //     4-byte float (float32 == the "<f8" bug). Direct dtype assertion.
+    let file = new H5File(memPath, "r");
+    let rows0: number;
+    let cols: number;
+    try {
+      const instances = file.get("instances") as any;
+      expect(instances.metadata.type).toBe(1); // H5T_FLOAT_CLASS
+      expect(instances.metadata.size).toBe(8); // float64 — 4 would mean float32
+      const shape = instances.shape!;
+      rows0 = shape[0];
+      cols = shape[1];
+      expect(rows0).toBeGreaterThan(0); // the fixture actually produced rows
+    } finally {
+      file.close();
+    }
+
+    // (b) Exact round-trip of a large ODD id through the writer's ACTUAL
+    //     `instances` dataset, using the same resize + write_slice the streaming
+    //     append performs. Under float32 this reads back as the nearest even value
+    //     (16_777_232) — this assertion directly encodes the corruption bug.
+    const BIG_ODD = 16_777_233; // 2^24 + 17 — not representable in float32
+    file = new H5File(memPath, "a");
+    try {
+      const ds = file.get("instances") as any;
+      ds.resize([rows0 + 1, cols]);
+      const row = new Float64Array(cols);
+      row[0] = BIG_ODD; // instance_id column
+      ds.write_slice(
+        [
+          [rows0, rows0 + 1],
+          [0, cols],
+        ],
+        row,
+      );
+    } finally {
+      file.close();
+    }
+
+    file = new H5File(memPath, "r");
+    try {
+      const ds = file.get("instances") as any;
+      const readBack = ds.slice([
+        [rows0, rows0 + 1],
+        [0, 1],
+      ]) as Float64Array;
+      expect(Number(readBack[0])).toBe(BIG_ODD); // exact — float32 → 16_777_232
+    } finally {
+      file.close();
+      module.FS.unlink(memPath);
+    }
   });
 });


### PR DESCRIPTION
## Problem (#231)

h5wasm keys off the dtype **char** and ignores the digit, so `"<f8"` resolves to **float32** (char `f` = 4 bytes) and `"<i8"` to int32 — a silent mismatch vs numpy. The **streaming** SLP writer (`openSlpWriter`) created the `instances` pose table with `"<f8"`, i.e. float32. That table holds integer id columns (`instance_id`, `frame_id`, `skeleton`, `track`, `point_id_start`/`point_id_end`, …). float32 can't represent odd integers above 2^24 (16,777,216), so on files with >~16.7M point rows the `point_id_start/end` values round to even → instance point-spans go 16/18 instead of the true node count → points get misattributed to the wrong skeleton nodes on read-back, silently. (Repro in #231: real 779 MB LUCID project, 21.7M points; first bad instance at row 986,896, start = 16,777,232 = 2²⁴+16.)

The eager (`saveSlpToBytes`) and lazy (`saveSlpMergedFromStores`) paths already write `instances` as HDF5 **compound** datasets with proper integer columns (#228/#218) — those are safe. Only the streaming path was still float32.

## Fix

- Streaming `instances` dtype `"<f8"` → `"<d"` (true float64, exact integers to 2⁵³).
- Defensive: the in-place `writeOneTableInPlace` fresh-create fallback for `instances` also `"<f8"` → `"<d"` (only used when a table is absent on disk, but would otherwise reintroduce a float32 id matrix).
- `frames` stays int32 (`"<i8"`, harmless below 2³¹ rows); `points`/`pred_points` stay float32 (coordinates/flags/scores only, no large ids). Explanatory comments added at each call site documenting the h5wasm dtype-char trap.

## Test

New test writes labels through the streaming writer, reopens with h5wasm, and asserts the on-disk `instances` dtype is float64 (`metadata.size === 8`) and that a large odd id (2²⁴+17) round-trips **exactly** through the real append dataset (would read back even under float32). Verified it fails when reverted to `"<f8"`.

Full suite: **2112 pass / 0 fail**; tsc + biome clean.

Targeted for the **0.5.6** release (alongside the already-merged save stack #223/#229/#228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)