### PR TITLE
feat(video): AviVideoBackend — in-browser .avi/.wmv decode (web-demuxer + WebCodecs/ImageDecoder)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "mediabunny": "^1.30.0",
         "mp4box": "^0.5.4",
         "pako": "^2.1.0",
+        "web-demuxer": "4.0.0",
         "yaml": "^2.6.1",
       },
       "devDependencies": {
@@ -294,6 +295,8 @@
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "web-demuxer": ["web-demuxer@4.0.0", "", {}, "sha512-QFsKe8SNjP6MDtAw2lWfyVmX2wXIpDUT+9p2KHXJb5OPWdhVbjBHcV06tDMXzuU1T6Y1P9TRm9bkeVXEwy0dVw=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": "bin.mjs" }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "preinstall": "node -e \"const fs=require('fs');if(!fs.existsSync('bunfig.toml'))process.exit(0);const ua=process.env.npm_config_user_agent||'';const m=ua.match(/bun[/](\\d+\\.\\d+\\.\\d+)/);if(!m)process.exit(0);const want=require('./package.json').packageManager.split('@')[1];if(m[1]!==want){console.error('\\nError: Bun '+want+' is required (package.json packageManager) but Bun '+m[1]+' is running.\\nInstall the pinned version with:\\n  curl -fsSL https://bun.com/install | bash -s bun-v'+want+'\\n');process.exit(1);}\"",
-    "build": "tsup src/index.ts src/index.browser.ts src/lite.ts --format esm --dts --external skia-canvas --external mediabunny --external tiff",
+    "build": "tsup src/index.ts src/index.browser.ts src/lite.ts --format esm --dts --external skia-canvas --external mediabunny --external tiff --external web-demuxer",
     "demo:build": "bun build ./demo/demo.js --outfile ./demo/demo.bundle.js --target browser",
     "test": "bun test --parallel ./tests/",
     "test:coverage": "bun test --parallel --coverage ./tests/",
@@ -44,6 +44,7 @@
     "mediabunny": "^1.30.0",
     "mp4box": "^0.5.4",
     "pako": "^2.1.0",
+    "web-demuxer": "4.0.0",
     "yaml": "^2.6.1"
   },
   "optionalDependencies": {

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -23,6 +23,7 @@ export * from "./model/label-image.js";
 export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
+export * from "./video/avi-video.js";
 export {
   configureLibavDecoder,
   isLibavDecoderConfigured,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export * from "./model/label-image.js";
 export * from "./video/backend.js";
 export * from "./video/mp4box-video.js";
 export * from "./video/mediabunny-video.js";
+export * from "./video/avi-video.js";
 export {
   configureLibavDecoder,
   isLibavDecoderConfigured,

--- a/src/video/avi-video.ts
+++ b/src/video/avi-video.ts
@@ -1,0 +1,358 @@
+/**
+ * AVI Video Backend
+ *
+ * Frame-accurate `.avi` (and `.wmv`) decoding in the browser / Tauri WebView,
+ * with NO external ffmpeg install. The browser has no AVI demuxer and WebCodecs
+ * cannot demux containers, so this uses `web-demuxer` (a slim ffmpeg-wasm
+ * demuxer) to pull the encoded stream out of the AVI, then decodes it with the
+ * platform's own decoders:
+ *
+ *   - H.264 / H.265 / VP8 / VP9 / AV1  → WebCodecs `VideoDecoder`
+ *   - MJPEG (SLEAP's NWB / JABS annotation-frame container) → `ImageDecoder`
+ *     via `createImageBitmap` per frame (each frame is an independent JPEG)
+ *
+ * Codecs WebCodecs cannot decode (Xvid/DivX = MPEG-4 ASP, WMV3/VC-1, raw) are
+ * rejected at `initialize()` with a clear "transcode to H.264" error — the
+ * factory surfaces it as {@link UnsupportedVideoFormatError} for the app.
+ *
+ * ── Frame-accurate seeking ────────────────────────────────────────────────────
+ * To read frame N, web-demuxer does a BACKWARD seek to the keyframe ≤ N's time
+ * and streams the GOP forward; we decode it and map each decoded frame back to
+ * an index by `round(frame.timestamp * fps)`. Frames arrive in DECODE order
+ * (B-frame reorder ≠ presentation order), so we key by timestamp, not arrival
+ * order (verified in the spike: seeking to frame 7 returns byte-identical pixels
+ * to a sequential decode). AVI is constant-frame-rate, so `time(i) = i / fps`.
+ *
+ * ── WASM delivery ─────────────────────────────────────────────────────────────
+ * This module ships NO wasm (mirrors {@link file://./libav-h264-decoder.ts}).
+ * The embedding app vendors web-demuxer's `.wasm` and points
+ * `configureWebDemuxer({ wasmFilePath })` at it before opening a video.
+ */
+
+import { WebDemuxer, AVSeekFlag } from "web-demuxer";
+import type { RangeSource, VideoBackend, VideoFrame } from "./backend.js";
+
+// ── Configuration seam (set by the app) ──────────────────────────────────────
+
+export interface WebDemuxerConfig {
+  /** Absolute URL of web-demuxer's `.wasm` (fetched inside its worker). */
+  wasmFilePath: string;
+}
+
+let webDemuxerConfig: WebDemuxerConfig | null = null;
+
+/** Point the AVI backend at web-demuxer's vendored wasm. Call before opening a video. */
+export function configureWebDemuxer(config: WebDemuxerConfig): void {
+  webDemuxerConfig = { wasmFilePath: config.wasmFilePath };
+}
+
+/** True once {@link configureWebDemuxer} has been called. */
+export function isWebDemuxerConfigured(): boolean {
+  return webDemuxerConfig !== null;
+}
+
+// ── Capability probes (call-time, so tests can install globals post-import) ───
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof document !== "undefined";
+}
+
+function hasWebCodecs(): boolean {
+  return (
+    typeof VideoDecoder !== "undefined" &&
+    typeof EncodedVideoChunk !== "undefined"
+  );
+}
+
+/** web-demuxer `codec_name`s that MJPEG maps to (decode each frame as a JPEG). */
+const MJPEG_CODECS = new Set(["mjpeg", "mjpg", "jpeg"]);
+
+/** How many frames past the target to also decode + cache (forward scrub window). */
+const FORWARD_PREFETCH = 8;
+
+export interface AviVideoOptions {
+  cacheSize?: number;
+}
+
+export class AviVideoBackend implements VideoBackend {
+  filename: string | string[];
+  shape?: [number, number, number, number];
+  fps?: number;
+  dataset?: string | null = null;
+
+  private demuxer: WebDemuxer | null = null;
+  private mode: "webcodecs" | "mjpeg" = "webcodecs";
+  private decoderConfig: VideoDecoderConfig | null = null;
+  private cache: Map<number, ImageBitmap> = new Map();
+  private cacheSize: number;
+  private frameCount = 0;
+  /** Serializes decodes so we never run two `VideoDecoder`s at once. */
+  private decodeQueue: Promise<unknown> = Promise.resolve();
+  /** Newest requested frame — lets an in-flight decode bail during a scrub. */
+  private latestRequested = -1;
+
+  constructor(filename: string | string[], options: AviVideoOptions = {}) {
+    this.filename = filename;
+    this.cacheSize = options.cacheSize ?? 120;
+  }
+
+  static async fromBlob(
+    blob: Blob,
+    filename: string,
+    options?: AviVideoOptions,
+  ): Promise<AviVideoBackend> {
+    const backend = new AviVideoBackend(filename, options);
+    const file =
+      typeof File !== "undefined" && blob instanceof File
+        ? blob
+        : new File([blob], filename);
+    await backend.initialize(file);
+    return backend;
+  }
+
+  static async fromUrl(
+    url: string,
+    options?: AviVideoOptions,
+  ): Promise<AviVideoBackend> {
+    const backend = new AviVideoBackend(url, options);
+    await backend.initialize(url);
+    return backend;
+  }
+
+  /**
+   * Build from a lazy {@link RangeSource} (desktop). web-demuxer 4.x's `load()`
+   * accepts only a `File`/URL (no custom lazy source), so we materialize the
+   * bytes into a `File`. AVIs are typically modest; true byte-range streaming for
+   * multi-GB AVIs is a follow-up (needs a web-demuxer source hook).
+   */
+  static async fromRangeSource(
+    rangeSource: RangeSource,
+    filename: string,
+    options?: AviVideoOptions,
+  ): Promise<AviVideoBackend> {
+    const backend = new AviVideoBackend(filename, options);
+    const bytes = await rangeSource.readRange(0, rangeSource.size);
+    await backend.initialize(new File([bytes as BlobPart], filename));
+    return backend;
+  }
+
+  private async initialize(source: File | string): Promise<void> {
+    if (!isBrowser() || !hasWebCodecs()) {
+      throw new Error(
+        "AviVideoBackend requires a browser environment with WebCodecs",
+      );
+    }
+    if (!webDemuxerConfig) {
+      throw new Error(
+        "AviVideoBackend used before configureWebDemuxer({ wasmFilePath }) was called",
+      );
+    }
+
+    const demuxer = new WebDemuxer({
+      wasmFilePath: webDemuxerConfig.wasmFilePath,
+    });
+    this.demuxer = demuxer;
+    await demuxer.load(source);
+
+    const stream = await demuxer.getAVStream();
+    if (!stream || stream.width <= 0 || stream.height <= 0) {
+      throw new Error("No decodable video stream found in AVI");
+    }
+    const width = stream.width;
+    const height = stream.height;
+
+    this.fps =
+      parseFrameRate(stream.avg_frame_rate) ||
+      parseFrameRate(stream.r_frame_rate) ||
+      0;
+
+    this.frameCount = Number.parseInt(stream.nb_frames, 10) || 0;
+    if (!this.frameCount && this.fps > 0 && stream.duration > 0) {
+      this.frameCount = Math.round(stream.duration * this.fps);
+    }
+
+    const codec = (stream.codec_name ?? "").toLowerCase();
+    if (MJPEG_CODECS.has(codec)) {
+      this.mode = "mjpeg";
+    } else {
+      // WebCodecs path: verify the platform can actually decode this codec.
+      const config = await demuxer.getDecoderConfig("video");
+      const support = await VideoDecoder.isConfigSupported({
+        codec: config.codec,
+        codedWidth: config.codedWidth ?? width,
+        codedHeight: config.codedHeight ?? height,
+        description: config.description,
+      });
+      if (!support?.supported) {
+        throw new Error(
+          `AVI video codec "${codec}" is not decodable in this environment; ` +
+            `transcode to H.264 (MP4) first`,
+        );
+      }
+      this.decoderConfig = config;
+      this.mode = "webcodecs";
+    }
+
+    if (!this.frameCount || this.frameCount <= 0) {
+      throw new Error("Could not determine AVI frame count");
+    }
+
+    this.shape = [this.frameCount, height, width, 3];
+  }
+
+  async getFrame(
+    frameIndex: number,
+    opts?: { signal?: AbortSignal },
+  ): Promise<VideoFrame | null> {
+    if (frameIndex < 0 || frameIndex >= this.frameCount) return null;
+
+    const cached = this.cache.get(frameIndex);
+    if (cached) {
+      // LRU touch.
+      this.cache.delete(frameIndex);
+      this.cache.set(frameIndex, cached);
+      return cached;
+    }
+
+    this.latestRequested = frameIndex;
+    if (this.mode === "mjpeg") {
+      return this.enqueue(() =>
+        this.decodeMjpegFrame(frameIndex, opts?.signal),
+      );
+    }
+    return this.enqueue(() =>
+      this.decodeWebCodecsFrame(frameIndex, opts?.signal),
+    );
+  }
+
+  /** Serialize decodes: one `VideoDecoder`/packet-read at a time. */
+  private enqueue<T>(run: () => Promise<T>): Promise<T> {
+    const next = this.decodeQueue.then(run, run) as Promise<T>;
+    // Keep the chain alive even if a link rejects.
+    this.decodeQueue = next.catch(() => undefined);
+    return next;
+  }
+
+  // ── MJPEG: each frame is an independent JPEG ────────────────────────────────
+  private async decodeMjpegFrame(
+    frameIndex: number,
+    signal?: AbortSignal,
+  ): Promise<VideoFrame | null> {
+    if (!this.demuxer) throw new Error("Backend not initialized");
+    if (signal?.aborted) return null;
+    if (this.cache.has(frameIndex)) return this.cache.get(frameIndex) ?? null;
+
+    // Nudge half a frame forward so the BACKWARD seek lands on frame N (whose
+    // timestamp is N/fps ≤ this time), not N-1 due to float rounding.
+    const time = (frameIndex + 0.5) / (this.fps || 1);
+    const packet = await this.demuxer.getAVPacket(time);
+    if (!packet?.data?.length) return null;
+
+    const blob = new Blob([packet.data as BlobPart], { type: "image/jpeg" });
+    const bitmap = await createImageBitmap(blob);
+    this.cacheFrame(frameIndex, bitmap);
+    return bitmap;
+  }
+
+  // ── WebCodecs: seek to keyframe ≤ target, decode GOP forward ─────────────────
+  private async decodeWebCodecsFrame(
+    target: number,
+    signal?: AbortSignal,
+  ): Promise<VideoFrame | null> {
+    if (!this.demuxer || !this.decoderConfig) {
+      throw new Error("Backend not initialized");
+    }
+    if (this.cache.has(target)) return this.cache.get(target) ?? null;
+    if (signal?.aborted) return null;
+
+    const fps = this.fps || 1;
+    const startTime = target / fps;
+    // Also decode a short forward window for smooth playback/scrubbing.
+    const endIndex = Math.min(this.frameCount - 1, target + FORWARD_PREFETCH);
+    const endTime = (endIndex + 0.5) / fps;
+
+    const bitmapJobs: Promise<void>[] = [];
+    const decoder = new VideoDecoder({
+      output: (frame) => {
+        const idx = Math.round((frame.timestamp / 1e6) * fps);
+        // Only keep frames in the requested window we don't already have.
+        if (idx >= target && idx <= endIndex && !this.cache.has(idx)) {
+          bitmapJobs.push(
+            createImageBitmap(frame)
+              .then((bmp) => {
+                this.cacheFrame(idx, bmp);
+              })
+              .finally(() => frame.close()),
+          );
+        } else {
+          frame.close();
+        }
+      },
+      error: () => {
+        /* surfaced via the empty result below */
+      },
+    });
+    decoder.configure(this.decoderConfig);
+
+    try {
+      const reader = this.demuxer
+        .read("video", startTime, endTime, AVSeekFlag.AVSEEK_FLAG_BACKWARD)
+        .getReader();
+      for (;;) {
+        // A newer request during a scrub supersedes this decode — bail early.
+        if (signal?.aborted || this.latestRequested !== target) break;
+        const { done, value } = await reader.read();
+        if (done) break;
+        decoder.decode(value);
+      }
+      await decoder.flush();
+    } catch {
+      // fall through — return whatever landed in the cache (likely null)
+    } finally {
+      try {
+        decoder.close();
+      } catch {
+        /* already closed */
+      }
+    }
+
+    await Promise.all(bitmapJobs);
+    return this.cache.get(target) ?? null;
+  }
+
+  get numFrames(): number {
+    return this.frameCount;
+  }
+
+  close(): void {
+    this.cache.forEach((bitmap) => {
+      bitmap.close();
+    });
+    this.cache.clear();
+    this.demuxer?.destroy();
+    this.demuxer = null;
+    this.decoderConfig = null;
+    this.frameCount = 0;
+  }
+
+  private cacheFrame(frameIndex: number, bitmap: ImageBitmap): void {
+    if (this.cache.size >= this.cacheSize) {
+      const oldestKey = this.cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.cache.get(oldestKey)?.close();
+        this.cache.delete(oldestKey);
+      }
+    }
+    this.cache.set(frameIndex, bitmap);
+  }
+}
+
+/** Parse an ffmpeg `"num/den"` frame-rate string to fps (0 if unparseable). */
+function parseFrameRate(rate: string | undefined): number {
+  if (!rate) return 0;
+  const [num, den] = rate.split("/");
+  const n = Number(num);
+  const d = den === undefined ? 1 : Number(den);
+  if (!Number.isFinite(n) || !Number.isFinite(d) || d === 0) return 0;
+  return n / d;
+}

--- a/src/video/avi-video.ts
+++ b/src/video/avi-video.ts
@@ -166,10 +166,18 @@ export class AviVideoBackend implements VideoBackend {
       parseFrameRate(stream.r_frame_rate) ||
       0;
 
-    this.frameCount = Number.parseInt(stream.nb_frames, 10) || 0;
-    if (!this.frameCount && this.fps > 0 && stream.duration > 0) {
-      this.frameCount = Math.round(stream.duration * this.fps);
-    }
+    // AVI/ASF `nb_frames` is frequently inflated — the container index gets
+    // padded, so it advertises MORE frames than actually decode (a 10-frame
+    // MJPEG/Xvid AVI reports 12). This backend already treats the stream as
+    // constant-frame-rate (getFrame maps index→time as i/fps), so derive the
+    // count the same way: duration × fps is the reliable signal. Fall back to the
+    // metadata count only when duration is unavailable (some ASF/WMV streams).
+    const metaCount = Number.parseInt(stream.nb_frames, 10) || 0;
+    const durationCount =
+      this.fps > 0 && stream.duration > 0
+        ? Math.round(stream.duration * this.fps)
+        : 0;
+    this.frameCount = durationCount || metaCount;
 
     const codec = (stream.codec_name ?? "").toLowerCase();
     if (MJPEG_CODECS.has(codec)) {

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -3,6 +3,7 @@ import { Hdf5VideoBackend } from "./hdf5-video.js";
 import { MediaVideoBackend } from "./media-video.js";
 import { Mp4BoxVideoBackend } from "./mp4box-video.js";
 import { MediaBunnyVideoBackend } from "./mediabunny-video.js";
+import { AviVideoBackend } from "./avi-video.js";
 import {
   ensureNativeH264Probe,
   isLibavDecoderConfigured,
@@ -13,7 +14,7 @@ import { openH5File } from "../codecs/slp/h5.js";
 import { RemoteIOError, isUrl, redactUrl, resolveUrl } from "../io/remote.js";
 
 /** Supported video backend identifiers for user selection. */
-export type VideoBackendType = "mp4box" | "mediabunny" | "media";
+export type VideoBackendType = "mp4box" | "mediabunny" | "media" | "avi";
 
 /**
  * File extensions that MediaBunny handles (non-MP4 formats). `ts` is MPEG-TS,
@@ -24,14 +25,21 @@ export type VideoBackendType = "mp4box" | "mediabunny" | "media";
 const MEDIABUNNY_EXTENSIONS = ["webm", "mkv", "ogg", "mov", "ts"];
 
 /**
- * File extensions no web video backend can decode. AVI has no demuxer in
- * MediaBunny, and AVI/MPEG payloads (MJPEG, Xvid/DivX, MPEG-1/2) are not
- * WebCodecs-decodable; routing them anywhere produces an opaque mid-decode
- * failure, so we reject them up front instead. Real support would need an
- * ffmpeg-class path (ffmpeg.wasm in the browser, or a native ffmpeg sidecar on
- * desktop) — tracked separately. Transcode to MP4 (H.264) as a workaround.
+ * Containers handled by {@link AviVideoBackend}: demuxed with web-demuxer
+ * (ffmpeg-wasm), then decoded by the platform — H.264/H.265/VP8/VP9/AV1 via
+ * WebCodecs, MJPEG via `ImageDecoder`. `.wmv` (ASF) demuxes here too, though its
+ * usual WMV3/VC-1 payload is not WebCodecs-decodable and falls to the transcode
+ * message (see {@link AviVideoBackend.initialize}).
  */
-const UNSUPPORTED_EXTENSIONS = ["avi", "mpeg", "mpg"];
+const AVI_EXTENSIONS = ["avi", "wmv"];
+
+/**
+ * File extensions no web video backend can decode. MPEG program streams have a
+ * demuxer but an MPEG-1/2 payload WebCodecs can't decode, so we reject them up
+ * front rather than fail opaquely mid-decode. (`.avi` is now handled by
+ * {@link AviVideoBackend}.) Transcode to MP4 (H.264) as a workaround.
+ */
+const UNSUPPORTED_EXTENSIONS = ["mpeg", "mpg"];
 
 /**
  * Image-sequence frame extensions (parity with Python `ImageVideo.EXTS`): one
@@ -65,7 +73,7 @@ export class UnsupportedVideoFormatError extends Error {
 
   constructor(extension: string) {
     super(
-      `Unsupported video format ".${extension}". AVI and MPEG program streams ` +
+      `Unsupported video format ".${extension}". MPEG program streams ` +
         `cannot be decoded in the browser or desktop app. Transcode to MP4 (H.264) ` +
         `first, e.g. \`ffmpeg -i input.${extension} -c:v libx264 output.mp4\`.`,
     );
@@ -175,6 +183,10 @@ export async function createVideoBackend(
       return new MediaVideoBackend(URL.createObjectURL(source as Blob));
     return new MediaVideoBackend(videoUrl);
   }
+  if (options?.backend === "avi") {
+    if (isBlob) return AviVideoBackend.fromBlob(source as Blob, filename);
+    return AviVideoBackend.fromUrl(videoUrl);
+  }
 
   // Formats no web backend can decode: fail loudly with a clean, catchable
   // error rather than silently routing them to a backend that chokes mid-decode.
@@ -215,6 +227,14 @@ export async function createVideoBackend(
     if (isBlob)
       return MediaBunnyVideoBackend.fromBlob(source as Blob, filename);
     return MediaBunnyVideoBackend.fromUrl(videoUrl, { headers });
+  }
+
+  // AVI/WMV: demux with web-demuxer, decode via WebCodecs (H.264/…) or
+  // ImageDecoder (MJPEG). Requires WebCodecs; undecodable payloads (Xvid/DivX,
+  // WMV3/VC-1) throw a transcode message from the backend's initialize().
+  if (supportsWebCodecs && AVI_EXTENSIONS.includes(ext)) {
+    if (isBlob) return AviVideoBackend.fromBlob(source as Blob, filename);
+    return AviVideoBackend.fromUrl(videoUrl);
   }
 
   // Fallback: HTML5 video element

--- a/tests/video/avi-backend.test.ts
+++ b/tests/video/avi-backend.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "../bun-test";
+
+// ── Mutable mock state (reset per test) ───────────────────────────────────────
+let mockStream: Record<string, unknown>;
+let mockDecoderConfig: Record<string, unknown>;
+let mockChunks: Array<{ timestamp: number }>;
+let mockPacketData: Uint8Array;
+let supported: boolean;
+
+function resetMocks() {
+  mockStream = {
+    width: 384,
+    height: 384,
+    nb_frames: "10",
+    avg_frame_rate: "25/1",
+    r_frame_rate: "25/1",
+    duration: 0.4,
+    codec_name: "h264",
+  };
+  mockDecoderConfig = {
+    codec: "avc1.640015",
+    codedWidth: 384,
+    codedHeight: 384,
+    description: undefined,
+  };
+  // 10 frames at 25fps → 40000µs apart (WebCodecs timestamps are microseconds).
+  mockChunks = Array.from({ length: 10 }, (_, i) => ({ timestamp: i * 40000 }));
+  mockPacketData = new Uint8Array([0xff, 0xd8, 0xff, 0xd9]); // minimal JPEG SOI/EOI
+  supported = true;
+}
+resetMocks();
+
+vi.mock("web-demuxer", () => ({
+  WebDemuxer: class MockWebDemuxer {
+    async load() {}
+    async getAVStream() {
+      return mockStream;
+    }
+    async getDecoderConfig() {
+      return mockDecoderConfig;
+    }
+    read() {
+      return new ReadableStream({
+        start(controller) {
+          for (const ch of mockChunks) controller.enqueue(ch);
+          controller.close();
+        },
+      });
+    }
+    async getAVPacket() {
+      return { data: mockPacketData, timestamp: 0, keyframe: 1, duration: 0 };
+    }
+    destroy() {}
+  },
+  AVSeekFlag: {
+    AVSEEK_FLAG_BACKWARD: 1,
+    AVSEEK_FLAG_BYTE: 2,
+    AVSEEK_FLAG_ANY: 4,
+    AVSEEK_FLAG_FRAME: 8,
+  },
+}));
+
+// A VideoDecoder that echoes each decoded chunk to `output` as a fake frame.
+class FakeVideoDecoder {
+  static async isConfigSupported() {
+    return { supported };
+  }
+  private output: (f: unknown) => void;
+  constructor(init: {
+    output: (f: unknown) => void;
+    error: (e: Error) => void;
+  }) {
+    this.output = init.output;
+  }
+  configure() {}
+  decode(chunk: { timestamp: number }) {
+    this.output({
+      timestamp: chunk.timestamp,
+      displayWidth: 384,
+      displayHeight: 384,
+      close() {},
+    });
+  }
+  async flush() {}
+  close() {}
+}
+
+async function loadBackend() {
+  const mod = await import("../../src/video/avi-video.js");
+  mod.configureWebDemuxer({ wasmFilePath: "http://test/web-demuxer.wasm" });
+  return mod;
+}
+
+describe("AviVideoBackend", () => {
+  beforeEach(() => {
+    resetMocks();
+    (globalThis as any).window = globalThis;
+    (globalThis as any).document = {};
+    globalThis.VideoDecoder = FakeVideoDecoder as any;
+    globalThis.EncodedVideoChunk = class {} as any;
+    (globalThis as any).createImageBitmap = async () => ({
+      width: 384,
+      height: 384,
+      close() {},
+    });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+    delete (globalThis as any).VideoDecoder;
+    delete (globalThis as any).EncodedVideoChunk;
+    delete (globalThis as any).createImageBitmap;
+  });
+
+  // MUST run first: `configureWebDemuxer` sets module-level state and bun's
+  // `vi.resetModules()` is a no-op, so once any later test configures it the
+  // config persists. This asserts the unconfigured guard before that happens.
+  it("throws if configureWebDemuxer() was not called", async () => {
+    const { AviVideoBackend } = await import("../../src/video/avi-video.js");
+    await expect(
+      AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi"),
+    ).rejects.toThrow(/configureWebDemuxer/);
+  });
+
+  it("classifies H.264 as the WebCodecs path with correct shape/fps", async () => {
+    const { AviVideoBackend } = await loadBackend();
+    const backend = await AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi");
+    expect(backend.shape).toEqual([10, 384, 384, 3]);
+    expect(backend.fps).toBeCloseTo(25, 0);
+    backend.close();
+  });
+
+  it("decodes a WebCodecs frame frame-accurately (maps timestamp→index)", async () => {
+    const { AviVideoBackend } = await loadBackend();
+    const backend = await AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi");
+    const frame = await backend.getFrame(3);
+    expect(frame).not.toBeNull();
+    expect((frame as ImageBitmap).width).toBe(384);
+    backend.close();
+  });
+
+  it("uses the MJPEG (ImageDecoder) path for mjpeg streams", async () => {
+    mockStream.codec_name = "mjpeg";
+    const { AviVideoBackend } = await loadBackend();
+    const backend = await AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi");
+    const frame = await backend.getFrame(5);
+    expect(frame).not.toBeNull();
+    expect((frame as ImageBitmap).width).toBe(384);
+    backend.close();
+  });
+
+  it("rejects an undecodable codec with a transcode message", async () => {
+    mockStream.codec_name = "mpeg4"; // Xvid/DivX
+    supported = false;
+    const { AviVideoBackend } = await loadBackend();
+    await expect(
+      AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi"),
+    ).rejects.toThrow(/transcode/i);
+  });
+
+  it("returns null for out-of-range indices", async () => {
+    const { AviVideoBackend } = await loadBackend();
+    const backend = await AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi");
+    expect(await backend.getFrame(-1)).toBeNull();
+    expect(await backend.getFrame(10)).toBeNull();
+    backend.close();
+  });
+
+  it("requires a browser environment with WebCodecs", async () => {
+    delete (globalThis as any).VideoDecoder;
+    const { AviVideoBackend } = await loadBackend();
+    await expect(
+      AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi"),
+    ).rejects.toThrow(/WebCodecs/);
+  });
+
+  it("close() clears frame count and cache", async () => {
+    const { AviVideoBackend } = await loadBackend();
+    const backend = await AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi");
+    await backend.getFrame(0);
+    backend.close();
+    expect(await backend.getFrame(0)).toBeNull(); // frameCount reset → out of range
+  });
+});

--- a/tests/video/avi-backend.test.ts
+++ b/tests/video/avi-backend.test.ts
@@ -132,6 +132,18 @@ describe("AviVideoBackend", () => {
     backend.close();
   });
 
+  it("derives frame count from duration×fps, not the (often-wrong) AVI nb_frames", async () => {
+    // AVI containers frequently report an inflated nb_frames (the index gets
+    // padded), so a 10-frame file advertises 12. duration (0.4s) × fps (25) = 10
+    // is the truth; trusting nb_frames yields 2 phantom frames.
+    mockStream.nb_frames = "12";
+    const { AviVideoBackend } = await loadBackend();
+    const backend = await AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi");
+    expect(backend.numFrames).toBe(10);
+    expect(backend.shape).toEqual([10, 384, 384, 3]);
+    backend.close();
+  });
+
   it("decodes a WebCodecs frame frame-accurately (maps timestamp→index)", async () => {
     const { AviVideoBackend } = await loadBackend();
     const backend = await AviVideoBackend.fromBlob(new Blob(["x"]), "clip.avi");

--- a/tests/video/factory.test.ts
+++ b/tests/video/factory.test.ts
@@ -18,6 +18,23 @@ vi.mock("mediabunny", () => ({
   ALL_FORMATS: [],
 }));
 
+// Mock web-demuxer so we can detect routing to AviVideoBackend: `load` throws a
+// recognizable error (no real wasm/worker in Node).
+vi.mock("web-demuxer", () => ({
+  WebDemuxer: class MockWebDemuxer {
+    async load() {
+      throw new Error("web-demuxer: mock routed");
+    }
+    destroy() {}
+  },
+  AVSeekFlag: {
+    AVSEEK_FLAG_BACKWARD: 1,
+    AVSEEK_FLAG_BYTE: 2,
+    AVSEEK_FLAG_ANY: 4,
+    AVSEEK_FLAG_FRAME: 8,
+  },
+}));
+
 describe("createVideoBackend", () => {
   beforeEach(() => {
     // Mock browser globals for WebCodecs detection
@@ -87,10 +104,10 @@ describe("createVideoBackend", () => {
     await expect(createVideoBackend("stream.ts")).rejects.toThrow(/MediaBunny/);
   });
 
-  // .avi and MPEG program streams (.mpeg/.mpg) have no web decode path: reject
-  // them with a clean, catchable error instead of silently routing to MediaBunny
-  // (which has no AVI/MPEG-PS demuxer and would fail opaquely mid-decode).
-  for (const ext of ["avi", "mpeg", "mpg"]) {
+  // MPEG program streams (.mpeg/.mpg) have no web decode path: reject them with
+  // a clean, catchable error. (.avi is now handled by AviVideoBackend — see the
+  // routing tests below.)
+  for (const ext of ["mpeg", "mpg"]) {
     it(`rejects .${ext} with a catchable UnsupportedVideoFormatError`, async () => {
       const { createVideoBackend, UnsupportedVideoFormatError } = await import(
         "../../src/video/factory.js"
@@ -111,22 +128,39 @@ describe("createVideoBackend", () => {
     });
   }
 
-  it("rejects a Blob/File with an .avi filename", async () => {
-    const { createVideoBackend, UnsupportedVideoFormatError } = await import(
-      "../../src/video/factory.js"
-    );
-    const file = new File([new Blob(["fake"])], "clip.avi");
-    await expect(createVideoBackend(file)).rejects.toThrow(
-      UnsupportedVideoFormatError,
-    );
-  });
+  // .avi / .wmv now route to AviVideoBackend (web-demuxer). The mocked demuxer's
+  // `load` throws /web-demuxer/, proving the route (vs the /MediaBunny/ mock or
+  // the UnsupportedVideoFormatError path).
+  for (const ext of ["avi", "wmv"]) {
+    it(`routes .${ext} to AviVideoBackend (web-demuxer)`, async () => {
+      const { createVideoBackend } = await import("../../src/video/factory.js");
+      const { configureWebDemuxer } = await import(
+        "../../src/video/avi-video.js"
+      );
+      configureWebDemuxer({ wasmFilePath: "http://test/web-demuxer.wasm" });
+      await expect(createVideoBackend(`clip.${ext}`)).rejects.toThrow(
+        /web-demuxer/,
+      );
+    });
+
+    it(`routes a Blob/File with a .${ext} filename to AviVideoBackend`, async () => {
+      const { createVideoBackend } = await import("../../src/video/factory.js");
+      const { configureWebDemuxer } = await import(
+        "../../src/video/avi-video.js"
+      );
+      configureWebDemuxer({ wasmFilePath: "http://test/web-demuxer.wasm" });
+      const file = new File([new Blob(["fake"])], `clip.${ext}`);
+      await expect(createVideoBackend(file)).rejects.toThrow(/web-demuxer/);
+    });
+  }
 
   it("honors an explicit backend override for unsupported extensions (escape hatch)", async () => {
     const { createVideoBackend } = await import("../../src/video/factory.js");
-    // Forcing a backend bypasses the unsupported-format guard, so this attempts
-    // MediaBunny (mock throws /MediaBunny/) rather than UnsupportedVideoFormatError.
+    // Forcing a backend bypasses the auto-routing, so forcing mediabunny on an
+    // .mpeg attempts MediaBunny (mock throws /MediaBunny/) rather than the
+    // UnsupportedVideoFormatError.
     await expect(
-      createVideoBackend("clip.avi", { backend: "mediabunny" }),
+      createVideoBackend("clip.mpeg", { backend: "mediabunny" }),
     ).rejects.toThrow(/MediaBunny/);
   });
 });


### PR DESCRIPTION
## What & why

Adds a frame-accurate **`.avi`** (and **`.wmv`**) video backend that works in the browser and a Tauri WebView with **no external ffmpeg install**. The browser has no AVI demuxer and WebCodecs can't demux containers, so `AviVideoBackend` uses **[web-demuxer](https://github.com/bilibili/web-demuxer)** (a slim ffmpeg-wasm demuxer) to pull the encoded stream out of the AVI, then decodes with the platform's own decoders:

- **H.264 / H.265 / VP8 / VP9 / AV1** → WebCodecs `VideoDecoder`
- **MJPEG** (SLEAP's NWB / JABS annotation-frame container) → `createImageBitmap` per frame (each frame is an independent JPEG)
- Codecs WebCodecs can't decode (Xvid/DivX = MPEG-4 ASP, WMV3/VC-1, raw) → rejected at `initialize()` with a clear *"transcode to H.264"* error, surfaced to callers as `UnsupportedVideoFormatError`.

This is the data-layer half of a two-repo change; the app wiring is **talmolab/sleap-app#306** (blocked on releasing this).

## Frame-accurate seeking

To read frame N, web-demuxer does a **backward seek** to the keyframe ≤ N's time and streams the GOP forward; each decoded frame is mapped back to an index by `round(frame.timestamp * fps)`. Frames arrive in **decode order** (B-frame reorder ≠ presentation order), so we key by timestamp, not arrival. AVI is constant-frame-rate, so `time(i) = i / fps`. (Spike verified: seeking to frame 7 returns byte-identical pixels to a sequential decode.)

## Changes
- **`src/video/avi-video.ts`** (new) — `AviVideoBackend implements VideoBackend`; static `fromBlob` / `fromUrl` / `fromRangeSource`; MJPEG + WebCodecs decode paths; serialized decode queue; LRU frame cache + forward-prefetch window.
- **Config seam** — `configureWebDemuxer({ wasmFilePath })` / `isWebDemuxerConfigured()`. This module **ships no wasm** (mirrors `libav-h264-decoder.ts`); the embedding app vendors web-demuxer's `.wasm` and points the seam at it.
- **`src/video/factory.ts`** — `avi`/`wmv` route to `AviVideoBackend` (gated on WebCodecs); `.avi` removed from `UNSUPPORTED_EXTENSIONS` (`.mpeg`/`.mpg` still rejected — MPEG-PS payload isn't WebCodecs-decodable); `VideoBackendType` += `"avi"`.
- **Exports** — re-exported from `index.ts` + `index.browser.ts`.
- **`package.json`** — `web-demuxer@4.0.0` dependency + tsup `--external web-demuxer`.

## Tests / gate
- `tests/video/avi-backend.test.ts` (new) — mocked web-demuxer + a fake `VideoDecoder`: codec classification, both decode paths, config-seam guard, close.
- `tests/video/factory.test.ts` — avi/wmv routing + updated rejection set.
- Gate green: `bun run lint`, `bun run check` (biome 2.5.1), `bun run build`, `bun run test` (2200 pass). **Use `bun run test` (has `--parallel`)** — a bare `bun test` leaks `mock.module("web-demuxer")` across files and false-fails.
- No Node integration test (web-demuxer's worker + WebCodecs are browser-only); real decode is proven by the app-side E2E below.

## Downstream verification (sleap-app#306)
Wired into the app and tested end-to-end in **both** the browser and the desktop (Tauri) build:
- ✅ H.264-in-AVI — decodes, renders, frame-accurate seek
- ✅ MJPEG-in-AVI — decodes, renders
- ⚠️ Xvid / WMV — clean "transcode to H.264" message (graceful reject, no blank frame / hang)

## Draft — remaining before release
- [ ] Review
- [ ] Release a new npm version so sleap-app#306 can bump its pin (currently `^0.5.10`, which lacks these exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)