### PR TITLE
fix(slp): read `/centroids` group in the streaming reader (browser/Tauri)

### DIFF
--- a/src/codecs/slp/centroids.ts
+++ b/src/codecs/slp/centroids.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared centroid reconstruction from columnar `/centroids` group data.
+ *
+ * Both the synchronous eager/lazy reader (`read.ts`) and the async streaming
+ * reader (`read-streaming.ts`) gather the same per-field columns; this turns
+ * those columns into `Centroid` objects so the construction logic (User vs
+ * Predicted, NaN sentinels, track/instance relinking, source normalization)
+ * lives in one place.
+ */
+import { type Centroid, UserCentroid, PredictedCentroid, normalizeCentroidSource } from "../../model/centroid.js";
+import type { Track } from "../../model/instance.js";
+
+/** Numeric columns of the `/centroids` group, keyed by field name. */
+export type CentroidColumns = Record<string, ArrayLike<number>>;
+
+/**
+ * Build `[centroid, videoIdx, frameIdx]` routing tuples from centroid columns.
+ * `data` holds the numeric columns (x, y, z, video, frame_idx, track, instance,
+ * is_predicted, score, tracking_score); `categories`/`names`/`sources` are the
+ * decoded string columns. `tracks` resolves the `track` index (−1 = none).
+ * Missing z/score/tracking_score → `null`; `instance` index (−1 = none) is
+ * stashed on `_instanceIdx` for deferred relinking by the caller.
+ */
+export function buildCentroidTuples(
+  data: CentroidColumns,
+  categories: string[],
+  names: string[],
+  sources: string[],
+  tracks: Track[],
+): [Centroid, number, number][] {
+  const xs = data.x ?? [];
+  const count = xs.length;
+  if (!count) return [];
+
+  const ys = data.y ?? [];
+  const zs = data.z ?? [];
+  const videoIndices = data.video ?? [];
+  const frameIndices = data.frame_idx ?? [];
+  const trackIndices = data.track ?? [];
+  const instanceIndices = data.instance ?? [];
+  const isPredictedCol = data.is_predicted ?? [];
+  const scores = data.score ?? [];
+  const trackingScores = data.tracking_score ?? [];
+
+  const centroids: [Centroid, number, number][] = [];
+  for (let i = 0; i < count; i++) {
+    const videoIdx = Number(videoIndices[i]);
+    const frameIdxVal = Number(frameIndices[i]);
+
+    const trackIdx = Number(trackIndices[i]);
+    const track =
+      trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
+
+    const zVal = zs.length > i ? Number(zs[i]) : Number.NaN;
+    const z = Number.isNaN(zVal) ? null : zVal;
+
+    const tsVal =
+      trackingScores.length > i ? Number(trackingScores[i]) : Number.NaN;
+    const trackingScore = Number.isNaN(tsVal) ? null : tsVal;
+
+    const instanceIdx = Number(instanceIndices[i]);
+
+    const options = {
+      x: Number(xs[i]),
+      y: Number(ys[i]),
+      z,
+      track,
+      trackingScore,
+      category: categories[i] ?? "",
+      name: names[i] ?? "",
+      // Normalize legacy camelCase `source` values written by older JS versions
+      // to Python's canonical snake_case (`centerOfMass` -> `center_of_mass`,
+      // etc.). `anchor:*` and arbitrary sources pass through unchanged.
+      source: normalizeCentroidSource(sources[i] ?? ""),
+    };
+
+    const isPred =
+      isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
+
+    let centroid: Centroid;
+    if (isPred) {
+      const scoreVal = Number(scores[i]);
+      centroid = new PredictedCentroid({
+        ...options,
+        score: Number.isNaN(scoreVal) ? 0 : scoreVal,
+      });
+    } else {
+      centroid = new UserCentroid(options);
+    }
+
+    if (instanceIdx >= 0) {
+      centroid._instanceIdx = instanceIdx;
+    }
+
+    centroids.push([centroid, videoIdx, frameIdxVal]);
+  }
+  return centroids;
+}

--- a/src/codecs/slp/centroids.ts
+++ b/src/codecs/slp/centroids.ts
@@ -7,7 +7,12 @@
  * Predicted, NaN sentinels, track/instance relinking, source normalization)
  * lives in one place.
  */
-import { type Centroid, UserCentroid, PredictedCentroid, normalizeCentroidSource } from "../../model/centroid.js";
+import {
+  type Centroid,
+  UserCentroid,
+  PredictedCentroid,
+  normalizeCentroidSource,
+} from "../../model/centroid.js";
 import type { Track } from "../../model/instance.js";
 
 /** Numeric columns of the `/centroids` group, keyed by field name. */

--- a/src/codecs/slp/read-streaming.ts
+++ b/src/codecs/slp/read-streaming.ts
@@ -38,6 +38,8 @@ import {
 import { buildSourceVideoFromDict } from "./source-video.js";
 import { Labels } from "../../model/labels.js";
 import { LabeledFrame } from "../../model/labeled-frame.js";
+import type { Centroid } from "../../model/centroid.js";
+import { buildCentroidTuples } from "./centroids.js";
 import { LazyDataStore, LazyFrameList } from "../../model/lazy.js";
 import { buildVideoIdMap } from "../../model/video-id-map.js";
 import {
@@ -150,6 +152,62 @@ export interface StreamingSlpOptions {
  * });
  * ```
  */
+/**
+ * Read the `/centroids` group (SLP first-class centroid annotations) via the
+ * streaming file API. Mirrors the eager `readCentroids`, but each column is an
+ * async range read. Returns `[centroid, videoIdx, frameIdx]` routing tuples;
+ * `[]` when the group is absent. Without this, a browser/Tauri load (which uses
+ * the streaming reader) silently drops centroids that the eager/lazy readers keep.
+ */
+async function readCentroidsStreaming(
+  file: StreamingH5File,
+  tracks: Track[],
+): Promise<[Centroid, number, number][]> {
+  try {
+    if (!file.keys().includes("centroids")) return [];
+    const numCol = async (name: string): Promise<ArrayLike<number>> => {
+      try {
+        const d = await file.getDatasetValue(`centroids/${name}`);
+        return normalizeDatasetArray(d.value) as ArrayLike<number>;
+      } catch {
+        return [];
+      }
+    };
+    const data: Record<string, ArrayLike<number>> = {
+      x: await numCol("x"),
+      y: await numCol("y"),
+      z: await numCol("z"),
+      video: await numCol("video"),
+      frame_idx: await numCol("frame_idx"),
+      track: await numCol("track"),
+      instance: await numCol("instance"),
+      is_predicted: await numCol("is_predicted"),
+      score: await numCol("score"),
+      tracking_score: await numCol("tracking_score"),
+    };
+    const strCol = async (name: string): Promise<string[]> => {
+      try {
+        const d = await file.getDatasetValue(`centroids/${name}`);
+        return normalizeDatasetArray(d.value).map((v) =>
+          typeof v === "string"
+            ? v
+            : v instanceof Uint8Array
+              ? new TextDecoder().decode(v)
+              : String(v ?? ""),
+        );
+      } catch {
+        return [];
+      }
+    };
+    const categories = await strCol("category");
+    const names = await strCol("name");
+    const sources = await strCol("source");
+    return buildCentroidTuples(data, categories, names, sources, tracks);
+  } catch {
+    return [];
+  }
+}
+
 export async function readSlpStreaming(
   source: StreamingH5Source,
   options?: StreamingSlpOptions,
@@ -376,6 +434,63 @@ export async function readFromStreamingFile(
         lazyStore._instanceCategoryLinks = catLinks;
         lazyStore._instanceCategoryEmbeddings = catEmbs;
       }
+    }
+  }
+
+  // Centroids (`/centroids` group). The eager and lazy readers read these; the
+  // streaming reader (browser/Tauri WebView) must too, or a loaded project
+  // silently drops its centroid annotations.
+  const centroidTuples = await readCentroidsStreaming(file, tracks);
+  if (centroidTuples.length) {
+    if (labeledFrames) {
+      const frameMap = new Map<string, LabeledFrame>();
+      for (const lf of labeledFrames) {
+        frameMap.set(`${videos.indexOf(lf.video)}:${lf.frameIdx}`, lf);
+      }
+      const getOrCreate = (vidIdx: number, frameIdx: number): LabeledFrame => {
+        const key = `${vidIdx}:${frameIdx}`;
+        let lf = frameMap.get(key);
+        if (!lf) {
+          lf = new LabeledFrame({ video: videos[vidIdx], frameIdx });
+          frameMap.set(key, lf);
+          labeledFrames.push(lf);
+        }
+        return lf;
+      };
+      for (const [c, vidIdx, frameIdx] of centroidTuples) {
+        if (vidIdx >= 0 && vidIdx < videos.length && frameIdx >= 0) {
+          getOrCreate(vidIdx, frameIdx).centroids.push(c);
+        }
+      }
+      // Resolve deferred instance refs (mirrors the eager reader).
+      const allInst = labeledFrames.flatMap((lf) => lf.instances);
+      for (const lf of labeledFrames) {
+        for (const c of lf.centroids) {
+          if (
+            c._instanceIdx !== null &&
+            c._instanceIdx >= 0 &&
+            c._instanceIdx < allInst.length
+          ) {
+            c.instance = allInst[c._instanceIdx];
+            c._instanceIdx = null;
+          }
+        }
+      }
+    } else if (lazyStore) {
+      const byFrame = new Map<string, Centroid[]>();
+      const undistributed: Centroid[] = [];
+      for (const [c, vidIdx, frameIdx] of centroidTuples) {
+        if (vidIdx >= 0 && frameIdx >= 0) {
+          const key = `${vidIdx}:${frameIdx}`;
+          const list = byFrame.get(key);
+          if (list) list.push(c);
+          else byFrame.set(key, [c]);
+        } else {
+          undistributed.push(c);
+        }
+      }
+      lazyStore._centroidByFrame = byFrame;
+      lazyStore._undistributedCentroids = undistributed;
     }
   }
 

--- a/src/codecs/slp/read.ts
+++ b/src/codecs/slp/read.ts
@@ -75,12 +75,8 @@ import {
   UserBoundingBox,
   PredictedBoundingBox,
 } from "../../model/bbox.js";
-import {
-  type Centroid,
-  UserCentroid,
-  PredictedCentroid,
-  normalizeCentroidSource,
-} from "../../model/centroid.js";
+import { type Centroid } from "../../model/centroid.js";
+import { buildCentroidTuples } from "./centroids.js";
 import {
   type LabelImage,
   UserLabelImage,
@@ -2854,72 +2850,5 @@ function readCentroids(
     );
   }
 
-  const xs = data.x ?? [];
-  const count = xs.length;
-  if (!count) return [];
-
-  const ys = data.y ?? [];
-  const zs = data.z ?? [];
-  const videoIndices = data.video ?? [];
-  const frameIndices = data.frame_idx ?? [];
-  const trackIndices = data.track ?? [];
-  const instanceIndices = data.instance ?? [];
-  const isPredictedCol = data.is_predicted ?? [];
-  const scores = data.score ?? [];
-  const trackingScores = data.tracking_score ?? [];
-
-  const centroids: [Centroid, number, number][] = [];
-  for (let i = 0; i < count; i++) {
-    const videoIdx = Number(videoIndices[i]);
-
-    const frameIdxVal = Number(frameIndices[i]);
-
-    const trackIdx = Number(trackIndices[i]);
-    const track =
-      trackIdx >= 0 && trackIdx < tracks.length ? tracks[trackIdx] : null;
-
-    const zVal = zs.length > i ? Number(zs[i]) : Number.NaN;
-    const z = Number.isNaN(zVal) ? null : zVal;
-
-    const tsVal =
-      trackingScores.length > i ? Number(trackingScores[i]) : Number.NaN;
-    const trackingScore = Number.isNaN(tsVal) ? null : tsVal;
-
-    const instanceIdx = Number(instanceIndices[i]);
-
-    const options = {
-      x: Number(xs[i]),
-      y: Number(ys[i]),
-      z,
-      track,
-      trackingScore,
-      category: categories[i] ?? "",
-      name: names[i] ?? "",
-      // Normalize legacy camelCase `source` values written by older JS versions
-      // to Python's canonical snake_case (`centerOfMass` -> `center_of_mass`,
-      // etc.). `anchor:*` and arbitrary sources pass through unchanged.
-      source: normalizeCentroidSource(sources[i] ?? ""),
-    };
-
-    const isPred =
-      isPredictedCol.length > i ? Number(isPredictedCol[i]) === 1 : false;
-
-    let centroid: Centroid;
-    if (isPred) {
-      const scoreVal = Number(scores[i]);
-      centroid = new PredictedCentroid({
-        ...options,
-        score: Number.isNaN(scoreVal) ? 0 : scoreVal,
-      });
-    } else {
-      centroid = new UserCentroid(options);
-    }
-
-    if (instanceIdx >= 0) {
-      centroid._instanceIdx = instanceIdx;
-    }
-
-    centroids.push([centroid, videoIdx, frameIdxVal]);
-  }
-  return centroids;
+  return buildCentroidTuples(data, categories, names, sources, tracks);
 }

--- a/tests/streaming-centroids.test.ts
+++ b/tests/streaming-centroids.test.ts
@@ -57,7 +57,12 @@ function centroidLabels(): Labels {
     skeletons: [pose],
     videos: [video],
     labeledFrames: [
-      new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [uc] }),
+      new LabeledFrame({
+        video,
+        frameIdx: 0,
+        instances: [inst],
+        centroids: [uc],
+      }),
       new LabeledFrame({ video, frameIdx: 1, instances: [], centroids: [pc] }),
     ],
   });
@@ -70,7 +75,10 @@ async function makeFakeStreamingFile(bytes: Uint8Array): Promise<{
   close: () => void;
 }> {
   const module = await ready;
-  const disk = join(tmpdir(), `stream_centroids_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`);
+  const disk = join(
+    tmpdir(),
+    `stream_centroids_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`,
+  );
   writeFileSync(disk, bytes);
   try {
     module.FS.mkdir("/tmp");
@@ -98,12 +106,19 @@ async function makeFakeStreamingFile(bytes: Uint8Array): Promise<{
       unwrapAttrs((get(dp)?.attrs as Record<string, unknown>) ?? {}),
     getDatasetMeta: async (dp: string) => {
       const d = get(dp);
-      return { shape: (d?.shape as number[]) ?? [], dtype: (d?.dtype as string) ?? "" };
+      return {
+        shape: (d?.shape as number[]) ?? [],
+        dtype: (d?.dtype as string) ?? "",
+      };
     },
     getDatasetValue: async (dp: string) => {
       if (dp in columns) return { value: columns[dp], shape: [], dtype: "" };
       const d = get(dp);
-      return { value: d?.value, shape: (d?.shape as number[]) ?? [], dtype: (d?.dtype as string) ?? "" };
+      return {
+        value: d?.value,
+        shape: (d?.shape as number[]) ?? [],
+        dtype: (d?.dtype as string) ?? "",
+      };
     },
   } as unknown as StreamingH5File;
 
@@ -126,7 +141,15 @@ async function makeFakeStreamingFile(bytes: Uint8Array): Promise<{
 }
 
 const readStreaming = (fake: StreamingH5File, lazy: boolean) =>
-  readFromStreamingFile(fake, "test.slp", "test.slp", false, undefined, false, lazy);
+  readFromStreamingFile(
+    fake,
+    "test.slp",
+    "test.slp",
+    false,
+    undefined,
+    false,
+    lazy,
+  );
 
 describe("streaming reader — centroids", () => {
   it("eager streaming reads /centroids (was silently dropped)", async () => {

--- a/tests/streaming-centroids.test.ts
+++ b/tests/streaming-centroids.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression: the STREAMING SLP reader (browser/Tauri WebView path) must read
+ * the `/centroids` group. It previously read none — the eager/lazy readers had
+ * `readCentroids` but `read-streaming.ts` did not — so a loaded project silently
+ * dropped its centroid annotations in the browser. Drives the exported
+ * `readFromStreamingFile` with a fake `StreamingH5File` (no Worker), same
+ * pattern as streaming-lazy.test.ts.
+ */
+import { describe, it, expect } from "./bun-test";
+import { readSlpLazy } from "../src/codecs/slp/read.js";
+import { readFromStreamingFile } from "../src/codecs/slp/read-streaming.js";
+import type { StreamingH5File } from "../src/codecs/slp/h5-streaming.js";
+import {
+  Labels,
+  LabeledFrame,
+  Instance,
+  Skeleton,
+  Video,
+  UserCentroid,
+  PredictedCentroid,
+  PredictedCentroid as _PC,
+  saveSlpToBytes,
+} from "../src/index.js";
+import { ready, File as H5File } from "h5wasm/node";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+void _PC;
+
+function unwrapAttrs(attrs: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(attrs ?? {})) {
+    out[k] =
+      v && typeof v === "object" && "value" in (v as Record<string, unknown>)
+        ? (v as { value: unknown }).value
+        : v;
+  }
+  return out;
+}
+
+/** A project: pose instance + a UserCentroid linked to it (frame 0), and a
+ * standalone PredictedCentroid on frame 1 (centroid-only frame). */
+function centroidLabels(): Labels {
+  const pose = new Skeleton({ nodes: ["nose", "tail"], name: "rodent" });
+  const video = new Video({ filename: "v.mp4" });
+  const inst = new Instance({
+    skeleton: pose,
+    points: [
+      { xy: [10, 10], visible: true, complete: true },
+      { xy: [30, 30], visible: true, complete: true },
+    ],
+  });
+  const uc = new UserCentroid({ x: 12, y: 12, instance: inst, name: "cm" });
+  const pc = new PredictedCentroid({ x: 99, y: 88, score: 0.77 });
+  return new Labels({
+    skeletons: [pose],
+    videos: [video],
+    labeledFrames: [
+      new LabeledFrame({ video, frameIdx: 0, instances: [inst], centroids: [uc] }),
+      new LabeledFrame({ video, frameIdx: 1, instances: [], centroids: [pc] }),
+    ],
+  });
+}
+
+/** Build a fake StreamingH5File over a temp .slp (compound pose tables from a
+ * real lazy store, other datasets from h5wasm/node). */
+async function makeFakeStreamingFile(bytes: Uint8Array): Promise<{
+  fake: StreamingH5File;
+  close: () => void;
+}> {
+  const module = await ready;
+  const disk = join(tmpdir(), `stream_centroids_${Date.now()}_${Math.random().toString(16).slice(2)}.slp`);
+  writeFileSync(disk, bytes);
+  try {
+    module.FS.mkdir("/tmp");
+  } catch {
+    /* exists */
+  }
+  const mem = `/tmp/stream_centroids_${Date.now()}.slp`;
+  module.FS.writeFile(mem, bytes);
+  const h5 = new H5File(mem, "r");
+
+  const store = (await readSlpLazy(disk, { openVideos: false }))._lazyDataStore;
+  if (!store) throw new Error("readSlpLazy produced no lazy store");
+  const columns: Record<string, Record<string, unknown[]>> = {
+    frames: store.framesData,
+    instances: store.instancesData,
+    points: store.pointsData,
+    pred_points: store.predPointsData,
+  };
+  const get = (dp: string) => h5.get(dp) as unknown as Record<string, unknown>;
+
+  const fake = {
+    keys: () => h5.keys() as string[],
+    getKeys: async () => h5.keys() as string[],
+    getAttrs: async (dp: string) =>
+      unwrapAttrs((get(dp)?.attrs as Record<string, unknown>) ?? {}),
+    getDatasetMeta: async (dp: string) => {
+      const d = get(dp);
+      return { shape: (d?.shape as number[]) ?? [], dtype: (d?.dtype as string) ?? "" };
+    },
+    getDatasetValue: async (dp: string) => {
+      if (dp in columns) return { value: columns[dp], shape: [], dtype: "" };
+      const d = get(dp);
+      return { value: d?.value, shape: (d?.shape as number[]) ?? [], dtype: (d?.dtype as string) ?? "" };
+    },
+  } as unknown as StreamingH5File;
+
+  return {
+    fake,
+    close: () => {
+      h5.close();
+      try {
+        module.FS.unlink(mem);
+      } catch {
+        /* ignore */
+      }
+      try {
+        unlinkSync(disk);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+const readStreaming = (fake: StreamingH5File, lazy: boolean) =>
+  readFromStreamingFile(fake, "test.slp", "test.slp", false, undefined, false, lazy);
+
+describe("streaming reader — centroids", () => {
+  it("eager streaming reads /centroids (was silently dropped)", async () => {
+    const bytes = await saveSlpToBytes(centroidLabels());
+    const { fake, close } = await makeFakeStreamingFile(bytes);
+    try {
+      const labels = await readStreaming(fake, false);
+      const cents = labels.labeledFrames.flatMap((lf) => lf.centroids);
+      expect(cents.length).toBe(2);
+      const user = cents.find((c) => !c.isPredicted)!;
+      const pred = cents.find((c) => c.isPredicted)!;
+      expect(user.xy).toEqual([12, 12]);
+      expect(user.name).toBe("cm");
+      // The centroid→instance link resolves to a live pose instance.
+      expect(user.instance).not.toBeNull();
+      expect((pred as PredictedCentroid).score).toBeCloseTo(0.77, 5);
+    } finally {
+      close();
+    }
+  });
+
+  it("lazy streaming materializes /centroids per frame", async () => {
+    const bytes = await saveSlpToBytes(centroidLabels());
+    const { fake, close } = await makeFakeStreamingFile(bytes);
+    try {
+      const labels = await readStreaming(fake, true);
+      let n = 0;
+      for (let i = 0; i < labels.length; i++) {
+        const frame = labels._lazyFrameList!.at(i);
+        n += frame?.centroids.length ?? 0;
+      }
+      expect(n).toBe(2);
+    } finally {
+      close();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The eager (`readSlp`) and lazy (`readSlpLazy`) readers both read the first-class `/centroids` group (added in #235), but the **streaming reader** (`readFromStreamingFile`) — the path the **browser and Tauri WebView** actually use — had no centroid handling at all.

A project loaded in the browser therefore **silently dropped every centroid annotation**. Measured against the same `.slp`:

| Reader | Centroids read |
|---|---|
| eager (`readSlp`, node) | 24 |
| streaming (browser, **before**) | **0** |
| streaming (browser, **after**) | **24** ✅ |

## Fix

- **Extract** the column→`Centroid` reconstruction (User vs Predicted, NaN sentinels, track/instance relinking, source normalization) out of the eager reader into a shared `buildCentroidTuples` (`codecs/slp/centroids.ts`), so the eager and streaming readers stay in lockstep by construction.
- **Add** `readCentroidsStreaming` + distribution in `read-streaming.ts`, covering both:
  - the **eager** streaming path — push onto `lf.centroids`, resolve deferred `_instanceIdx` → live pose instance;
  - the **lazy** streaming path — populate `_centroidByFrame` / `_undistributedCentroids`.
- **Test** `tests/streaming-centroids.test.ts`: a fake `StreamingH5File` drives `readFromStreamingFile` and asserts both paths materialize centroids, including the centroid→pose-instance back-link.

## Verification

- `bun run test` — 2123 pass, 0 fail; `tsc --noEmit` clean.
- Confirmed in a **real browser** (system Chrome via Playwright, app streaming load path): reads all 24 centroids, matching node exactly.

## Note

This class of bug — code that only runs under the browser/WASM h5wasm build — cannot be caught by the current node/bun unit suite. Filing a follow-up issue proposing a browser-environment test harness so future streaming/WASM-only regressions surface in CI.

https://claude.ai/code/session_01Q6tAAhTSZww7RY2Hu46cBW