### PR TITLE
chore(release): bump version to 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Bump `package.json` version `0.5.5` → `0.5.6` ahead of the v0.5.6 release.

Save/edit-save overhaul for large embedded `.pkg.slp`, plus Python-interop fixes for pose tables and centroids.

## Included (v0.5.5 → main, 6 PRs)

### Features
- **In-place label edit-save** (#229): `updateLabelsInPlace` rewrites only the label tables (frames/instances/points) in an existing `.pkg.slp`, leaving the embedded image blobs untouched — ~100× faster saves on large embedded files.
- **Streaming embedded-video append writer** (#223): the write B-seam appends frames incrementally instead of staging the whole file in memory, enabling saves of very large (multi-GB) embedded projects.

### Fixes — Python interoperability
- **Compound pose tables** (#228, closes #218): `instances`, `points`, and `pred_points` are written as HDF5 compound datasets with proper integer/float columns matching Python `sleap-io`, chunked so they can be edited in place.
- **float64 point ids** (#232, closes #231): the streaming/in-place `instances` table is written as true float64 (`"<d"`), so `point_id_start`/`point_id_end` no longer round to even values past 2^24 (~16.7M point rows) and silently misassign points to the wrong skeleton nodes.
- **Centroid `source` casing** (#233): persisted as snake_case (`center_of_mass`, `bbox_center`) — the Python-canonical form; legacy camelCase is normalized on read.
- **Centroid layout** (#235): centroids are written as a `/centroids` group, matching the on-disk structure Python `sleap-io` / `sleap-nn` expect for multi-skeleton (centroid + instance) training.

## Notes
- #228 changes the on-disk layout of the pose tables (float matrix → HDF5 compound). Files written by 0.5.6 are readable by Python `sleap-io` (compound-native) and by 0.5.6+ readers.
- **Layout direction:** the pose tables (#228) ship as *compound* this release, but the agreed migration target is *columnar* (per-field datasets, h5wasm/jsfive-friendly), tracked in #237. Centroids (#235) and the 2.5/2.7/2.8 subsystems are already columnar. No interop break — every current write layout is Python-readable today.
- **Deferred:** read-side validation/repair of legacy files whose point spans ≠ skeleton node count (#230) → 0.5.7.

## Downstream
- Unblocks sleap-app #220 (save overhaul) — bump its `@talmolab/sleap-io.js` pin `0.5.4` → `0.5.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
