### PR TITLE
fix(slp): classic-SLEAP skeleton nx_graph read + MediaVideo empty-dataset over-match

### DIFF
--- a/src/codecs/slp/parsers.ts
+++ b/src/codecs/slp/parsers.ts
@@ -6,7 +6,7 @@
 import { Skeleton, Node } from "../../model/skeleton.js";
 import { Track } from "../../model/instance.js";
 import { Camera, FrameGroup, InstanceGroup } from "../../model/camera.js";
-import { Identity } from "../../model/identity.js";
+import type { Identity } from "../../model/identity.js";
 import { Instance3D, PredictedInstance3D } from "../../model/instance3d.js";
 
 const textDecoder = new TextDecoder();
@@ -341,7 +341,19 @@ export function parseSkeletons(metadataJson: unknown): Skeleton[] {
     const typeCache = new Map<number, number>();
     const typeState = { nextId: 1 };
 
-    const entryNodes = (entry.nodes as Array<{ id?: number } | number>) ?? [];
+    // Classic PyQt-SLEAP jsonpickles each skeleton and wraps its networkx
+    // node-link graph under `nx_graph`; modern sleap-io writes the node-link
+    // dict FLAT on the entry. Read nodes/links/graph from whichever is present —
+    // otherwise a classic entry has no `entry.nodes`, and the empty-node
+    // fallback below wrongly adopts the ENTIRE global node list (e.g.
+    // clip.2node.slp's 2-node skeleton decoding to the parent 13-node fly).
+    const graphSrc =
+      entry.nx_graph && typeof entry.nx_graph === "object"
+        ? (entry.nx_graph as Record<string, unknown>)
+        : entry;
+
+    const entryNodes =
+      (graphSrc.nodes as Array<{ id?: number } | number>) ?? [];
     const skeletonNodeIds = entryNodes.map((node) =>
       Number(typeof node === "object" ? (node.id ?? 0) : node),
     );
@@ -360,7 +372,7 @@ export function parseSkeletons(metadataJson: unknown): Skeleton[] {
     });
 
     const links =
-      (entry.links as Array<{
+      (graphSrc.links as Array<{
         source: number;
         target: number;
         type?: unknown;
@@ -398,7 +410,7 @@ export function parseSkeletons(metadataJson: unknown): Skeleton[] {
         return true;
       });
 
-    const graph = entry.graph as { name?: string } | undefined;
+    const graph = graphSrc.graph as { name?: string } | undefined;
     const skeleton = new Skeleton({
       nodes,
       edges: mappedEdges,

--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -902,10 +902,14 @@ function hasOwn(obj: Record<string, unknown>, key: string): boolean {
  * persisted `backendMetadata.dataset`.
  */
 function hdf5Dataset(video: Video): string | null {
+  // A non-HDF5 backend (e.g. MediaVideo from a `.slp`) carries an EMPTY dataset
+  // placeholder (`""`). Treat empty as "no dataset" so such videos are not
+  // misclassified as HDF5 and then matched to one another on equal-empty
+  // datasets (`"" === ""`) — which made any two plain `.mp4` videos "match".
   const fromBackend = video.backend?.dataset;
-  if (fromBackend != null) return fromBackend;
+  if (typeof fromBackend === "string" && fromBackend !== "") return fromBackend;
   const fromMeta = video.backendMetadata.dataset;
-  return typeof fromMeta === "string" ? fromMeta : null;
+  return typeof fromMeta === "string" && fromMeta !== "" ? fromMeta : null;
 }
 
 /**

--- a/tests/codecs/skeleton-nx-graph.test.ts
+++ b/tests/codecs/skeleton-nx-graph.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression: classic PyQt-SLEAP `.slp` files serialize each skeleton as a
+ * jsonpickle of `sleap.skeleton.Skeleton`, wrapping the networkx node-link graph
+ * under an `nx_graph` key — `{ description, nx_graph: { nodes, links, graph, … },
+ * preview_image }` — whereas modern sleap-io writes the node-link dict FLAT on the
+ * entry (`{ nodes, links, graph, … }`).
+ *
+ * `parseSkeletons` only read the flat shape (`entry.nodes` / `entry.links`). For a
+ * classic file it found no `entry.nodes`, then fell back to "all global nodes",
+ * so a 2-node skeleton on a project whose global `nodes` list still carried the
+ * parent 13-node fly (e.g. `clip.2node.slp`) decoded to a 13-node, edge-less
+ * skeleton — silently different from what Python sleap-io reads, which made
+ * Merge-into-Project wrongly block on "skeleton mismatch".
+ *
+ * This asserts the classic `nx_graph` shape decodes to the correct SUBSET.
+ */
+import { describe, it, expect } from "../bun-test";
+import { parseSkeletons } from "../../src/codecs/slp/parsers.js";
+
+// 13-node global list (parent fly); the 2-node skeleton references head=11,
+// thorax=4 by index — mirroring tracks/clip.2node.slp.
+const GLOBAL_13 = [
+  "forelegL4",
+  "wingR",
+  "hindlegR4",
+  "eyeL",
+  "thorax",
+  "abdomen",
+  "eyeR",
+  "wingL",
+  "forelegR4",
+  "midlegL4",
+  "midlegR4",
+  "head",
+  "hindlegL4",
+].map((name) => ({ name }));
+
+const bodyEdgeType = {
+  "py/reduce": [{ "py/type": "sleap.skeleton.EdgeType" }, { "py/tuple": [1] }],
+};
+
+describe("parseSkeletons — classic nx_graph-wrapped skeleton", () => {
+  it("decodes only the referenced subset, not the whole global node list", () => {
+    const metadataJson = {
+      nodes: GLOBAL_13,
+      skeletons: [
+        {
+          description: null,
+          nx_graph: {
+            directed: true,
+            graph: { name: "Skeleton-3", num_edges_inserted: 12 },
+            multigraph: true,
+            nodes: [{ id: 11 }, { id: 4 }], // head, thorax
+            links: [
+              {
+                edge_insert_idx: 0,
+                key: 0,
+                source: 4,
+                target: 11,
+                type: bodyEdgeType,
+              },
+            ],
+          },
+          preview_image: null,
+        },
+      ],
+    };
+
+    const skeletons = parseSkeletons(metadataJson);
+    expect(skeletons.length).toBe(1);
+    const s = skeletons[0];
+    expect(s.nodes.map((n) => n.name)).toEqual(["head", "thorax"]);
+    expect(s.name).toBe("Skeleton-3");
+    // Edge thorax(4)->head(11) remapped to local indices [thorax=1, head=0].
+    expect(s.edges.length).toBe(1);
+  });
+
+  it("still decodes the flat (sleap-io) shape correctly", () => {
+    const metadataJson = {
+      nodes: [{ name: "A" }, { name: "B" }, { name: "C" }],
+      skeletons: [
+        {
+          directed: true,
+          graph: { name: "flat" },
+          multigraph: true,
+          nodes: [{ id: 0 }, { id: 2 }], // A, C — subset of a 3-node global list
+          links: [],
+        },
+      ],
+    };
+    const s = parseSkeletons(metadataJson)[0];
+    expect(s.nodes.map((n) => n.name)).toEqual(["A", "C"]);
+    expect(s.name).toBe("flat");
+  });
+});

--- a/tests/model/video-match-empty-dataset.test.ts
+++ b/tests/model/video-match-empty-dataset.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression: a `MediaVideo` `.slp` backend carries `dataset: ""` (an empty
+ * placeholder, not a real HDF5 dataset). `hdf5Dataset` returned that empty
+ * string, so `isHdf5Video` was wrongly `true` and `matchesPath` took the HDF5
+ * branch, where two such videos "match" because their empty datasets are equal
+ * (`"" === ""`).
+ *
+ * Effect: ANY two plain-`.mp4` videos with an empty dataset matched each other,
+ * regardless of filename — so sleap-app's Merge-into-Project attached donor
+ * frames to the wrong video and never detected a genuinely new video.
+ *
+ * A real HDF5/embedded video has a NON-empty dataset and must still match by it.
+ */
+import { describe, it, expect } from "../bun-test";
+import { Video } from "../../src/model/video.js";
+import { VideoMatcher, VideoMatchMethod } from "../../src/model/matching.js";
+
+const media = (filename: string) =>
+  new Video({ filename, backendMetadata: { dataset: "" }, openBackend: false });
+
+describe("VideoMatcher — MediaVideo with empty dataset", () => {
+  it("does NOT match two different-basename videos (was wrongly true)", async () => {
+    const a = media("/some/dir/centered_pair_low_quality.mp4");
+    const b = media("/other/dir/clip.mp4");
+    const matcher = new VideoMatcher(VideoMatchMethod.BASENAME);
+    expect(await matcher.match(a, b)).toBe(false);
+  });
+
+  it("still matches same-basename videos", async () => {
+    const a = media("/some/dir/clip.mp4");
+    const b = media("/other/dir/clip.mp4");
+    const matcher = new VideoMatcher(VideoMatchMethod.BASENAME);
+    expect(await matcher.match(a, b)).toBe(true);
+  });
+
+  it("matchesPath basename compares filenames, not empty datasets", () => {
+    const a = media("/a/foo.mp4");
+    const different = media("/b/bar.mp4");
+    const same = media("/c/foo.mp4");
+    expect(a.matchesPath(different, false)).toBe(false);
+    expect(a.matchesPath(same, false)).toBe(true);
+  });
+});


### PR DESCRIPTION
Two SLP-read/match correctness bugs that made sleap-app's **Merge into Project** misbehave (block valid merges; match unrelated videos). Both found while verifying that feature.

## 1. Classic PyQt-SLEAP skeletons wrapped under `nx_graph`
`parseSkeletons` only read the **flat** node-link shape (`entry.nodes`/`entry.links`) that modern sleap-io writes. Classic PyQt SLEAP jsonpickles each skeleton and wraps its networkx graph under **`nx_graph`**, so `entry.nodes` was absent → the empty-node fallback adopted the **entire global `nodes` list**. A 2-node skeleton on a project whose global list still carried the parent 13-node fly (`clip.2node.slp`) decoded to a **13-node, edge-less** skeleton → skeleton matching broke.
**Fix:** read nodes/links/graph from `entry.nx_graph` when present, else flat. (Sole path for all SLP readers.)

## 2. MediaVideo empty-dataset over-match
A MediaVideo `.slp` backend carries `dataset: ""`. `hdf5Dataset` returned that empty string, so `isHdf5Video` was wrongly `true` and `matchesPath` took the HDF5 branch — matching any two plain `.mp4` videos on their equal-empty datasets (`"" === ""`), regardless of filename.
**Fix:** treat an empty dataset as absent (not HDF5).

## Verification
- New unit tests: `skeleton-nx-graph.test.ts`, `video-match-empty-dataset.test.ts`.
- Real files: `clip.2node.slp` now reads `[head, thorax]` + 1 edge (matches Python); `centered_pair` vs `clip` no longer match while same-video train/val still do.
- Full suite **2191 pass / 0 fail**, biome (2.5.1) clean at error level, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)