### PR TITLE
chore: release 0.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Version bump `0.5.10 → 0.5.11` to publish the **AviVideoBackend** (#252) — in-browser `.avi`/`.wmv` decode (web-demuxer + WebCodecs/ImageDecoder).

**Stacked on #252** (`feat/avi-backend`): its base auto-retargets to `main` once #252 merges. Merge this **after** #252, then cut a GitHub Release `v0.5.11` to trigger `npm publish`.

## Release checklist
- [ ] Merge #252 (AviVideoBackend) first
- [ ] Merge this version bump
- [ ] Create GitHub Release `v0.5.11` → `release.yml` publishes to npm
- [ ] Bump `@talmolab/sleap-io.js` → `^0.5.11` in sleap-app (unblocks #306 → #307)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TB4adk7c5bt9FmfGFr6M4a