### PR TITLE
chore(release): bump version to 0.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Cuts 0.5.8: DLC read core (#243) + embed PNG-encode fix (#245) + Linux H.264 fallback (#244). Unblocks sleap-app #249/#256/#250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)