### PR TITLE
fix(slp): write centroids as a `/centroids` group (Python interop)

### DIFF
--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -2792,31 +2792,71 @@ function readCentroids(
   _videos: Video[],
   tracks: Track[],
 ): [Centroid, number, number][] {
-  const centroidsDs = file.get("centroids");
-  if (!centroidsDs) return [];
-  const data = normalizeStructDataset(centroidsDs);
+  // Two on-disk layouts are supported:
+  //  - Python / current JS: a `/centroids` GROUP with one child dataset per
+  //    field (x, y, z, video, frame_idx, track, instance, is_predicted, score,
+  //    tracking_score) plus string children (category/name/source).
+  //  - Legacy JS: a flat `/centroids` matrix dataset + `field_names` attr, with
+  //    sibling `centroid_categories`/`centroid_names`/`centroid_sources`.
+  let data: Record<string, ArrayLike<number>>;
+  let categories: string[];
+  let names: string[];
+  let sources: string[];
+
+  if (file.get("centroids/x")) {
+    // Group layout (matches Python sleap-io).
+    const col = (name: string): ArrayLike<number> =>
+      (file.get(`centroids/${name}`)?.value as ArrayLike<number>) ?? [];
+    data = {
+      x: col("x"),
+      y: col("y"),
+      z: col("z"),
+      video: col("video"),
+      frame_idx: col("frame_idx"),
+      track: col("track"),
+      instance: col("instance"),
+      is_predicted: col("is_predicted"),
+      score: col("score"),
+      tracking_score: col("tracking_score"),
+    };
+    const strCol = (name: string): string[] => {
+      const ds = file.get(`centroids/${name}`);
+      if (!ds) return [];
+      try {
+        return ((ds.value as ArrayLike<unknown>) ?? []).length
+          ? Array.from(ds.value as ArrayLike<unknown>, decodeStr)
+          : [];
+      } catch {
+        // Python may store these as vlen-str, which h5wasm can't always read;
+        // the centroid position/type/link still round-trips without them.
+        return [];
+      }
+    };
+    categories = strCol("category");
+    names = strCol("name");
+    sources = strCol("source");
+  } else {
+    const centroidsDs = file.get("centroids");
+    if (!centroidsDs) return [];
+    data = normalizeStructDataset(centroidsDs);
+    categories = readStringMetadata(
+      file,
+      "centroid_categories",
+      centroidsDs,
+      "categories",
+    );
+    names = readStringMetadata(file, "centroid_names", centroidsDs, "names");
+    sources = readStringMetadata(
+      file,
+      "centroid_sources",
+      centroidsDs,
+      "sources",
+    );
+  }
+
   const xs = data.x ?? [];
   const count = xs.length;
   if (!count) return [];
-
-  const categories = readStringMetadata(
-    file,
-    "centroid_categories",
-    centroidsDs,
-    "categories",
-  );
-  const names = readStringMetadata(
-    file,
-    "centroid_names",
-    centroidsDs,
-    "names",
-  );
-  const sources = readStringMetadata(
-    file,
-    "centroid_sources",
-    centroidsDs,
-    "sources",
-  );
 
   const ys = data.y ?? [];
   const zs = data.z ?? [];

--- a/src/codecs/slp/write.ts
+++ b/src/codecs/slp/write.ts
@@ -4849,36 +4849,36 @@ function writeCentroids(
 ): void {
   if (!centroids.length) return;
 
-  const rows: number[][] = [];
+  const n = centroids.length;
+  const x = new Float64Array(n);
+  const y = new Float64Array(n);
+  const z = new Float64Array(n);
+  const video = new Int32Array(n);
+  const frameIdx = new Int32Array(n);
+  const track = new Int32Array(n);
+  const instance = new Int32Array(n);
+  const isPredicted = new Uint8Array(n);
+  const score = new Float64Array(n);
+  const trackingScore = new Float64Array(n);
   const categories: string[] = [];
   const names: string[] = [];
   const sources: string[] = [];
 
-  for (let i = 0; i < centroids.length; i++) {
+  for (let i = 0; i < n; i++) {
     const c = centroids[i];
-    const videoIdx = contexts ? contexts[i][0] : -1;
-    const frameIdx = contexts ? contexts[i][1] : -1;
-    const trackIdx = c.track ? tracks.indexOf(c.track as any) : -1;
-    const score = c.isPredicted ? (c as PredictedCentroid).score : Number.NaN;
+    x[i] = c.x;
+    y[i] = c.y;
+    z[i] = c.z ?? Number.NaN;
+    video[i] = contexts ? contexts[i][0] : -1;
+    frameIdx[i] = contexts ? contexts[i][1] : -1;
+    track[i] = c.track ? tracks.indexOf(c.track as any) : -1;
     // Fall back to stored _instanceIdx when no live instance link (e.g., lazy mode).
-    const instanceIdx = c.instance
+    instance[i] = c.instance
       ? instances.indexOf(c.instance as Instance)
       : (c._instanceIdx ?? -1);
-    const isPredicted = c.isPredicted ? 1 : 0;
-    const trackingScore = c.trackingScore ?? Number.NaN;
-
-    rows.push([
-      c.x,
-      c.y,
-      c.z ?? Number.NaN,
-      videoIdx,
-      frameIdx,
-      trackIdx,
-      instanceIdx,
-      isPredicted,
-      score,
-      trackingScore,
-    ]);
+    isPredicted[i] = c.isPredicted ? 1 : 0;
+    score[i] = c.isPredicted ? (c as PredictedCentroid).score : Number.NaN;
+    trackingScore[i] = c.trackingScore ?? Number.NaN;
     categories.push(c.category);
     names.push(c.name);
     // Persist the canonical snake_case source for Python/PyQt interop. Normally
@@ -4888,26 +4888,25 @@ function writeCentroids(
     sources.push(normalizeCentroidSource(c.source));
   }
 
-  createMatrixDataset(
-    file,
-    "centroids",
-    rows,
-    [
-      "x",
-      "y",
-      "z",
-      "video",
-      "frame_idx",
-      "track",
-      "instance",
-      "is_predicted",
-      "score",
-      "tracking_score",
-    ],
-    "<f8",
-  );
-
-  writeStringDataset(file, "centroid_categories", categories);
-  writeStringDataset(file, "centroid_names", names);
-  writeStringDataset(file, "centroid_sources", sources);
+  // Match Python sleap-io's on-disk layout: a `/centroids` GROUP with one named
+  // dataset per field (NOT a flat matrix), so Python/PyQt sleap-io can read
+  // JS-written centroids. (Previously JS wrote a 2-D matrix dataset + a
+  // `field_names` attr, which Python's group-expecting reader rejects with
+  // "Field names only allowed for compound types".)
+  file.create_group("centroids");
+  const col = (name: string, data: ArrayLike<number>, dtype: string) =>
+    file.create_dataset({ name: `centroids/${name}`, data, shape: [n], dtype });
+  col("x", x, "<d");
+  col("y", y, "<d");
+  col("z", z, "<d");
+  col("video", video, "<i4");
+  col("frame_idx", frameIdx, "<i4");
+  col("track", track, "<i4");
+  col("instance", instance, "<i4");
+  col("is_predicted", isPredicted, "<B");
+  col("score", score, "<d");
+  col("tracking_score", trackingScore, "<d");
+  file.create_dataset({ name: "centroids/category", data: categories });
+  file.create_dataset({ name: "centroids/name", data: names });
+  file.create_dataset({ name: "centroids/source", data: sources });
 }

--- a/tests/python-compat-gen.test.ts
+++ b/tests/python-compat-gen.test.ts
@@ -13,9 +13,10 @@ import { LabeledFrame } from "../src/model/labeled-frame.js";
 import { ROI } from "../src/model/roi.js";
 import { SegmentationMask } from "../src/model/mask.js";
 import { UserBoundingBox } from "../src/model/bbox.js";
+import { UserCentroid, PredictedCentroid } from "../src/model/centroid.js";
 import { Track } from "../src/model/instance.js";
 import { ready, File as H5File } from "h5wasm/node";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { writeFileSync, unlinkSync, readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -31,6 +32,35 @@ function tmpSlp(): string {
     tmpdir(),
     `sleap-io-js-test-${Date.now()}-${Math.random().toString(16).slice(2)}.slp`,
   );
+}
+
+// Centroid annotations landed in sleap-io after the current PyPI release
+// (0.6.x has no `sleap_io.model.centroid`); they ship in sleap-io main / the
+// version sleap-nn bundles. Probe once so the Python-direction centroid tests
+// SKIP (rather than fail) until `uv run --with sleap-io` resolves a build that
+// has them, at which point they activate automatically.
+let _pyHasCentroids: boolean | undefined;
+function pythonHasCentroids(): boolean {
+  if (_pyHasCentroids === undefined) {
+    try {
+      execFileSync(
+        "uv",
+        [
+          "run",
+          "--with",
+          "sleap-io",
+          "python",
+          "-c",
+          "import sleap_io.model.centroid",
+        ],
+        { timeout: 120000, stdio: "pipe" },
+      );
+      _pyHasCentroids = true;
+    } catch {
+      _pyHasCentroids = false;
+    }
+  }
+  return _pyHasCentroids;
 }
 
 describe("Python compatibility (#76)", () => {
@@ -397,6 +427,164 @@ print("OK: Python reads JS-written image sequence")
         { encoding: "utf-8", timeout: 120000 },
       );
       expect(result).toContain("OK: Python reads JS-written image sequence");
+    } finally {
+      try {
+        unlinkSync(slpPath);
+      } catch {}
+      try {
+        unlinkSync(pyPath);
+      } catch {}
+    }
+  });
+});
+
+describe("Centroid annotation cross-compat (#centroids)", () => {
+  // Build a project with a pose instance + a UserCentroid linked to it, and a
+  // standalone PredictedCentroid on another frame. Exercises the `/centroids`
+  // group layout that Python sleap-io reads (`grp["x"]`, `grp["instance"]`...).
+  function centroidLabels(): Labels {
+    const skeleton = new Skeleton({
+      name: "rodent",
+      nodes: ["snout", "neck", "tailbase"],
+    });
+    const video = new Video({ filename: "fake.mp4" });
+    const inst = new Instance({
+      skeleton,
+      points: [
+        { xy: [10, 10], visible: true, complete: true },
+        { xy: [12, 12], visible: true, complete: true },
+        { xy: [14, 14], visible: true, complete: true },
+      ],
+    });
+    const uc = new UserCentroid({ x: 12, y: 12, instance: inst, name: "cm" });
+    const pc = new PredictedCentroid({ x: 99, y: 88, score: 0.77 });
+    return new Labels({
+      skeletons: [skeleton],
+      videos: [video],
+      labeledFrames: [
+        new LabeledFrame({
+          video,
+          frameIdx: 0,
+          instances: [inst],
+          centroids: [uc],
+        }),
+        new LabeledFrame({
+          video,
+          frameIdx: 1,
+          instances: [],
+          centroids: [pc],
+        }),
+      ],
+    });
+  }
+
+  it("round-trips: sleap-io.js reads its own centroids", async () => {
+    const { readSlp } = await import("../src/codecs/slp/read.js");
+    const loaded = await readSlp(await saveSlpToBytes(centroidLabels()), {
+      openVideos: false,
+    });
+    const cents = loaded.labeledFrames.flatMap((lf) => lf.centroids);
+    expect(cents.length).toBe(2);
+    const user = cents.find((c) => !c.isPredicted)!;
+    const pred = cents.find((c) => c.isPredicted)!;
+    expect(user.xy).toEqual([12, 12]);
+    expect(user.name).toBe("cm");
+    expect(user.instance).not.toBeNull(); // linked pose instance survives
+    expect((pred as PredictedCentroid).score).toBeCloseTo(0.77, 5);
+  });
+
+  it("Python sleap-io reads JS-written centroids (would crash pre-fix)", async () => {
+    if (!pythonHasCentroids()) {
+      console.warn(
+        "[skip] Python sleap-io lacks centroid support (PyPI 0.6.x); activates once released.",
+      );
+      return;
+    }
+    const slpPath = tmpSlp();
+    const pyPath = slpPath.replace(/\.slp$/, ".py");
+    try {
+      writeFileSync(slpPath, await saveSlpToBytes(centroidLabels()));
+      // Pre-fix, JS wrote `/centroids` as a 2-D matrix dataset, so Python's
+      // group-expecting reader raised "Field names only allowed for compound
+      // types" and load_slp failed. This asserts the group layout is readable.
+      const pyScript = `
+import sleap_io as sio
+labels = sio.load_slp(${JSON.stringify(slpPath)})
+cents = [c for lf in labels.labeled_frames for c in lf.centroids]
+assert len(cents) == 2, f"Expected 2 centroids, got {len(cents)}"
+user = [c for c in cents if not c.is_predicted]
+pred = [c for c in cents if c.is_predicted]
+assert len(user) == 1 and len(pred) == 1, f"Wrong user/pred split: {len(user)}/{len(pred)}"
+assert tuple(user[0].xy) == (12.0, 12.0), f"Bad user xy: {user[0].xy}"
+assert user[0].name == "cm", f"Bad name: {user[0].name!r}"
+assert user[0].instance is not None, "User centroid lost its instance link"
+assert abs(pred[0].score - 0.77) < 1e-4, f"Bad predicted score: {pred[0].score}"
+print("OK: Python reads JS-written centroids")
+`;
+      writeFileSync(pyPath, pyScript);
+      const result = execFileSync(
+        "uv",
+        ["run", "--with", "sleap-io", "python", pyPath],
+        { encoding: "utf-8", timeout: 120000 },
+      );
+      expect(result).toContain("OK: Python reads JS-written centroids");
+    } finally {
+      try {
+        unlinkSync(slpPath);
+      } catch {}
+      try {
+        unlinkSync(pyPath);
+      } catch {}
+    }
+  });
+
+  it("sleap-io.js reads Python-written centroids", async () => {
+    if (!pythonHasCentroids()) {
+      console.warn(
+        "[skip] Python sleap-io lacks centroid support (PyPI 0.6.x); activates once released.",
+      );
+      return;
+    }
+    const { readSlp } = await import("../src/codecs/slp/read.js");
+    const slpPath = tmpSlp();
+    const pyPath = slpPath.replace(/\.slp$/, ".py");
+    try {
+      // Python writes the canonical `/centroids` group; JS must read it (pre-fix
+      // JS silently returned 0 centroids from a Python file).
+      const pyScript = `
+import numpy as np
+import sleap_io as sio
+from sleap_io.model.centroid import UserCentroid, PredictedCentroid
+
+skel = sio.Skeleton(["snout", "neck", "tailbase"], name="rodent")
+video = sio.Video.from_filename("fake.mp4")
+inst = sio.Instance.from_numpy(np.array([[10, 10], [12, 12], [14, 14]], "float32"), skeleton=skel)
+uc = UserCentroid(x=12.0, y=12.0, instance=inst, name="cm")
+pc = PredictedCentroid(x=99.0, y=88.0, score=0.77)
+lf0 = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst], centroids=[uc])
+lf1 = sio.LabeledFrame(video=video, frame_idx=1, centroids=[pc])
+labels = sio.Labels(videos=[video], skeletons=[skel], labeled_frames=[lf0, lf1])
+sio.save_slp(labels, ${JSON.stringify(slpPath)}, embed=False)
+print("OK: Python wrote centroids")
+`;
+      writeFileSync(pyPath, pyScript);
+      const out = execFileSync(
+        "uv",
+        ["run", "--with", "sleap-io", "python", pyPath],
+        { encoding: "utf-8", timeout: 120000 },
+      );
+      expect(out).toContain("OK: Python wrote centroids");
+
+      const loaded = await readSlp(new Uint8Array(readFileSync(slpPath)), {
+        openVideos: false,
+      });
+      const cents = loaded.labeledFrames.flatMap((lf) => lf.centroids);
+      expect(cents.length).toBe(2);
+      const user = cents.find((c) => !c.isPredicted)!;
+      const pred = cents.find((c) => c.isPredicted)!;
+      expect(user.xy).toEqual([12, 12]);
+      expect(user.name).toBe("cm");
+      expect((pred as PredictedCentroid).score).toBeCloseTo(0.77, 4);
     } finally {
       try {
         unlinkSync(slpPath);


### PR DESCRIPTION
Fixes #234.

## Problem

sleap-io.js wrote centroids as a single 2-D **matrix** dataset `/centroids` (+ a `field_names` attr) plus sibling `centroid_categories`/`centroid_names`/`centroid_sources` string datasets, while Python `sleap-io` writes/reads a `/centroids` **group** with one named dataset per field. As a result:

- **JS → Python: hard crash.** `sio.load_slp()` on a JS-written file containing centroids raises `ValueError: Field names only allowed for compound types` — the file is entirely unloadable by Python (and thus sleap-nn).
- **Python → JS: silent drop.** A Python-written file's centroids read back as 0 in JS.

This blocks the active-learning path (seed centroids in a JS app → train a locator in sleap-nn via Python `sleap-io`).

## Fix

- `writeCentroids` (`src/codecs/slp/write.ts`) now creates a `/centroids` **group** with the 13 Python-canonical datasets: `x`, `y`, `z` (`<f8`), `video`, `frame_idx`, `track`, `instance` (`<i4`, `-1` = none), `is_predicted` (`<u1`), `score`, `tracking_score` (NaN = absent), and `category`/`name`/`source` string datasets — matching Python's on-disk layout.
- `readCentroids` (`src/codecs/slp/read.ts`) reads the group form, and **falls back** to the legacy flat-matrix layout when `/centroids` is a dataset, so previously-written JS files still load.
- Additive only: no `format_id` bump, nothing added to the metadata JSON, group written only when ≥1 centroid exists.

## Tests

Added to `tests/python-compat-gen.test.ts`:
- JS→JS centroid round-trip (always on): position, type, name, predicted score, and the `Centroid.instance` link survive.
- JS→Python and Python→JS cross-compat round-trips. These **skip** when the installed `sleap-io` predates the centroid module (current PyPI `0.6.x` has none); they activate automatically once centroids ship to PyPI.

Verified locally against the `sleap-io` build that sleap-nn bundles (0.8.0-dev, which has the centroid module): Python `load_slp` now reads a JS-written centroids file (correct xy, `is_predicted`, score, name, and resolved instance link), and JS reads a Python-written centroids file.

Existing centroid/SLP/streaming tests pass; `tsc --noEmit` and `biome check` clean on the changed files.