### PR TITLE
chore: release 0.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release **0.5.11**.

Ships #253:
- feat(video): grayscale-forcing support via `GrayscaleVideoBackend`

Unblocks sleap-app #308 (Import videos as grayscale), which needs `GrayscaleVideoBackend` on the published package.

Version bump only (`package.json` 0.5.10 → 0.5.11). Merging this + creating the `v0.5.11` GitHub Release triggers `release.yml` → `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)