### PR TITLE
chore: release 0.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talmolab/sleap-io.js",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "private": false,
   "type": "module",
   "exports": {


### PR DESCRIPTION
Version bump `0.5.10 → 0.5.11`. First release including the **AviVideoBackend** (#252, in-browser `.avi`/`.wmv` decode) alongside the grayscale backend (#253).

Cut a GitHub Release `v0.5.11` after merge → `release.yml` publishes to npm.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TB4adk7c5bt9FmfGFr6M4a