### PR TITLE
feat(video): add grayscale-forcing support via GrayscaleVideoBackend

### DIFF
--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -67,12 +67,17 @@ export {
   createVideoBackend,
   UnsupportedVideoFormatError,
   type VideoBackendType,
+  type CreateVideoBackendOptions,
 } from "./video/factory.js";
 // CropRect is re-exported transitively via ./transform/index.js (single source).
 export {
   CropVideoBackend,
   type CropWrapOptions,
 } from "./video/crop-backend.js";
+export {
+  GrayscaleVideoBackend,
+  type GrayscaleWrapOptions,
+} from "./video/grayscale-backend.js";
 export * from "./io/main.js";
 export * from "./io/remote.js";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,12 +77,17 @@ export {
   createVideoBackend,
   UnsupportedVideoFormatError,
   type VideoBackendType,
+  type CreateVideoBackendOptions,
 } from "./video/factory.js";
 // CropRect is re-exported transitively via ./transform/index.js (single source).
 export {
   CropVideoBackend,
   type CropWrapOptions,
 } from "./video/crop-backend.js";
+export {
+  GrayscaleVideoBackend,
+  type GrayscaleWrapOptions,
+} from "./video/grayscale-backend.js";
 export * from "./io/main.js";
 export * from "./io/remote.js";
 export {

--- a/src/model/video.ts
+++ b/src/model/video.ts
@@ -4,6 +4,7 @@ import type {
   GetFrameOptions,
 } from "../video/backend.js";
 import { CropVideoBackend } from "../video/crop-backend.js";
+import { GrayscaleVideoBackend } from "../video/grayscale-backend.js";
 import {
   cropPoints,
   uncropPoints,
@@ -369,19 +370,35 @@ export class Video {
     }
     const fill: Fill = opts.fill ?? 0;
     const shareDecode = opts.shareDecode ?? true;
-    const inner = this.backend;
+
+    // Canonical wrap order is Grayscale(Crop(rawInner)): if this video's
+    // backend is already grayscale-wrapped, unwrap it, crop the TRUE inner,
+    // then re-wrap grayscale on the outside. Cropping is spatial and
+    // grayscale-forcing is channel-only — the two operations commute — but a
+    // single canonical order avoids ever nesting Crop(Grayscale(...)), which
+    // would otherwise let the two wrappers be composed in either order
+    // depending on call sequence.
+    const grayscaleLayer =
+      this.backend instanceof GrayscaleVideoBackend ? this.backend : null;
+    const inner = grayscaleLayer ? grayscaleLayer.inner : this.backend;
     const croppedBackend = CropVideoBackend.wrap({
       inner,
       crop: rect,
       fill,
       ownsInner: !shareDecode,
     });
+    const finalBackend = grayscaleLayer
+      ? GrayscaleVideoBackend.wrap({
+          inner: croppedBackend,
+          grayscale: grayscaleLayer.grayscale,
+        })
+      : croppedBackend;
 
     const [x1, y1, x2, y2] = croppedBackend.crop;
     const srcShape = this.shape;
     const cropped = new Video({
       filename: this.filename,
-      backend: croppedBackend,
+      backend: finalBackend,
       sourceVideo: this,
       openBackend: this.openBackend,
     });
@@ -709,6 +726,56 @@ export class Video {
       return (this.backendMetadata.grayscale as boolean | null) ?? null;
     }
     return null;
+  }
+
+  /**
+   * Force (or release the forcing of) this video's grayscale state.
+   *
+   * Port of Python `Video.grayscale` setter (video.py): rebuilds the backend
+   * as a {@link GrayscaleVideoBackend} wrapping the current TRUE inner (any
+   * existing grayscale layer is unwrapped and replaced, never nested — see
+   * {@link GrayscaleVideoBackend.wrap}), and persists the value into
+   * {@link backendMetadata} so a closed/reopened video (which reads
+   * `backendMetadata.shape`/`backendMetadata.grayscale` rather than a live
+   * backend) still reports it — the same persistence pattern {@link crop}
+   * already uses for `crop`/`crop_fill`/`shape`.
+   *
+   * Matches Python's setter signature (`bool`, not the tri-state
+   * `bool | null` the constructor/{@link createVideoBackend} accept):
+   * autodetection is a construction-time choice, not something re-requested
+   * through this property.
+   *
+   * @throws Error If this video has no open backend (mirrors {@link crop},
+   *   which has the same requirement — the JS port has no filesystem
+   *   auto-open to fall back to).
+   */
+  set grayscale(value: boolean) {
+    if (this.backend == null) {
+      throw new Error(
+        "Cannot set grayscale on a video with no open backend. Provide a " +
+          "backend (the JS port has no filesystem auto-open) before setting " +
+          "grayscale.",
+      );
+    }
+    const inner =
+      this.backend instanceof GrayscaleVideoBackend
+        ? this.backend.inner
+        : this.backend;
+    this.backend = GrayscaleVideoBackend.wrap({ inner, grayscale: value });
+    this.backendMetadata = { ...this.backendMetadata, grayscale: value };
+    if (hasOwn(this.backendMetadata, "shape")) {
+      const shape = this.backendMetadata.shape as
+        | [number, number, number, number]
+        | null;
+      if (shape != null) {
+        this.backendMetadata.shape = [
+          shape[0],
+          shape[1],
+          shape[2],
+          value ? 1 : (inner.shape?.[3] ?? shape[3]),
+        ];
+      }
+    }
   }
 
   /**

--- a/src/transform/frame.ts
+++ b/src/transform/frame.ts
@@ -218,3 +218,76 @@ export function cropFrame(
   }
   return { data: out, width: cropW, height: cropH, channels };
 }
+
+/**
+ * Detect whether a decoded frame is grayscale by comparing its first and last
+ * color channel for exact equality across every pixel — parity with Python
+ * `VideoBackend.detect_grayscale` (`test_img[..., 0] == test_img[..., -1]`).
+ *
+ * For an `ImageData` input (always 4-channel RGBA with an always-opaque alpha
+ * lane), the comparison skips alpha and compares R (channel 0) against B
+ * (channel 2) — the last COLOR channel — mirroring the existing convention in
+ * `image-video.ts`'s `isGrayscale`. For a {@link RawFrame}, channels are
+ * compared literally (channel 0 vs. `channels - 1`), matching Python's raw
+ * numpy-array semantics exactly. A single-channel frame is trivially
+ * grayscale.
+ *
+ * @param frame Decoded source frame (`ImageData` RGBA or a {@link RawFrame}).
+ *   A raw `ImageBitmap` is rejected — rasterize it first.
+ */
+export function detectGrayscale(frame: FrameLike): boolean {
+  if (isImageBitmap(frame)) {
+    throw new Error(
+      "detectGrayscale cannot inspect a raw ImageBitmap: its pixels are not " +
+        "synchronously readable. Rasterize it to an ImageData first.",
+    );
+  }
+  const { data, channels } = frameInfo(frame);
+  if (channels <= 1) return true;
+  const lastColorChannel = isImageData(frame) ? 2 : channels - 1;
+  for (let i = 0; i < data.length; i += channels) {
+    if (data[i] !== data[i + lastColorChannel]) return false;
+  }
+  return true;
+}
+
+/**
+ * Collapse a decoded frame to a single channel by taking channel 0 of every
+ * pixel — parity with Python's `img[..., [0]]` slice, applied by
+ * `VideoBackend.get_frame`/`get_frames` when `grayscale` is (or resolves to)
+ * `true`. Always returns a {@link RawFrame} with `channels: 1`: a browser
+ * `ImageData` is hard-coded 4-channel RGBA and cannot represent a single
+ * channel, so the result is never re-wrapped as `ImageData` — mirrors how
+ * {@link cropFrame} already returns a differently-shaped `RawFrame` for
+ * non-`ImageData` input.
+ *
+ * @param frame Decoded source frame (`ImageData` RGBA or a {@link RawFrame}).
+ *   A raw `ImageBitmap` is rejected — rasterize it first (same contract as
+ *   {@link cropFrame}).
+ */
+export function grayscaleFrame(frame: FrameLike): RawFrame {
+  if (isImageBitmap(frame)) {
+    throw new Error(
+      "grayscaleFrame cannot collapse a raw ImageBitmap: its pixels are not " +
+        "synchronously readable. Rasterize it to an ImageData first.",
+    );
+  }
+  const { data, width, height, channels } = frameInfo(frame);
+  if (channels === 1) {
+    // Already 1-channel: return a defensive copy for output-ownership
+    // consistency with the multi-channel branch below.
+    const copy =
+      data instanceof Uint8ClampedArray
+        ? new Uint8ClampedArray(data)
+        : new Uint8Array(data);
+    return { data: copy, width, height, channels: 1 };
+  }
+  const out =
+    data instanceof Uint8ClampedArray
+      ? new Uint8ClampedArray(width * height)
+      : new Uint8Array(width * height);
+  for (let i = 0, p = 0; p < out.length; i += channels, p++) {
+    out[p] = data[i];
+  }
+  return { data: out, width, height, channels: 1 };
+}

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -2,8 +2,9 @@
  * Crop transform primitives for virtual cropping (SLP format 2.3).
  *
  * Pure, browser-safe ports of the Python `sleap_io.transform` crop helpers:
- * coordinate offsetting ({@link cropPoints}/{@link uncropPoints}) and frame
- * cropping with out-of-bounds pad-fill ({@link cropFrame}).
+ * coordinate offsetting ({@link cropPoints}/{@link uncropPoints}), frame
+ * cropping with out-of-bounds pad-fill ({@link cropFrame}), and grayscale
+ * detection/collapsing ({@link detectGrayscale}/{@link grayscaleFrame}).
  */
 
 export {
@@ -15,6 +16,8 @@ export {
 } from "./points.js";
 export {
   cropFrame,
+  detectGrayscale,
+  grayscaleFrame,
   type FrameLike,
   type RawFrame,
   type Fill,

--- a/src/video/factory.ts
+++ b/src/video/factory.ts
@@ -1,4 +1,5 @@
 import type { VideoBackend } from "./backend.js";
+import { GrayscaleVideoBackend } from "./grayscale-backend.js";
 import { Hdf5VideoBackend } from "./hdf5-video.js";
 import { MediaVideoBackend } from "./media-video.js";
 import { Mp4BoxVideoBackend } from "./mp4box-video.js";
@@ -77,26 +78,61 @@ export class UnsupportedVideoFormatError extends Error {
   }
 }
 
+export interface CreateVideoBackendOptions {
+  dataset?: string;
+  embedded?: boolean;
+  frameNumbers?: number[];
+  frameSizes?: number[];
+  format?: string;
+  channelOrder?: string;
+  shape?: [number, number, number, number];
+  fps?: number;
+  backend?: VideoBackendType;
+  /**
+   * Extra HTTP request headers (e.g. `{ Authorization: "Bearer …" }`) applied
+   * to remote video byte fetches. Forwarded to {@link Mp4BoxVideoBackend} and
+   * {@link MediaBunnyVideoBackend.fromUrl}. URL filenames are run through
+   * {@link resolveUrl} (rejecting `s3://`/`az://`/`abfs://`).
+   */
+  headers?: Record<string, string>;
+  /**
+   * Whether to force (or autodetect) grayscale. Mirrors Python
+   * `Video.from_filename(..., grayscale)`: `true` forces every frame to 1
+   * channel, `false` forces the source's native channel count (never
+   * collapses), `null` autodetects on the first frame read. Omitting this
+   * option entirely (`undefined`) skips grayscale-wrapping altogether — the
+   * returned backend reports whatever channel count it naturally decodes,
+   * exactly as before this option existed.
+   *
+   * When set, the backend built below is wrapped in a
+   * {@link GrayscaleVideoBackend}; see that class for the wrapping contract.
+   */
+  grayscale?: boolean | null;
+}
+
+/**
+ * Build a {@link VideoBackend} for `source`, auto-selecting the concrete
+ * backend by file extension/environment (see the branches below), then
+ * optionally wrapping it in a {@link GrayscaleVideoBackend} when
+ * `options.grayscale` is given (any value including `null` — `undefined`
+ * skips wrapping).
+ */
 export async function createVideoBackend(
   source: string | string[] | File | Blob,
-  options?: {
-    dataset?: string;
-    embedded?: boolean;
-    frameNumbers?: number[];
-    frameSizes?: number[];
-    format?: string;
-    channelOrder?: string;
-    shape?: [number, number, number, number];
-    fps?: number;
-    backend?: VideoBackendType;
-    /**
-     * Extra HTTP request headers (e.g. `{ Authorization: "Bearer …" }`) applied
-     * to remote video byte fetches. Forwarded to {@link Mp4BoxVideoBackend} and
-     * {@link MediaBunnyVideoBackend.fromUrl}. URL filenames are run through
-     * {@link resolveUrl} (rejecting `s3://`/`az://`/`abfs://`).
-     */
-    headers?: Record<string, string>;
-  },
+  options?: CreateVideoBackendOptions,
+): Promise<VideoBackend> {
+  const backend = await createConcreteVideoBackend(source, options);
+  if (options?.grayscale === undefined) return backend;
+  return GrayscaleVideoBackend.wrap({
+    inner: backend,
+    grayscale: options.grayscale,
+  });
+}
+
+/** The original `createVideoBackend` body, before grayscale-wrapping. */
+async function createConcreteVideoBackend(
+  source: string | string[] | File | Blob,
+  options?: CreateVideoBackendOptions,
 ): Promise<VideoBackend> {
   // Image-sequence video (Python `ImageVideo`): `source` is a LIST of image
   // paths, one image per frame. Route to ImageVideoBackend before the single-

--- a/src/video/grayscale-backend.ts
+++ b/src/video/grayscale-backend.ts
@@ -1,0 +1,265 @@
+// src/video/grayscale-backend.ts
+//
+// Virtual, on-read grayscale-forcing wrapper for an inner `VideoBackend`.
+//
+// Port of Python sleap-io's grayscale handling, which lives on the
+// `VideoBackend` base class itself (`sleap_io/io/video_reading.py`):
+// `get_frame`/`get_frames` slice `img[..., [0]]` whenever `self.grayscale` is
+// (or resolves to) `True`, and `grayscale=None` autodetects on the first frame
+// read by comparing the first and last channel for equality, caching the
+// result. The JS `VideoBackend` is a plain interface with no shared base-class
+// `getFrame`, so this wrapper centralizes the behavior once instead of
+// touching every concrete backend (`media-video.ts`, `mediabunny-video.ts`,
+// `mp4box-video.ts`, `hdf5-video.ts`, `streaming-hdf5-video.ts`,
+// `image-video.ts`, `seq-video.ts`) — mirroring how `crop-backend.ts` already
+// centralizes cropping instead of touching every backend.
+//
+// Browser-safe: this module never statically imports a Node-only decoder (it
+// delegates any such need to `image-decode.ts`'s `toReadableFrame`).
+
+import type { VideoBackend, VideoFrame, GetFrameOptions } from "./backend.js";
+import { grayscaleFrame, detectGrayscale } from "../transform/frame.js";
+import { toReadableFrame } from "./image-decode.js";
+import { CropVideoBackend } from "./crop-backend.js";
+
+/** Options for {@link GrayscaleVideoBackend.wrap}. */
+export interface GrayscaleWrapOptions {
+  /**
+   * The backend to wrap (may itself be a `CropVideoBackend`; never itself a
+   * `GrayscaleVideoBackend` — {@link GrayscaleVideoBackend.wrap} unwraps and
+   * replaces an existing grayscale layer instead of nesting).
+   */
+  inner: VideoBackend;
+  /**
+   * `true` forces every frame to 1 channel; `false` forces the inner's native
+   * channel count (never collapses, even if the source is genuinely
+   * grayscale); `null` autodetects on the first `getFrame` call and caches the
+   * resolved value on {@link GrayscaleVideoBackend.grayscale}. Tri-state,
+   * matching Python's `grayscale: bool | None` exactly.
+   */
+  grayscale: boolean | null;
+}
+
+/**
+ * Virtual, on-read grayscale-forcing view of an inner {@link VideoBackend}.
+ *
+ * Implements the {@link VideoBackend} interface, reporting a channel-forced
+ * `[F, H, W, 1]` shape once `grayscale` has resolved `true`: {@link getFrame}
+ * decodes the inner frame, normalizes it to readable pixels via
+ * {@link toReadableFrame} (rasterizing an opaque `ImageBitmap` / decoding
+ * undecoded encoded bytes as needed — the same normalization
+ * {@link "./crop-backend.js".CropVideoBackend} performs before cropping),
+ * autodetects on first read when unresolved, then applies the pure
+ * {@link grayscaleFrame} slice. The frame count and spatial dimensions are
+ * unchanged (grayscale-forcing is a channel operation, not spatial or
+ * temporal).
+ *
+ * Always construct via {@link GrayscaleVideoBackend.wrap} (never the raw
+ * constructor) so the "inner is never a GrayscaleVideoBackend" invariant holds
+ * by construction.
+ *
+ * Note on `grayscale: null` (autodetect): because `shape` is a synchronous
+ * getter and JS has no equivalent of Python's blocking `img_shape` property
+ * (which decodes a test frame inline), the autodetect resolution only happens
+ * on the first `getFrame()` call — `shape`/`grayscale` read as "unresolved"
+ * (the inner's native channel count) until then. This is the same general
+ * async-vs-sync characteristic already present elsewhere in this port (e.g.
+ * `ImageVideoBackend.create()` decodes frame 0 up front precisely so `shape`
+ * is resolved by construction time when no `shape` is supplied).
+ */
+export class GrayscaleVideoBackend implements VideoBackend {
+  /** Derived from `inner.filename`. */
+  filename: string | string[];
+  /**
+   * The wrapped source backend. Decodes full frames; this wrapper collapses
+   * their channels. Invariant: `inner` is never itself a
+   * `GrayscaleVideoBackend` (enforced by {@link wrap}).
+   */
+  readonly inner: VideoBackend;
+  /**
+   * Resolved/requested grayscale state. `true`/`false` are fixed at
+   * construction; `null` (autodetect) is mutated in place to the resolved
+   * value by the first {@link getFrame} call — mirrors Python's
+   * `self.grayscale` being written by `detect_grayscale()`.
+   */
+  grayscale: boolean | null;
+
+  /**
+   * Private-by-convention constructor: prefer {@link GrayscaleVideoBackend.wrap},
+   * which enforces the "inner is never a GrayscaleVideoBackend" invariant.
+   */
+  private constructor(inner: VideoBackend, grayscale: boolean | null) {
+    this.inner = inner;
+    this.grayscale = grayscale;
+    this.filename = inner.filename;
+  }
+
+  /**
+   * Wrap `inner` in a grayscale-forcing view.
+   *
+   * If `inner` is already a `GrayscaleVideoBackend`, it is unwrapped first —
+   * the new `grayscale` setting replaces the old one outright (any previously
+   * resolved autodetect result is intentionally dropped in favor of the new
+   * request), so wrapping never nests and always reflects the latest call.
+   */
+  static wrap(options: GrayscaleWrapOptions): GrayscaleVideoBackend {
+    const inner =
+      options.inner instanceof GrayscaleVideoBackend
+        ? options.inner.inner
+        : options.inner;
+    return new GrayscaleVideoBackend(inner, options.grayscale);
+  }
+
+  /** Inner backend's dataset name (delegated; a grayscale wrapper is channel-only). */
+  get dataset(): string | null | undefined {
+    return this.inner.dataset;
+  }
+
+  /** Inner backend's frame rate (delegated). */
+  get fps(): number | undefined {
+    return this.inner.fps;
+  }
+
+  /** Inner backend's embedded frame numbers (delegated; channel-forcing is frame-preserving). */
+  get frameNumbers(): number[] | undefined {
+    return this.inner.frameNumbers;
+  }
+
+  /** Inner backend's embedded blob format (delegated). */
+  get embeddedFormat(): string | undefined {
+    return this.inner.embeddedFormat;
+  }
+
+  /** Inner backend's embedded blob channel order (delegated). */
+  get embeddedChannelOrder(): string | undefined {
+    return this.inner.embeddedChannelOrder;
+  }
+
+  /**
+   * Raw stored blob for `frameNumber`, delegated to the inner backend
+   * verbatim. The stored blob is the inner's un-collapsed encoding; a raw byte
+   * consumer (e.g. re-embedding) is expected to decode it itself, same as for
+   * an unwrapped backend.
+   */
+  getFrameBuffer(frameNumber: number): Promise<Uint8Array | null> {
+    return this.inner.getFrameBuffer
+      ? this.inner.getFrameBuffer(frameNumber)
+      : Promise.resolve(null);
+  }
+
+  /** Deferred-metadata load, delegated to the inner backend (no-op if absent). */
+  ensureLoaded(): Promise<void> {
+    return this.inner.ensureLoaded?.() ?? Promise.resolve();
+  }
+
+  /** Inner backend's per-frame presentation times (delegated; channel-only wrapper). */
+  async getFrameTimes(): Promise<number[] | null> {
+    if (typeof this.inner.getFrameTimes === "function") {
+      return this.inner.getFrameTimes();
+    }
+    return null;
+  }
+
+  /** Inner backend's first-frame liveness probe (delegated; defaults to `true` if absent). */
+  async probeFirstFrame(): Promise<boolean> {
+    if (typeof this.inner.probeFirstFrame === "function") {
+      return this.inner.probeFirstFrame();
+    }
+    return true;
+  }
+
+  /**
+   * Channel-forced shape `[F, H, W, C]`: `C` is `1` once `grayscale` has
+   * resolved `true`, `3` when explicitly `false`, and the inner's own
+   * declared channel count when unresolved (`null` — see the class-level note
+   * on autodetect timing).
+   *
+   * Mirrors Python `VideoBackend.img_shape`, which unconditionally sets
+   * `channels = 1` for `grayscale is True` and `channels = 3` for
+   * `grayscale is False` — NOT the inner's own declared count in either case.
+   * This matters because `false` must positively override an inner that
+   * independently declares itself 1-channel (e.g. `ImageVideoBackend`'s own
+   * construction-time autodetection): `Video.grayscale`'s getter is
+   * shape-driven (`shape[-1] === 1`), so without this override, setting
+   * `grayscale = false` on such a video would still read back as grayscale.
+   *
+   * Returns `undefined` only when the inner has no resolved shape.
+   */
+  get shape(): [number, number, number, number] | undefined {
+    const innerShape = this.inner.shape;
+    if (!innerShape) return undefined;
+    if (this.grayscale === true) {
+      return [innerShape[0], innerShape[1], innerShape[2], 1];
+    }
+    if (this.grayscale === false) {
+      return [innerShape[0], innerShape[1], innerShape[2], 3];
+    }
+    return innerShape;
+  }
+
+  /**
+   * Read a single frame, forcing or autodetecting grayscale.
+   *
+   * - `grayscale === false`: never collapse — the inner frame is returned
+   *   untouched (no decode/normalize overhead).
+   * - `grayscale === true`: always collapse to 1 channel via
+   *   {@link grayscaleFrame}.
+   * - `grayscale === null`: autodetect via {@link resolveAutodetect}, CACHE
+   *   the resolved value onto `this.grayscale`, then collapse only if it
+   *   resolved `true` — mirrors Python's `get_frame`:
+   *   `if self.grayscale is None: self.detect_grayscale(img)`.
+   *
+   * Returns `null` when the inner returns `null` (no such frame).
+   */
+  async getFrame(
+    frameIndex: number,
+    opts?: GetFrameOptions,
+  ): Promise<VideoFrame | null> {
+    const src = await this.inner.getFrame(frameIndex, opts);
+    if (src == null) return null;
+    if (this.grayscale === false) return src;
+
+    if (this.grayscale === null) {
+      this.grayscale = await this.resolveAutodetect(frameIndex, opts, src);
+    }
+    if (!this.grayscale) return src;
+    const readable = await toReadableFrame(src, this.inner.shape);
+    return grayscaleFrame(readable) as unknown as VideoFrame;
+  }
+
+  /**
+   * Resolve the `null` (autodetect) case for frame `frameIndex`.
+   *
+   * When `inner` is a {@link CropVideoBackend}, detection is run on the
+   * FULL, UNCROPPED first frame (`inner.inner`, not `inner` itself) — a
+   * degenerate or unusual crop region (e.g. a 1px-wide slice, or a region
+   * that happens to look grayscale in isolation on an otherwise-color source)
+   * must never skew the result. This mirrors Python's
+   * `CropVideoBackend.detect_grayscale`, which explicitly "resolves grayscale
+   * from the inner, ignoring any passed cropped image." For any other inner,
+   * detection runs on `frameSrc` (already decoded by the caller) directly.
+   */
+  private async resolveAutodetect(
+    frameIndex: number,
+    opts: GetFrameOptions | undefined,
+    frameSrc: VideoFrame,
+  ): Promise<boolean> {
+    if (this.inner instanceof CropVideoBackend) {
+      const fullSrc = await this.inner.inner.getFrame(frameIndex, opts);
+      if (fullSrc != null) {
+        const fullReadable = await toReadableFrame(
+          fullSrc,
+          this.inner.inner.shape,
+        );
+        return detectGrayscale(fullReadable);
+      }
+    }
+    const readable = await toReadableFrame(frameSrc, this.inner.shape);
+    return detectGrayscale(readable);
+  }
+
+  /** Release this wrapper's handle by releasing the inner's (always cascades). */
+  close(): void {
+    this.inner.close();
+  }
+}

--- a/src/video/image-decode.ts
+++ b/src/video/image-decode.ts
@@ -1,13 +1,17 @@
 // src/video/image-decode.ts
 //
-// Shared image decode/rasterize helpers, used by both `CropVideoBackend` (to
-// rasterize/decode inner frames before cropping) and `ImageVideoBackend` (to
-// decode each image-sequence frame).
+// Shared image decode/rasterize helpers, used by `CropVideoBackend` (to
+// rasterize/decode inner frames before cropping), `GrayscaleVideoBackend` (to
+// normalize inner frames before collapsing channels), and `ImageVideoBackend`
+// (to decode each image-sequence frame).
 //
 // Browser-safe: this module never statically imports a Node-only decoder.
 // Decoding/rasterizing uses `createImageBitmap` + `OffscreenCanvas` when
 // available (browser) else a lazy dynamic `import("skia-canvas")` (Node),
 // exactly like `seq-video.ts`. Bundlers must keep `skia-canvas` external.
+
+import type { VideoFrame } from "./backend.js";
+import type { RawFrame } from "../transform/frame.js";
 
 /** Rasterize an opaque `ImageBitmap` to RGBA `ImageData` (OffscreenCanvas / skia). */
 export async function rasterizeBitmap(bitmap: ImageBitmap): Promise<ImageData> {
@@ -171,6 +175,61 @@ export async function encodeBitmapToPng(
   // Node: rasterize (skia drawImage) to ImageData, then PNG-encode it.
   const img = await rasterizeBitmap(bitmap);
   return encodeImageDataToPng(img);
+}
+
+/** PNG / JPEG magic-byte sniff for undecoded encoded frame bytes. */
+export function isEncodedBytes(bytes: Uint8Array): boolean {
+  if (bytes.length < 4) return false;
+  // JPEG: FF D8 FF; PNG: 89 50 4E 47.
+  const jpeg = bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff;
+  const png =
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47;
+  return jpeg || png;
+}
+
+/**
+ * Normalize any {@link VideoFrame} into something a pure/sync pixel transform
+ * (e.g. `cropFrame`, `grayscaleFrame`) can read pixels from: an `ImageData` or
+ * a {@link RawFrame}.
+ *
+ * - `ImageData`-shaped: returned as-is.
+ * - `ImageBitmap`: rasterized to `ImageData` (OffscreenCanvas / skia-canvas).
+ * - Encoded bytes (PNG/JPEG): decoded to `ImageData`.
+ * - Raw pixel bytes: wrapped as a {@link RawFrame} using `rawShape`'s
+ *   width/height/channels (the `[frames, height, width, channels]` shape of
+ *   the backend that produced `frame`).
+ *
+ * @throws Error If `frame` is raw pixel bytes and no `rawShape` is given to
+ *   interpret them.
+ */
+export async function toReadableFrame(
+  frame: VideoFrame,
+  rawShape?: [number, number, number, number],
+): Promise<ImageData | RawFrame> {
+  if (isImageBitmapLike(frame)) {
+    return rasterizeBitmap(frame as ImageBitmap);
+  }
+  if (isImageDataLike(frame)) {
+    return frame as unknown as ImageData;
+  }
+  const bytes =
+    frame instanceof ArrayBuffer
+      ? new Uint8Array(frame)
+      : (frame as Uint8Array);
+  if (isEncodedBytes(bytes)) {
+    return decodeEncoded(bytes);
+  }
+  if (!rawShape) {
+    throw new Error(
+      "toReadableFrame received raw pixel bytes but no shape was given to " +
+        "interpret them. Provide the producing backend's resolved shape.",
+    );
+  }
+  const [, height, width, channels] = rawShape;
+  return { data: bytes, width, height, channels };
 }
 
 /** Decode encoded (PNG/JPEG/…) image bytes to RGBA `ImageData` (browser / skia). */

--- a/src/video/image-video.ts
+++ b/src/video/image-video.ts
@@ -15,6 +15,7 @@ import { VideoBackend, VideoFrame, GetFrameOptions } from "./backend.js";
 import { decodeEncoded } from "./image-decode.js";
 import { getImageBytesReader, type ImageBytesReader } from "./image-source.js";
 import { LruCache } from "./lru-cache.js";
+import { detectGrayscale } from "../transform/frame.js";
 
 export interface ImageVideoOptions {
   /** Image paths, one per frame. */
@@ -149,7 +150,7 @@ export class ImageVideoBackend implements VideoBackend {
       seedFrame = await decodeEncoded(seedBytes);
       height = seedFrame.height;
       width = seedFrame.width;
-      channels = isGrayscale(seedFrame) ? 1 : 3;
+      channels = detectGrayscale(seedFrame) ? 1 : 3;
     }
 
     const be = new ImageVideoBackend(
@@ -280,17 +281,4 @@ export class ImageVideoBackend implements VideoBackend {
     this.decodedCache.clear();
     this.inflight.clear();
   }
-}
-
-/**
- * Grayscale iff the first and last colour channels (R vs B in RGBA) are equal
- * for every pixel — parity with Python `VideoBackend.detect_grayscale`, which
- * compares `test_img[..., 0]` against `test_img[..., -1]`.
- */
-function isGrayscale(img: ImageData): boolean {
-  const d = img.data;
-  for (let i = 0; i < d.length; i += 4) {
-    if (d[i] !== d[i + 2]) return false;
-  }
-  return true;
 }

--- a/tests/model/video-grayscale.test.ts
+++ b/tests/model/video-grayscale.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for `Video.grayscale` (getter + new setter), and its interaction
+ * with `Video.crop` / `deduplicateWith` / `mergeWith` (`src/model/video.ts`).
+ *
+ * Port of Python `Video.grayscale` getter/setter (video.py:225-239) plus the
+ * grayscale-backend composition this JS port adds via `GrayscaleVideoBackend`
+ * (`src/video/grayscale-backend.ts`).
+ */
+import { describe, it, expect } from "../bun-test";
+import { Video } from "../../src/model/video.js";
+import { CropVideoBackend } from "../../src/video/crop-backend.js";
+import { GrayscaleVideoBackend } from "../../src/video/grayscale-backend.js";
+import type { VideoBackend, VideoFrame } from "../../src/video/backend.js";
+import type { RawFrame } from "../../src/transform/frame.js";
+
+/** Fake backend with a known shape; getFrame returns a tiny color ImageData. */
+function makeBackend(
+  width: number,
+  height: number,
+  filename = "src.mp4",
+): VideoBackend {
+  return {
+    filename,
+    shape: [1, height, width, 1],
+    dataset: "video0/video",
+    fps: 25,
+    async getFrame(i: number): Promise<VideoFrame | null> {
+      if (i !== 0) return null;
+      const data = new Uint8ClampedArray(width * height * 4);
+      for (let p = 0; p < width * height; p++) {
+        const v = p % 200;
+        data[p * 4] = v;
+        data[p * 4 + 1] = v;
+        data[p * 4 + 2] = (v + 77) % 256; // R !== B: genuinely color.
+        data[p * 4 + 3] = 255;
+      }
+      return { data, width, height, colorSpace: "srgb" } as ImageData;
+    },
+    close() {},
+  };
+}
+
+function makeVideo(width = 8, height = 6): Video {
+  return new Video({
+    filename: "src.mp4",
+    backend: makeBackend(width, height),
+  });
+}
+
+describe("Video.grayscale — getter (pre-existing behavior, unaffected)", () => {
+  it("derives true/false from shape[-1] when a backend/shape is known", () => {
+    const video = makeVideo();
+    video.backend!.shape = [1, 6, 8, 1];
+    expect(video.grayscale).toBe(true);
+    video.backend!.shape = [1, 6, 8, 3];
+    expect(video.grayscale).toBe(false);
+  });
+
+  it("falls back to backendMetadata.grayscale when shape is unknown", () => {
+    const video = new Video({
+      filename: "x.mp4",
+      backend: null,
+      backendMetadata: { grayscale: true },
+    });
+    expect(video.grayscale).toBe(true);
+  });
+
+  it("returns null when nothing is known", () => {
+    const video = new Video({ filename: "x.mp4", backend: null });
+    expect(video.grayscale).toBeNull();
+  });
+});
+
+describe("Video.grayscale — setter", () => {
+  it("throws when there is no open backend", () => {
+    const video = new Video({ filename: "x.mp4", backend: null });
+    expect(() => {
+      video.grayscale = true;
+    }).toThrow(/no open backend/);
+  });
+
+  it("wraps the backend in a GrayscaleVideoBackend and forces collapsing", async () => {
+    const video = makeVideo();
+    video.grayscale = true;
+    expect(video.backend).toBeInstanceOf(GrayscaleVideoBackend);
+    expect(video.grayscale).toBe(true);
+    const frame = (await video.getFrame(0)) as RawFrame;
+    expect(frame.channels).toBe(1);
+  });
+
+  it("persists into backendMetadata.grayscale (survives a closed/metadata-only read)", () => {
+    const video = makeVideo();
+    video.grayscale = true;
+    expect(video.backendMetadata.grayscale).toBe(true);
+    // Simulate a closed video (no live backend): the getter must still work.
+    video.backend = null;
+    expect(video.grayscale).toBe(true);
+  });
+
+  it("setting true then false then true never nests GrayscaleVideoBackend", () => {
+    const video = makeVideo();
+    const rawInner = video.backend!;
+    video.grayscale = true;
+    video.grayscale = false;
+    video.grayscale = true;
+    const wrapped = video.backend as GrayscaleVideoBackend;
+    expect(wrapped.inner).toBe(rawInner);
+    expect(wrapped.inner instanceof GrayscaleVideoBackend).toBe(false);
+    expect(wrapped.grayscale).toBe(true);
+  });
+
+  it("setting false never collapses, even after a prior true", async () => {
+    const video = makeVideo();
+    video.grayscale = true;
+    video.grayscale = false;
+    expect(video.grayscale).toBe(false);
+    const frame = (await video.getFrame(0)) as ImageData;
+    expect(frame.data.length).toBe(8 * 6 * 4);
+  });
+});
+
+describe("Video.crop composition with grayscale — canonical Grayscale(Crop(inner)) order", () => {
+  it("grayscale set BEFORE crop: the cropped video stays grayscale-forced and is spatially cropped", async () => {
+    const video = makeVideo(10, 10);
+    video.grayscale = true;
+    const cropped = video.crop([2, 2, 6, 6]);
+
+    expect(cropped.backend).toBeInstanceOf(GrayscaleVideoBackend);
+    const grayLayer = cropped.backend as GrayscaleVideoBackend;
+    expect(grayLayer.inner).toBeInstanceOf(CropVideoBackend);
+    expect(grayLayer.grayscale).toBe(true);
+
+    const frame = (await cropped.getFrame(0)) as RawFrame;
+    expect(frame.width).toBe(4);
+    expect(frame.height).toBe(4);
+    expect(frame.channels).toBe(1);
+    expect(cropped.shape).toEqual([1, 4, 4, 1]);
+  });
+
+  it("crop FIRST, then grayscale set on the cropped video: same canonical composition", async () => {
+    const video = makeVideo(10, 10);
+    const cropped = video.crop([2, 2, 6, 6]);
+    cropped.grayscale = true;
+
+    expect(cropped.backend).toBeInstanceOf(GrayscaleVideoBackend);
+    const grayLayer = cropped.backend as GrayscaleVideoBackend;
+    expect(grayLayer.inner).toBeInstanceOf(CropVideoBackend);
+
+    const frame = (await cropped.getFrame(0)) as RawFrame;
+    expect(frame.width).toBe(4);
+    expect(frame.height).toBe(4);
+    expect(frame.channels).toBe(1);
+  });
+
+  it("cropRect/isCropped/cropFill still resolve correctly when the backend is grayscale-wrapped", () => {
+    const video = makeVideo(10, 10);
+    video.grayscale = true;
+    const cropped = video.crop([1, 1, 5, 5], { fill: 42 });
+
+    expect(cropped.isCropped).toBe(true);
+    expect(cropped.cropRect).toEqual([1, 1, 5, 5]);
+    expect(cropped.cropFill).toBe(42);
+  });
+
+  it("cropping twice on a grayscale-forced video flattens the crop layer (WRAP LAW) under the grayscale layer", () => {
+    const video = makeVideo(20, 20);
+    video.grayscale = true;
+    const c1 = video.crop([2, 2, 12, 12]); // 10x10
+    const c2 = c1.crop([1, 1, 9, 9]); // in-bounds of c1 -> flattens
+
+    const grayLayer = c2.backend as GrayscaleVideoBackend;
+    expect(grayLayer.inner).toBeInstanceOf(CropVideoBackend);
+    const cropLayer = grayLayer.inner as CropVideoBackend;
+    // Flattened: the crop's own inner is the ORIGINAL raw backend, not c1's crop.
+    expect(cropLayer.inner instanceof CropVideoBackend).toBe(false);
+    expect(cropLayer.crop).toEqual([3, 3, 11, 11]); // composed rect.
+  });
+});
+
+describe("deduplicateWith / mergeWith carry `grayscale` forward", () => {
+  function imageSeqVideo(paths: string[], grayscale: boolean | null): Video {
+    return new Video({
+      filename: paths,
+      backend: null,
+      backendMetadata: grayscale != null ? { grayscale } : {},
+      openBackend: false,
+    });
+  }
+
+  it("deduplicateWith carries this video's grayscale value onto the result", () => {
+    const a = imageSeqVideo(["1.png", "2.png", "3.png"], true);
+    const b = imageSeqVideo(["2.png"], null);
+    const result = a.deduplicateWith(b);
+    expect(result).not.toBeNull();
+    expect(result!.grayscale).toBe(true);
+  });
+
+  it("mergeWith carries this video's grayscale value onto the result", () => {
+    const a = imageSeqVideo(["1.png", "2.png"], false);
+    const b = imageSeqVideo(["3.png"], null);
+    const result = a.mergeWith(b);
+    expect(result.grayscale).toBe(false);
+  });
+
+  it("deduplicateWith/mergeWith carry `null` (unknown) as null, not a stringified value", () => {
+    const a = imageSeqVideo(["1.png", "2.png"], null);
+    const b = imageSeqVideo(["3.png"], null);
+    expect(a.mergeWith(b).grayscale).toBeNull();
+  });
+});

--- a/tests/transform/grayscale-frame.test.ts
+++ b/tests/transform/grayscale-frame.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for the grayscale transform primitives (`src/transform/frame.ts`):
+ * `detectGrayscale` and `grayscaleFrame`.
+ *
+ * Ports Python `sleap_io.io.video_reading.VideoBackend.detect_grayscale`
+ * (`test_img[..., 0] == test_img[..., -1]`) and the `img[..., [0]]` slice
+ * applied by `get_frame`/`get_frames` when `grayscale` is `True`.
+ */
+import { describe, it, expect } from "../bun-test";
+import {
+  detectGrayscale,
+  grayscaleFrame,
+  type RawFrame,
+} from "../../src/transform/frame.js";
+
+/** A RawFrame with `channels` lanes per pixel, each lane set to `value(x, y, c)`. */
+function makeRawFrame(
+  w: number,
+  h: number,
+  channels: number,
+  value: (x: number, y: number, c: number) => number,
+): RawFrame {
+  const data = new Uint8Array(w * h * channels);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      for (let c = 0; c < channels; c++) {
+        data[(y * w + x) * channels + c] = value(x, y, c);
+      }
+    }
+  }
+  return { data, width: w, height: h, channels };
+}
+
+/** An ImageData-shaped RGBA frame (always 4 channels, alpha forced opaque). */
+function makeImageData(
+  w: number,
+  h: number,
+  rgb: (x: number, y: number) => [number, number, number],
+): ImageData {
+  const data = new Uint8ClampedArray(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const [r, g, b] = rgb(x, y);
+      const i = (y * w + x) * 4;
+      data[i] = r;
+      data[i + 1] = g;
+      data[i + 2] = b;
+      data[i + 3] = 255;
+    }
+  }
+  return { data, width: w, height: h, colorSpace: "srgb" } as ImageData;
+}
+
+describe("detectGrayscale", () => {
+  it("is true for a RawFrame where every pixel's channel 0 equals the last channel", () => {
+    const frame = makeRawFrame(3, 3, 3, (x, y, c) => (c === 1 ? 99 : x + y));
+    expect(detectGrayscale(frame)).toBe(true);
+  });
+
+  it("is false for a RawFrame where channel 0 differs from the last channel anywhere", () => {
+    const frame = makeRawFrame(3, 3, 3, (x, y, c) =>
+      x === 2 && y === 2 ? c * 10 : 5,
+    );
+    expect(detectGrayscale(frame)).toBe(false);
+  });
+
+  it("is trivially true for a 1-channel RawFrame", () => {
+    const frame = makeRawFrame(2, 2, 1, (x, y) => x + y);
+    expect(detectGrayscale(frame)).toBe(true);
+  });
+
+  it("compares channel 0 vs the LAST channel, not channel 1, for >3 channels", () => {
+    // channel 0 == channel 3 (last) everywhere, but channel 1 differs — must
+    // still report grayscale=true (Python compares only first vs last).
+    const frame = makeRawFrame(2, 2, 4, (x, y, c) => (c === 1 ? 255 : 7));
+    expect(detectGrayscale(frame)).toBe(true);
+  });
+
+  it("ImageData: true for R === B everywhere (alpha and G are ignored)", () => {
+    const img = makeImageData(4, 4, () => [42, 200, 42]);
+    expect(detectGrayscale(img)).toBe(true);
+  });
+
+  it("ImageData: false when R !== B anywhere, even with matching alpha", () => {
+    const img = makeImageData(4, 4, (x, y) =>
+      x === 3 && y === 3 ? [10, 10, 20] : [5, 5, 5],
+    );
+    expect(detectGrayscale(img)).toBe(false);
+  });
+
+  it("throws on a raw ImageBitmap (pixels not synchronously readable)", () => {
+    const fakeBitmap = { width: 4, height: 4, close: () => {} };
+    expect(() => detectGrayscale(fakeBitmap as unknown as ImageData)).toThrow(
+      /ImageBitmap/,
+    );
+  });
+});
+
+describe("grayscaleFrame", () => {
+  it("collapses a 3-channel RawFrame to channel 0, channels: 1", () => {
+    const frame = makeRawFrame(3, 2, 3, (x, y, c) =>
+      c === 0 ? y * 3 + x : 255,
+    );
+    const out = grayscaleFrame(frame);
+    expect(out.channels).toBe(1);
+    expect(out.width).toBe(3);
+    expect(out.height).toBe(2);
+    expect(Array.from(out.data)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("collapses ImageData (RGBA) to a 1-channel RawFrame taking the R lane", () => {
+    const img = makeImageData(2, 2, (x, y) => [10 * (y * 2 + x) + 1, 0, 0]);
+    const out = grayscaleFrame(img);
+    expect(out.channels).toBe(1);
+    expect(Array.from(out.data)).toEqual([1, 11, 21, 31]);
+  });
+
+  it("is idempotent: collapsing an already-1-channel frame is a byte-identical copy", () => {
+    const frame = makeRawFrame(2, 2, 1, (x, y) => y * 2 + x);
+    const once = grayscaleFrame(frame);
+    const twice = grayscaleFrame(once);
+    expect(Array.from(twice.data)).toEqual(Array.from(once.data));
+    expect(twice.channels).toBe(1);
+    // Defensive copy: mutating the second output must not alias the first.
+    twice.data[0] = 250;
+    expect(once.data[0]).not.toBe(250);
+  });
+
+  it("preserves the source typed-array kind (Uint8ClampedArray in, Uint8ClampedArray out)", () => {
+    const img = makeImageData(2, 2, () => [1, 2, 3]);
+    const out = grayscaleFrame(img);
+    expect(out.data).toBeInstanceOf(Uint8ClampedArray);
+  });
+
+  it("throws on a raw ImageBitmap (pixels not synchronously readable)", () => {
+    const fakeBitmap = { width: 4, height: 4, close: () => {} };
+    expect(() => grayscaleFrame(fakeBitmap as unknown as ImageData)).toThrow(
+      /ImageBitmap/,
+    );
+  });
+});

--- a/tests/video/factory-grayscale.test.ts
+++ b/tests/video/factory-grayscale.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `createVideoBackend(..., { grayscale })` — the factory-level entry point for
+ * grayscale-forcing (port of Python `Video.from_filename(..., grayscale)`).
+ *
+ * Exercises the real `ImageVideoBackend` path end-to-end (real PNG bytes,
+ * decoded via `skia-canvas`) through the public factory API, for forced
+ * true/false and autodetect — closing the gap flagged in the Python test
+ * inventory research (no direct forced-True/False test exists for
+ * `ImageVideo` upstream; only incidental/autodetect coverage does).
+ */
+import { describe, it, expect } from "../bun-test";
+import { createVideoBackend } from "../../src/video/factory.js";
+import { GrayscaleVideoBackend } from "../../src/video/grayscale-backend.js";
+import { ImageVideoBackend } from "../../src/video/image-video.js";
+import { setImageBytesReader } from "../../src/video/image-source.js";
+import type { RawFrame } from "../../src/transform/frame.js";
+
+async function makePng(
+  w: number,
+  h: number,
+  rgb: [number, number, number],
+): Promise<Uint8Array> {
+  const sc = await import("skia-canvas");
+  const canvas = new sc.Canvas(w, h);
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  ctx.fillRect(0, 0, w, h);
+  return new Uint8Array(await canvas.toBuffer("png"));
+}
+
+describe("createVideoBackend — omitted grayscale option (default, unwrapped)", () => {
+  it("returns the plain ImageVideoBackend, not wrapped", async () => {
+    const red = await makePng(2, 2, [255, 0, 0]);
+    setImageBytesReader(async () => red);
+    try {
+      const be = await createVideoBackend(["a.png"] as unknown as string);
+      expect(be).toBeInstanceOf(ImageVideoBackend);
+      expect(be instanceof GrayscaleVideoBackend).toBe(false);
+    } finally {
+      setImageBytesReader(null);
+    }
+  });
+});
+
+describe("createVideoBackend — grayscale: true (color source)", () => {
+  it("wraps the backend and forces every frame to 1 channel", async () => {
+    const red = await makePng(3, 3, [200, 20, 20]);
+    setImageBytesReader(async () => red);
+    try {
+      const be = await createVideoBackend(["a.png"] as unknown as string, {
+        grayscale: true,
+      });
+      expect(be).toBeInstanceOf(GrayscaleVideoBackend);
+      expect(be.shape).toEqual([1, 3, 3, 1]);
+      const frame = (await be.getFrame(0)) as RawFrame;
+      expect(frame.channels).toBe(1);
+      expect(frame.data[0]).toBe(200); // R channel of rgb(200,20,20).
+    } finally {
+      setImageBytesReader(null);
+    }
+  });
+});
+
+describe("createVideoBackend — grayscale: false", () => {
+  it("never collapses a genuinely-color source (frame stays full RGBA)", async () => {
+    const red = await makePng(3, 3, [200, 20, 20]);
+    setImageBytesReader(async () => red);
+    try {
+      const be = await createVideoBackend(["r.png"] as unknown as string, {
+        grayscale: false,
+      });
+      const frame = (await be.getFrame(0)) as ImageData;
+      expect(frame.data.length).toBe(3 * 3 * 4);
+      expect(frame.data[0]).toBe(200);
+    } finally {
+      setImageBytesReader(null);
+    }
+  });
+
+  it(
+    "forces the reported shape to 3 channels even when the inner " +
+      "ImageVideoBackend already auto-detected 1-channel at its own " +
+      "construction time (Python img_shape parity)",
+    async () => {
+      const gray = await makePng(3, 3, [128, 128, 128]);
+      setImageBytesReader(async () => gray);
+      try {
+        const be = await createVideoBackend(["g.png"] as unknown as string, {
+          grayscale: false,
+        });
+        // ImageVideoBackend.create() already resolved its OWN shape to
+        // channels=1 for this genuinely-gray source, independent of the
+        // grayscale-wrapping option; `grayscale: false` must still positively
+        // override that to 3, or `Video.grayscale`'s shape-driven getter
+        // would read this video back as grayscale despite the explicit false.
+        expect(be.shape).toEqual([1, 3, 3, 3]);
+      } finally {
+        setImageBytesReader(null);
+      }
+    },
+  );
+});
+
+describe("createVideoBackend — grayscale: null (autodetect)", () => {
+  it("resolves true for a genuinely-gray source after the first frame read", async () => {
+    const gray = await makePng(2, 2, [64, 64, 64]);
+    setImageBytesReader(async () => gray);
+    try {
+      const be = await createVideoBackend(["g.png"] as unknown as string, {
+        grayscale: null,
+      });
+      expect(be).toBeInstanceOf(GrayscaleVideoBackend);
+      const frame = (await be.getFrame(0)) as RawFrame;
+      expect(frame.channels).toBe(1);
+      expect((be as GrayscaleVideoBackend).grayscale).toBe(true);
+    } finally {
+      setImageBytesReader(null);
+    }
+  });
+
+  it("resolves false for a genuinely-color source after the first frame read", async () => {
+    // R (10) !== B (90): genuinely color under the R-vs-B detection rule.
+    const red = await makePng(2, 2, [10, 200, 90]);
+    setImageBytesReader(async () => red);
+    try {
+      const be = await createVideoBackend(["r.png"] as unknown as string, {
+        grayscale: null,
+      });
+      await be.getFrame(0);
+      expect((be as GrayscaleVideoBackend).grayscale).toBe(false);
+    } finally {
+      setImageBytesReader(null);
+    }
+  });
+});

--- a/tests/video/grayscale-backend.test.ts
+++ b/tests/video/grayscale-backend.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Unit tests for `GrayscaleVideoBackend` (`src/video/grayscale-backend.ts`),
+ * the on-read grayscale-forcing wrapper — port of the grayscale-forcing /
+ * autodetect behavior baked into Python's `VideoBackend.get_frame` /
+ * `detect_grayscale`.
+ *
+ * Covers: forced true/false, null-autodetect (+ caching after first read),
+ * delegation of every optional `VideoBackend` field, the "never nest" wrap
+ * law, composition with a real `CropVideoBackend` (including full-frame
+ * autodetection), and all three `toReadableFrame` normalization branches
+ * (ImageData, raw bytes, encoded PNG bytes).
+ */
+import { describe, it, expect } from "../bun-test";
+import { GrayscaleVideoBackend } from "../../src/video/grayscale-backend.js";
+import { CropVideoBackend } from "../../src/video/crop-backend.js";
+import type { VideoBackend, VideoFrame } from "../../src/video/backend.js";
+import type { RawFrame } from "../../src/transform/frame.js";
+
+/**
+ * A fake backend returning a deterministic ImageData-shaped frame. `color`
+ * controls whether R/B differ (a genuinely color source) or match (a
+ * genuinely grayscale source). Tracks `close()`/`getFrame()` calls.
+ */
+class FakeBackend implements VideoBackend {
+  filename: string;
+  shape: [number, number, number, number];
+  dataset: string | null = "video0/video";
+  fps = 30;
+  frameNumbers: number[] | undefined = [0, 1, 2];
+  embeddedFormat = "png";
+  embeddedChannelOrder = "RGB";
+  closed = 0;
+  getFrameCalls = 0;
+  private color: boolean;
+
+  constructor(
+    width: number,
+    height: number,
+    opts: { color: boolean; filename?: string },
+  ) {
+    this.filename = opts.filename ?? "fake.mp4";
+    this.shape = [3, height, width, 1];
+    this.color = opts.color;
+  }
+
+  async getFrame(frameIndex: number): Promise<VideoFrame | null> {
+    this.getFrameCalls += 1;
+    if (frameIndex < 0 || frameIndex >= 3) return null;
+    const [, h, w] = this.shape;
+    const data = new Uint8ClampedArray(w * h * 4);
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const v = (y * w + x) % 200;
+        const i = (y * w + x) * 4;
+        data[i] = v;
+        data[i + 1] = v;
+        data[i + 2] = this.color ? (v + 50) % 256 : v;
+        data[i + 3] = 255;
+      }
+    }
+    return { data, width: w, height: h, colorSpace: "srgb" } as ImageData;
+  }
+
+  async getFrameBuffer(frameNumber: number): Promise<Uint8Array | null> {
+    return new Uint8Array([frameNumber]);
+  }
+
+  async getFrameTimes(): Promise<number[] | null> {
+    return [0, 1, 2];
+  }
+
+  async ensureLoaded(): Promise<void> {}
+
+  async probeFirstFrame(): Promise<boolean> {
+    return true;
+  }
+
+  close(): void {
+    this.closed += 1;
+  }
+}
+
+describe("GrayscaleVideoBackend — forced true", () => {
+  it("collapses a color frame to 1 channel", async () => {
+    const inner = new FakeBackend(4, 4, { color: true });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    const frame = (await be.getFrame(0)) as RawFrame;
+    expect(frame.channels).toBe(1);
+  });
+
+  it("reports shape [..., 1] immediately, without reading a frame", () => {
+    const inner = new FakeBackend(4, 4, { color: true });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    expect(be.shape).toEqual([3, 4, 4, 1]);
+    expect(inner.getFrameCalls).toBe(0);
+  });
+
+  it("collapses a genuinely-grayscale source too (idempotent forcing)", async () => {
+    const inner = new FakeBackend(4, 4, { color: false });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    const frame = (await be.getFrame(0)) as RawFrame;
+    expect(frame.channels).toBe(1);
+  });
+});
+
+describe("GrayscaleVideoBackend — forced false", () => {
+  it("never collapses, even a genuinely-grayscale source", async () => {
+    const inner = new FakeBackend(4, 4, { color: false });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: false });
+    const frame = (await be.getFrame(0)) as ImageData;
+    expect(frame.data.length).toBe(4 * 4 * 4);
+  });
+
+  it("forces channels to 3 in the reported shape, even overriding an inner that declares 1", () => {
+    // FakeBackend always declares shape channels=1 (see its constructor) —
+    // `grayscale: false` must positively override this so `Video.grayscale`'s
+    // shape-driven getter reads back false, not true (Python `img_shape`
+    // parity: `if self.grayscale is False: channels = 3`).
+    const inner = new FakeBackend(4, 4, { color: false });
+    expect(inner.shape[3]).toBe(1);
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: false });
+    expect(be.shape).toEqual([3, 4, 4, 3]);
+  });
+
+  it("returns byte-identical pixels to calling the inner directly (no transform applied)", async () => {
+    const innerA = new FakeBackend(4, 4, { color: true });
+    const innerB = new FakeBackend(4, 4, { color: true });
+    const be = GrayscaleVideoBackend.wrap({ inner: innerA, grayscale: false });
+    const direct = (await innerB.getFrame(0)) as ImageData;
+    const wrapped = (await be.getFrame(0)) as ImageData;
+    expect(Array.from(wrapped.data)).toEqual(Array.from(direct.data));
+  });
+});
+
+describe("GrayscaleVideoBackend — null (autodetect)", () => {
+  it("resolves true for a genuinely-grayscale source and caches it", async () => {
+    const inner = new FakeBackend(4, 4, { color: false });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: null });
+    expect(be.grayscale).toBeNull();
+    const frame = (await be.getFrame(0)) as RawFrame;
+    expect(frame.channels).toBe(1);
+    expect(be.grayscale).toBe(true);
+  });
+
+  it("resolves false for a genuinely-color source and caches it", async () => {
+    const inner = new FakeBackend(4, 4, { color: true });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: null });
+    const frame = (await be.getFrame(0)) as ImageData;
+    expect(frame.data.length).toBe(4 * 4 * 4);
+    expect(be.grayscale).toBe(false);
+  });
+
+  it("does not re-run autodetection on a second getFrame call", async () => {
+    const inner = new FakeBackend(4, 4, { color: false });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: null });
+    await be.getFrame(0);
+    expect(be.grayscale).toBe(true);
+    // Swap in a color inner to prove the second call trusts the cached
+    // `true` instead of re-detecting (which would resolve false here).
+    (be as unknown as { inner: VideoBackend }).inner = new FakeBackend(4, 4, {
+      color: true,
+    });
+    const frame2 = (await be.getFrame(1)) as RawFrame;
+    expect(frame2.channels).toBe(1);
+  });
+
+  it("shape is unresolved (inner's native channel count) before the first getFrame", () => {
+    const inner = new FakeBackend(4, 4, { color: false });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: null });
+    // Documented async-vs-sync limitation: `shape` is a sync getter and
+    // cannot trigger a decode, so it reflects the inner's native shape until
+    // the first `getFrame()` resolves autodetection.
+    expect(be.shape).toEqual(inner.shape);
+  });
+});
+
+describe("GrayscaleVideoBackend — delegation", () => {
+  it("delegates every optional VideoBackend field to the inner", async () => {
+    const inner = new FakeBackend(4, 4, { color: true });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: false });
+    expect(be.dataset).toBe("video0/video");
+    expect(be.fps).toBe(30);
+    expect(be.frameNumbers).toEqual([0, 1, 2]);
+    expect(be.embeddedFormat).toBe("png");
+    expect(be.embeddedChannelOrder).toBe("RGB");
+    expect(await be.getFrameBuffer(1)).toEqual(new Uint8Array([1]));
+    expect(await be.getFrameTimes()).toEqual([0, 1, 2]);
+    expect(await be.probeFirstFrame()).toBe(true);
+    expect(be.filename).toBe("fake.mp4");
+  });
+
+  it("close() always cascades to the inner", () => {
+    const inner = new FakeBackend(4, 4, { color: true });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    be.close();
+    expect(inner.closed).toBe(1);
+  });
+
+  it("getFrameBuffer resolves null when the inner has none", async () => {
+    const inner: VideoBackend = {
+      filename: "x.mp4",
+      shape: [1, 2, 2, 3],
+      async getFrame() {
+        return null;
+      },
+      close() {},
+    };
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: false });
+    expect(await be.getFrameBuffer(0)).toBeNull();
+  });
+
+  it("probeFirstFrame defaults to true when the inner omits it", async () => {
+    const inner: VideoBackend = {
+      filename: "x.mp4",
+      shape: [1, 2, 2, 3],
+      async getFrame() {
+        return null;
+      },
+      close() {},
+    };
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: false });
+    expect(await be.probeFirstFrame()).toBe(true);
+  });
+
+  it("getFrameTimes resolves null when the inner omits it", async () => {
+    const inner: VideoBackend = {
+      filename: "x.mp4",
+      shape: [1, 2, 2, 3],
+      async getFrame() {
+        return null;
+      },
+      close() {},
+    };
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: false });
+    expect(await be.getFrameTimes()).toBeNull();
+  });
+});
+
+describe("GrayscaleVideoBackend.wrap — never nests (WRAP LAW)", () => {
+  it("unwraps and replaces an existing grayscale layer instead of nesting", () => {
+    const inner = new FakeBackend(4, 4, { color: true });
+    const g1 = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    const g2 = GrayscaleVideoBackend.wrap({ inner: g1, grayscale: false });
+    expect(g2.inner).toBe(inner);
+    expect(g2.inner instanceof GrayscaleVideoBackend).toBe(false);
+    expect(g2.grayscale).toBe(false);
+  });
+
+  it("dropping a previously-resolved autodetect result on re-wrap", async () => {
+    const inner = new FakeBackend(4, 4, { color: false });
+    const g1 = GrayscaleVideoBackend.wrap({ inner, grayscale: null });
+    await g1.getFrame(0);
+    expect(g1.grayscale).toBe(true);
+    // Re-wrapping with grayscale: null again must re-arm autodetection, not
+    // inherit g1's already-resolved `true`.
+    const g2 = GrayscaleVideoBackend.wrap({ inner: g1, grayscale: null });
+    expect(g2.grayscale).toBeNull();
+  });
+});
+
+describe("GrayscaleVideoBackend — null frame passthrough", () => {
+  it("propagates a null frame (no such index) untouched", async () => {
+    const inner = new FakeBackend(4, 4, { color: true });
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    expect(await be.getFrame(99)).toBeNull();
+  });
+});
+
+describe("GrayscaleVideoBackend — raw (non-ImageData) pixel bytes", () => {
+  it("collapses a raw Uint8Array frame using the inner's shape to interpret it", async () => {
+    const w = 3;
+    const h = 2;
+    const raw = new Uint8Array(w * h * 3);
+    for (let i = 0; i < raw.length; i++) raw[i] = i;
+    const inner: VideoBackend = {
+      filename: "raw.bin",
+      shape: [1, h, w, 3],
+      async getFrame() {
+        return raw;
+      },
+      close() {},
+    };
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    const frame = (await be.getFrame(0)) as RawFrame;
+    expect(frame.channels).toBe(1);
+    expect(frame.width).toBe(w);
+    expect(frame.height).toBe(h);
+    // Channel 0 of each pixel: strides of 3 starting at 0, 3, 6, 9, 12, 15.
+    expect(Array.from(frame.data)).toEqual([0, 3, 6, 9, 12, 15]);
+  });
+
+  it("throws a clear error for raw bytes with no shape to interpret them", async () => {
+    const inner: VideoBackend = {
+      filename: "raw.bin",
+      async getFrame() {
+        return new Uint8Array([1, 2, 3, 4]);
+      },
+      close() {},
+    };
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: null });
+    await expect(be.getFrame(0)).rejects.toThrow(/shape/);
+  });
+});
+
+describe("GrayscaleVideoBackend — encoded (PNG) bytes", () => {
+  it("decodes PNG bytes and collapses them to 1 channel", async () => {
+    const sc = await import("skia-canvas");
+    const canvas = new sc.Canvas(3, 3);
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "rgb(10, 20, 30)";
+    ctx.fillRect(0, 0, 3, 3);
+    const png = new Uint8Array(await canvas.toBuffer("png"));
+
+    const inner: VideoBackend = {
+      filename: "e.png",
+      shape: [1, 3, 3, 3],
+      async getFrame() {
+        return png;
+      },
+      close() {},
+    };
+    const be = GrayscaleVideoBackend.wrap({ inner, grayscale: true });
+    const frame = (await be.getFrame(0)) as RawFrame;
+    expect(frame.channels).toBe(1);
+    expect(frame.width).toBe(3);
+    expect(frame.height).toBe(3);
+    expect(frame.data[0]).toBe(10); // R channel of rgb(10,20,30).
+  });
+});
+
+describe("GrayscaleVideoBackend composed with a real CropVideoBackend", () => {
+  it("Grayscale(Crop(inner)): crops correctly AND collapses channels", async () => {
+    const inner = new FakeBackend(10, 10, { color: true });
+    const cropped = CropVideoBackend.wrap({
+      inner,
+      crop: [2, 2, 6, 6],
+      fill: 0,
+    });
+    const be = GrayscaleVideoBackend.wrap({ inner: cropped, grayscale: true });
+    const frame = (await be.getFrame(0)) as RawFrame;
+    expect(frame.width).toBe(4);
+    expect(frame.height).toBe(4);
+    expect(frame.channels).toBe(1);
+    expect(be.shape).toEqual([3, 4, 4, 1]);
+  });
+
+  it("autodetection resolves from the FULL uncropped frame, not the crop", async () => {
+    // A source that is genuinely color everywhere EXCEPT the exact crop
+    // region, which — looked at in isolation — appears grayscale (R === B).
+    // Autodetect must see the full frame (bypassing the crop) and correctly
+    // resolve to color (false), matching Python's `CropVideoBackend
+    // .detect_grayscale`, which explicitly ignores the cropped image.
+    const w = 6;
+    const h = 6;
+    let fullFrameReads = 0;
+    const inner: VideoBackend = {
+      filename: "mixed.mp4",
+      shape: [1, h, w, 1],
+      async getFrame(frameIndex: number) {
+        if (frameIndex !== 0) return null;
+        fullFrameReads += 1;
+        const data = new Uint8ClampedArray(w * h * 4);
+        for (let y = 0; y < h; y++) {
+          for (let x = 0; x < w; x++) {
+            const i = (y * w + x) * 4;
+            const inCropRegion = x >= 1 && x < 3 && y >= 1 && y < 3;
+            data[i] = 50;
+            data[i + 1] = 50;
+            // Grayscale (R===B) ONLY inside the crop region; color everywhere else.
+            data[i + 2] = inCropRegion ? 50 : 200;
+            data[i + 3] = 255;
+          }
+        }
+        return { data, width: w, height: h, colorSpace: "srgb" } as ImageData;
+      },
+      close() {},
+    };
+    const cropped = CropVideoBackend.wrap({
+      inner,
+      crop: [1, 1, 3, 3],
+      fill: 0,
+    });
+    const be = GrayscaleVideoBackend.wrap({
+      inner: cropped,
+      grayscale: null,
+    });
+    const frame = (await be.getFrame(0)) as ImageData;
+    // Resolved false (color) from the full frame, so the crop's own 4-channel
+    // ImageData passes through untouched.
+    expect(be.grayscale).toBe(false);
+    expect(frame.data.length).toBe(2 * 2 * 4); // 2x2 crop, 4 channels, untouched.
+    // Exactly 2 full-frame reads: one for detection, one for the crop's own
+    // decode (no extra decode beyond what correctness requires).
+    expect(fullFrameReads).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Ports Python `sleap-io`'s grayscale forcing/autodetection to the JS video pipeline. Today `sleap-io.js` has grayscale-*detection* scattered internally (`ImageVideoBackend`, `.seq` mono codecs) but no way for a caller to actually force a video to 1 channel — this closes that gap, motivated by the legacy Qt SLEAP GUI's "Import as grayscale" checkbox (`sleap/gui/dialogs/importvideos.py`), which `sleap-app` doesn't yet expose because this library couldn't support it.

Python centralizes the behavior in `VideoBackend`'s base-class `get_frame` (`img[..., [0]]` slice + `detect_grayscale()`). The JS `VideoBackend` is a plain interface with no shared base implementation, so this adds a wrapping backend — `GrayscaleVideoBackend` — following the exact pattern `CropVideoBackend` already established for cropping, instead of touching every concrete backend (media/mediabunny/mp4box/hdf5/streaming-hdf5/image/seq).

### What's added
- `transform/frame.ts`: `detectGrayscale`/`grayscaleFrame` — pure, sync pixel helpers (parity with Python's `detect_grayscale` and the `img[..., [0]]` slice). `image-video.ts`'s private duplicate detector is refactored to reuse the shared one.
- `video/grayscale-backend.ts` (new): `GrayscaleVideoBackend.wrap({ inner, grayscale })` — tri-state (`true` force / `false` never / `null` autodetect-once-and-cache). When composed with `CropVideoBackend`, autodetection resolves from the **full uncropped** frame, matching Python's `CropVideoBackend.detect_grayscale` override.
- `video/factory.ts`: `createVideoBackend(source, { grayscale })` — omitting the option skips wrapping entirely (fully backward compatible).
- `model/video.ts`: `Video.grayscale` was getter-only; added a real setter that rebuilds the backend via `GrayscaleVideoBackend.wrap` and persists into `backendMetadata` (same pattern `crop()` already uses). `crop()` now composes canonically as `Grayscale(Crop(inner))` regardless of which order the caller calls `.crop()` / sets `.grayscale` in.
- Public exports added to `index.ts`/`index.browser.ts`/`transform/index.ts`.

### Design note worth a second pair of eyes
`GrayscaleVideoBackend.shape` forces the reported channel count to `3` when `grayscale === false` (not just "pass through unchanged") — mirroring Python's `img_shape`, which unconditionally sets `channels = 3` for explicit `False`. This is required for correctness: `Video.grayscale`'s getter is shape-driven (`shape[-1] === 1`), and some backends (`ImageVideoBackend`) already self-detect 1-channel independently at construction time — without this override, setting `grayscale = false` on such a video would still read back as grayscale. Caught this via a failing test while implementing, not by inspection — see `src/video/grayscale-backend.ts`'s `shape` getter docstring.

### Scope / deliberate follow-ups
Per-backend real-fixture integration tests (actual `.mp4`/`.seq`/HDF5 binary fixtures) are **not** included here — the wrapper is backend-agnostic and is exercised thoroughly via a `FakeBackend` (matching `crop-backend.test.ts`'s existing convention) plus one real end-to-end path through `ImageVideoBackend` via the public factory API (real PNG bytes, `skia-canvas`-decoded). Adding real `.seq`/HDF5/mp4 fixtures for this specific feature would be a reasonable fast-follow but wasn't included to keep this PR focused on the core architecture.
Wiring an actual UI toggle into `sleap-app`'s video-import flow is a separate, smaller follow-up once this ships.

## Test plan
- [x] `bun run test` — full suite: 2246 pass / 1 skip / 0 fail (159 files, no regressions)
- [x] 56 new tests across 4 files:
  - `tests/transform/grayscale-frame.test.ts` — `detectGrayscale`/`grayscaleFrame` pixel-level correctness, idempotency, ImageBitmap rejection
  - `tests/video/grayscale-backend.test.ts` — forced true/false/null-autodetect + caching, delegation of every optional `VideoBackend` field, "never nest" wrap law, all three `toReadableFrame` normalization branches (ImageData/raw bytes/encoded PNG), composition with a real `CropVideoBackend` including full-frame autodetection
  - `tests/video/factory-grayscale.test.ts` — `createVideoBackend({ grayscale })` end-to-end through the real `ImageVideoBackend` path
  - `tests/model/video-grayscale.test.ts` — `Video.grayscale` getter/setter, `crop()` composition in both call orders, `deduplicateWith`/`mergeWith` carry-forward
- [x] `bunx tsc --noEmit` clean
- [x] `bun run check` (biome) — 0 errors (fixed 2 pre-existing-style format issues in files this PR touched)
- [x] `bun run build` — tsup + dts build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)