### PR TITLE
feat(video): libav.js H.264 software-decoder fallback for mediabunny

### DIFF
--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -23,6 +23,16 @@ export * from "./model/label-image.js";
 export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
+export {
+  configureLibavDecoder,
+  isLibavDecoderConfigured,
+  registerLibavH264Decoder,
+  ensureNativeH264Probe,
+  nativeH264DecodableSync,
+  overrideNativeH264Decodable,
+  LibavH264Decoder,
+  type LibavDecoderConfig,
+} from "./video/libav-h264-decoder.js";
 export * from "./video/streaming-hdf5-video.js";
 export * from "./video/image-video.js";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,16 @@ export * from "./model/label-image.js";
 export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
+export {
+  configureLibavDecoder,
+  isLibavDecoderConfigured,
+  registerLibavH264Decoder,
+  ensureNativeH264Probe,
+  nativeH264DecodableSync,
+  overrideNativeH264Decodable,
+  LibavH264Decoder,
+  type LibavDecoderConfig,
+} from "./video/libav-h264-decoder.js";
 export * from "./video/streaming-hdf5-video.js";
 export * from "./video/image-video.js";
 export {

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -1,8 +1,12 @@
-import { VideoBackend } from "./backend.js";
+import type { VideoBackend } from "./backend.js";
 import { Hdf5VideoBackend } from "./hdf5-video.js";
 import { MediaVideoBackend } from "./media-video.js";
 import { Mp4BoxVideoBackend } from "./mp4box-video.js";
 import { MediaBunnyVideoBackend } from "./mediabunny-video.js";
+import {
+  ensureNativeH264Probe,
+  isLibavDecoderConfigured,
+} from "./libav-h264-decoder.js";
 import { SeqVideoBackend } from "./seq-video.js";
 import { ImageVideoBackend } from "./image-video.js";
 import { openH5File } from "../codecs/slp/h5.js";
@@ -184,6 +188,21 @@ export async function createVideoBackend(
     typeof window !== "undefined" &&
     typeof window.VideoDecoder !== "undefined" &&
     typeof window.EncodedVideoChunk !== "undefined";
+
+  // MP4 with the libav H.264 fallback configured: Mp4Box (the default MP4 path)
+  // uses a raw WebCodecs VideoDecoder and has NO custom-decoder hook, so when
+  // native H.264 decode is unavailable (e.g. Linux/WebKitGTK without the codec),
+  // route through MediaBunny instead — that's where the registered software
+  // decoder engages. Only diverts when native genuinely can't decode, so the
+  // Mp4Box happy path is untouched on capable machines.
+  if (ext === "mp4" && isLibavDecoderConfigured()) {
+    const nativeOk = await ensureNativeH264Probe();
+    if (!nativeOk) {
+      if (isBlob)
+        return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
+      return MediaBunnyVideoBackend.fromUrl(videoUrl, { headers });
+    }
+  }
 
   // MP4: prefer Mp4Box (better sequential performance)
   if (supportsWebCodecs && ext === "mp4") {

--- a/src/video/h264-colorspace.ts
+++ b/src/video/h264-colorspace.ts
@@ -1,0 +1,256 @@
+/**
+ * Derive a WebCodecs `VideoColorSpaceInit` for an H.264 stream.
+ *
+ * When we emit a decoded frame as an untagged I420 `VideoFrame`, the browser's
+ * canvas guesses the YUV→RGB matrix/range — and different engines guess
+ * differently (this caused a visible color shift on WebKitGTK vs native). Tagging
+ * the frame with the stream's actual colorspace makes our output match native.
+ *
+ * We read the color signaling from the SPS VUI when present; otherwise we apply
+ * the standard resolution heuristic (BT.601 for SD, BT.709 for HD, studio range),
+ * which is what a conformant decoder uses for unspecified streams — so tagging it
+ * explicitly matches the native decoder's behavior.
+ *
+ * Pure and dependency-free → unit-tested directly.
+ */
+
+/** Reads bits + Exp-Golomb from an RBSP (emulation-prevention bytes removed). */
+class BitReader {
+  private pos = 0;
+  constructor(private readonly buf: Uint8Array) {}
+
+  bit(): number {
+    const byte = this.buf[this.pos >> 3] ?? 0;
+    const b = (byte >> (7 - (this.pos & 7))) & 1;
+    this.pos++;
+    return b;
+  }
+
+  bits(n: number): number {
+    let v = 0;
+    for (let i = 0; i < n; i++) v = (v << 1) | this.bit();
+    return v >>> 0;
+  }
+
+  /** Unsigned Exp-Golomb. */
+  ue(): number {
+    let zeros = 0;
+    while (this.pos < this.buf.length * 8 && this.bit() === 0) zeros++;
+    if (zeros === 0) return 0;
+    return (1 << zeros) - 1 + this.bits(zeros);
+  }
+
+  /** Signed Exp-Golomb. */
+  se(): number {
+    const k = this.ue();
+    const sign = k & 1 ? 1 : -1;
+    return sign * Math.ceil(k / 2);
+  }
+
+  hasMore(): boolean {
+    return this.pos < this.buf.length * 8;
+  }
+}
+
+/** Strip H.264 emulation-prevention bytes (00 00 03 → 00 00) from an RBSP. */
+function stripEmulation(nal: Uint8Array): Uint8Array {
+  const out = new Uint8Array(nal.length);
+  let o = 0;
+  for (let i = 0; i < nal.length; i++) {
+    if (
+      i >= 2 &&
+      nal[i] === 0x03 &&
+      nal[i - 1] === 0x00 &&
+      nal[i - 2] === 0x00 &&
+      i + 1 < nal.length &&
+      nal[i + 1] <= 0x03
+    ) {
+      continue; // drop the 0x03
+    }
+    out[o++] = nal[i];
+  }
+  return out.subarray(0, o);
+}
+
+const HIGH_PROFILES = new Set([
+  100, 110, 122, 244, 44, 83, 86, 118, 128, 138, 139, 134, 135,
+]);
+
+function skipScalingList(br: BitReader, size: number): void {
+  let lastScale = 8;
+  let nextScale = 8;
+  for (let j = 0; j < size; j++) {
+    if (nextScale !== 0) {
+      const delta = br.se();
+      nextScale = (lastScale + delta + 256) % 256;
+    }
+    if (nextScale !== 0) lastScale = nextScale;
+  }
+}
+
+export interface SpsColour {
+  fullRange: boolean;
+  /** H.264 enum values; undefined when colour_description absent. */
+  primaries?: number;
+  transfer?: number;
+  matrix?: number;
+}
+
+/**
+ * Parse the color signaling out of an SPS NAL (which includes its 1-byte NAL
+ * header). Returns null if the bitstream can't be parsed. `fullRange` defaults to
+ * false when no VUI/video-signal-type is present.
+ */
+export function parseSpsColour(nal: Uint8Array): SpsColour | null {
+  try {
+    if (nal.length < 4) return null;
+    const rbsp = stripEmulation(nal.subarray(1)); // drop NAL header byte
+    const br = new BitReader(rbsp);
+
+    const profileIdc = br.bits(8);
+    br.bits(8); // constraint flags + reserved
+    br.bits(8); // level_idc
+    br.ue(); // seq_parameter_set_id
+
+    let chromaFormatIdc = 1;
+    if (HIGH_PROFILES.has(profileIdc)) {
+      chromaFormatIdc = br.ue();
+      if (chromaFormatIdc === 3) br.bit(); // separate_colour_plane_flag
+      br.ue(); // bit_depth_luma_minus8
+      br.ue(); // bit_depth_chroma_minus8
+      br.bit(); // qpprime_y_zero_transform_bypass_flag
+      if (br.bit()) {
+        // seq_scaling_matrix_present_flag
+        const count = chromaFormatIdc !== 3 ? 8 : 12;
+        for (let i = 0; i < count; i++) {
+          if (br.bit()) skipScalingList(br, i < 6 ? 16 : 64);
+        }
+      }
+    }
+
+    br.ue(); // log2_max_frame_num_minus4
+    const pocType = br.ue();
+    if (pocType === 0) {
+      br.ue(); // log2_max_pic_order_cnt_lsb_minus4
+    } else if (pocType === 1) {
+      br.bit(); // delta_pic_order_always_zero_flag
+      br.se(); // offset_for_non_ref_pic
+      br.se(); // offset_for_top_to_bottom_field
+      const n = br.ue();
+      for (let i = 0; i < n; i++) br.se();
+    }
+
+    br.ue(); // max_num_ref_frames
+    br.bit(); // gaps_in_frame_num_value_allowed_flag
+    br.ue(); // pic_width_in_mbs_minus1
+    br.ue(); // pic_height_in_map_units_minus1
+    const frameMbsOnly = br.bit();
+    if (!frameMbsOnly) br.bit(); // mb_adaptive_frame_field_flag
+    br.bit(); // direct_8x8_inference_flag
+    if (br.bit()) {
+      // frame_cropping_flag
+      br.ue();
+      br.ue();
+      br.ue();
+      br.ue();
+    }
+
+    const vuiPresent = br.bit();
+    if (!vuiPresent) return { fullRange: false };
+
+    if (br.bit()) {
+      // aspect_ratio_info_present_flag
+      const idc = br.bits(8);
+      if (idc === 255) {
+        br.bits(16); // sar_width
+        br.bits(16); // sar_height
+      }
+    }
+    if (br.bit()) br.bit(); // overscan_info_present_flag → overscan_appropriate_flag
+
+    if (br.bit()) {
+      // video_signal_type_present_flag
+      br.bits(3); // video_format
+      const fullRange = br.bit() === 1;
+      if (br.bit()) {
+        // colour_description_present_flag
+        const primaries = br.bits(8);
+        const transfer = br.bits(8);
+        const matrix = br.bits(8);
+        return { fullRange, primaries, transfer, matrix };
+      }
+      return { fullRange };
+    }
+    return { fullRange: false };
+  } catch {
+    return null;
+  }
+}
+
+// H.264 (ITU-T H.273) enum → WebCodecs string. Undefined = leave unset.
+// Only the SDR values in the WebCodecs lib typings are mapped; HDR/BT.2020
+// (10-bit) values fall through to undefined → the SD/HD default. Our decoder
+// emits 8-bit I420, so SDR coverage is sufficient.
+function mapPrimaries(v?: number): VideoColorPrimaries | undefined {
+  switch (v) {
+    case 1:
+      return "bt709";
+    case 5:
+      return "bt470bg";
+    case 6:
+    case 7:
+      return "smpte170m";
+    default:
+      return undefined;
+  }
+}
+function mapTransfer(v?: number): VideoTransferCharacteristics | undefined {
+  switch (v) {
+    case 1:
+    case 6:
+    case 14:
+    case 15:
+      return "bt709";
+    case 13:
+      return "iec61966-2-1";
+    default:
+      return undefined;
+  }
+}
+function mapMatrix(v?: number): VideoMatrixCoefficients | undefined {
+  switch (v) {
+    case 0:
+      return "rgb";
+    case 1:
+      return "bt709";
+    case 5:
+      return "bt470bg";
+    case 6:
+    case 7:
+      return "smpte170m";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Build a `VideoColorSpaceInit` for an SPS NAL (may be null), using the codedHeight
+ * to pick the SD/HD default when the stream doesn't signal colour explicitly.
+ */
+export function colorSpaceFromSps(
+  nal: Uint8Array | null,
+  config: { codedHeight?: number },
+): VideoColorSpaceInit {
+  const colour = nal ? parseSpsColour(nal) : null;
+  const height = config.codedHeight ?? 720;
+  // Standard default for unspecified streams: BT.601 for SD, BT.709 for HD.
+  const sd = height <= 576;
+  const defaultName = sd ? "smpte170m" : "bt709";
+
+  return {
+    primaries: mapPrimaries(colour?.primaries) ?? defaultName,
+    transfer: mapTransfer(colour?.transfer) ?? (sd ? "smpte170m" : "bt709"),
+    matrix: mapMatrix(colour?.matrix) ?? defaultName,
+    fullRange: colour?.fullRange ?? false,
+  };
+}

--- a/src/video/libav-h264-decoder.ts
+++ b/src/video/libav-h264-decoder.ts
@@ -1,0 +1,385 @@
+/**
+ * Software H.264 decoder for mediabunny, backed by a libav.js (FFmpeg) WASM build.
+ *
+ * Why: on the Linux desktop build (Tauri → WebKitGTK) many machines cannot decode
+ * H.264 via native WebCodecs (the GStreamer H.264 plugin is omitted for patent
+ * reasons), so MP4 videos render as blank frames. This registers a mediabunny
+ * `CustomVideoDecoder` that decodes H.264 entirely in WASM as a *fallback*.
+ *
+ * ── Zero-regression gate ──────────────────────────────────────────────────────
+ * mediabunny uses a registered custom decoder UNCONDITIONALLY whenever its static
+ * `supports()` returns true — it never falls back to native. So `supports()` gates
+ * on a cached, async native-capability probe (`VideoDecoder.isConfigSupported`):
+ * it returns true ONLY when native H.264 decode is unavailable. On macOS, Windows,
+ * and Linux-with-codec, native works → `supports()` is false → native is used →
+ * no regression. The probe is capability-based, not OS-based (some Linux boxes have
+ * the codec; some browsers lack it).
+ *
+ * ── WASM delivery ─────────────────────────────────────────────────────────────
+ * This module ships no WASM. The embedding app vendors the libav.js build and
+ * points `configureLibavDecoder({ wasmBaseUrl })` at it; the decoder loads the
+ * loader `.mjs` from that base URL at runtime. Keeps an H.264 decoder off npm and
+ * out of everyone's bundle — it loads only when actually needed.
+ *
+ * The decode path (extradata init, AVCC→decode, PTS, B-frame reorder, I420 output)
+ * was validated byte-exact vs native WebCodecs. See docs/plans for the spike.
+ */
+import {
+  CustomVideoDecoder,
+  type EncodedPacket,
+  registerDecoder,
+  VideoSample,
+} from "mediabunny";
+import { colorSpaceFromSps } from "./h264-colorspace.js";
+
+// ── Configuration seam (set by the app) ──────────────────────────────────────
+
+export interface LibavDecoderConfig {
+  /** Base URL under which the libav.js loader + wasm files are served. */
+  wasmBaseUrl: string;
+  /** Loader entry filename (default: the decoder-h264 variant loader). */
+  loaderFileName?: string;
+}
+
+let decoderConfig: Required<LibavDecoderConfig> | null = null;
+
+/** Configure where the libav.js WASM decoder is loaded from. Call before opening video. */
+export function configureLibavDecoder(config: LibavDecoderConfig): void {
+  decoderConfig = {
+    wasmBaseUrl: config.wasmBaseUrl.replace(/\/$/, ""),
+    loaderFileName: config.loaderFileName ?? "libav-6.9.8.1-decoder-h264.mjs",
+  };
+}
+
+/** True once {@link configureLibavDecoder} has been called. */
+export function isLibavDecoderConfigured(): boolean {
+  return decoderConfig !== null;
+}
+
+// ── Native-capability probe (cached) ─────────────────────────────────────────
+
+let nativeProbe: Promise<void> | null = null;
+let nativeCanDecodeH264: boolean | null = null;
+let nativeOverride: boolean | null | undefined;
+
+/**
+ * Test/dev override for the native-H.264 capability the gate sees. Pass `false`
+ * to force the software fallback even on a machine that CAN decode natively
+ * (useful for exercising the decoder end-to-end); `undefined` clears it.
+ */
+export function overrideNativeH264Decodable(
+  value: boolean | null | undefined,
+): void {
+  nativeOverride = value;
+}
+
+/** The capability the gate/routing actually use — override if set, else probe. */
+function effectiveNativeH264(): boolean | null {
+  return nativeOverride !== undefined ? nativeOverride : nativeCanDecodeH264;
+}
+
+/**
+ * Resolve (once) whether this environment can decode H.264 via native WebCodecs.
+ * Must complete before the first decode so the sync `supports()` reads a ready
+ * value — {@link MediaBunnyVideoBackend} awaits this in `initialize()`. Returns
+ * the effective capability (honoring {@link overrideNativeH264Decodable}).
+ */
+export async function ensureNativeH264Probe(): Promise<boolean> {
+  if (nativeProbe === null) {
+    nativeProbe = (async () => {
+      if (typeof VideoDecoder === "undefined") {
+        nativeCanDecodeH264 = false;
+        return;
+      }
+      // Representative H.264 configs: High@4.0, Main@3.0, Baseline@3.0.
+      const codecs = ["avc1.640028", "avc1.4D401E", "avc1.42E01E"];
+      for (const codec of codecs) {
+        try {
+          const support = await VideoDecoder.isConfigSupported({ codec });
+          if (support?.supported) {
+            nativeCanDecodeH264 = true;
+            return;
+          }
+        } catch {
+          /* try next */
+        }
+      }
+      nativeCanDecodeH264 = false;
+    })();
+  }
+  await nativeProbe;
+  return effectiveNativeH264() === true;
+}
+
+/**
+ * Synchronous view of the effective capability: `true`/`false` once resolved (or
+ * overridden), `null` before. Used by the routing layer to decide MP4 →
+ * MediaBunny fallback.
+ */
+export function nativeH264DecodableSync(): boolean | null {
+  return effectiveNativeH264();
+}
+
+/**
+ * Pure gate decision (exported for testing): use the libav software decoder only
+ * for H.264 (`"avc"`), only when the app configured it, and only when native
+ * decode is known-unavailable. A `null` probe (not yet resolved) → `false`, so we
+ * never override native before we know it can't decode.
+ */
+export function shouldUseLibavH264(
+  codec: string,
+  configured: boolean,
+  nativeCanDecode: boolean | null,
+): boolean {
+  return codec === "avc" && configured && nativeCanDecode === false;
+}
+
+// ── libav.js loader (from the injected base URL) ──────────────────────────────
+
+interface LibAVFactory {
+  LibAV(opts?: {
+    noworker?: boolean;
+    nothreads?: boolean;
+    yesthreads?: boolean;
+    base?: string;
+  }): Promise<LibAVInstance>;
+  base?: string;
+}
+// The libav.js surface is large and untyped here; we touch only a few members.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LibAVInstance = any;
+
+let libavPromise: Promise<LibAVInstance> | null = null;
+async function getLibAV(): Promise<LibAVInstance> {
+  if (!decoderConfig) {
+    throw new Error(
+      "libav H.264 decoder used before configureLibavDecoder() was called",
+    );
+  }
+  if (!libavPromise) {
+    const { wasmBaseUrl, loaderFileName } = decoderConfig;
+    libavPromise = (async () => {
+      const url = `${wasmBaseUrl}/${loaderFileName}`;
+      // Runtime-computed URL so bundlers don't try to resolve it statically.
+      const mod = (await import(
+        /* @vite-ignore */ /* webpackIgnore: true */ url
+      )) as {
+        default: LibAVFactory;
+      };
+      const factory = mod.default;
+      factory.base = wasmBaseUrl;
+      // Single-thread only for now — the threaded (SAB) variant is a follow-up
+      // and would require vendoring the `.thr` wasm too.
+      return factory.LibAV({ noworker: true, nothreads: true });
+    })();
+  }
+  return libavPromise;
+}
+
+// ── The decoder ───────────────────────────────────────────────────────────────
+
+const AV_CODEC_ID_H264 = 27;
+const PTS_TB = 1_000_000; // microseconds
+const START_CODE = new Uint8Array([0, 0, 0, 1]);
+
+interface LibavFrame {
+  data: Uint8Array;
+  width: number;
+  height: number;
+  format: number;
+  pts?: number;
+  ptshi?: number;
+  sample_aspect_ratio?: [number, number];
+}
+
+export class LibavH264Decoder extends CustomVideoDecoder {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private libav: any = null;
+  private c = -1;
+  private pkt = -1;
+  private frame = -1;
+  private nalLen = 4;
+  private paramSets: Uint8Array = new Uint8Array(0);
+  private colorSpace: VideoColorSpaceInit | undefined;
+
+  static supports(codec: string, _config: VideoDecoderConfig): boolean {
+    return shouldUseLibavH264(
+      codec,
+      decoderConfig !== null,
+      effectiveNativeH264(),
+    );
+  }
+
+  async init(): Promise<void> {
+    this.libav = await getLibAV();
+    const desc = this.config.description
+      ? toU8(this.config.description)
+      : undefined;
+    if (desc) {
+      this.parseAvcC(desc);
+      this.colorSpace = colorSpaceFromSps(this.spsNal(desc), this.config);
+    }
+    const byName = await this.libav.avcodec_find_decoder_by_name("h264");
+    [, this.c, this.pkt, this.frame] = await this.libav.ff_init_decoder(
+      byName ? "h264" : AV_CODEC_ID_H264,
+    );
+  }
+
+  async decode(packet: EncodedPacket): Promise<void> {
+    const isKey = packet.type === "key";
+    const annexb = this.avccToAnnexB(toU8(packet.data), isKey);
+    const pts = Math.round(packet.timestamp * PTS_TB);
+    const frames: LibavFrame[] = await this.libav.ff_decode_multi(
+      this.c,
+      this.pkt,
+      this.frame,
+      [
+        {
+          data: annexb,
+          pts,
+          ptshi: 0,
+          dts: pts,
+          dtshi: 0,
+          stream_index: 0,
+          flags: isKey ? 1 : 0,
+        },
+      ],
+      { fin: false, copyoutFrame: "video_packed" },
+    );
+    for (const f of frames) this.emit(f);
+  }
+
+  async flush(): Promise<void> {
+    if (!this.libav || this.c < 0) return;
+    const frames: LibavFrame[] = await this.libav.ff_decode_multi(
+      this.c,
+      this.pkt,
+      this.frame,
+      [],
+      { fin: true, copyoutFrame: "video_packed" },
+    );
+    for (const f of frames) this.emit(f);
+  }
+
+  async close(): Promise<void> {
+    if (this.libav && this.c >= 0) {
+      try {
+        await this.libav.ff_free_decoder(this.c, this.pkt, this.frame);
+      } catch {
+        /* ignore */
+      }
+    }
+    this.c = this.pkt = this.frame = -1;
+  }
+
+  private emit(f: LibavFrame): void {
+    const width = f.width;
+    const height = f.height;
+    const ptsMicros = f.pts ?? 0;
+
+    let displayWidth = width;
+    let displayHeight = height;
+    const sar = f.sample_aspect_ratio;
+    if (sar && sar[0] > 0 && sar[1] > 0 && sar[0] !== sar[1]) {
+      if (sar[0] > sar[1]) displayWidth = Math.round((width * sar[0]) / sar[1]);
+      else displayHeight = Math.round((height * sar[1]) / sar[0]);
+    }
+
+    const vf = new VideoFrame(f.data as BufferSource, {
+      format: "I420",
+      codedWidth: width,
+      codedHeight: height,
+      timestamp: ptsMicros,
+      displayWidth,
+      displayHeight,
+      colorSpace: this.colorSpace,
+    });
+    this.onSample(new VideoSample(vf, { timestamp: ptsMicros / PTS_TB }));
+  }
+
+  /** Extract the first SPS NAL (Annex-B, without start code) from the avcC. */
+  private spsNal(d: Uint8Array): Uint8Array | null {
+    // d[5] low 5 bits = numSPS; first SPS begins at offset 8 (after its length).
+    if (d.length < 8) return null;
+    const numSps = d[5] & 0x1f;
+    if (numSps < 1) return null;
+    const len = (d[6] << 8) | d[7];
+    if (8 + len > d.length) return null;
+    return d.subarray(8, 8 + len);
+  }
+
+  private parseAvcC(d: Uint8Array): void {
+    this.nalLen = (d[4] & 0x03) + 1;
+    const parts: Uint8Array[] = [];
+    let off = 5;
+    const numSps = d[off++] & 0x1f;
+    for (let i = 0; i < numSps; i++) {
+      const len = (d[off] << 8) | d[off + 1];
+      off += 2;
+      parts.push(START_CODE, d.subarray(off, off + len));
+      off += len;
+    }
+    const numPps = d[off++];
+    for (let i = 0; i < numPps; i++) {
+      const len = (d[off] << 8) | d[off + 1];
+      off += 2;
+      parts.push(START_CODE, d.subarray(off, off + len));
+      off += len;
+    }
+    this.paramSets = concatBytes(parts);
+  }
+
+  private avccToAnnexB(data: Uint8Array, includeParams: boolean): Uint8Array {
+    const parts: Uint8Array[] = [];
+    if (includeParams && this.paramSets.length) parts.push(this.paramSets);
+    let off = 0;
+    while (off + this.nalLen <= data.length) {
+      let len = 0;
+      for (let i = 0; i < this.nalLen; i++) len = (len << 8) | data[off + i];
+      off += this.nalLen;
+      if (len <= 0 || off + len > data.length) break;
+      parts.push(START_CODE, data.subarray(off, off + len));
+      off += len;
+    }
+    return concatBytes(parts);
+  }
+}
+
+// ── Registration ──────────────────────────────────────────────────────────────
+
+let registered = false;
+
+/**
+ * Register the libav H.264 fallback decoder with mediabunny (idempotent) and kick
+ * off the native-capability probe. No-op decode impact on machines with native
+ * H.264 (see the `supports()` gate). Call after {@link configureLibavDecoder}.
+ */
+export async function registerLibavH264Decoder(): Promise<void> {
+  // Synchronous guard (no await between check and set) so concurrent callers —
+  // e.g. React StrictMode double-invoking the effect — register exactly once.
+  if (!registered) {
+    registered = true;
+    registerDecoder(LibavH264Decoder);
+  }
+  await ensureNativeH264Probe();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function toU8(buf: AllowSharedBufferSource): Uint8Array {
+  if (buf instanceof Uint8Array) return buf;
+  if (buf instanceof ArrayBuffer) return new Uint8Array(buf);
+  return new Uint8Array((buf as ArrayBufferView).buffer);
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}

--- a/src/video/mediabunny-video.ts
+++ b/src/video/mediabunny-video.ts
@@ -18,6 +18,10 @@ import {
   EncodedPacketSink,
   ALL_FORMATS,
 } from "mediabunny";
+import {
+  ensureNativeH264Probe,
+  isLibavDecoderConfigured,
+} from "./libav-h264-decoder.js";
 
 export interface MediaBunnyOptions {
   cacheSize?: number;
@@ -104,6 +108,13 @@ export class MediaBunnyVideoBackend implements VideoBackend {
 
   private async initialize(): Promise<void> {
     if (!this.input) throw new Error("Input not set");
+
+    // If the libav H.264 fallback decoder is configured, make sure the native-
+    // capability probe has resolved before the sink lazily creates its decoder —
+    // the custom decoder's sync `supports()` reads that cached result.
+    if (isLibavDecoderConfigured()) {
+      await ensureNativeH264Probe();
+    }
 
     const videoTrack = await this.input.getPrimaryVideoTrack();
     if (!videoTrack) {

--- a/tests/video/h264-colorspace.test.ts
+++ b/tests/video/h264-colorspace.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for `src/video/h264-colorspace.ts` — deriving a WebCodecs
+ * VideoColorSpaceInit from an H.264 SPS (or the SD/HD default when the stream
+ * doesn't signal colour). Guards the fix for the WebKitGTK color shift (untagged
+ * I420 frames get a wrong browser-default YUV→RGB conversion).
+ */
+import { describe, it, expect } from "../bun-test";
+import {
+  parseSpsColour,
+  colorSpaceFromSps,
+} from "../../src/video/h264-colorspace.js";
+
+// Real High-profile SPS NAL extracted from the synthetic fixture's avcC. Includes
+// emulation-prevention bytes (00 00 03) → also exercises stripEmulation.
+const SPS_HIGH = new Uint8Array([
+  103, 100, 0, 13, 172, 217, 65, 65, 251, 1, 16, 0, 0, 3, 0, 16, 0, 0, 3, 3, 0,
+  241, 66, 153, 96,
+]);
+
+describe("colorSpaceFromSps defaults (no explicit colour)", () => {
+  it("uses BT.601 (smpte170m), limited range for SD", () => {
+    const cs = colorSpaceFromSps(null, { codedHeight: 480 });
+    expect(cs.primaries).toBe("smpte170m");
+    expect(cs.matrix).toBe("smpte170m");
+    expect(cs.transfer).toBe("smpte170m");
+    expect(cs.fullRange).toBe(false);
+  });
+
+  it("uses BT.709, limited range for HD", () => {
+    const cs = colorSpaceFromSps(null, { codedHeight: 1080 });
+    expect(cs.primaries).toBe("bt709");
+    expect(cs.matrix).toBe("bt709");
+    expect(cs.transfer).toBe("bt709");
+    expect(cs.fullRange).toBe(false);
+  });
+
+  it("treats 576 as the SD/HD boundary", () => {
+    expect(colorSpaceFromSps(null, { codedHeight: 576 }).matrix).toBe(
+      "smpte170m",
+    );
+    expect(colorSpaceFromSps(null, { codedHeight: 577 }).matrix).toBe("bt709");
+  });
+
+  it("defaults codedHeight to HD when missing", () => {
+    expect(colorSpaceFromSps(null, {}).matrix).toBe("bt709");
+  });
+});
+
+describe("parseSpsColour", () => {
+  it("parses a real High-profile SPS without throwing", () => {
+    const c = parseSpsColour(SPS_HIGH);
+    expect(c).not.toBeNull();
+    expect(typeof c!.fullRange).toBe("boolean");
+  });
+
+  it("returns null for too-short input", () => {
+    expect(parseSpsColour(new Uint8Array([1, 2]))).toBeNull();
+    expect(parseSpsColour(new Uint8Array())).toBeNull();
+  });
+
+  it("yields a valid, fully-populated init from a real SPS", () => {
+    const cs = colorSpaceFromSps(SPS_HIGH, { codedHeight: 240 });
+    expect(typeof cs.fullRange).toBe("boolean");
+    // Every field is set (either signalled or defaulted) so the browser never guesses.
+    expect(cs.primaries).toBeDefined();
+    expect(cs.transfer).toBeDefined();
+    expect(cs.matrix).toBeDefined();
+  });
+});

--- a/tests/video/libav-h264-decoder.test.ts
+++ b/tests/video/libav-h264-decoder.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for the libav H.264 fallback decoder's gate + configuration
+ * (`src/video/libav-h264-decoder.ts`). The actual WASM decode is browser-only and
+ * was validated byte-exact vs native in the spike; here we lock down the
+ * zero-regression gate and the config seam.
+ */
+import { describe, it, expect } from "../bun-test";
+import {
+  shouldUseLibavH264,
+  configureLibavDecoder,
+  isLibavDecoderConfigured,
+  ensureNativeH264Probe,
+  nativeH264DecodableSync,
+  overrideNativeH264Decodable,
+} from "../../src/video/libav-h264-decoder.js";
+
+describe("shouldUseLibavH264 gate (anti-regression)", () => {
+  it("engages only for H.264 when configured AND native cannot decode", () => {
+    expect(shouldUseLibavH264("avc", true, false)).toBe(true);
+  });
+
+  it("does NOT engage when native CAN decode — no macOS/Windows regression", () => {
+    expect(shouldUseLibavH264("avc", true, true)).toBe(false);
+  });
+
+  it("does NOT engage before the probe resolves (null) — never preempt native", () => {
+    expect(shouldUseLibavH264("avc", true, null)).toBe(false);
+  });
+
+  it("does NOT engage when unconfigured", () => {
+    expect(shouldUseLibavH264("avc", false, false)).toBe(false);
+  });
+
+  it("does NOT engage for non-H.264 codecs", () => {
+    expect(shouldUseLibavH264("vp8", true, false)).toBe(false);
+    expect(shouldUseLibavH264("hevc", true, false)).toBe(false);
+    expect(shouldUseLibavH264("av1", true, false)).toBe(false);
+  });
+});
+
+describe("configuration seam", () => {
+  it("starts unconfigured", () => {
+    expect(isLibavDecoderConfigured()).toBe(false);
+  });
+
+  it("becomes configured after configureLibavDecoder", () => {
+    configureLibavDecoder({ wasmBaseUrl: "/decoders/libav-h264/" });
+    expect(isLibavDecoderConfigured()).toBe(true);
+  });
+});
+
+describe("native-capability probe", () => {
+  it("reports native H.264 unavailable when WebCodecs is absent (bun/node env)", async () => {
+    expect(typeof (globalThis as { VideoDecoder?: unknown }).VideoDecoder).toBe(
+      "undefined",
+    );
+    const ok = await ensureNativeH264Probe();
+    expect(ok).toBe(false);
+    expect(nativeH264DecodableSync()).toBe(false);
+  });
+});
+
+describe("native override (force fallback for testing)", () => {
+  it("forces native-unavailable (fallback engages) then clears back to the probe", () => {
+    overrideNativeH264Decodable(true); // pretend native works
+    expect(nativeH264DecodableSync()).toBe(true);
+    overrideNativeH264Decodable(false); // force fallback
+    expect(nativeH264DecodableSync()).toBe(false);
+    overrideNativeH264Decodable(undefined); // clear → real probe value
+    expect(nativeH264DecodableSync()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a mediabunny `CustomVideoDecoder` that decodes H.264 entirely in WASM (a libav.js/FFmpeg build the **app** vendors), so **Linux desktop (Tauri → WebKitGTK)** users whose system can't decode H.264 natively see MP4 video instead of blank frames. The `avdec_h264` GStreamer plugin is omitted by many distros for patent reasons, which is what causes the blank frames today.

Pairs with the app-side wiring PR: **talmolab/sleap-app#feat/linux-h264-decode-app**.

## Zero-regression by design

mediabunny uses a registered custom decoder *unconditionally* when its static `supports()` returns true — it never falls back to native. So `supports()` gates on a **cached, async `VideoDecoder.isConfigSupported` probe**: the decoder engages **only when native H.264 decode is unavailable** — capability-based, not OS-based (some Linux boxes have the codec; some browsers lack it). macOS, Windows, and Linux-with-codec keep using native → no regression. `factory.ts` likewise routes MP4 → MediaBunny (which has the custom-decoder hook, unlike Mp4Box) only on that same fallback condition.

## What's here

- `src/video/libav-h264-decoder.ts` — the shim (AVCC→decode, PTS, B-frame reorder, I420 output, SAR + colorSpace propagation), a `configureLibavDecoder({ wasmBaseUrl })` URL seam, `ensureNativeH264Probe()`, `registerLibavH264Decoder()`, the pure `shouldUseLibavH264()` gate, and an `overrideNativeH264Decodable()` dev/test force-toggle.
- `src/video/h264-colorspace.ts` — SPS-VUI parse → `VideoColorSpaceInit` with SD=BT.601 / HD=BT.709 limited-range defaults (fixes a WebKitGTK color shift on untagged I420 frames).
- `MediaBunnyVideoBackend` awaits the probe in `initialize()`; exported from **both** entry points.
- **io ships no WASM** — the decoder is kept off npm / out of the bundle and loaded from the app's vendored copy only when needed.

## Testing

- 15 new unit tests (the anti-regression gate + SPS colorspace parser on real bytes); **full suite 2141 pass**, biome + tsc + build clean; browser-bundle stays node-builtin-free.
- Decode path validated **byte-exact vs native WebCodecs** on macOS (synthetic High-profile GOP-12; real 384×384 fixture incl. random seek).
- **Validated end-to-end in the real Tauri app on Linux/WebKitGTK**: forced fallback loads + scrubs an external-MP4 project, predicted instances land frame-accurately, no console errors; unforced run confirms native path + zero regression.

## Follow-ups (separate)

- Threaded (SAB) build variant for extra 1080p seek headroom.
- HEVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)