### PR TITLE
chore: release 0.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.5.10**.

Ships #250:
- fix(slp): read classic PyQt-SLEAP skeletons wrapped under `nx_graph`
- fix(matching): don't treat an empty MediaVideo dataset as an HDF5 dataset (over-match)

Unblocks sleap-app #277 / #279 (Merge into Project), which pin `^0.5.10`.

Version bump only (`package.json` 0.5.9 → 0.5.10). Merging this + creating the `v0.5.10` GitHub Release triggers `release.yml` → `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)