### PR TITLE
chore: release 0.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Patch release publishing the NWB (ndx-pose) import reader from #248 (readNwb / loadNwb / isNwbFile — predictions + annotations). Cuts 0.5.9 so app PR #273 can bump off a published io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)