### PR TITLE
chore(release): bump version to 0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Cuts **0.5.7**. Contents since 0.5.6:
- #240 — OPFS sync-access-handle write device for browser large-file save (no SAB)
- #238 — read the `/centroids` group in the streaming reader (browser/Tauri)

After merge, publish a `v0.5.7` GitHub Release to trigger the npm publish (release.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)