### PR TITLE
fix(centroid): persist `source` as snake_case for Python interop

### DIFF
--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -79,6 +79,7 @@ import {
   type Centroid,
   UserCentroid,
   PredictedCentroid,
+  normalizeCentroidSource,
 } from "../../model/centroid.js";
 import {
   type LabelImage,
@@ -2854,7 +2855,10 @@ function readCentroids(
       trackingScore,
       category: categories[i] ?? "",
       name: names[i] ?? "",
-      source: sources[i] ?? "",
+      // Normalize legacy camelCase `source` values written by older JS versions
+      // to Python's canonical snake_case (`centerOfMass` -> `center_of_mass`,
+      // etc.). `anchor:*` and arbitrary sources pass through unchanged.
+      source: normalizeCentroidSource(sources[i] ?? ""),
     };
 
     const isPred =

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -21,6 +21,7 @@ import type {
 } from "../../model/mask.js";
 import type { BoundingBox, PredictedBoundingBox } from "../../model/bbox.js";
 import type { Centroid, PredictedCentroid } from "../../model/centroid.js";
+import { normalizeCentroidSource } from "../../model/centroid.js";
 import type {
   LabelImage,
   PredictedLabelImage,
@@ -4880,7 +4881,11 @@ function writeCentroids(
     ]);
     categories.push(c.category);
     names.push(c.name);
-    sources.push(c.source);
+    // Persist the canonical snake_case source for Python/PyQt interop. Normally
+    // `c.source` is already snake_case (set by `fromInstance`/reader), but
+    // normalize defensively in case a caller built the Centroid with a legacy
+    // camelCase source directly.
+    sources.push(normalizeCentroidSource(c.source));
   }
 
   createMatrixDataset(

--- a/src/model/centroid.ts
+++ b/src/model/centroid.ts
@@ -8,6 +8,35 @@ import { Skeleton } from "./skeleton.js";
 import type { Identity } from "./identity.js";
 import type { Embedding } from "./embedding.js";
 
+/**
+ * Normalize a centroid `source`/`method` string to its canonical snake_case
+ * form for Python/PyQt on-disk interop.
+ *
+ * The SLP on-disk format is snake_case (Python-compatible). Historically the JS
+ * side used camelCase method names (`"centerOfMass"`, `"bboxCenter"`) both for
+ * the `fromInstance` `method` param and — via that param — for the persisted
+ * `source` value, which mismatched Python `sleap-io`. This maps the legacy
+ * camelCase names to Python's snake_case:
+ * - `"centerOfMass"` -> `"center_of_mass"`
+ * - `"bboxCenter"`   -> `"bbox_center"`
+ *
+ * All other values pass through unchanged: already-snake_case names
+ * (`"center_of_mass"`, `"bbox_center"`), `"anchor"` / `"anchor:<node>"`, and
+ * arbitrary sources (e.g. `"trackmate"`). Used by both `Centroid.fromInstance`
+ * (to normalize the `method` param) and the SLP reader (to normalize legacy
+ * camelCase `source` values on load).
+ */
+export function normalizeCentroidSource(source: string): string {
+  switch (source) {
+    case "centerOfMass":
+      return "center_of_mass";
+    case "bboxCenter":
+      return "bbox_center";
+    default:
+      return source;
+  }
+}
+
 /** Shared single-node skeleton for centroid-to-instance conversions. */
 let _centroidSkeleton: Skeleton | null = null;
 
@@ -152,7 +181,12 @@ export class Centroid {
    *
    * @param instance - Source instance.
    * @param options - Options for centroid extraction.
-   * @param options.method - "centerOfMass" (default), "bboxCenter", or "anchor".
+   * @param options.method - Computation method. Accepts both the legacy JS
+   *   camelCase names (`"centerOfMass"` (default), `"bboxCenter"`, `"anchor"`)
+   *   and Python's snake_case names (`"center_of_mass"`, `"bbox_center"`). The
+   *   persisted `source` is always the canonical snake_case value
+   *   (`"center_of_mass"`, `"bbox_center"`, or `"anchor:<node>"`) to match
+   *   Python `sleap-io` on disk.
    * @param options.node - Node name or index for "anchor" method.
    * @returns UserCentroid or PredictedCentroid depending on instance type.
    */
@@ -164,7 +198,9 @@ export class Centroid {
       [key: string]: unknown;
     },
   ): Centroid {
-    const method = options?.method ?? "centerOfMass";
+    // Normalize the method to its canonical snake_case form, accepting legacy
+    // camelCase inputs. The normalized value doubles as the persisted `source`.
+    const method = normalizeCentroidSource(options?.method ?? "centerOfMass");
 
     // Gather visible points
     const visiblePoints: [number, number][] = [];
@@ -181,17 +217,17 @@ export class Centroid {
     let x: number;
     let y: number;
 
-    if (method === "centerOfMass") {
+    if (method === "center_of_mass") {
       if (!visiblePoints.length) {
-        throw new Error("No visible points for centerOfMass.");
+        throw new Error("No visible points for center_of_mass.");
       }
       x =
         visiblePoints.reduce((sum, p) => sum + p[0], 0) / visiblePoints.length;
       y =
         visiblePoints.reduce((sum, p) => sum + p[1], 0) / visiblePoints.length;
-    } else if (method === "bboxCenter") {
+    } else if (method === "bbox_center") {
       if (!visiblePoints.length) {
-        throw new Error("No visible points for bboxCenter.");
+        throw new Error("No visible points for bbox_center.");
       }
       const xs = visiblePoints.map((p) => p[0]);
       const ys = visiblePoints.map((p) => p[1]);
@@ -218,7 +254,7 @@ export class Centroid {
       y = pt.xy[1];
     } else {
       throw new Error(
-        `Unknown method ${JSON.stringify(method)}. Expected 'centerOfMass', 'bboxCenter', or 'anchor'.`,
+        `Unknown method ${JSON.stringify(method)}. Expected 'center_of_mass', 'bbox_center', or 'anchor' (camelCase 'centerOfMass'/'bboxCenter' also accepted).`,
       );
     }
 

--- a/src/model/instance.ts
+++ b/src/model/instance.ts
@@ -512,7 +512,10 @@ export class Instance {
   /**
    * Create a Centroid from this instance.
    *
-   * @param method - "centerOfMass" (default), "bboxCenter", or "anchor".
+   * @param method - Computation method. Accepts the legacy camelCase names
+   *   (`"centerOfMass"` (default), `"bboxCenter"`, `"anchor"`) and Python's
+   *   snake_case names (`"center_of_mass"`, `"bbox_center"`). The persisted
+   *   `source` is always canonical snake_case for Python interop.
    * @param node - Node specification for "anchor" method.
    * @returns UserCentroid or PredictedCentroid depending on instance type.
    */

--- a/tests/centroid.test.ts
+++ b/tests/centroid.test.ts
@@ -5,6 +5,7 @@ import {
   PredictedCentroid,
   getCentroidSkeleton,
   CENTROID_SKELETON,
+  normalizeCentroidSource,
 } from "../src/model/centroid.js";
 import { Instance, PredictedInstance, Track } from "../src/model/instance.js";
 import { Skeleton } from "../src/model/skeleton.js";
@@ -126,7 +127,8 @@ describe("Centroid", () => {
     expect(c).toBeInstanceOf(UserCentroid);
     expect(c.x).toBe(20);
     expect(c.y).toBe(30);
-    expect(c.source).toBe("centerOfMass");
+    // Default camelCase method persists Python-canonical snake_case source.
+    expect(c.source).toBe("center_of_mass");
     expect(c.instance).toBe(inst);
   });
 
@@ -142,7 +144,26 @@ describe("Centroid", () => {
     const c = Centroid.fromInstance(inst, { method: "bboxCenter" });
     expect(c.x).toBe(50);
     expect(c.y).toBe(100);
-    expect(c.source).toBe("bboxCenter");
+    // camelCase method arg normalizes to snake_case source on disk.
+    expect(c.source).toBe("bbox_center");
+  });
+
+  it("fromInstance accepts snake_case method (Python parity)", () => {
+    const skel = new Skeleton(["a", "b"]);
+    const inst = new Instance({
+      points: [
+        { xy: [0, 0], visible: true, complete: true },
+        { xy: [100, 200], visible: true, complete: true },
+      ],
+      skeleton: skel,
+    });
+    const com = Centroid.fromInstance(inst, { method: "center_of_mass" });
+    expect(com.x).toBe(50);
+    expect(com.y).toBe(100);
+    expect(com.source).toBe("center_of_mass");
+
+    const bbox = Centroid.fromInstance(inst, { method: "bbox_center" });
+    expect(bbox.source).toBe("bbox_center");
   });
 
   it("fromInstance anchor method", () => {
@@ -206,6 +227,36 @@ describe("Centroid", () => {
     expect(() => Centroid.fromInstance(inst, { method: "invalid" })).toThrow(
       /Unknown method/,
     );
+  });
+
+  it("fromInstance anchor persists snake_case-agnostic 'anchor:<node>' source", () => {
+    const skel = new Skeleton(["head", "tail"]);
+    const inst = new Instance({
+      points: [
+        { xy: [10, 20], visible: true, complete: true, name: "head" },
+        { xy: [30, 40], visible: true, complete: true, name: "tail" },
+      ],
+      skeleton: skel,
+    });
+    const c = Centroid.fromInstance(inst, { method: "anchor", node: "tail" });
+    expect(c.source).toBe("anchor:tail");
+  });
+});
+
+describe("normalizeCentroidSource (Python-interop snake_case)", () => {
+  it("maps legacy camelCase on-disk values to canonical snake_case", () => {
+    // Simulates reading a source value written by an older JS version.
+    expect(normalizeCentroidSource("centerOfMass")).toBe("center_of_mass");
+    expect(normalizeCentroidSource("bboxCenter")).toBe("bbox_center");
+  });
+
+  it("passes through already-canonical and arbitrary sources unchanged", () => {
+    expect(normalizeCentroidSource("center_of_mass")).toBe("center_of_mass");
+    expect(normalizeCentroidSource("bbox_center")).toBe("bbox_center");
+    expect(normalizeCentroidSource("anchor")).toBe("anchor");
+    expect(normalizeCentroidSource("anchor:head")).toBe("anchor:head");
+    expect(normalizeCentroidSource("trackmate")).toBe("trackmate");
+    expect(normalizeCentroidSource("")).toBe("");
   });
 });
 


### PR DESCRIPTION
## Problem
sleap-io.js writes the SLP on-disk format in **snake_case for Python/PyQt compatibility** (all persisted field names are snake_case; the code says so explicitly). The centroid `source` value was the lone exception: `Centroid.fromInstance` stored the JS camelCase method name (`"centerOfMass"` / `"bboxCenter"`) and `read`/`writeCentroids` round-tripped it verbatim to the HDF5 `centroid_sources` dataset. So a JS-computed centroid persisted `centerOfMass`, but Python `sleap-io` uses `center_of_mass` / `bbox_center` — a silent cross-tool metadata mismatch.

## Fix
- New shared helper `normalizeCentroidSource(source)`: `"centerOfMass"→"center_of_mass"`, `"bboxCenter"→"bbox_center"`; `"anchor"` / `"anchor:<node>"` / already-snake_case / arbitrary strings pass through unchanged.
- `Centroid.fromInstance` now stores canonical **snake_case** `source` (matches Python's `Centroid.source`).
- `readCentroids` normalizes **legacy camelCase on read** → snake_case (back-compat for files already written by older sleap-io.js).
- `writeCentroids` normalizes defensively on write.
- The `method` parameter still accepts the legacy camelCase values **and** now Python-style snake_case.

## Testing
- `tests/centroid.test.ts`: assertions updated to snake_case; added coverage for snake_case method input, the normalizer (camelCase→snake, passthrough of anchor/snake/arbitrary/empty), and anchor round-trip.
- Gate: full suite **2116 pass / 0 fail**, tsc clean, biome clean.

Independent of the 0.5.6 save-stack work; can ship whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)